### PR TITLE
docs: fix connect() called before load_builtin_dataset() in introduction

### DIFF
--- a/doc/source/overview/introduction.md
+++ b/doc/source/overview/introduction.md
@@ -21,10 +21,10 @@ import neug
 
 # Step 1: Load and analyze data (Embedded Mode)
 db = neug.Database("/path/to/database") 
-conn = db.connect()
-
 # Load sample data
 db.load_builtin_dataset("tinysnb")
+
+conn = db.connect()
 
 # Run analytics
 result = conn.execute("""


### PR DESCRIPTION
## Related Issues
N/A

## What does this PR do?
Fixes incorrect ordering in the Quick Example code snippet in the introduction doc, where `db.connect()` was called before `db.load_builtin_dataset()`.

## What changes in this PR?
- `doc/source/overview/introduction.md`: Move `conn = db.connect()` to after `db.load_builtin_dataset("tinysnb")` so the example correctly loads data before creating a connection.