### PR TITLE
fix: Correct the `is_optional` interface behavior for certain columns

### DIFF
--- a/include/neug/execution/common/columns/arrow_context_column.h
+++ b/include/neug/execution/common/columns/arrow_context_column.h
@@ -155,6 +155,11 @@ class ArrowStreamContextColumn : public IContextColumn {
     return Value(DataType::SQLNULL);
   }
 
+  bool is_optional() const override {
+    LOG(FATAL) << "is_optional not implemented for arrow stream column";
+    return false;
+  }
+
  private:
   std::shared_ptr<arrow::RecordBatch> first_batch_;
   std::vector<std::shared_ptr<IRecordBatchSupplier>> suppliers_;

--- a/include/neug/execution/common/columns/edge_columns.h
+++ b/include/neug/execution/common/columns/edge_columns.h
@@ -501,6 +501,8 @@ class SDMLEdgeColumn : public IEdgeColumn {
     return std::get<1>(tup) != std::numeric_limits<vid_t>::max();
   }
 
+  bool is_optional() const override { return is_optional_; }
+
  private:
   friend class SDMLEdgeColumnBuilder;
   Direction dir_;
@@ -620,6 +622,8 @@ class BDMLEdgeColumn : public IEdgeColumn {
     const auto& tup = edges_[idx];
     return std::get<1>(tup) != std::numeric_limits<vid_t>::max();
   }
+
+  bool is_optional() const override { return is_optional_; }
 
  private:
   friend class BDMLEdgeColumnBuilder;

--- a/include/neug/execution/common/columns/i_context_column.h
+++ b/include/neug/execution/common/columns/i_context_column.h
@@ -74,7 +74,7 @@ class IContextColumn {
   virtual Value get_elem(size_t idx) const = 0;
   virtual bool has_value(size_t idx) const { return true; }
 
-  virtual bool is_optional() const { return false; }
+  virtual bool is_optional() const = 0;
 
   virtual bool generate_dedup_offset(std::vector<size_t>& offsets) const {
     LOG(ERROR) << "generate_dedup_offset not implemented for "

--- a/include/neug/execution/common/columns/list_columns.h
+++ b/include/neug/execution/common/columns/list_columns.h
@@ -86,6 +86,8 @@ class ListColumn : public IContextColumn {
     return ptr;
   }
 
+  bool is_optional() const override { return false; }
+
  private:
   template <typename T>
   std::pair<std::shared_ptr<IContextColumn>, std::vector<size_t>> unfold_impl()


### PR DESCRIPTION
Fixes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the `is_optional()` interface behavior by making it a pure virtual method in `IContextColumn` (removing the incorrect default `return false`) and adding the missing overrides to `SDMLEdgeColumn`, `BDMLEdgeColumn`, and `ListColumn`. The core fix is correct: `SDMLEdgeColumn` and `BDMLEdgeColumn` already tracked their optional state via a private `is_optional_` field but were silently returning `false` from the base class instead of reflecting the actual state.

**Changes:**
- `i_context_column.h`: `is_optional()` promoted to pure virtual (`= 0`), removing the incorrect silent `false` default.
- `edge_columns.h`: `SDMLEdgeColumn` and `BDMLEdgeColumn` now properly override `is_optional()` by returning their private `is_optional_` field — the actual bug fix.
- `list_columns.h`: `ListColumn` adds `return false`, correct since list columns are never optional.
- `arrow_context_column.h`: `ArrowStreamContextColumn` adds an override using `LOG(FATAL)`, which is a **behavioral regression**. Previously the base class returned `false` safely; `ArrowArrayContextColumn` (its sibling) correctly returns `false`. Generic execution paths such as `sink.cc`, `project_utils.cc`, and `group_by_utils.cc` all call `is_optional()` on `IContextColumn` pointers and would crash if they ever receive an `ArrowStreamContextColumn`.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for the edge column fixes, but the `ArrowStreamContextColumn::is_optional()` using `LOG(FATAL)` is a potential crash regression that should be addressed.
- The core fix for `SDMLEdgeColumn` and `BDMLEdgeColumn` is correct and well-targeted. However, `ArrowStreamContextColumn::is_optional()` introduces a `LOG(FATAL)` where the old code returned `false` safely. Generic execution paths (`sink.cc`, `project_utils.cc`, `group_by_utils.cc`) call `is_optional()` on any `IContextColumn`, so if a stream column flows through those paths the process will be killed. The sibling class `ArrowArrayContextColumn` correctly returns `false`, and that same approach should be used here.
- include/neug/execution/common/columns/arrow_context_column.h — the `ArrowStreamContextColumn::is_optional()` implementation should return `false` instead of calling `LOG(FATAL)`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| include/neug/execution/common/columns/i_context_column.h | Changed `is_optional()` from a virtual method with a default `return false` to a pure virtual method, forcing all concrete subclasses to explicitly implement it. All known concrete subclasses now provide an implementation. |
| include/neug/execution/common/columns/edge_columns.h | Added the missing `is_optional()` override to `SDMLEdgeColumn` and `BDMLEdgeColumn`, both now correctly delegate to the private `is_optional_` field that was already populated by the corresponding builders. |
| include/neug/execution/common/columns/list_columns.h | Added `is_optional() { return false; }` to `ListColumn` to satisfy the new pure-virtual interface. Correct — list columns are never nullable/optional in this design. |
| include/neug/execution/common/columns/arrow_context_column.h | Added `is_optional()` to `ArrowStreamContextColumn` using `LOG(FATAL)`, which is a behavioral regression — the previous default returned `false` safely. Any generic code path (sink, project, group_by) that receives this column type will now crash instead of reading a safe `false`. |

</details>

<h3>Class Diagram</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class IContextColumn {
        <<abstract>>
        +is_optional() bool *
        +get_elem(idx) Value *
        +has_value(idx) bool
    }

    class IEdgeColumn {
        <<abstract>>
        +get_elem(idx) Value
        +get_edge(idx) EdgeRecord *
        +is_optional() bool *
    }

    class SDSLEdgeColumn {
        -is_optional_ bool
        +is_optional() bool ✓
    }

    class MSEdgeColumn {
        -is_optional_ bool
        +is_optional() bool ✓
    }

    class BDSLEdgeColumn {
        -is_optional_ bool
        +is_optional() bool ✓
    }

    class SDMLEdgeColumn {
        -is_optional_ bool
        +is_optional() bool ✓ (added)
    }

    class BDMLEdgeColumn {
        -is_optional_ bool
        +is_optional() bool ✓ (added)
    }

    class ListColumn {
        +is_optional() bool ✓ (added, returns false)
    }

    class ArrowArrayContextColumn {
        +is_optional() bool ✓ (returns false)
    }

    class ArrowStreamContextColumn {
        +is_optional() bool ⚠️ (LOG FATAL)
    }

    IContextColumn <|-- IEdgeColumn
    IEdgeColumn <|-- SDSLEdgeColumn
    IEdgeColumn <|-- MSEdgeColumn
    IEdgeColumn <|-- BDSLEdgeColumn
    IEdgeColumn <|-- SDMLEdgeColumn
    IEdgeColumn <|-- BDMLEdgeColumn
    IContextColumn <|-- ListColumn
    IContextColumn <|-- ArrowArrayContextColumn
    IContextColumn <|-- ArrowStreamContextColumn
```

<sub>Last reviewed commit: ["Correct the is_optio..."](https://github.com/alibaba/neug/commit/f356bd3d7648347d1ba6e47856c92bd104e9897a)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->