### PR TITLE
fix: fix macos extension rpath so the neug lib is not dlopened twice

### DIFF
--- a/extension/CMakeLists.txt
+++ b/extension/CMakeLists.txt
@@ -19,7 +19,7 @@ function(set_extension_properties target_name output_name extension_name)
     message(STATUS "Setting LIBRARY_OUTPUT_DIRECTORY for ${target_name} to: ${extension_dir}")
     # macOS dyld uses @loader_path, Linux uses $ORIGIN. Multiple paths: semicolon-separated.
     if(APPLE)
-        set(_ext_rpath
+        set(_ext_rpath 
             "@loader_path/../../neug/.dylibs"
             "@loader_path/../.."
             "@loader_path")


### PR DESCRIPTION
Committed-by: Xiaoli Zhou from Dev container

Committed-by: Xiaoli Zhou from Dev container

<!--
Thanks for your contribution! please review https://github.com/alibaba/neug/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

as titled.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

