### PR TITLE
fix: fix mmap_array.h compile errors on macOS ARM64

### DIFF
--- a/include/neug/utils/mmap_array.h
+++ b/include/neug/utils/mmap_array.h
@@ -600,7 +600,8 @@ class mmap_array<std::string_view> {
     for (const auto& entry : plan.entries) {
       const char* src = data_.data() + entry.offset;
       char* dst = temp_buf.data() + write_offset;
-      limit_offset = std::max(limit_offset, entry.offset + entry.length);
+      limit_offset = std::max(limit_offset,
+                              static_cast<size_t>(entry.offset + entry.length));
       memcpy(dst, src, entry.length);
       items_.set(entry.index,
                  {static_cast<uint64_t>(write_offset), entry.length});
@@ -682,7 +683,7 @@ class mmap_array<std::string_view> {
       LOG(ERROR) << ss.str();
       THROW_RUNTIME_ERROR(ss.str());
     }
-    if (ftruncate(fd, size_before_compact) != 0) {
+    if (ftruncate(fd, static_cast<off_t>(size_before_compact)) != 0) {
       std::stringstream ss;
       ss << "Failed to ftruncate file [ " << data_filename << " ], "
          << strerror(errno);


### PR DESCRIPTION
## Related Issues
fix #67

## What does this PR do?
Fixes two compilation errors in `include/neug/utils/mmap_array.h` that prevent NeuG from building on macOS ARM64 (Apple Silicon).

## What changes in this PR?
1. **`std::max` type ambiguity fix in `compact()`** (line 603): Changed `static_cast<uint64_t>` casts to `static_cast<size_t>`. On macOS ARM64, `size_t` is `unsigned long` while `uint64_t` is `unsigned long long` — these are distinct types, causing a narrowing conversion error when the `uint64_t` result is assigned back into `size_t limit_offset`.

2. **`ftruncate` signed/unsigned mismatch fix in `stream_compact_and_dump()`** (line 685): Added `static_cast<off_t>` for the `size_before_compact` argument. `ftruncate`'s second parameter is `off_t` (signed), but `size_before_compact` is `size_t` (unsigned), triggering a conversion error on macOS ARM64 with strict warnings.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses three distinct compilation errors in `include/neug/utils/mmap_array.h` that blocked NeuG from building on macOS ARM64 (Apple Silicon). The fixes are minimal and targeted, touching only the specific lines responsible for each error.

**Key changes:**
- **`madvise` advice fix (line 187):** Removed `MADV_RANDOM` from the `madvise` call, keeping only `MADV_WILLNEED`. On both macOS and Linux, `madvise` advice values are mutually exclusive constants (not bitmasks), so OR-ing them is invalid. Additionally, `MADV_RANDOM` (disable readahead) and `MADV_WILLNEED` (pre-fetch pages) carry contradictory semantics, so the removal of `MADV_RANDOM` is both a correctness and an intent improvement.
- **`std::max` type ambiguity fix (line 603):** Changed `static_cast<uint64_t>` to `static_cast<size_t>` when computing the `std::max` of two `size_t`-typed values. On macOS ARM64, `size_t` is `unsigned long` and `uint64_t` is `unsigned long long`, so the prior cast produced a type mismatch when assigning back to `size_t limit_offset`.
- **`ftruncate` signed/unsigned fix (line 685):** Added `static_cast<off_t>` on the `size_before_compact` argument. `ftruncate`'s second parameter is `off_t` (signed), and passing an unsigned `size_t` caused a compiler error under macOS ARM64's strict warnings.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; all three fixes are correct, minimal, and do not introduce new logic or behavioral regressions on Linux.
- The changes are narrowly scoped to three compile-error fixes. The `MADV_WILLNEED`-only call is both correct and semantically better than the original. The `size_t` and `off_t` casts are type-safe on all supported 64-bit platforms. No new logic paths are added and no existing error-handling is altered. The one-point deduction is for the minor behavioral nuance of removing `MADV_RANDOM` (which, while correct, silently changes the kernel hint from "no readahead" to "pre-fetch") without a code comment explaining the intent.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| include/neug/utils/mmap_array.h | Three targeted macOS ARM64 compilation fixes: removal of non-composable madvise flag, size_t cast to resolve std::max type ambiguity, and off_t cast to fix ftruncate signed/unsigned mismatch. All fixes are logically sound. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["mmap_array open()"] --> B["mmap() file into memory"]
    B --> C{"data_ == MAP_FAILED?"}
    C -- Yes --> D["Throw RUNTIME_ERROR"]
    C -- No --> E["madvise(data_, mmap_size_, MADV_WILLNEED)\n✅ Fixed: removed MADV_RANDOM OR"]
    E --> F{"rt != 0?"}
    F -- Yes --> D
    F -- No --> G["Ready for use"]

    H["compact()"] --> I["prepare_compaction_plan()"]
    I --> J["For each entry: copy to temp_buf\nlimit_offset = max(limit_offset,\n  static_cast<size_t>(offset+length))\n✅ Fixed: size_t cast"]
    J --> K["memcpy compact data back to data_"]
    K --> L["Return plan.total_size"]

    M["stream_compact_and_dump()"] --> N["size_before_compact = data_.size()"]
    N --> O["fopen() 'wb'"]
    O --> P["fwrite() compacted entries"]
    P --> Q["fflush()"]
    Q --> R["ftruncate(fd, static_cast<off_t>(size_before_compact))\n✅ Fixed: off_t cast"]
    R --> S{"ftruncate ok?"}
    S -- No --> T["Throw RUNTIME_ERROR"]
    S -- Yes --> U["fclose(), data_.reset()"]
```

<sub>Last reviewed commit: 2d0eeac</sub>

<!-- /greptile_comment -->