### PR TITLE
fix: Visiting string prop on bundled edge is not possible

### DIFF
--- a/include/neug/storages/csr/generic_view.h
+++ b/include/neug/storages/csr/generic_view.h
@@ -334,14 +334,10 @@ struct EdgeDataAccessor {
   }
         FOR_EACH_DATA_TYPE_NO_STRING(TYPE_DISPATCHER)
 #undef TYPE_DISPATCHER
-      case DataTypeId::kVarchar: {
-        *reinterpret_cast<std::string_view*>(const_cast<void*>(
-            it.get_data_ptr())) = PropUtils<std::string_view>::to_typed(prop);
-        break;
-      }
       default:
-        LOG(FATAL) << "type - " << std::to_string(data_type_)
-                   << " - not implemented";
+        THROW_RUNTIME_ERROR("Could not set bundled data for type " +
+                            std::to_string(data_type_));
+        break;
       }
     }
   }
@@ -370,13 +366,9 @@ struct EdgeDataAccessor {
   }
       FOR_EACH_DATA_TYPE_NO_STRING(TYPE_DISPATCHER)
 #undef TYPE_DISPATCHER
-    case DataTypeId::kVarchar: {
-      return PropUtils<std::string_view>::to_prop(
-          get_bundled_data_from_ptr<std::string_view>(data_ptr));
-    }
     default:
-      LOG(FATAL) << "type - " << std::to_string(data_type_)
-                 << " - not implemented";
+      THROW_RUNTIME_ERROR("Could not get bundled data for type " +
+                          std::to_string(data_type_));
       return Property::empty();
     }
   }


### PR DESCRIPTION
Fix #21 
This pull request updates error handling in the `EdgeDataAccessor` struct within `include/neug/storages/csr/generic_view.h`, replacing fatal log statements with runtime exceptions and removing special handling for the `kVarchar` data type. These changes improve robustness and consistency in error reporting.

Error handling improvements:

* Replaced `LOG(FATAL)` statements with `THROW_RUNTIME_ERROR` for unsupported data types in both the setter and getter methods, ensuring exceptions are thrown instead of terminating the process. [[1]](diffhunk://#diff-00f81dc78c5aadbf2d169832569c394901cb80e4d4c80bf3483986ed6293b9a7L337-R340) [[2]](diffhunk://#diff-00f81dc78c5aadbf2d169832569c394901cb80e4d4c80bf3483986ed6293b9a7L373-R371)

Code simplification:

* Removed the explicit case for `DataTypeId::kVarchar` in both setter and getter methods, streamlining the data type dispatch logic. [[1]](diffhunk://#diff-00f81dc78c5aadbf2d169832569c394901cb80e4d4c80bf3483986ed6293b9a7L337-R340) [[2]](diffhunk://#diff-00f81dc78c5aadbf2d169832569c394901cb80e4d4c80bf3483986ed6293b9a7L373-R371)