### PR TITLE
docs: fix README Quick Example code errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,12 @@ import neug
 
 # Step 1: Load and analyze data (Embedded Mode)
 db = neug.Database("/path/to/database") 
-conn = db.connect()
 
-# Load sample data
+# Load sample data (must load data before creating connection)
 db.load_builtin_dataset("tinysnb")
+
+# Create connection to execute queries
+conn = db.connect()
 
 # Run analytics - find triangles in the graph
 result = conn.execute("""
@@ -48,8 +50,9 @@ result = conn.execute("""
     RETURN a.fName, b.fName, c.fName
 """)
 
+# Access results by index (QueryResult returns a list for each row)
 for record in result:
-    print(f"{record['a.fName']}, {record['b.fName']}, {record['c.fName']} are mutual friends")
+    print(f"{record[0]}, {record[1]}, {record[2]} are mutual friends")
 
 # Step 2: Serve applications (Service Mode)  
 conn.close()


### PR DESCRIPTION
## Related Issues
fix #15

## What does this PR do?
Fixes two errors in the README Quick Example that prevent it from running correctly.

## What changes in this PR?
- Fix connection order: Move `db.load_builtin_dataset()` before `db.connect()` to avoid "already a read-write connection" error
- Fix result access: Change `record['a.fName']` to `record[0]` since QueryResult returns a list for each row, not a dict
