### PR TITLE
fix: catch OSError in neug-cli readline history loading on macOS

### DIFF
--- a/tools/python_bind/neug/neug_cli.py
+++ b/tools/python_bind/neug/neug_cli.py
@@ -18,6 +18,7 @@
 
 import atexit
 import cmd
+import errno
 import logging
 import os
 import re
@@ -68,11 +69,15 @@ class NeugShell(cmd.Cmd):
         if readline:
             try:
                 readline.read_history_file(self._histfile)
-            except (FileNotFoundError, OSError):
-                # OSError (errno 22) can occur when libedit (macOS) tries to read
-                # a history file written by GNU readline, or when the file is
-                # otherwise incompatible. Safe to ignore.
+            except FileNotFoundError:
                 pass
+            except OSError as e:
+                # OSError (errno 22/EINVAL): libedit (macOS) cannot parse a
+                # GNU readline history file. Safe to ignore.
+                # Re-raise for any other OS error (e.g. EPERM) so unexpected
+                # problems still surface to the user.
+                if e.errno != errno.EINVAL:
+                    raise
             atexit.register(self._save_history, self._histfile)
         else:
             logger.info("Command history disabled; readline support not detected.")


### PR DESCRIPTION
## Related Issues
fix #74

## What does this PR do?
Fixes a crash in `neug-cli` on macOS where `neug-cli open <db-path>` fails immediately with `OSError: [Errno 22] Invalid argument` when `~/.neug_history` exists but was written by a GNU readline-backed session (e.g. Docker/Linux).

## What changes in this PR?
- **`tools/python_bind/neug/neug_cli.py`**: In `NeugShell.__init__`, broaden the exception handler for `readline.read_history_file()` from `FileNotFoundError` to `(FileNotFoundError, OSError)`.

**Root cause**: On macOS, Python's `readline` module links against **libedit** (Apple's BSD editline) rather than GNU readline. When `~/.neug_history` contains data in GNU readline's format, libedit raises `OSError` (errno 22, `EINVAL`) instead of parsing it. The original code only caught `FileNotFoundError`, so this error propagated uncaught and crashed the CLI shell before it could open.

**Fix**:
```python
# Before
try:
    readline.read_history_file(self._histfile)
except FileNotFoundError:
    pass

# After
try:
    readline.read_history_file(self._histfile)
except (FileNotFoundError, OSError):
    # OSError (errno 22): libedit (macOS) cannot read a GNU readline
    # format history file. Safe to ignore.
    pass
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a macOS-specific crash in `neug-cli` where `readline.read_history_file()` raises `OSError` (errno 22, `EINVAL`) when libedit (Apple's BSD editline, which backs Python's `readline` on macOS) encounters a history file written by GNU readline (e.g., from a Linux/Docker session). The original code only caught `FileNotFoundError`, causing the shell to crash before it could open. The fix is minimal, well-commented, and consistent with how `_save_history` already handles write-side OSErrors.

**Key changes:**
- `tools/python_bind/neug/neug_cli.py` — exception handler in `NeugShell.__init__` broadened from `FileNotFoundError` to `(FileNotFoundError, OSError)`.

**Minor concern:**
- Catching the full `OSError` base class silently swallows unrelated OS errors (e.g., `PermissionError`, `IsADirectoryError`). A more surgical fix would re-raise for any `errno` other than `EINVAL` (22), keeping the silent-ignore behaviour strictly scoped to the known libedit incompatibility.

<h3>Confidence Score: 4/5</h3>

- Safe to merge; the fix correctly resolves the macOS crash with only a minor concern about exception scope.
- The change is a one-line targeted bug fix for a well-described, reproducible crash. The logic is correct and the comment explains the reasoning. The only concern is that `OSError` is broader than the specific `errno.EINVAL` case, which could silently suppress unrelated OS errors on the history file — but since the history file is non-critical optional functionality, the practical impact is very low.
- No files require special attention beyond the minor `OSError` scoping note in `tools/python_bind/neug/neug_cli.py`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tools/python_bind/neug/neug_cli.py | Broadens the exception handler for `readline.read_history_file()` from `FileNotFoundError` to `(FileNotFoundError, OSError)` to handle libedit incompatibility on macOS. The fix is correct but catches `OSError` more broadly than needed — only `errno.EINVAL` (22) corresponds to the described libedit issue. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["NeugShell.__init__()"] --> B{readline available?}
    B -- No --> C[Log: history disabled]
    B -- Yes --> D["readline.read_history_file(~/.neug_history)"]
    D -- Success --> E["atexit.register(_save_history)"]
    D -- FileNotFoundError --> F["Ignore — file doesn't exist yet"]
    D -- "OSError (e.g. errno 22/EINVAL on macOS libedit)" --> G["Ignore — incompatible GNU readline format"]
    F --> E
    G --> E
    E --> H[Shell starts normally]
```

<sub>Last reviewed commit: e743460</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->