### PR TITLE
feat: Enable testing of Python 3.14 wheel package on Linux

### DIFF
--- a/.github/workflows/nightly-pypi-package-test.yml
+++ b/.github/workflows/nightly-pypi-package-test.yml
@@ -25,11 +25,6 @@ jobs:
           - ubuntu-24.04-arm
           - macos-14
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
-        exclude:
-          - os: ubuntu-latest
-            python-version: "3.14"
-          - os: ubuntu-24.04-arm
-            python-version: "3.14"
         include:
           - os: ubuntu-latest
             platform-name: "linux-x86_64"


### PR DESCRIPTION
Fixes https://github.com/alibaba/neug/issues/104

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables Python 3.14 wheel testing on Linux by removing the `exclude` entries that previously blocked `ubuntu-latest` (x86_64) and `ubuntu-24.04-arm` (arm64) from the CI matrix for Python 3.14. macOS (`macos-14`) was already testing Python 3.14 before this change.

- Removes the two-entry `exclude` block under the matrix strategy — no other workflow logic is modified.
- The existing `allow-prereleases: true` flag on `actions/setup-python@v5` already handles pre-release Python versions, so no additional setup changes are needed.
- After this change the full 3×7 (21-combination) matrix will run on every nightly schedule and `workflow_dispatch`, giving complete coverage of all supported OS/Python-version pairs.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a minimal, focused CI configuration change with no production code impact.
- The change is a straightforward removal of two `exclude` entries from a CI matrix. The workflow already has `allow-prereleases: true` to handle Python 3.14, and macOS was already exercising 3.14 successfully. There is no risk of breaking existing behaviour.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/nightly-pypi-package-test.yml | Removes the matrix `exclude` block that was preventing Python 3.14 from being tested on `ubuntu-latest` and `ubuntu-24.04-arm`, enabling Linux wheel testing for Python 3.14. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Matrix Strategy] --> B{OS}
    B --> C[ubuntu-latest\nlinux-x86_64]
    B --> D[ubuntu-24.04-arm\nlinux-arm64]
    B --> E[macos-14\nmacos-arm64]

    C --> F[Python Versions]
    D --> F
    E --> F

    F --> G[3.8]
    F --> H[3.9]
    F --> I[3.10]
    F --> J[3.11]
    F --> K[3.12]
    F --> L[3.13]
    F --> M[3.14\n✅ Now enabled on Linux]

    style M fill:#90EE90,stroke:#228B22
```

<sub>Reviews (1): Last reviewed commit: ["Enable testing of Python 3.14 wheel pack..."](https://github.com/alibaba/neug/commit/53212dd4cd5844eb12fda64cf9357c2ea272bb50) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26015293)</sub>

<!-- /greptile_comment -->