### PR TITLE
feat: add codegraph-qa skill

### DIFF
--- a/skills/codegraph/SKILL.md
+++ b/skills/codegraph/SKILL.md
@@ -1,0 +1,389 @@
+---
+name: codegraph-qa
+description: Use CodeScope to analyze any indexed codebase via its graph database (neug) and vector index (zvec). Supports Python, JavaScript/TypeScript, C, and Java (including Hadoop-scale repositories). Covers call graphs, dependency analysis, dead code detection, hotspots, module coupling, architectural layering, commit history, change attribution, semantic code search, impact analysis, full architecture reports, and bug root cause analysis from GitHub issues. Use this skill whenever the user asks about code structure, code dependencies, who calls what, why something changed, finding similar functions, generating architecture reports, understanding module boundaries, analyzing GitHub issues/bugs, finding bug root causes, understanding why a project has many bugs, tracing bugs to code, indexing Java projects, or any question that benefits from a code knowledge graph — even if they don't mention "CodeScope" by name. If a `.codegraph` or similar index directory exists in the workspace, this skill applies.
+---
+
+# CodeScope Q&A
+
+CodeScope indexes source code into a two-layer knowledge graph — **structure** (functions, calls, imports, classes, modules) and **evolution** (commits, file changes, function modifications) — plus **semantic embeddings** for every function. Supports **Python, JavaScript/TypeScript, C, and Java** (including Hadoop-scale repositories with 8K+ files). This combination enables analyses that grep, LSP, or pure vector search cannot do alone. It can also **fetch GitHub issues and trace bugs to code** — mapping bug reports to root cause candidates using the graph + vector infrastructure.
+
+## When to Use This Skill
+
+- User asks about call chains, callers, callees, or dependencies
+- User wants to find dead code, hotspots, or architectural layers
+- User asks about code history, who changed what, or why something was modified
+- User wants to find semantically similar functions across a codebase
+- User wants a full architecture analysis or report
+- User asks about module coupling, circular dependencies, or bridge functions
+- User wants to index or analyze a Java project (Maven, Gradle, plain Java)
+- User wants to analyze GitHub issues or bug reports to find root causes
+- User asks "why does this project have so many bugs" or "what code is most buggy"
+- User wants to trace a bug report to the most relevant code locations
+- A `.codegraph` directory (or similar index) exists in the workspace
+
+## Getting Started
+
+### Installation
+
+```bash
+pip install codegraph-ai
+```
+
+### Environment Variables (optional)
+
+```bash
+# Create Python virtural environment
+python -m venv .venv
+
+source .venv/bin/activate
+
+# Point to a pre-built database (skip indexing)
+export CODESCOPE_DB_DIR="/path/to/.linux_db"
+
+# Offline mode for HuggingFace models
+export HF_HUB_OFFLINE="1"
+```
+
+### Check Index Status
+
+```bash
+codegraph status --db $CODESCOPE_DB_DIR
+```
+
+If no index exists, create one:
+
+```bash
+codegraph init --repo . --lang auto --commits 500
+```
+
+Supported languages: `python`, `c`, `javascript`, `typescript`, `java`, or `auto` (auto-detects from file extensions).
+
+The `--commits` flag ingests git history (for evolution queries). Without it, only structural analysis is available. Add `--backfill-limit 200` to also compute function-level `MODIFIES` edges (slower but enables `change_attribution` and `co_change`).
+
+## Two Interfaces: CLI vs Python
+
+**Use the CLI** for status and reports:
+
+```bash
+codegraph status --db $CODESCOPE_DB_DIR
+codegraph analyze --db $CODESCOPE_DB_DIR --output report.md
+```
+
+**Use the Python API** for queries and custom analyses:
+
+```python
+import os
+os.environ['HF_HUB_OFFLINE'] = '1'  # required
+
+from codegraph.core import CodeScope
+cs = CodeScope(os.environ['CODESCOPE_DB_DIR'])
+
+# Cypher query
+rows = list(cs.conn.execute('''
+    MATCH (caller:Function)-[:CALLS]->(f:Function {name: "free_irq"})
+    RETURN caller.name, caller.file_path LIMIT 10
+'''))
+for r in rows:
+    print(r)
+
+cs.close()  # always close when done
+```
+
+The Python API is more powerful — it gives you raw Cypher access and lets you chain queries.
+
+## Core Python API
+
+### Raw Queries
+
+These are the building blocks for any custom analysis:
+
+| Method | What it does |
+|--------|-------------|
+| `cs.conn.execute(cypher)` | Run any Cypher query against the graph — returns list of tuples |
+| `cs.vector_only_search(query, topk=10)` | Semantic search over all function embeddings — returns `[{id, score}]` |
+| `cs.summary()` | Print a human-readable overview of the indexed codebase |
+
+### Structural Analysis
+
+| Method | What it does |
+|--------|-------------|
+| `cs.impact(func_name, change_desc, max_hops=3)` | Find callers up to N hops, ranked by semantic relevance to the change |
+| `cs.hotspots(topk=10)` | Rank functions by structural risk (fan-in × fan-out) |
+| `cs.dead_code()` | Find functions with zero callers (excluding entry points) |
+| `cs.circular_deps()` | Detect circular import chains at file level |
+| `cs.module_coupling(topk=10)` | Find cross-module coupling pairs with call counts |
+| `cs.bridge_functions(topk=30)` | Find functions called from the most distinct modules |
+| `cs.layer_discovery(topk=30)` | Auto-discover infrastructure / mid / consumer layers |
+| `cs.stability_analysis(topk=50)` | Correlate fan-in with modification frequency |
+| `cs.class_hierarchy(class_name=None)` | Return inheritance tree for a class (or all classes) |
+
+### Semantic Search
+
+| Method | What it does |
+|--------|-------------|
+| `cs.similar(function, scope, topk=10)` | Find functions similar to a given function within a module scope |
+| `cs.cross_locate(query, topk=10)` | Find semantically related functions, then reveal call-chain connections |
+| `cs.semantic_cross_pollination(query, topk=15)` | Find similar functions across distant subsystems |
+
+### Evolution (requires `--commits` during init)
+
+| Method | What it does |
+|--------|-------------|
+| `cs.change_attribution(func_name, file_path=None, limit=20)` | Which commits modified a function? (requires backfill) |
+| `cs.co_change(func_name, file_path=None, min_commits=2, topk=10)` | Functions that are always modified together |
+| `cs.intent_search(query, topk=10)` | Find commits matching a natural-language intent |
+| `cs.commit_modularity(topk=20)` | Score commits by how many modules they touch |
+| `cs.hot_cold_map(topk=30)` | Module modification density |
+
+### Report Generation
+
+```python
+from codegraph.analyzer import generate_report
+report = generate_report(cs)  # full architecture analysis as markdown
+```
+
+Or via CLI:
+
+```bash
+codegraph analyze --output reports/analysis.md
+```
+
+The report covers: overview stats, subsystem distribution, top modules, architectural layers (with Mermaid diagrams), bridge functions, fan-in/fan-out hotspots, cross-module coupling, evolution hotspots, and dead code density.
+
+## Java Support
+
+CodeScope includes a full Java adapter that handles enterprise-scale repositories like Apache Hadoop (~8K files, ~97K functions indexed in ~3.5 minutes).
+
+### What Gets Indexed
+
+| Element | Graph Node/Edge | Notes |
+|---------|----------------|-------|
+| Classes | `Class` node | Includes generics, annotations |
+| Interfaces | `Class` node | `extends` → `INHERITS` edge |
+| Enums | `Class` node | Enum methods extracted |
+| Methods | `Function` node | Full generic signatures, JavaDoc |
+| Constructors | `Function` node (name=`<init>`) | Including `super()` calls |
+| Method calls | `CALLS` edge | Receiver context preserved (`obj.method()`) |
+| `new` expressions | `CALLS` edge to `ClassName.<init>` | Constructor invocations |
+| Imports | `IMPORTS` edge (file→file) | Single, wildcard, static |
+| Inner classes | `Class` node (name=`Outer.Inner`) | Prefixed with outer class |
+| Inheritance | `INHERITS` edge | `extends` + `implements` |
+
+### Indexing a Java Project
+
+```bash
+codegraph init --repo /path/to/java-project --lang java --commits 500
+```
+
+Or with auto-detection (auto-detects `.java` files):
+
+```bash
+codegraph init --repo /path/to/java-project --lang auto
+```
+
+### Java-Specific Exclusions
+
+By default, these directories are excluded when indexing Java projects: `target/`, `build/`, `.gradle/`, `.idea/`, `.settings/`, `bin/`, `out/`, `test/`, `tests/`, `src/test/`.
+
+### Java Query Examples
+
+```python
+# Find all classes that extend a specific class
+list(cs.conn.execute("""
+    MATCH (c:Class)-[:INHERITS]->(p:Class {name: 'FileSystem'})
+    RETURN c.name, c.file_path
+"""))
+
+# Find all methods in a specific class
+list(cs.conn.execute("""
+    MATCH (c:Class {name: 'DefaultParser'})-[:HAS_METHOD]->(f:Function)
+    RETURN f.name, f.signature
+"""))
+
+# Find constructor call chains
+list(cs.conn.execute("""
+    MATCH (f:Function)-[:CALLS]->(init:Function {name: '<init>'})
+    WHERE init.class_name = 'Configuration'
+    RETURN f.name, f.file_path LIMIT 10
+"""))
+```
+
+## Bug Root Cause Analysis
+
+CodeScope can fetch GitHub issues and map them to code using the graph + vector infrastructure. This is the core workflow for answering questions like "why does this project have so many bugs?" or "where in the code does this bug come from?"
+
+### Prerequisites
+
+- A code graph must already be indexed for the target repository
+- `gh` CLI must be installed and authenticated (`gh auth login`)
+
+### Bug Analysis API
+
+#### Single Issue Analysis
+
+```python
+# Analyze a specific GitHub issue against the indexed code graph
+result = cs.analyze_issue("owner", "repo", 1234, topk=10)
+print(result.format_report())
+```
+
+This:
+1. Fetches the issue from GitHub (or loads from cache)
+2. Parses file paths, function names, and stack traces from the issue body
+3. Matches extracted paths to File nodes in the graph
+4. Uses semantic search (`cross_locate`) to find related code
+5. Traces callers of mentioned functions via `impact()`
+6. Ranks and returns root cause candidates with explanation
+
+#### Batch Bug Analysis
+
+```python
+# Analyze top-k bug issues and get aggregated hotspot data
+results = cs.analyze_top_bugs("owner", "repo", k=10, label="bug")
+for r in results:
+    print(f"#{r.issue.number}: {r.issue.title}")
+    for c in r.candidates[:3]:
+        print(f"  {c.function_name} ({c.file_path}) score={c.score:.2f}")
+```
+
+#### CLI Commands
+
+```bash
+# Fetch and parse a single issue (no graph needed)
+codegraph fetch-issue owner repo 1234
+
+# Fetch top-k bugs from a repo
+codegraph fetch-bugs owner repo --top 10 --label bug
+
+# Analyze a single bug against the code graph
+codegraph analyze-bug owner repo 1234 --db .codegraph --topk 10
+
+# Batch analyze top bugs
+codegraph analyze-bugs owner repo --db .codegraph --top 10 --label bug
+```
+
+#### Lower-Level Components
+
+For custom analysis pipelines, the components can be used individually:
+
+```python
+from codegraph.issue_fetcher import fetch_and_parse_issue
+from codegraph.bug_locator import (
+    resolve_paths_to_files,
+    find_semantic_matches,
+    trace_callers,
+    rank_root_causes,
+    analyze_bug,
+)
+
+# Fetch and parse (with caching)
+issue = fetch_and_parse_issue("owner", "repo", 1234)
+print(issue.extracted_paths)   # file paths found in body
+print(issue.extracted_funcs)   # function names from stack traces
+print(issue.linked_commits)    # merge commit SHAs from linked PRs
+
+# Match paths to graph nodes
+path_matches = resolve_paths_to_files(cs, issue.extracted_paths)
+
+# Semantic search using issue description
+semantic_matches = find_semantic_matches(cs, f"{issue.title}\n{issue.body}")
+
+# Trace callers of mentioned functions
+caller_traces = trace_callers(cs, issue.extracted_funcs, max_hops=2)
+
+# Combine into ranked candidates
+candidates = rank_root_causes(path_matches, semantic_matches, caller_traces, issue.extracted_funcs)
+```
+
+### Scoring System
+
+Root cause candidates are scored by combining multiple signals:
+
+| Signal | Score | Description |
+|--------|-------|-------------|
+| Direct mention | +1.0 | Function name appears in issue body/stack trace |
+| File path match | +0.8 | Function is in a file mentioned in the issue |
+| Semantic match | +score | Raw cosine similarity (0.0-1.0) from `cross_locate` |
+| Caller relationship | +0.5/hops | Function calls a mentioned function (decays with distance) |
+
+### Issue Cache
+
+Parsed issues are cached at `~/.codegraph/issue_cache/{owner}_{repo}_{number}.json`. Cache hits skip the GitHub API call entirely (sub-millisecond). To force a refresh, pass `use_cache=False` or use `--no-cache` on CLI.
+
+```python
+from codegraph.issue_cache import clear_cache
+clear_cache(owner="openclaw", repo="openclaw")  # clear specific repo
+clear_cache()  # clear all
+```
+
+### Stack Trace Parsing
+
+The parser automatically extracts file paths and function names from stack traces in Python, C/C++, JavaScript/Node.js, Go, and Rust formats. It also extracts `func_name()` references in backticks and inline code.
+
+## How to Route Questions
+
+The key decision is: **does the user want an exact structural answer, a fuzzy semantic one, or a bug-to-code mapping?**
+
+| User asks... | Best approach |
+|-------------|---------------|
+| "Who calls `free_irq`?" | Cypher: `MATCH (c:Function)-[:CALLS]->(f:Function {name: 'free_irq'}) RETURN c.name, c.file_path` |
+| "Find functions related to memory allocation" | `cs.vector_only_search("memory allocation")` or `cs.cross_locate("memory allocation")` |
+| "What's the most complex function?" | `cs.hotspots(topk=1)` |
+| "Is there dead code in the networking stack?" | `cs.dead_code()` then filter by file path |
+| "How has `schedule()` changed recently?" | `cs.change_attribution("schedule", "kernel/sched/core.c")` |
+| "Which modules are tightly coupled?" | `cs.module_coupling(topk=20)` |
+| "Generate a full architecture report" | `codegraph analyze` or `generate_report(cs)` |
+| "What's the architectural role of `mm/`?" | `cs.layer_discovery()` then find `mm` entries |
+| "Which functions act as API boundaries?" | `cs.bridge_functions(topk=30)` |
+| "Find commits about fixing race conditions" | `cs.intent_search("fix race condition")` |
+| "What functions are always changed together with `kmalloc`?" | `cs.co_change("kmalloc")` |
+| "Why does this project have so many bugs?" | `cs.analyze_top_bugs("owner", "repo", k=10)` then aggregate hotspots |
+| "Analyze issue #1234 from GitHub" | `cs.analyze_issue("owner", "repo", 1234)` |
+| "What code is related to this bug?" | `cs.analyze_issue(...)` or manual `cross_locate(bug_description)` |
+| "Find the root cause of the crash in issue #42" | `cs.analyze_issue("owner", "repo", 42)` |
+| "Which modules have the most bugs?" | `cs.analyze_top_bugs(...)` then aggregate by file/module |
+| "Index this Java project" | `codegraph init --repo . --lang java` |
+| "What classes extend FileSystem in Hadoop?" | Cypher: `MATCH (c:Class)-[:INHERITS]->(p:Class {name: 'FileSystem'}) RETURN c.name, c.file_path` |
+| "Find all constructors called in this module" | Cypher: `MATCH (f:Function)-[:CALLS]->(init:Function {name: '<init>'}) WHERE f.file_path CONTAINS 'module' RETURN ...` |
+
+For **novel investigations** not covered by pre-built methods, compose raw Cypher queries. See [patterns.md](./patterns.md) for templates. For bug analysis patterns, see [bug-analysis.md](./bug-analysis.md).
+
+## Important Filters for Cypher
+
+When writing Cypher queries, these filters prevent misleading results:
+
+- **`f.is_historical = 0`** — exclude deleted/renamed functions that are still in the graph as historical records
+- **`f.is_external = 0`** (on File nodes) — exclude system headers/library files
+- **`c.version_tag = 'bf'`** — only backfilled commits have `MODIFIES` edges; non-backfilled commits only have `TOUCHES` (file-level) edges
+- **Always use `LIMIT`** — large codebases can return hundreds of thousands of rows
+
+## Checking Data Availability
+
+Before running evolution queries, check what's available:
+
+```python
+# How many commits are indexed?
+list(cs.conn.execute("MATCH (c:Commit) RETURN count(c)"))
+
+# How many have MODIFIES edges (backfilled)?
+list(cs.conn.execute("MATCH (c:Commit) WHERE c.version_tag = 'bf' RETURN count(c)"))
+```
+
+If no commits exist, evolution methods will return empty results — guide the user to run `codegraph ingest` first. If commits exist but aren't backfilled, `TOUCHES` (file-level) queries still work but `MODIFIES` (function-level) queries won't.
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `Database locked` | Crashed process left neug lock | `rm <db>/graph.db/neugdb.lock` |
+| `Can't open lock file` | zvec LOCK file deleted | `touch <db>/vectors/LOCK` |
+| `Can't lock read-write collection` | Another process holds lock | Kill the other process |
+| `recovery idmap failed` | Stale WAL files | Remove empty `.log` files from `<db>/vectors/idmap.0/` |
+
+The CLI auto-cleans lock issues on startup when possible.
+
+## References
+
+- **[schema.md](./schema.md)** — Full graph schema: node types, edge types, properties, Cypher syntax notes
+- **[patterns.md](./patterns.md)** — Ready-to-use Cypher query templates and composition strategies
+- **[bug-analysis.md](./bug-analysis.md)** — Bug analysis workflows: single issue, batch analysis, hotspot aggregation, custom pipelines

--- a/skills/codegraph/bug-analysis.md
+++ b/skills/codegraph/bug-analysis.md
@@ -1,0 +1,242 @@
+# Bug Analysis Workflows
+
+Patterns for tracing GitHub bugs to code using CodeScope's graph + vector infrastructure.
+
+## Table of Contents
+
+- [Quick Start](#quick-start)
+- [Single Issue Analysis](#single-issue-analysis)
+- [Batch Bug Hotspot Analysis](#batch-bug-hotspot-analysis)
+- [Custom Analysis Pipelines](#custom-analysis-pipelines)
+- [Combining Bug Analysis with Structural Analysis](#combining-bug-analysis-with-structural-analysis)
+
+## Quick Start
+
+```python
+import os
+os.environ['HF_HUB_OFFLINE'] = '1'
+
+from codegraph.core import CodeScope
+cs = CodeScope(".codegraph")
+
+# "Why does this project have so many bugs?"
+results = cs.analyze_top_bugs("owner", "repo", k=10, label="bug")
+for r in results:
+    print(f"#{r.issue.number}: {r.issue.title}")
+    if r.candidates:
+        top = r.candidates[0]
+        print(f"  -> {top.function_name} ({top.file_path})")
+
+cs.close()
+```
+
+## Single Issue Analysis
+
+### Basic Analysis
+
+```python
+result = cs.analyze_issue("openclaw", "openclaw", 43608)
+print(result.format_report())
+```
+
+The result object (`BugAnalysisResult`) contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `issue` | `ParsedIssue` | Parsed issue with extracted paths/funcs/commits |
+| `candidates` | `list[RootCauseCandidate]` | Ranked root cause locations |
+| `path_matches` | `int` | How many extracted paths matched graph File nodes |
+| `semantic_matches` | `int` | How many semantic matches were found |
+| `caller_traces` | `int` | How many mentioned functions had traceable callers |
+| `analysis_time_ms` | `float` | Total analysis time |
+
+### Inspecting the Parsed Issue
+
+```python
+from codegraph.issue_fetcher import fetch_and_parse_issue
+
+issue = fetch_and_parse_issue("owner", "repo", 1234)
+
+# What the parser found in the issue body:
+print(issue.extracted_paths)      # ['src/handler.py', 'src/db.py']
+print(issue.extracted_funcs)      # ['handle_request', 'execute_query']
+print(issue.extracted_locations)  # [('src/handler.py', 42), ('src/db.py', 15)]
+print(issue.linked_commits)      # ['abc123...'] from linked PRs
+print(issue.labels)              # ['bug', 'regression']
+```
+
+### Inspecting Candidates
+
+```python
+for c in result.candidates:
+    print(f"{c.function_name} @ {c.file_path}")
+    print(f"  Score: {c.score:.3f}")
+    print(f"  Reasons: {c.reasons}")
+    # Reasons examples:
+    #   "mentioned in issue"
+    #   "in mentioned file src/handler.py"
+    #   "semantic match (0.85)"
+    #   "caller of handle_request (2 hops)"
+```
+
+## Batch Bug Hotspot Analysis
+
+### Find the Buggiest Code
+
+```python
+results = cs.analyze_top_bugs("owner", "repo", k=10, label="bug")
+
+# Aggregate: which files appear across the most bug analyses?
+file_counts = {}
+func_counts = {}
+module_counts = {}
+
+for r in results:
+    for c in r.candidates[:5]:  # top 5 per bug
+        file_counts[c.file_path] = file_counts.get(c.file_path, 0) + 1
+        func_counts[c.function_name] = func_counts.get(c.function_name, 0) + 1
+        # module = first 2-3 path segments
+        parts = c.file_path.split("/")
+        module = "/".join(parts[:3]) if len(parts) >= 3 else c.file_path
+        module_counts[module] = module_counts.get(module, 0) + 1
+
+print("Files with most bug associations:")
+for f, n in sorted(file_counts.items(), key=lambda x: -x[1])[:10]:
+    print(f"  {f}: {n} bugs")
+
+print("Functions with most bug associations:")
+for f, n in sorted(func_counts.items(), key=lambda x: -x[1])[:10]:
+    print(f"  {f}: {n} bugs")
+
+print("Modules with most bug associations:")
+for m, n in sorted(module_counts.items(), key=lambda x: -x[1])[:10]:
+    print(f"  {m}: {n} bugs")
+```
+
+### Cross-Reference with Structural Hotspots
+
+```python
+# Are the buggiest functions also the riskiest (high fan-in x fan-out)?
+hotspots = cs.hotspots(topk=50)
+hotspot_names = {h.name for h in hotspots}
+
+buggy_and_risky = [f for f in func_counts if f in hotspot_names]
+print(f"Functions that are both structurally risky AND frequently buggy:")
+for f in buggy_and_risky:
+    print(f"  {f}: {func_counts[f]} bugs, hotspot risk present")
+```
+
+## Custom Analysis Pipelines
+
+### Manual Bug-to-Code Mapping
+
+When you don't have a GitHub issue but have a bug description:
+
+```python
+from codegraph.bug_locator import find_semantic_matches, trace_callers
+
+# Semantic search: find code related to the bug description
+matches = find_semantic_matches(cs, "gateway crashes when processing messages", topk=10)
+for m in matches:
+    print(f"  {m['name']} ({m['file_path']}) score={m['score']:.2f}")
+
+# If you know which function is involved, trace its callers
+callers = trace_callers(cs, ["handle_message", "process_data"], max_hops=2)
+for t in callers:
+    print(f"  Callers of {t['function']}:")
+    for c in t['callers']:
+        print(f"    {c['name']} ({c['file']}, {c['hops']} hops)")
+```
+
+### Linking Bugs to Commits
+
+When issues have linked PRs with merge commits:
+
+```python
+issue = fetch_and_parse_issue("owner", "repo", 1234)
+
+for sha in issue.linked_commits:
+    # Find what the fix commit modified
+    rows = list(cs.conn.execute(f"""
+        MATCH (c:Commit)-[:MODIFIES]->(f:Function)
+        WHERE c.hash STARTS WITH '{sha[:12]}'
+        RETURN f.name, f.file_path
+    """))
+    if rows:
+        print(f"Commit {sha[:12]} modified:")
+        for name, path in rows:
+            print(f"  {name} ({path})")
+```
+
+### Bug Pattern Detection
+
+Find if multiple bugs point to the same subsystem:
+
+```python
+results = cs.analyze_top_bugs("owner", "repo", k=20, label="bug")
+
+# Group bugs by the module of their top candidate
+module_bugs = {}
+for r in results:
+    if r.candidates:
+        top = r.candidates[0]
+        parts = top.file_path.split("/")
+        module = "/".join(parts[:2])
+        module_bugs.setdefault(module, []).append(r.issue.number)
+
+for module, bugs in sorted(module_bugs.items(), key=lambda x: -len(x[1])):
+    if len(bugs) >= 2:
+        print(f"{module}: {len(bugs)} bugs (#{', #'.join(str(b) for b in bugs)})")
+```
+
+## Combining Bug Analysis with Structural Analysis
+
+### "Is this bug in a risky part of the architecture?"
+
+```python
+result = cs.analyze_issue("owner", "repo", 1234)
+if result.candidates:
+    top = result.candidates[0]
+    # Check if the implicated function is a bridge function
+    bridges = cs.bridge_functions(topk=50)
+    bridge_names = {b.name for b in bridges}
+    if top.function_name in bridge_names:
+        print(f"Warning: {top.function_name} is a bridge function "
+              f"(called from many modules) — bug may have wide impact")
+
+    # Check module coupling
+    couplings = cs.module_coupling(topk=20)
+    # ...examine if the implicated module is tightly coupled
+```
+
+### "What would break if we fix this bug?"
+
+```python
+result = cs.analyze_issue("owner", "repo", 1234)
+if result.candidates:
+    func = result.candidates[0].function_name
+    impacts = cs.impact(func, "bug fix", max_hops=3)
+    print(f"Fixing {func} could affect {len(impacts)} callers:")
+    for imp in impacts[:10]:
+        print(f"  {imp.name} ({imp.file_path})")
+```
+
+## CLI Quick Reference
+
+```bash
+# Fetch and inspect a single issue (no graph needed)
+codegraph fetch-issue owner repo 1234
+
+# Fetch top bugs from a repo
+codegraph fetch-bugs owner repo --top 10 --label bug
+
+# Analyze a bug against indexed code
+codegraph analyze-bug owner repo 1234 --db .codegraph
+
+# Batch analyze top bugs
+codegraph analyze-bugs owner repo --db .codegraph --top 10
+
+# Force refresh (skip cache)
+codegraph fetch-issue owner repo 1234 --no-cache
+codegraph analyze-bug owner repo 1234 --db .codegraph --no-cache
+```

--- a/skills/codegraph/evals/evals.json
+++ b/skills/codegraph/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "codegraph-qa",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I have pallets/click indexed in my .codegraph database. There's a bug report on GitHub — issue #3185 — about flag_value not working. Can you analyze it and find what code is most likely the root cause?",
+      "expected_output": "Should use cs.analyze_issue('pallets', 'click', 3185) and return root cause candidates related to flag_value/option processing in click's core code",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "openclaw seems to have a lot of bugs. I've indexed the openclaw repo. Can you fetch the top 5 bug issues and tell me which parts of the codebase are most problematic?",
+      "expected_output": "Should use cs.analyze_top_bugs('openclaw', 'openclaw', k=5) and provide an aggregated hotspot summary showing which modules/files appear across multiple bugs",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "I found a GitHub issue (openclaw/openclaw#43608) about cron tasks not executing even though the API returns success. The codebase is already indexed. Help me trace where the bug might be.",
+      "expected_output": "Should use cs.analyze_issue('openclaw', 'openclaw', 43608) and identify cron-related code (src/cron/, src/cli/cron-cli/) as root cause candidates",
+      "files": []
+    }
+  ]
+}

--- a/skills/codegraph/patterns.md
+++ b/skills/codegraph/patterns.md
@@ -1,0 +1,134 @@
+# CodeScope Cypher Patterns
+
+Run these via `cs.conn.execute(query)`. All queries return lists of tuples.
+
+## Structural Queries
+
+**Who calls a function?**
+```cypher
+MATCH (caller:Function)-[:CALLS]->(f:Function {name: 'free_irq'})
+RETURN caller.name, caller.file_path
+ORDER BY caller.name LIMIT 30
+```
+
+**What does a function call?**
+```cypher
+MATCH (f:Function {name: 'sched_fork'})-[:CALLS]->(callee:Function)
+RETURN callee.name, callee.file_path
+```
+
+**Transitive callers (up to 3 hops):**
+```cypher
+MATCH (caller:Function)-[:CALLS*1..3]->(f:Function {name: 'kfree'})
+RETURN DISTINCT caller.name, caller.file_path LIMIT 50
+```
+
+**Functions in a module:**
+```cypher
+MATCH (f:Function)<-[:DEFINES_FUNC]-(file:File)-[:BELONGS_TO]->(m:Module)
+WHERE m.path_prefix = 'net/core'
+RETURN f.name, file.path LIMIT 30
+```
+
+**Cross-module calls (e.g. fs → mm):**
+```cypher
+MATCH (f1:Function)-[:CALLS]->(f2:Function),
+      (file1:File)-[:DEFINES_FUNC]->(f1),
+      (file2:File)-[:DEFINES_FUNC]->(f2),
+      (file1)-[:BELONGS_TO]->(m1:Module {path_prefix: 'fs'}),
+      (file2)-[:BELONGS_TO]->(m2:Module {path_prefix: 'mm'})
+RETURN f1.name, f2.name, count(*) AS calls
+ORDER BY calls DESC LIMIT 20
+```
+
+**Fan-in and fan-out:**
+```cypher
+MATCH (caller:Function)-[:CALLS]->(f:Function)-[:CALLS]->(callee:Function)
+WHERE f.is_historical = 0
+WITH f, count(DISTINCT caller) AS fi, count(DISTINCT callee) AS fo
+RETURN f.name, f.file_path, fi, fo, fi * fo AS risk
+ORDER BY risk DESC LIMIT 20
+```
+
+**Module sizes:**
+```cypher
+MATCH (f:Function)<-[:DEFINES_FUNC]-(file:File)-[:BELONGS_TO]->(m:Module)
+WHERE f.is_historical = 0
+RETURN m.path_prefix, count(f) AS func_count
+ORDER BY func_count DESC LIMIT 30
+```
+
+**Functions by name pattern:**
+```cypher
+MATCH (f:Function) WHERE f.name STARTS WITH 'irq_'
+RETURN f.name, f.file_path LIMIT 20
+```
+
+```cypher
+MATCH (f:Function) WHERE f.name CONTAINS 'alloc'
+RETURN f.name, f.file_path LIMIT 30
+```
+
+## Evolution Queries
+
+**Functions modified by a commit:**
+```cypher
+MATCH (c:Commit)-[:MODIFIES]->(f:Function)
+WHERE c.hash STARTS WITH 'abc123'
+RETURN f.name, f.file_path
+```
+
+**Commits touching a file:**
+```cypher
+MATCH (c:Commit)-[:TOUCHES]->(file:File {path: 'kernel/sched/core.c'})
+RETURN c.hash, c.message, c.author
+```
+
+**Co-changed functions (modified together frequently):**
+```cypher
+MATCH (c:Commit)-[:MODIFIES]->(f1:Function),
+      (c)-[:MODIFIES]->(f2:Function)
+WHERE f1.id < f2.id
+RETURN f1.name, f2.name, count(c) AS co_changes
+ORDER BY co_changes DESC LIMIT 20
+```
+
+**Largest commits (most functions changed):**
+```cypher
+MATCH (c:Commit)-[:MODIFIES]->(f:Function)
+RETURN c.hash, c.message, count(f) AS funcs_changed
+ORDER BY funcs_changed DESC LIMIT 10
+```
+
+**Historical (deleted/renamed) functions:**
+```cypher
+MATCH (f:Function) WHERE f.is_historical = 1
+RETURN f.name, f.file_path LIMIT 30
+```
+
+**Backfill progress:**
+```cypher
+MATCH (c:Commit) WHERE c.version_tag = 'bf'
+RETURN count(c) AS backfilled
+```
+
+**Most frequently modified files:**
+```cypher
+MATCH (c:Commit)-[:TOUCHES]->(f:File)
+RETURN f.path, count(c) AS commits
+ORDER BY commits DESC LIMIT 20
+```
+
+## Composition Strategies
+
+These patterns combine multiple query types for deeper insights:
+
+**Semantic + Structural**: Use `cs.vector_only_search("error recovery")` to find semantically similar functions, then query the graph to check if they share callers or modules. This reveals hidden architectural patterns.
+
+**Hypothesis Testing**: Query fan-in counts and MODIFIES counts for the same functions, then analyze correlation to validate architectural assumptions (e.g. "are the most-called functions also the most stable?").
+
+**Evolution Forensics**: Find multi-module commits, examine which functions changed, and classify as refactoring vs feature vs bugfix by looking at how many modules and how many functions were touched.
+
+**Dependency Archaeology**: Find zero fan-in functions (dead code candidates), check `is_historical` for ghost functions, then trace which commits removed their callers — this tells you when and why code became dead.
+
+**Incremental Investigation**: Start with `cs.summary()` for high-level coverage, then check backfill state. If `MODIFIES` is sparse, use `TOUCHES`-based (file-level) analysis instead of function-level.

--- a/skills/codegraph/schema.md
+++ b/skills/codegraph/schema.md
@@ -1,0 +1,54 @@
+# CodeScope Graph Schema
+
+## Nodes
+
+| Node | Key Properties | Notes |
+|------|---------------|-------|
+| `File` | id, path, language, loc, is_external | `is_external=1` for system headers / library stubs |
+| `Function` | id, name, qualified_name, signature, file_path, start_line, end_line, doc_comment, class_name, is_historical | `is_historical=1` for deleted/renamed functions |
+| `Class` | id, name, qualified_name, file_path | |
+| `Module` | id, name, path_prefix | Auto-discovered from directories (e.g. `kernel/sched`) |
+| `Commit` | id, hash, message, author, timestamp, version_tag | `version_tag='bf'` means MODIFIES edges computed |
+| `Metadata` | id, value | Pipeline state (e.g. `oldest_commit`) |
+
+## Edges
+
+| Edge | From → To | Meaning |
+|------|-----------|---------|
+| `CALLS` | Function → Function | Static call graph (resolved from AST) |
+| `DEFINES_FUNC` | File → Function | File defines this function |
+| `DEFINES_CLASS` | File → Class | File defines this class |
+| `HAS_METHOD` | Class → Function | Class contains this method |
+| `IMPORTS` | File → File | Include / import dependency |
+| `BELONGS_TO` | File → Module | File belongs to this module |
+| `INHERITS` | Class → Class | Class inheritance |
+| `MODIFIES` | Commit → Function | Commit changed this function (requires backfill) |
+| `TOUCHES` | Commit → File | Commit changed this file (always present) |
+
+## Backfill State
+
+Not all commits have MODIFIES edges — only those with `version_tag = 'bf'`. TOUCHES edges are always present for all ingested commits.
+
+```cypher
+MATCH (c:Commit) WHERE c.version_tag = 'bf' RETURN count(c) AS backfilled
+```
+
+```cypher
+MATCH (c:Commit) RETURN count(c) AS total_commits
+```
+
+## Neug Cypher Reference
+
+**Supported syntax:**
+- `MATCH`, `WHERE`, `RETURN`, `ORDER BY`, `LIMIT`, `WITH`
+- Aggregations: `count()`, `count(DISTINCT x)`
+- Inline property filters: `{name: 'foo'}`
+- Variable-length paths: `[*1..3]`
+- String predicates: `STARTS WITH`, `CONTAINS`, `ENDS WITH`
+- Comparisons: `=`, `<>`, `<`, `>`, `<=`, `>=`
+- Boolean: `AND`, `OR`, `NOT`
+
+**Limitations:**
+- `OPTIONAL MATCH` is not available in the pip package
+- Chained `MATCH` after `WITH` may be limited — prefer single `MATCH` clauses with multiple patterns separated by commas
+- No `CREATE`, `SET`, `DELETE` via Cypher — graph mutations go through the Python API


### PR DESCRIPTION
# Summary
Add a new skill: codegraph-qa for CodeScope code analysis.

# Features
This skill is able to analyze indexed codebases using CodeScope's graph database (neug) and vector index (zvec), providing:

- Structural Analysis: Call graphs, dependency analysis, dead code detection, hotspots, module coupling, architectural layering
- Semantic Search: Find similar functions, cross-locate related code
- Evolution Analysis: Commit history, change attribution, co-change patterns
- Report Generation: Full architecture reports with Mermaid diagrams

# Files Added

- skills/codegraph/SKILL.md - Main skill documentation
- skills/codegraph/schema.md - Graph schema reference
- skills/codegraph/patterns.md - Cypher query templates
- skills/codegraph/evals/evals.json - Evaluation test cases

# Usage
Users can ask questions like:

- "Who calls this function?"
- "Find dead code in the project"
- "Which modules are tightly coupled?"
- "Generate an architecture report"
- "What changed in this function recently?"

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new `codegraph-qa` skill for CodeScope, a code analysis tool that builds a two-layer knowledge graph (structural + evolutionary) over source code. The skill provides Claude with detailed instructions, API references, Cypher query patterns, and bug analysis workflows to answer questions about code structure, dependencies, call graphs, and bug root causes using the `codegraph-ai` Python package backed by `neug` (graph DB) and `zvec` (vector index).

The skill documentation is comprehensive and well-organized. A few issues were found:
- A typo ("virtural") in `SKILL.md`'s environment setup section
- Inconsistent module path extraction depths (`parts[:3]` vs `parts[:2]`) between two code examples in `bug-analysis.md`, which will produce different grouping behavior when users combine patterns
- A raw f-string Cypher interpolation pattern in `bug-analysis.md` that, while safe for hex SHA values, teaches an unsafe pattern that could be misapplied with other string values
- Minor CLI flag inconsistencies between `SKILL.md` and `bug-analysis.md` (e.g., `--label bug` and `--topk` present in one but not the other)
- `bug-analysis.md` is not mentioned in the PR description's "Files Added" section despite being a significant addition
- The new `skills/` top-level directory is separate from the existing `.cursor/skills/` convention — this may be intentional if targeting a different AI tool ecosystem, but no explanation is provided

<h3>Confidence Score: 4/5</h3>

- Safe to merge after addressing the module depth inconsistency in bug-analysis.md; remaining issues are minor documentation quality concerns.
- This is a documentation-only PR adding a new skill definition. No executable code is changed. The main risk is teaching incorrect patterns to users — specifically the inconsistent module path depths which would produce silently wrong aggregation results. The Cypher injection concern is low-risk for the specific SHA use case but is a documentation anti-pattern. The typo and CLI flag inconsistencies are cosmetic.
- skills/codegraph/bug-analysis.md — the module path depth inconsistency (parts[:3] vs parts[:2]) is the most impactful issue and should be resolved before merge.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| skills/codegraph/SKILL.md | Main skill entrypoint defining the codegraph-qa skill; comprehensive API reference with well-structured sections, but contains one typo ("virtural") and slight CLI flag inconsistencies vs bug-analysis.md. |
| skills/codegraph/bug-analysis.md | Bug analysis workflow guide with useful patterns, but has two notable issues: inconsistent module path depths (parts[:3] vs parts[:2]) across sections, and a raw f-string Cypher interpolation pattern that could teach unsafe practices. |
| skills/codegraph/patterns.md | Cypher query template library; well-organized with clear structural and evolution query patterns, consistent use of LIMIT and is_historical filters as recommended in SKILL.md. |
| skills/codegraph/schema.md | Clean graph schema reference documenting all node types, edge types, properties, and neug Cypher limitations (notably OPTIONAL MATCH unavailability); no issues found. |
| skills/codegraph/evals/evals.json | Three evaluation cases covering single-issue analysis, batch bug hotspot analysis, and commit tracing; evaluation coverage is minimal (3 cases) and all use the same two example repos (openclaw, pallets/click), but is a reasonable starting point. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Skill as codegraph-qa Skill
    participant CS as CodeScope (Python API)
    participant GH as GitHub (gh CLI)
    participant Neug as neug Graph DB
    participant Zvec as zvec Vector Index

    User->>Skill: Ask code structure / bug question
    Skill->>CS: CodeScope(db_dir)

    alt Structural Query
        Skill->>Neug: cs.conn.execute(Cypher)
        Neug-->>Skill: List of tuples
    end

    alt Semantic Search
        Skill->>Zvec: cs.vector_only_search(query)
        Zvec-->>Skill: [{id, score}]
    end

    alt Bug Root Cause Analysis
        Skill->>GH: fetch_and_parse_issue(owner, repo, number)
        GH-->>Skill: ParsedIssue (paths, funcs, commits)
        Skill->>Neug: resolve_paths_to_files()
        Skill->>Zvec: find_semantic_matches()
        Skill->>Neug: trace_callers() via CALLS edges
        Skill->>Skill: rank_root_causes()
        Skill-->>User: BugAnalysisResult (candidates + scores)
    end

    alt Report Generation
        Skill->>CS: generate_report(cs)
        CS->>Neug: Structural queries
        CS->>Zvec: Embedding queries
        CS-->>Skill: Markdown report with Mermaid diagrams
    end

    Skill->>CS: cs.close()
    Skill-->>User: Answer / report
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `skills/codegraph/bug-analysis.md`, line 499-502 ([link](https://github.com/alibaba/neug/blob/12fb3bd3c8a0627e6bb56827f3c8ac4e879c3acb/skills/codegraph/bug-analysis.md#L499-L502)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Inconsistent module path depth between code snippets**

   In the "Batch Bug Hotspot Analysis" section (here), module paths are extracted using the first **3** path segments (`parts[:3]`). However, in the "Bug Pattern Detection" section (line 584), the same concept is computed using the first **2** segments (`parts[:2]`). Users who combine both snippets will get different grouping results for the same data — e.g., `src/cron/tasks.py` becomes `src/cron/tasks` in one context and `src/cron` in the other.

   These two snippets should use a consistent depth. Most real-world projects would use 2–3 segments, but it should be the same number throughout the document so that patterns can be combined without surprising discrepancies.


2. `skills/codegraph/bug-analysis.md`, line 557-566 ([link](https://github.com/alibaba/neug/blob/12fb3bd3c8a0627e6bb56827f3c8ac4e879c3acb/skills/codegraph/bug-analysis.md#L557-L566)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Direct f-string interpolation into Cypher query**

   The `sha[:12]` value is interpolated directly into a Cypher query string via an f-string. While commit SHAs are always hexadecimal and therefore safe in this specific case, documenting this pattern as a template encourages users to adapt it with other, less constrained string values (e.g., function names, file paths from issue bodies) that could contain `'` characters and break or inject into the query.

   A safer pattern to document would be to use parameterized queries (if the `neug` API supports them) or at minimum add a note warning readers not to interpolate non-hexadecimal values using the same approach.

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: ["add codegraph-qa ski..."](https://github.com/alibaba/neug/commit/12fb3bd3c8a0627e6bb56827f3c8ac4e879c3acb)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->