### PR TITLE
fix: fix coverage report upload in workflow

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -18,3 +18,9 @@ comment:
   layout: "reach,diff,flags,files,footer"
   behavior: default
   require_changes: no
+
+ignore:
+  - "third_party/"
+  - "tests/"
+  - "include/neug/compiler/"
+  - "src/compiler/"

--- a/.github/workflows/neug-test.yml
+++ b/.github/workflows/neug-test.yml
@@ -406,11 +406,10 @@ jobs:
         sudo apt install lcov -y
         cd ${GITHUB_WORKSPACE}/tools/python_bind/build/neug_py_bind
         make coverage
-        mv coverage_filtered.info coverage.info
 
     - name: Upload coverage to Codecov
       if: steps.scope.outputs.extension_only != 'true' && (github.ref == 'refs/heads/main' && github.repository == 'alibaba/neug' && github.event_name == 'push')
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: ${{ github.workspace }}/tools/python_bind/build/neug_py_bind/coverage.info
+        file: ${{ github.workspace }}/tools/python_bind/build/neug_py_bind/coverage_filtered.info


### PR DESCRIPTION
Fixes https://github.com/alibaba/neug/issues/3

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the `CODECOV_TOKEN` secret to the `Upload coverage to Codecov` step in `.github/workflows/neug-test.yml`, fixing authenticated uploads that were likely failing due to the missing token.

- **What changed**: The `token: ${{ secrets.CODECOV_TOKEN }}` input was added to the `codecov/codecov-action@v4` step.
- **Why it's needed**: Codecov requires an upload token for private repositories (and increasingly for public ones with `v4` of the action), so omitting it causes uploads to be rejected or silently dropped.
- **Risk**: The change is minimal and well-scoped — it only affects the coverage-upload step, which is already gated behind a strict condition (`main` branch push on the canonical repository).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — the change is a single-line, well-understood CI fix with no impact on application code.
- Only one line is added to a CI workflow file: the Codecov upload token. The change is low-risk, targeted, and follows the recommended usage pattern for `codecov/codecov-action@v4`. The secret is referenced via the GitHub Secrets mechanism, so no credentials are exposed.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/neug-test.yml | Adds `CODECOV_TOKEN` secret to the Codecov upload step — a straightforward fix that enables authenticated coverage uploads; no logic issues found. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions Runner
    participant CC as Codecov Service

    GH->>GH: Run tests & generate coverage.info
    alt main branch push
        GH->>CC: Upload coverage report<br/>(with CODECOV_TOKEN secret)
        CC-->>GH: Upload acknowledged
    else other branches / non-push events
        GH->>GH: Skip upload (condition not met)
    end
```

<sub>Last reviewed commit: f5b541d</sub>

<!-- /greptile_comment -->