### PR TITLE
fix: Remove official extensions check during the bind extension process

### DIFF
--- a/include/neug/compiler/extension/extension.h
+++ b/include/neug/compiler/extension/extension.h
@@ -96,10 +96,6 @@ struct NEUG_API ExtensionUtils {
 
   static constexpr const char* EXTENSION_FILE_NAME = "lib{}.neug_extension";
 
-  static constexpr const char* OFFICIAL_EXTENSION[] = {
-      "JSON",
-  };
-
   static constexpr const char* EXTENSION_LOADER_SUFFIX = "_loader";
 
   static constexpr const char* EXTENSION_INSTALLER_SUFFIX = "_installer";
@@ -110,8 +106,6 @@ struct NEUG_API ExtensionUtils {
       const std::string& extensionName, const std::string& extensionRepo);
 
   static std::string getExtensionFileName(const std::string& name);
-
-  static bool isOfficialExtension(const std::string& extension);
 
   template <typename T>
   static void addTableFunc(main::MetadataManager& database) {

--- a/src/compiler/binder/bind/bind_extension.cpp
+++ b/src/compiler/binder/bind/bind_extension.cpp
@@ -33,48 +33,11 @@ using namespace neug::parser;
 namespace neug {
 namespace binder {
 
-static void bindInstallExtension(const ExtensionAuxInfo& auxInfo) {
-  if (!ExtensionUtils::isOfficialExtension(auxInfo.path)) {
-    THROW_BINDER_EXCEPTION(common::stringFormat(
-        "{} is not an official extension.\nNon-official extensions "
-        "can be installed directly by: `LOAD EXTENSION [EXTENSION_PATH]`.",
-        auxInfo.path));
-  }
-}
-
-static void bindLoadExtension(const ExtensionAuxInfo& auxInfo) {
-  if (ExtensionUtils::isOfficialExtension(auxInfo.path)) {
-    return;
-  }
-  auto localFileSystem = common::LocalFileSystem("");
-  if (!localFileSystem.fileOrPathExists(auxInfo.path,
-                                        nullptr /* clientContext */)) {
-    THROW_BINDER_EXCEPTION(common::stringFormat(
-        "The extension {} is neither an official extension, nor does "
-        "the extension path: '{}' exists.",
-        auxInfo.path, auxInfo.path));
-  }
-}
-
 std::unique_ptr<BoundStatement> Binder::bindExtension(
     const Statement& statement) {
   auto extensionStatement = statement.constPtrCast<ExtensionStatement>();
   auto auxInfo = extensionStatement->getAuxInfo();
-  switch (auxInfo->action) {
-  case ExtensionAction::INSTALL:
-    bindInstallExtension(*auxInfo);
-    break;
-  case ExtensionAction::LOAD:
-    bindLoadExtension(*auxInfo);
-    break;
-  case ExtensionAction::UNINSTALL:
-    break;
-  default:
-    NEUG_UNREACHABLE;
-  }
-  if (ExtensionUtils::isOfficialExtension(auxInfo->path)) {
-    common::StringUtils::toLower(auxInfo->path);
-  }
+  common::StringUtils::toLower(auxInfo->path);
   return std::make_unique<BoundExtensionStatement>(std::move(auxInfo));
 }
 

--- a/src/compiler/extension/extension.cpp
+++ b/src/compiler/extension/extension.cpp
@@ -129,16 +129,6 @@ std::string ExtensionUtils::getExtensionFileName(const std::string& name) {
                               common::StringUtils::getLower(name));
 }
 
-bool ExtensionUtils::isOfficialExtension(const std::string& extension) {
-  auto extensionUpperCase = common::StringUtils::getUpper(extension);
-  for (auto& officialExtension : OFFICIAL_EXTENSION) {
-    if (officialExtension == extensionUpperCase) {
-      return true;
-    }
-  }
-  return false;
-}
-
 ExtensionLibLoader::ExtensionLibLoader(const std::string& extensionName,
                                        const std::string& path)
     : extensionName{extensionName} {


### PR DESCRIPTION
Committed-by: Xiaoli Zhou from Dev container

<!--
Thanks for your contribution! please review https://github.com/alibaba/neug/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
as titled.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes all official-extension validation from the bind phase of the extension pipeline — eliminating the `isOfficialExtension()` helper, the `OFFICIAL_EXTENSION` allow-list, and the per-action bind guards for `INSTALL` and `LOAD`. The intent is to allow non-official extensions to be installed and loaded without being blocked at bind time.

Key changes and concerns:

- **Logic bug — unconditional `toLower` on all paths** (`bind_extension.cpp:40`): Previously, `StringUtils::toLower()` was only applied to *official* extension names (bare names like `"JSON"`). Non-official extensions used user-provided file-system paths, which must not be lowercased on case-sensitive file systems (Linux). The new code applies `toLower` unconditionally, silently corrupting paths like `/opt/Extensions/MyExt.neug_extension` → `/opt/extensions/myext.neug_extension` and causing hard-to-diagnose load failures.
- **Removal of install validation**: `bindInstallExtension` previously rejected non-official extension names from `INSTALL EXTENSION`, directing users to `LOAD EXTENSION` for custom paths. Removing this gate is the stated goal of the PR, but it means the runtime `install_extension` executor will now attempt an HTTP download from the official repo for any arbitrary name, surfacing a less-friendly error only at execution time.
- **Removal of file-existence check for LOAD**: `bindLoadExtension` checked whether a user-specified path existed before proceeding. Removing this means path typos surface later with a less descriptive error.
- The `isFullPath()` utility method is still declared in `extension.h` and could be used to guard the `toLower` call appropriately.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is: the unconditional `toLower` on all extension paths will break user-supplied file-system paths on case-sensitive systems.
- The removal of the official-extension gate is intentional and the header/implementation deletions are clean. However, the unconditional application of `toLower` to every path — including user-supplied absolute file paths — is a regression that will silently corrupt paths on Linux, breaking `LOAD EXTENSION "/Path/To/Ext.so"` style usage.
- Primary attention needed on `src/compiler/binder/bind/bind_extension.cpp` line 40 — the unconditional `toLower` call.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/compiler/binder/bind/bind_extension.cpp | All bind-time validation (official-extension guard for INSTALL, file-existence check for LOAD) has been removed, and `toLower` is now applied unconditionally to every path — including user-supplied file-system paths — which will corrupt case-sensitive paths on Linux. |
| include/neug/compiler/extension/extension.h | Removes the `OFFICIAL_EXTENSION` array and the `isOfficialExtension()` declaration. Change is consistent with removing the official-extension gate; `isFullPath()` remains available. |
| src/compiler/extension/extension.cpp | Removes the `isOfficialExtension()` implementation. Straightforward deletion with no other side-effects. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User issues INSTALL / LOAD / UNINSTALL] --> B[Parser: transformExtension]
    B --> C[ExtensionAuxInfo\naction + path]
    C --> D[Binder::bindExtension]

    subgraph OLD ["Old bindExtension"]
        D1{action?}
        D1 -->|INSTALL| D2[bindInstallExtension\nReject if not official]
        D1 -->|LOAD| D3[bindLoadExtension\nCheck file exists if not official]
        D1 -->|UNINSTALL| D4[no-op]
        D3 --> D5{isOfficialExtension?}
        D5 -->|Yes| D6[toLower path]
        D5 -->|No| D7[keep path as-is]
    end

    subgraph NEW ["New bindExtension (this PR)"]
        N1[toLower ALL paths unconditionally ⚠️]
    end

    D --> OLD
    D --> NEW

    OLD --> E[BoundExtensionStatement]
    NEW --> E
    E --> F[Planner / Executor\nINSTALL downloads from repo\nLOAD opens .so / .neug_extension]
```

<sub>Last reviewed commit: affb529</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->