### PR TITLE
ci: Use `workflow_call` to reuse workflow `format-check`

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -32,7 +32,7 @@ jobs:
     if: github.event_name == 'pull_request'
     uses: ./.github/workflows/format-check.yml
     with:
-      is_pull_request: ${{ github.event_name == 'pull_request' }}
+      is_pull_request: true
 
   build_wheels_linux_x86_64:
     needs: format_check

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -31,10 +31,12 @@ jobs:
   format_check:
     if: github.event_name == 'pull_request'
     uses: ./.github/workflows/format-check.yml
+    with:
+      is_pull_request: ${{ github.event_name == 'pull_request' }}
 
   build_wheels_linux_x86_64:
     needs: format_check
-    if: ${{ (github.event_name != 'pull_request') || (needs.format_check.result == 'success') }}
+    if: ${{ needs.format_check.result == 'success' || needs.format_check.result == 'skipped' }}
     runs-on: [self-hosted, linux, x64]
     steps:
       - name: checkout
@@ -108,7 +110,7 @@ jobs:
 
   build_wheels_linux_arm64:
     needs: format_check
-    if: ${{ (github.event_name != 'pull_request') || (needs.format_check.result == 'success') }}
+    if: ${{ needs.format_check.result == 'success' || needs.format_check.result == 'skipped' }}
     runs-on: [self-hosted, linux, arm64]
     steps:
       - name: checkout
@@ -184,7 +186,7 @@ jobs:
   build_wheels_macos_x86_64:
     needs: format_check
     if: false
-    # if: ${{ github.event_name != 'pull_request' || needs.format_check.result == 'success' }}
+    # if: ${{ needs.format_check.result == 'success' || needs.format_check.result == 'skipped' }}
     runs-on: macos-13
     steps:
       - name: checkout
@@ -268,7 +270,7 @@ jobs:
     needs: format_check
     runs-on: macos-14
     if: false
-    # if: ${{ github.event_name != 'pull_request' || needs.format_check.result == 'success' }}
+    # if: ${{ needs.format_check.result == 'success' || needs.format_check.result == 'skipped' }}
     steps:
       - name: checkout
         id: checkout

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -28,7 +28,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  format_check:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/format-check.yml
+
   build_wheels_linux_x86_64:
+    needs: format_check
+    if: ${{ (github.event_name != 'pull_request') || (needs.format_check.result == 'success') }}
     runs-on: [self-hosted, linux, x64]
     steps:
       - name: checkout
@@ -101,8 +107,9 @@ jobs:
           neug-cli --version
 
   build_wheels_linux_arm64:
+    needs: format_check
+    if: ${{ (github.event_name != 'pull_request') || (needs.format_check.result == 'success') }}
     runs-on: [self-hosted, linux, arm64]
-    if: true
     steps:
       - name: checkout
         id: checkout
@@ -175,8 +182,10 @@ jobs:
           neug-cli --version
 
   build_wheels_macos_x86_64:
-    runs-on: macos-13
+    needs: format_check
     if: false
+    # if: ${{ github.event_name != 'pull_request' || needs.format_check.result == 'success' }}
+    runs-on: macos-13
     steps:
       - name: checkout
         id: checkout
@@ -256,8 +265,10 @@ jobs:
           neug-cli --version
 
   build_wheels_macos_aarch64:
+    needs: format_check
     runs-on: macos-14
     if: false
+    # if: ${{ github.event_name != 'pull_request' || needs.format_check.result == 'success' }}
     steps:
       - name: checkout
         id: checkout

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -11,6 +11,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.repository }}-format-check-${{ github.event.number || github.head_ref || github.sha }}-${{ github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   check-format:
     runs-on: ubuntu-22.04

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -2,12 +2,11 @@ name: Format Check
 
 on:
   workflow_call:
+    inputs:
+      is_pull_request:
+        type: boolean
+        default: false
   workflow_dispatch:
-
-
-concurrency:
-  group: ${{ github.repository }}-${{ github.event.number || github.head_ref || github.sha || github.run_id }}-format-check
-  cancel-in-progress: true
 
 jobs:
   check-format:
@@ -17,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Conventional PR Check
-      if: github.event_name == 'pull_request'
+      if: inputs.is_pull_request
       uses: amannn/action-semantic-pull-request@v5
       id: pr-convention
       env:

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -6,7 +6,7 @@ on:
 
 
 concurrency:
-  group: ${{ github.repository }}-${{ github.event.number || github.head_ref || github.sha || github.run_id }}-${{ github.workflow }}
+  group: ${{ github.repository }}-${{ github.event.number || github.head_ref || github.sha || github.run_id }}-format-check
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -55,7 +55,7 @@ jobs:
       uses: marocchino/sticky-pull-request-comment@v2
       # When the previous steps fails, the workflow would stop. By adding this
       # condition you can continue the execution with the populated error message.
-      if: github.event_name == 'pull_request' && always() && (steps.pr-convention.outputs.error_message != null)
+      if: inputs.is_pull_request && always() && (steps.pr-convention.outputs.error_message != null)
       with:
         header: pr-title-lint-error
         message: |
@@ -72,7 +72,7 @@ jobs:
 
       # Delete a previous comment when the issue has been resolved
     - name: Delete Comment if PR Title is conventional
-      if: github.event_name == 'pull_request' && steps.lint_pr_title.outputs.error_message == null
+      if: inputs.is_pull_request && steps.lint_pr_title.outputs.error_message == null
       uses: marocchino/sticky-pull-request-comment@v2
       with:   
         header: pr-title-lint-error

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,13 +1,12 @@
 name: Format Check
 
 on:
-    pull_request:
-      branches:
-        - main
+  workflow_call:
+  workflow_dispatch:
 
 
 concurrency:
-  group: ${{ github.repository }}-${{ github.event.number || github.head_ref || github.sha }}-${{ github.workflow }}
+  group: ${{ github.repository }}-${{ github.event.number || github.head_ref || github.sha || github.run_id }}-${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:
@@ -18,6 +17,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Conventional PR Check
+      if: github.event_name == 'pull_request'
       uses: amannn/action-semantic-pull-request@v5
       id: pr-convention
       env:
@@ -56,7 +56,7 @@ jobs:
       uses: marocchino/sticky-pull-request-comment@v2
       # When the previous steps fails, the workflow would stop. By adding this
       # condition you can continue the execution with the populated error message.
-      if: always() && (steps.pr-convention.outputs.error_message != null)
+      if: github.event_name == 'pull_request' && always() && (steps.pr-convention.outputs.error_message != null)
       with:
         header: pr-title-lint-error
         message: |
@@ -73,7 +73,7 @@ jobs:
 
       # Delete a previous comment when the issue has been resolved
     - name: Delete Comment if PR Title is conventional
-      if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+      if: github.event_name == 'pull_request' && steps.lint_pr_title.outputs.error_message == null
       uses: marocchino/sticky-pull-request-comment@v2
       with:   
         header: pr-title-lint-error

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -7,6 +7,9 @@ on:
         type: boolean
         default: false
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   check-format:
@@ -16,7 +19,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Conventional PR Check
-      if: inputs.is_pull_request
+      if: inputs.is_pull_request || github.event_name == 'pull_request'
       uses: amannn/action-semantic-pull-request@v5
       id: pr-convention
       env:
@@ -55,7 +58,7 @@ jobs:
       uses: marocchino/sticky-pull-request-comment@v2
       # When the previous steps fails, the workflow would stop. By adding this
       # condition you can continue the execution with the populated error message.
-      if: inputs.is_pull_request && always() && (steps.pr-convention.outputs.error_message != null)
+      if: (inputs.is_pull_request || github.event_name == 'pull_request') && always() && (steps.pr-convention.outputs.error_message != null)
       with:
         header: pr-title-lint-error
         message: |
@@ -72,7 +75,7 @@ jobs:
 
       # Delete a previous comment when the issue has been resolved
     - name: Delete Comment if PR Title is conventional
-      if: inputs.is_pull_request && steps.lint_pr_title.outputs.error_message == null
+      if: (inputs.is_pull_request || github.event_name == 'pull_request') && steps.lint_pr_title.outputs.error_message == null
       uses: marocchino/sticky-pull-request-comment@v2
       with:   
         header: pr-title-lint-error

--- a/.github/workflows/neug-test.yml
+++ b/.github/workflows/neug-test.yml
@@ -44,7 +44,7 @@ jobs:
     if: github.event_name == 'pull_request'
     uses: ./.github/workflows/format-check.yml
     with :
-      is_pull_request: ${{ github.event_name == 'pull_request' }}
+      is_pull_request: true
 
   # ============================================================
   # Unified Job: Build NeuG + run C++, Python, and E2E tests

--- a/.github/workflows/neug-test.yml
+++ b/.github/workflows/neug-test.yml
@@ -43,6 +43,8 @@ jobs:
   format_check:
     if: github.event_name == 'pull_request'
     uses: ./.github/workflows/format-check.yml
+    with :
+      is_pull_request: ${{ github.event_name == 'pull_request' }}
 
   # ============================================================
   # Unified Job: Build NeuG + run C++, Python, and E2E tests

--- a/.github/workflows/neug-test.yml
+++ b/.github/workflows/neug-test.yml
@@ -40,10 +40,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  format_check:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/format-check.yml
+
   # ============================================================
   # Unified Job: Build NeuG + run C++, Python, and E2E tests
   # ============================================================
   build_and_test:
+    needs: format_check
+    if: ${{ needs.format_check.result == 'success' || needs.format_check.result == 'skipped' }}
     runs-on: [self-hosted]
     container:
       image: neug-registry.cn-hongkong.cr.aliyuncs.com/neug/neug-dev:v0.1.0


### PR DESCRIPTION
If format-check fails, other workflow should not be runned.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the CI setup so that `format-check.yml` is exposed as a reusable workflow via `workflow_call`, and both `build-wheel.yml` and `neug-test.yml` call it as a gating `format_check` job before running their own build/test jobs. An `is_pull_request` boolean input is introduced so PR-specific steps (conventional PR title check, comment posting/deletion) are correctly skipped when the workflow is invoked through `workflow_call` on non-PR events. The concurrency group was updated to include `github.run_id` to prevent one caller from cancelling the other's format-check run.

Key changes:
- `format-check.yml`: adds `workflow_call` (with `is_pull_request` input) and `workflow_dispatch` triggers; updates all three PR-gated steps to use `inputs.is_pull_request || github.event_name == 'pull_request'`; scopes the concurrency group with `github.run_id`
- `build-wheel.yml`: new `format_check` job (PR-only); all active build jobs gate on `success || skipped`; disabled macOS jobs gain a `needs: format_check` alongside their existing `if: false`
- `neug-test.yml`: new `format_check` job (PR-only); `build_and_test` gates on `success || skipped`; contains a non-standard `with :` (space before colon) on the `format_check` job that may cause the `is_pull_request` input to be silently ignored by GitHub Actions' YAML parser

<h3>Confidence Score: 3/5</h3>

- Mostly safe, but the `with :` typo in `neug-test.yml` could break the format-check gate on every PR run in that workflow.
- The overall design is sound and the `is_pull_request` input approach correctly gates PR-specific steps. However, the extraneous space in `with :` on line 46 of `neug-test.yml` is a concrete syntax risk that may cause the `is_pull_request` input to not be passed, effectively rendering the format-check gate a no-op for that workflow. The commented-out `if` conditions on the disabled macOS jobs are a minor maintenance concern but do not affect runtime behaviour.
- `neug-test.yml` (line 46 — `with :` syntax issue) and `build-wheel.yml` (commented-out `if` conditions on macOS jobs alongside newly added `needs: format_check`)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/format-check.yml | Adds `workflow_call` trigger with `is_pull_request` boolean input; updates concurrency group to include `github.run_id` to prevent cross-caller cancellation; gates all three PR-specific steps behind `inputs.is_pull_request || github.event_name == 'pull_request'`. Logic is correct. |
| .github/workflows/build-wheel.yml | Adds `format_check` reusable-workflow job guarded by `pull_request` event; downstream jobs correctly handle both `success` and `skipped` states. Commented-out `if` conditions on the two disabled macOS jobs alongside newly added `needs: format_check` may confuse future maintainers. |
| .github/workflows/neug-test.yml | Adds `format_check` reusable-workflow job with correct `skipped`-state handling on `build_and_test`. Contains a non-standard `with :` (space before colon) on line 46 that may cause the `is_pull_request` input to be silently dropped by the YAML parser. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant PR as Pull Request Event
    participant BW as build-wheel.yml
    participant NT as neug-test.yml
    participant FC as format-check.yml (workflow_call)
    participant FCd as format-check.yml (direct pull_request)

    PR->>BW: triggers (pull_request / push / workflow_dispatch)
    PR->>NT: triggers (pull_request / push / workflow_dispatch)
    PR->>FCd: triggers directly (pull_request on main)

    BW->>FC: calls via workflow_call (if: pull_request only)<br/>with: is_pull_request=true
    NT->>FC: calls via workflow_call (if: pull_request only)<br/>with: is_pull_request=true

    FC-->>BW: result: success / failure / skipped
    FC-->>NT: result: success / failure / skipped

    BW->>BW: build_wheels_linux_x86_64<br/>(runs if success OR skipped)
    BW->>BW: build_wheels_linux_arm64<br/>(runs if success OR skipped)
    BW->>BW: build_wheels_macos_*<br/>(always skipped: if=false)

    NT->>NT: build_and_test<br/>(runs if success OR skipped)
```

<sub>Last reviewed commit: e8386b7</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->