### PR TITLE
feat: adapt parquet extension to new VFS interface

### DIFF
--- a/extension/parquet/include/parquet_read_function.h
+++ b/extension/parquet/include/parquet_read_function.h
@@ -22,6 +22,7 @@
 #include "parquet_options.h"
 #include "neug/compiler/function/function.h"
 #include "neug/compiler/function/read_function.h"
+#include "neug/compiler/main/metadata_registry.h"
 #include "neug/execution/execute/ops/batch/batch_update_utils.h"
 #include "neug/utils/reader/options.h"
 #include "neug/utils/reader/reader.h"
@@ -48,9 +49,15 @@ struct ParquetReadFunction {
   static execution::Context execFunc(
       std::shared_ptr<reader::ReadSharedState> state) {
     // Get file system from provider
-    LocalFileSystemProvider fsProvider;
-    auto fileInfo = fsProvider.provide(state->schema.file);
-    state->schema.file.paths = fileInfo.resolvedPaths;
+    const auto& vfs = neug::main::MetadataRegistry::getVFS();
+    const auto& fs = vfs->Provide(state->schema.file);
+    auto resolvedPaths = std::vector<std::string>();
+    for (const auto& path : state->schema.file.paths) {
+      const auto& resolved = fs->glob(path);
+      resolvedPaths.insert(resolvedPaths.end(), resolved.begin(),
+                           resolved.end());
+    }
+    state->schema.file.paths = std::move(resolvedPaths);
     
     // Create Parquet-specific options builder
     auto optionsBuilder =
@@ -58,7 +65,7 @@ struct ParquetReadFunction {
     
     // Create Arrow reader with Parquet options
     auto reader = std::make_unique<reader::ArrowReader>(
-        state, std::move(optionsBuilder), fileInfo.fileSystem);
+        state, std::move(optionsBuilder), fs->toArrowFileSystem());
     
     // Execute read operation.
     // ArrowReader::read() throws exceptions (via THROW_IO_EXCEPTION /
@@ -81,9 +88,15 @@ struct ParquetReadFunction {
     externalSchema.file = schema;
     
     // Resolve file paths
-    LocalFileSystemProvider fsProvider;
-    auto fileInfo = fsProvider.provide(state->schema.file);
-    state->schema.file.paths = fileInfo.resolvedPaths;
+    const auto& vfs = neug::main::MetadataRegistry::getVFS();
+    const auto& fs = vfs->Provide(state->schema.file);
+    auto resolvedPaths = std::vector<std::string>();
+    for (const auto& path : state->schema.file.paths) {
+      const auto& resolved = fs->glob(path);
+      resolvedPaths.insert(resolvedPaths.end(), resolved.begin(),
+                           resolved.end());
+    }
+    state->schema.file.paths = std::move(resolvedPaths);
     
     // Create Parquet-specific options builder
     auto optionsBuilder =
@@ -91,7 +104,7 @@ struct ParquetReadFunction {
     
     // Create Arrow reader with Parquet options
     auto reader = std::make_shared<reader::ArrowReader>(
-        state, std::move(optionsBuilder), fileInfo.fileSystem);
+        state, std::move(optionsBuilder), fs->toArrowFileSystem());
     
     // Create sniffer to infer schema from Parquet metadata
     auto sniffer = std::make_shared<reader::ArrowSniffer>(reader);


### PR DESCRIPTION
## Related Issues

## What does this PR do?
Adapts the Parquet read extension (`ParquetReadFunction`) to use the new VFS (Virtual File System) interface via `MetadataRegistry::getVFS()`, replacing the previous `LocalFileSystemProvider` approach.

## What changes in this PR?
- `extension/parquet/include/parquet_read_function.h`:
  - Replace `LocalFileSystemProvider` with `MetadataRegistry::getVFS()` in both `execFunc` and `sniffFunc`.
  - Path resolution now calls `vfs->Provide(...)` and iterates per-path `fs->glob(...)` to build `resolvedPaths`, consistent with how other extensions handle VFS-aware path resolution.
  - Arrow file system passed to `ArrowReader` is now `fs->toArrowFileSystem()` instead of `fileInfo.fileSystem`.
  - Add `#include "neug/compiler/main/metadata_registry.h"`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adapts `ParquetReadFunction` to use the new VFS interface (`MetadataRegistry::getVFS()`) for file-system access, replacing the now-removed `LocalFileSystemProvider`. The change brings the Parquet extension in line with how the JSON extension already handles path resolution and Arrow file-system construction.

- The new VFS path-resolution logic (calling `vfs->Provide()` then iterating `fs->glob()`) is a direct copy of the pattern from `json_read_function.h`, making the change consistent with the rest of the codebase.
- `#include <arrow/filesystem/localfs.h>` (line 20) was needed by the old `LocalFileSystemProvider` but was not removed; it is now a stale include.
- `const auto& fs = vfs->Provide(...)` binds a `const` reference to a `std::unique_ptr<FileSystem>` temporary — lifetime extension makes it correct, but `auto fs = vfs->Provide(...)` would be more idiomatic. The same pattern exists in `json_read_function.h`.
- The VFS setup and glob loop is duplicated verbatim in both `execFunc` and `sniffFunc`; a small private helper would reduce the redundancy.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — the change is a faithful port of an established pattern and introduces no new logic errors.
- The implementation directly mirrors the already-working JSON extension pattern and `getVFS()` throws on null rather than silently returning nullptr. The only findings are minor style issues (stale include, unusual `const&` binding, duplicated code block) with no impact on correctness or safety.
- No files require special attention beyond the stale include noted in `extension/parquet/include/parquet_read_function.h`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| extension/parquet/include/parquet_read_function.h | Replaces `LocalFileSystemProvider` with `MetadataRegistry::getVFS()` in both `execFunc` and `sniffFunc`, faithfully mirroring the pattern already used by the JSON extension. Minor issues: stale `#include <arrow/filesystem/localfs.h>` was not removed, and the path-resolution loop is duplicated across both functions. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant ParquetReadFunction
    participant MetadataRegistry
    participant FileSystemRegistry
    participant FileSystem
    participant ArrowReader

    Caller->>ParquetReadFunction: execFunc(state) / sniffFunc(schema)
    ParquetReadFunction->>MetadataRegistry: getVFS()
    MetadataRegistry-->>ParquetReadFunction: FileSystemRegistry*
    ParquetReadFunction->>FileSystemRegistry: Provide(fileSchema)
    FileSystemRegistry-->>ParquetReadFunction: unique_ptr<FileSystem>
    loop for each path in schema.file.paths
        ParquetReadFunction->>FileSystem: glob(path)
        FileSystem-->>ParquetReadFunction: resolved paths
    end
    ParquetReadFunction->>ParquetReadFunction: update state->schema.file.paths
    ParquetReadFunction->>FileSystem: toArrowFileSystem()
    FileSystem-->>ParquetReadFunction: unique_ptr<arrow::fs::FileSystem>
    ParquetReadFunction->>ArrowReader: new ArrowReader(state, optionsBuilder, arrowFs)
    ArrowReader-->>ParquetReadFunction: reader
    ParquetReadFunction->>ArrowReader: read(localState, ctx) / sniff()
    ArrowReader-->>Caller: Context / EntrySchema
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `extension/parquet/include/parquet_read_function.h`, line 19-21 ([link](https://github.com/alibaba/neug/blob/7aa87e95d530fb44f8214b1e578b93eb7cbc3e32/extension/parquet/include/parquet_read_function.h#L19-L21)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Stale `#include <arrow/filesystem/localfs.h>`**

   The `#include <arrow/filesystem/localfs.h>` include was needed by the old `LocalFileSystemProvider` code, but was not removed when it was replaced. The new VFS-based path only uses `arrow::fs::FileSystem` (via `toArrowFileSystem()`), which is already covered by the existing `#include <arrow/filesystem/filesystem.h>`. This include is now dead code and should be removed.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["adapt to the new vfs for parquet"](https://github.com/alibaba/neug/commit/7aa87e95d530fb44f8214b1e578b93eb7cbc3e32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26007327)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->