### PR TITLE
refactor: Unify MemoryLevel definition for storage

### DIFF
--- a/bin/benchmark.cc
+++ b/bin/benchmark.cc
@@ -236,8 +236,10 @@ int main(int argc, char** argv) {
   cxxopts::Options options("benchmark", "Benchmarking tool for NeuG");
   options.add_options()("help", "Display help message")(
       "data-path,d", "", cxxopts::value<std::string>())(
-      "memory-level,m", "", cxxopts::value<int>()->default_value("1"))(
-      "benchmark-config,c", "", cxxopts::value<std::string>());
+      "memory-level,m",
+      "1 for InMemory, 2 for SyncToFile, 3 for HugePagePrefered",
+      cxxopts::value<int>()->default_value("1"))("benchmark-config,c", "",
+                                                 cxxopts::value<std::string>());
   google::InitGoogleLogging(argv[0]);
   FLAGS_logtostderr = true;
   cxxopts::ParseResult vm = options.parse(argc, argv);
@@ -246,7 +248,8 @@ int main(int argc, char** argv) {
     std::cout << options.help() << std::endl;
     return 0;
   }
-  int memory_level = vm["memory-level"].as<int>();
+  neug::MemoryLevel memory_level =
+      static_cast<neug::MemoryLevel>(vm["memory-level"].as<int>());
 
   std::string data_path = "";
   if (!vm.count("data-path")) {

--- a/bin/rt_server.cc
+++ b/bin/rt_server.cc
@@ -54,7 +54,8 @@ int main(int argc, char** argv) {
       "p,http-port", "HTTP port of query handler",
       cxxopts::value<uint16_t>()->default_value("10000"))(
       "d,data-path", "Data directory path", cxxopts::value<std::string>())(
-      "m,memory-level", "Memory level for graph data",
+      "m,memory-level",
+      "1 for InMemory, 2 for SyncToFile, 3 for HugePagePrefered",
       cxxopts::value<int>()->default_value("1"))(
       "sharding-mode", "Sharding mode (exclusive or cooperative)",
       cxxopts::value<std::string>()->default_value("cooperative"))(
@@ -79,7 +80,8 @@ int main(int argc, char** argv) {
     return 0;
   }
 
-  int memory_level = vm["memory-level"].as<int>();
+  MemoryLevel memory_level =
+      static_cast<MemoryLevel>(vm["memory-level"].as<int>());
   uint32_t shard_num = vm["shard-num"].as<uint32_t>();
   uint16_t http_port = vm["http-port"].as<uint16_t>();
 
@@ -99,7 +101,7 @@ int main(int argc, char** argv) {
   neug::NeugDBConfig config(data_path, shard_num);
   config.memory_level = memory_level;
   config.wal_uri = vm["wal-uri"].as<std::string>();
-  if (config.memory_level >= 2) {
+  if (config.memory_level == neug::MemoryLevel::kHugePagePrefered) {
     config.enable_auto_compaction = true;
   }
   db.Open(config);

--- a/include/neug/config.h.in
+++ b/include/neug/config.h.in
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 /**
@@ -37,6 +38,21 @@ enum class DBMode {
 };
 
 /**
+ * @brief Memory usage level enumeration.
+ *
+ * Defines the memory usage strategy for NeugDB, allowing users to choose
+ * between different levels of memory optimization and performance.
+ *
+ * @since v0.1.0
+ */
+enum class MemoryLevel : uint8_t {
+  kUnSet = 0,
+  kInMemory = 1,
+  kSyncToFile = 2,
+  kHugePagePrefered = 3
+};
+
+/**
  * @brief Configuration structure for NeugDB initialization.
  *
  * NeugDBConfig provides comprehensive configuration options for
@@ -49,7 +65,7 @@ enum class DBMode {
  * config.data_dir = "/path/to/graph";
  * config.thread_num = 8;
  * config.mode = neug::DBMode::READ_WRITE;
- * config.memory_level = 2;  // Use hugepages
+ * config.memory_level = 1;  // Use memory-mapped virtual memory
  * config.enable_auto_compaction = true;
  * config.checkpoint_on_close = true;
  *
@@ -58,10 +74,10 @@ enum class DBMode {
  * @endcode
  *
  * **Memory Levels:**
- * - 0: Sync with disk (lowest memory, highest I/O latency)
+ * - 0: Unset
  * - 1: Memory-mapped virtual memory (default, balanced)
- * - 2: Prefer hugepages (better TLB performance)
- * - 3: Force hugepages (best performance, requires system config)
+ * - 2: Sync with disk (lowest memory, highest I/O latency)
+ * - 3: Prefer hugepages (better TLB performance)
  *
  * @see NeugDB::Open For using this configuration
  *
@@ -80,7 +96,7 @@ struct NeugDBConfig {
         planner_kind("gopt"),
         thread_num(1),
         enable_auto_compaction(false),
-        memory_level(1),
+        memory_level(MemoryLevel::kInMemory),
         wal_uri("{GRAPH_DATA_DIR}/wal"),
         compact_csr(true),
         compact_on_close(true),
@@ -100,7 +116,7 @@ struct NeugDBConfig {
         planner_kind("gopt"),
         thread_num(thread_num_),
         enable_auto_compaction(false),
-        memory_level(1),
+        memory_level(MemoryLevel::kInMemory),
         wal_uri("{GRAPH_DATA_DIR}/wal"),
         compact_csr(true),
         compact_on_close(true),
@@ -131,9 +147,8 @@ struct NeugDBConfig {
    * - 0: Sync with disk
    * - 1: Memory-mapped virtual memory (default)
    * - 2: Prefer hugepages
-   * - 3: Force hugepages
    */
-  int memory_level;
+  MemoryLevel memory_level;
 
   /// WAL (Write-Ahead Log) storage URI. Use {GRAPH_DATA_DIR} as placeholder.
   std::string wal_uri;

--- a/include/neug/storages/graph/edge_table.h
+++ b/include/neug/storages/graph/edge_table.h
@@ -49,11 +49,7 @@ class EdgeTable {
 
   void SetEdgeSchema(std::shared_ptr<const EdgeSchema> meta);
 
-  void Open(const std::string& work_dir);
-
-  void OpenInMemory(const std::string& work_dir);
-
-  void OpenWithHugepages(const std::string& work_dir);
+  void Open(const std::string& work_dir, MemoryLevel memory_level);
 
   void Dump(const std::string& checkpoint_dir_path);
 
@@ -104,8 +100,7 @@ class EdgeTable {
 
   void AddProperties(const std::vector<std::string>& names,
                      const std::vector<DataType>& types,
-                     const std::vector<Property>& default_values = {},
-                     const std::vector<StorageStrategy>& strategies = {});
+                     const std::vector<Property>& default_values = {});
 
   void DeleteProperties(const std::vector<std::string>& col_names);
 
@@ -140,7 +135,7 @@ class EdgeTable {
 
   std::shared_ptr<const EdgeSchema> meta_;
   std::string work_dir_;
-  int memory_level_{0};
+  MemoryLevel memory_level_{MemoryLevel::kSyncToFile};
   std::atomic<int32_t> csr_alter_version_{0};
   std::unique_ptr<CsrBase> out_csr_;
   std::unique_ptr<CsrBase> in_csr_;

--- a/include/neug/storages/graph/property_graph.h
+++ b/include/neug/storages/graph/property_graph.h
@@ -102,7 +102,7 @@ class PropertyGraph {
    * @brief Construct PropertyGraph with default settings.
    *
    * Implementation: Initializes vertex_label_total_count_=0,
-   * edge_label_total_count_=0, memory_level_=1.
+   * edge_label_total_count_=0, memory_level_=kInMemory
    *
    * @since v0.1.0
    */
@@ -127,10 +127,10 @@ class PropertyGraph {
    *
    * @since v0.1.0
    */
-  void Open(const std::string& work_dir, int memory_level);
+  void Open(const std::string& work_dir, MemoryLevel memory_level);
 
   void Open(const Schema& schema, const std::string& work_dir,
-            int memory_level);
+            MemoryLevel memory_level);
 
   void Compact(bool compact_csr, float reserve_ratio, timestamp_t ts);
 
@@ -626,7 +626,7 @@ class PropertyGraph {
   std::unordered_map<uint32_t, EdgeTable> edge_tables_;
 
   size_t vertex_label_total_count_, edge_label_total_count_;
-  int memory_level_;
+  MemoryLevel memory_level_;
 };
 
 }  // namespace neug

--- a/include/neug/storages/graph/schema.h
+++ b/include/neug/storages/graph/schema.h
@@ -58,7 +58,6 @@ inline void process_default_values(
  * - Label name and description
  * - Property definitions (types, names, defaults)
  * - Primary key specification
- * - Storage strategies for properties
  *
  * **Usage Example:**
  * @code{.cpp}
@@ -90,7 +89,6 @@ struct VertexSchema {
    * @param property_types_ Data types for each property
    * @param property_names_ Names for each property
    * @param primary_keys_ Primary key specification (type, name, index)
-   * @param storage_strategies_ Storage strategy for each property
    * @param default_property_values_ Default values for properties
    * @param description_ Human-readable description
    * @param max_num_ Maximum number of vertices of this type
@@ -102,7 +100,6 @@ struct VertexSchema {
                const std::vector<std::string>& property_names_,
                const std::vector<std::tuple<DataType, std::string, size_t>>&
                    primary_keys_,
-               const std::vector<StorageStrategy>& storage_strategies_,
                const std::vector<Property>& default_property_values_ = {},
                const std::string& description_ = "",
                size_t max_num_ = static_cast<size_t>(1) << 32)
@@ -110,12 +107,10 @@ struct VertexSchema {
         property_types(property_types_),
         property_names(property_names_),
         primary_keys(primary_keys_),
-        storage_strategies(storage_strategies_),
         default_property_values(default_property_values_),
         description(description_),
         max_num(max_num_) {
     vprop_soft_deleted.resize(property_names_.size(), false);
-    storage_strategies.resize(property_types_.size(), StorageStrategy::kMem);
     if (default_property_values.empty()) {
       for (size_t i = 0; i < property_types_.size(); ++i) {
         default_property_values.emplace_back(
@@ -133,11 +128,9 @@ struct VertexSchema {
 
   void add_properties(const std::vector<std::string>& names,
                       const std::vector<DataType>& types,
-                      const std::vector<StorageStrategy>& strategies,
                       const std::vector<Property>& default_values = {});
 
   void set_properties(const std::vector<DataType>& types,
-                      const std::vector<StorageStrategy>& strategies,
                       const std::vector<Property>& default_values = {});
 
   void rename_properties(const std::vector<std::string>& names,
@@ -175,7 +168,6 @@ struct VertexSchema {
   std::vector<std::string> property_names;
   // <DataType, property_name, index_in_property_list>
   std::vector<std::tuple<DataType, std::string, size_t>> primary_keys;
-  std::vector<StorageStrategy> storage_strategies;
   std::vector<Property> default_property_values;
   std::vector<std::string> default_property_strings;
   std::string description;
@@ -197,7 +189,6 @@ struct VertexSchema {
  * vertex types. It includes:
  * - Edge label name and endpoints (src -> dst)
  * - Property definitions
- * - Edge storage strategies (for both directions)
  * - Mutability settings
  *
  * **Edge Strategies:**
@@ -240,7 +231,6 @@ struct EdgeSchema {
    * @param ie_strategy_ Incoming edge storage strategy
    * @param properties_ Data types for edge properties
    * @param property_names_ Names for edge properties
-   * @param strategies_ Storage strategy for each property
    * @param default_property_values_ Default values for properties
    *
    * @since v0.1.0
@@ -253,7 +243,6 @@ struct EdgeSchema {
              EdgeStrategy ie_strategy_,
              const std::vector<DataType>& properties_,
              const std::vector<std::string>& property_names_,
-             const std::vector<StorageStrategy>& strategies_,
              const std::vector<Property>& default_property_values_ = {})
       : src_label_name(src_label_name_),
         dst_label_name(dst_label_name_),
@@ -266,12 +255,9 @@ struct EdgeSchema {
         ie_strategy(ie_strategy_),
         properties(properties_),
         property_names(property_names_),
-        strategies(strategies_),
         default_property_values(default_property_values_) {
     eprop_soft_deleted.resize(property_names_.size(), false);
-    strategies.resize(properties_.size(), StorageStrategy::kMem);
     assert(properties.size() == property_names.size());
-    assert(properties.size() == strategies.size());
     if (default_property_values.empty()) {
       for (size_t i = 0; i < properties_.size(); ++i) {
         default_property_values.emplace_back(
@@ -280,7 +266,6 @@ struct EdgeSchema {
     }
     assert(properties.size() == default_property_values.size());
     CHECK(properties.size() == property_names.size());
-    CHECK(properties.size() == strategies.size());
     process_default_values(default_property_values, default_property_strings);
   }
 
@@ -292,7 +277,6 @@ struct EdgeSchema {
 
   void add_properties(const std::vector<std::string>& names,
                       const std::vector<DataType>& types,
-                      const std::vector<StorageStrategy>& new_strategies = {},
                       const std::vector<Property>& default_values = {});
 
   void rename_properties(const std::vector<std::string>& names,
@@ -322,7 +306,6 @@ struct EdgeSchema {
   EdgeStrategy ie_strategy;
   std::vector<DataType> properties;
   std::vector<std::string> property_names;
-  std::vector<StorageStrategy> strategies;
   std::vector<Property> default_property_values;
   std::vector<std::string> default_property_strings;
 
@@ -467,7 +450,6 @@ class Schema {
       const std::string& label, const std::vector<DataType>& property_types,
       const std::vector<std::string>& property_names,
       const std::vector<std::tuple<DataType, std::string, size_t>>& primary_key,
-      const std::vector<StorageStrategy>& strategies = {},
       size_t max_vnum = static_cast<size_t>(1) << 32,
       const std::string& description = "",
       const std::vector<Property>& default_property_values = {});
@@ -476,7 +458,6 @@ class Schema {
                     const std::string& edge_label,
                     const std::vector<DataType>& properties,
                     const std::vector<std::string>& prop_names,
-                    const std::vector<StorageStrategy>& strategies = {},
                     EdgeStrategy oe = EdgeStrategy::kMultiple,
                     EdgeStrategy ie = EdgeStrategy::kMultiple,
                     bool oe_mutable = true, bool ie_mutable = true,
@@ -507,7 +488,6 @@ class Schema {
       const std::string& label,
       const std::vector<std::string>& properties_names,
       const std::vector<DataType>& properties_types,
-      const std::vector<StorageStrategy>& storage_strategies,
       const std::vector<Property>& properties_default_values);
 
   void AddEdgeProperties(
@@ -611,7 +591,6 @@ class Schema {
 
   void set_vertex_properties(
       label_t label_id, const std::vector<DataType>& types,
-      const std::vector<StorageStrategy>& strategies = {},
       const std::vector<Property>& default_property_values = {});
 
   std::vector<DataType> get_vertex_properties(const std::string& label) const;
@@ -632,9 +611,6 @@ class Schema {
   const std::string& get_vertex_description(const std::string& label) const;
 
   const std::string& get_vertex_description(label_t label) const;
-
-  std::vector<StorageStrategy> get_vertex_storage_strategies(
-      const std::string& label) const;
 
   size_t get_max_vnum(const std::string& label) const;
 

--- a/include/neug/storages/graph/vertex_table.h
+++ b/include/neug/storages/graph/vertex_table.h
@@ -83,7 +83,7 @@ class VertexTable {
       : table_(std::make_unique<Table>()),
         vertex_schema_(vertex_schema),
         v_ts_(),
-        memory_level_(1),
+        memory_level_(MemoryLevel::kInMemory),
         work_dir_("") {
     assert(vertex_schema->primary_keys.size() == 1);
     pk_type_ = std::get<0>(vertex_schema->primary_keys[0]);
@@ -111,7 +111,7 @@ class VertexTable {
     std::swap(work_dir_, other.work_dir_);
   }
 
-  void Open(const std::string& work_dir, int memory_level);
+  void Open(const std::string& work_dir, MemoryLevel memory_level);
 
   void Dump(const std::string& target_dir);
 
@@ -180,11 +180,9 @@ class VertexTable {
 
   void RevertDeleteVertex(vid_t lid, timestamp_t ts);
 
-  void AddProperties(
-      const std::vector<std::string>& property_names,
-      const std::vector<DataType>& property_types,
-      const std::vector<Property>& default_property_values,
-      const std::vector<StorageStrategy>& storage_strategies = {});
+  void AddProperties(const std::vector<std::string>& property_names,
+                     const std::vector<DataType>& property_types,
+                     const std::vector<Property>& default_property_values);
 
   void DeleteProperties(const std::vector<std::string>& properties);
 
@@ -316,7 +314,7 @@ class VertexTable {
   DataType pk_type_;
   std::shared_ptr<const VertexSchema> vertex_schema_;
   VertexTimestamp v_ts_;
-  int memory_level_;
+  MemoryLevel memory_level_;
 
   std::string work_dir_;
 

--- a/include/neug/storages/loader/abstract_property_graph_loader.h
+++ b/include/neug/storages/loader/abstract_property_graph_loader.h
@@ -30,7 +30,7 @@ class AbstractPropertyGraphLoader : public IFragmentLoader {
         schema_(schema),
         loading_config_(loading_config),
         thread_num_(loading_config_.GetParallelism()) {
-    graph_.Open(schema_, work_dir_, 0);
+    graph_.Open(schema_, work_dir_, MemoryLevel::kSyncToFile);
   }
 
   virtual ~AbstractPropertyGraphLoader() = default;

--- a/include/neug/utils/allocators.h
+++ b/include/neug/utils/allocators.h
@@ -20,6 +20,7 @@
 #include <string>
 #include <vector>
 
+#include "neug/config.h"
 #include "neug/utils/mmap_array.h"
 
 namespace neug {
@@ -28,14 +29,14 @@ class ArenaAllocator {
   static constexpr size_t batch_size = 16 * 1024 * 1024;
 
  public:
-  ArenaAllocator(MemoryStrategy strategy, const std::string& prefix)
+  ArenaAllocator(MemoryLevel strategy, const std::string& prefix)
       : strategy_(strategy),
         prefix_(prefix),
         cur_loc_(0),
         cur_size_(0),
         allocated_memory_(0),
         allocated_batches_(0) {
-    if (strategy_ != MemoryStrategy::kSyncToFile) {
+    if (strategy_ != MemoryLevel::kSyncToFile) {
       prefix_.clear();
     }
   }
@@ -79,7 +80,7 @@ class ArenaAllocator {
     allocated_batches_ += size;
     if (prefix_.empty()) {
       mmap_array<char>* buf = new mmap_array<char>();
-      if (strategy_ == MemoryStrategy::kHugepagePrefered) {
+      if (strategy_ == MemoryLevel::kHugePagePrefered) {
         buf->open_with_hugepages("");
       } else {
         buf->open("", false);
@@ -96,7 +97,7 @@ class ArenaAllocator {
     }
   }
 
-  MemoryStrategy strategy_;
+  MemoryLevel strategy_;
   std::string prefix_;
   std::vector<mmap_array<char>*> mmap_buffers_;
 

--- a/include/neug/utils/id_indexer.h
+++ b/include/neug/utils/id_indexer.h
@@ -243,10 +243,10 @@ class LFIndexer {
             std::shared_ptr<ExtraTypeInfo> extra_type_info = nullptr) {
     keys_ = nullptr;
     switch (type) {
-#define TYPE_DISPATCHER(enum_val, T)                                 \
-  case DataTypeId::enum_val: {                                       \
-    keys_ = std::make_shared<TypedColumn<T>>(StorageStrategy::kMem); \
-    break;                                                           \
+#define TYPE_DISPATCHER(enum_val, T)            \
+  case DataTypeId::enum_val: {                  \
+    keys_ = std::make_shared<TypedColumn<T>>(); \
+    break;                                      \
   }
       TYPE_DISPATCHER(kInt64, int64_t)
       TYPE_DISPATCHER(kInt32, int32_t)
@@ -262,7 +262,7 @@ class LFIndexer {
           max_length = str_type_info->max_length;
         }
       }
-      keys_ = std::make_shared<StringColumn>(StorageStrategy::kMem, max_length);
+      keys_ = std::make_shared<StringColumn>(max_length);
       break;
     }
     default: {
@@ -473,16 +473,26 @@ class LFIndexer {
     indices_size_ = indices_.size();
   }
 
-  void open_with_hugepages(const std::string& name, bool hugepage_table) {
+  void open_with_hugepages(const std::string& name) {
     if (std::filesystem::exists(name + ".meta")) {
       load_meta(name + ".meta");
     } else {
       num_elements_.store(0);
     }
-    keys_->open_with_hugepages(name + ".keys", true);
-    if (hugepage_table) {
+    try {
+      keys_->open_with_hugepages(name + ".keys");
+    } catch (const std::exception& e) {
+      LOG(WARNING)
+          << "Failed to open keys with hugepages, fallback to open in memory: "
+          << e.what();
+      keys_->open_in_memory(name + ".keys");
+    }
+    try {
       indices_.open_with_hugepages(name + ".indices");
-    } else {
+    } catch (const std::exception& e) {
+      LOG(WARNING) << "Failed to open indices with hugepages, fallback to open "
+                      "in memory: "
+                   << e.what();
       indices_.open(name + ".indices", false);
     }
     indices_size_ = indices_.size();

--- a/include/neug/utils/mmap_array.h
+++ b/include/neug/utils/mmap_array.h
@@ -72,12 +72,6 @@ namespace neug {
 template <typename T>
 class TypedColumn;
 
-enum class MemoryStrategy {
-  kSyncToFile,
-  kMemoryOnly,
-  kHugepagePrefered,
-};
-
 template <typename T>
 class mmap_array {
  public:

--- a/include/neug/utils/property/column.h
+++ b/include/neug/utils/property/column.h
@@ -51,7 +51,7 @@ class ColumnBase {
 
   virtual void open_in_memory(const std::string& name) = 0;
 
-  virtual void open_with_hugepages(const std::string& name, bool force) = 0;
+  virtual void open_with_hugepages(const std::string& name) = 0;
 
   virtual void close() = 0;
 
@@ -79,16 +79,13 @@ class ColumnBase {
 
   virtual void ingest(uint32_t index, OutArchive& arc) = 0;
 
-  virtual StorageStrategy storage_strategy() const = 0;
-
   virtual void ensure_writable(const std::string& work_dir) = 0;
 };
 
 template <typename T>
 class TypedColumn : public ColumnBase {
  public:
-  explicit TypedColumn(StorageStrategy strategy)
-      : size_(0), strategy_(strategy) {}
+  explicit TypedColumn() : size_(0) {}
   ~TypedColumn() { close(); }
 
   void open(const std::string& name, const std::string& snapshot_dir,
@@ -117,19 +114,14 @@ class TypedColumn : public ColumnBase {
     }
   }
 
-  void open_with_hugepages(const std::string& name, bool force) override {
-    if (strategy_ == StorageStrategy::kMem || force) {
-      if (!name.empty() && std::filesystem::exists(name)) {
-        buffer_.open_with_hugepages(name);
-        size_ = buffer_.size();
-      } else {
-        buffer_.reset();
-        buffer_.set_hugepage_prefered(true);
-        size_ = 0;
-      }
-    } else if (strategy_ == StorageStrategy::kDisk) {
-      LOG(INFO) << "Open " << name << " with normal mmap pages";
-      open_in_memory(name);
+  void open_with_hugepages(const std::string& name) override {
+    if (!name.empty() && std::filesystem::exists(name)) {
+      buffer_.open_with_hugepages(name);
+      size_ = buffer_.size();
+    } else {
+      buffer_.reset();
+      buffer_.set_hugepage_prefered(true);
+      size_ = 0;
     }
   }
 
@@ -193,8 +185,6 @@ class TypedColumn : public ColumnBase {
     set_value(index, val);
   }
 
-  StorageStrategy storage_strategy() const override { return strategy_; }
-
   const mmap_array<T>& buffer() const { return buffer_; }
   size_t buffer_size() const { return size_; }
 
@@ -205,7 +195,6 @@ class TypedColumn : public ColumnBase {
  private:
   mmap_array<T> buffer_;
   size_t size_;
-  StorageStrategy strategy_;
 };
 
 using BoolColumn = TypedColumn<bool>;
@@ -224,13 +213,13 @@ using IntervalColumn = TypedColumn<Interval>;
 template <>
 class TypedColumn<EmptyType> : public ColumnBase {
  public:
-  explicit TypedColumn(StorageStrategy strategy) : strategy_(strategy) {}
+  explicit TypedColumn() {}
   ~TypedColumn() {}
 
   void open(const std::string& name, const std::string& snapshot_dir,
             const std::string& work_dir) override {}
   void open_in_memory(const std::string& name) override {}
-  void open_with_hugepages(const std::string& name, bool force) override {}
+  void open_with_hugepages(const std::string& name) override {}
   void dump(const std::string& filename) override {}
   void close() override {}
   size_t size() const override { return 0; }
@@ -252,34 +241,23 @@ class TypedColumn<EmptyType> : public ColumnBase {
 
   void ingest(uint32_t index, OutArchive& arc) override {}
 
-  StorageStrategy storage_strategy() const override { return strategy_; }
-
   void ensure_writable(const std::string& work_dir) override {}
-
- private:
-  StorageStrategy strategy_;
 };
 
 template <>
 class TypedColumn<std::string_view> : public ColumnBase {
  public:
-  TypedColumn(StorageStrategy strategy, uint16_t width)
+  TypedColumn(uint16_t width)
+      : size_(0), pos_(0), width_(width), type_(DataTypeId::kVarchar) {}
+  explicit TypedColumn()
       : size_(0),
         pos_(0),
-        strategy_(strategy),
-        width_(width),
-        type_(DataTypeId::kVarchar) {}
-  explicit TypedColumn(StorageStrategy strategy)
-      : size_(0),
-        pos_(0),
-        strategy_(strategy),
         width_(STRING_DEFAULT_MAX_LENGTH),
         type_(DataTypeId::kVarchar) {}
   TypedColumn(TypedColumn<std::string_view>&& rhs) {
     buffer_.swap(rhs.buffer_);
     size_ = rhs.size_;
     pos_ = rhs.pos_.load();
-    strategy_ = rhs.strategy_;
     width_ = rhs.width_;
     type_ = rhs.type_;
   }
@@ -311,16 +289,10 @@ class TypedColumn<std::string_view> : public ColumnBase {
     init_pos(prefix + ".pos");
   }
 
-  void open_with_hugepages(const std::string& prefix, bool force) override {
-    if (strategy_ == StorageStrategy::kMem || force) {
-      buffer_.open_with_hugepages(prefix);
-      size_ = buffer_.size();
-      init_pos(prefix + ".pos");
-
-    } else if (strategy_ == StorageStrategy::kDisk) {
-      LOG(INFO) << "Open " << prefix << " with normal mmap pages";
-      open_in_memory(prefix);
-    }
+  void open_with_hugepages(const std::string& prefix) override {
+    buffer_.open_with_hugepages(prefix);
+    size_ = buffer_.size();
+    init_pos(prefix + ".pos");
   }
 
   void close() override { buffer_.reset(); }
@@ -428,8 +400,6 @@ class TypedColumn<std::string_view> : public ColumnBase {
 
   const mmap_array<std::string_view>& buffer() const { return buffer_; }
 
-  StorageStrategy storage_strategy() const override { return strategy_; }
-
   size_t buffer_size() const { return size_; }
 
   void ensure_writable(const std::string& work_dir) override {
@@ -450,7 +420,6 @@ class TypedColumn<std::string_view> : public ColumnBase {
   mmap_array<std::string_view> buffer_;
   size_t size_;
   std::atomic<size_t> pos_;
-  StorageStrategy strategy_;
   std::shared_mutex rw_mutex_;
   uint16_t width_;
   DataTypeId type_;
@@ -458,8 +427,7 @@ class TypedColumn<std::string_view> : public ColumnBase {
 
 using StringColumn = TypedColumn<std::string_view>;
 
-std::shared_ptr<ColumnBase> CreateColumn(
-    DataType type, StorageStrategy strategy = StorageStrategy::kMem);
+std::shared_ptr<ColumnBase> CreateColumn(DataType type);
 
 /// Create RefColumn for ease of usage for hqps
 class RefColumnBase {

--- a/include/neug/utils/property/table.h
+++ b/include/neug/utils/property/table.h
@@ -21,6 +21,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "neug/config.h"
 #include "neug/utils/property/column.h"
 #include "neug/utils/property/property.h"
 #include "neug/utils/property/types.h"
@@ -34,19 +35,15 @@ class Table {
 
   void open(const std::string& name, const std::string& work_dir,
             const std::vector<std::string>& col_name,
-            const std::vector<DataType>& property_types,
-            const std::vector<StorageStrategy>& strategies_);
+            const std::vector<DataType>& property_types);
 
   void open_in_memory(const std::string& name, const std::string& work_dir,
                       const std::vector<std::string>& col_name,
-                      const std::vector<DataType>& property_types,
-                      const std::vector<StorageStrategy>& strategies_);
+                      const std::vector<DataType>& property_types);
 
   void open_with_hugepages(const std::string& name, const std::string& work_dir,
                            const std::vector<std::string>& col_name,
-                           const std::vector<DataType>& property_types,
-                           const std::vector<StorageStrategy>& strategies_,
-                           bool force = false);
+                           const std::vector<DataType>& property_types);
 
   void dump(const std::string& name, const std::string& snapshot_dir);
 
@@ -55,9 +52,8 @@ class Table {
   void add_columns(const std::vector<std::string>& col_names,
                    const std::vector<DataType>& col_types,
                    const std::vector<Property>& default_property_values,
-                   size_t column_size,
-                   const std::vector<StorageStrategy>& strategies_ = {},
-                   int memory_level = 0);
+                   size_t capacity,
+                   MemoryLevel memory_level = MemoryLevel::kInMemory);
 
   const std::vector<std::string>& column_names() const;
 
@@ -123,8 +119,7 @@ class Table {
   void mark_column_deleted(const std::string& col_name);
   void buildColumnPtrs();
   void initColumns(const std::vector<std::string>& col_name,
-                   const std::vector<DataType>& types,
-                   const std::vector<StorageStrategy>& strategies_);
+                   const std::vector<DataType>& types);
 
   std::unordered_map<std::string, int> col_id_map_;
   std::vector<std::string> col_names_;

--- a/include/neug/utils/property/types.h
+++ b/include/neug/utils/property/types.h
@@ -87,12 +87,6 @@ static constexpr const char* DT_TIMESTAMP =
     "DT_TIMESTAMP";  // millisecond timestamp
 static constexpr const uint16_t STRING_DEFAULT_MAX_LENGTH = 256;
 
-enum class StorageStrategy {
-  kNone,
-  kMem,
-  kDisk,
-};
-
 enum class EdgeStrategy {
   kNone,
   kSingle,
@@ -452,6 +446,7 @@ static const DateTime DEFAULT_DATE_TIME_VALUE = DateTime(0);
 namespace std {
 
 std::string to_string(neug::DataTypeId type);
+std::string to_string(neug::MemoryLevel level);
 
 inline ostream& operator<<(ostream& os, const neug::EdgeStrategy& strategy) {
   switch (strategy) {

--- a/src/main/neug_db.cc
+++ b/src/main/neug_db.cc
@@ -215,18 +215,12 @@ void NeugDB::initAllocators() {
   // Initialize the default allocator for ingesting wals
   remove_directory(allocator_dir(work_dir_));
   std::filesystem::create_directories(allocator_dir(work_dir_));
-  MemoryStrategy strategy = MemoryStrategy::kMemoryOnly;
-  if (config_.memory_level == 0) {
-    strategy = MemoryStrategy::kSyncToFile;
-  } else if (config_.memory_level >= 2) {
-    strategy = MemoryStrategy::kHugepagePrefered;
-  }
   assert(config_.thread_num > 0);
   for (int i = 0; i < config_.thread_num; ++i) {
     allocators_.emplace_back(std::make_shared<Allocator>(
-        strategy, strategy != MemoryStrategy::kSyncToFile
-                      ? ""
-                      : wal_ingest_allocator_prefix(work_dir_, i)));
+        config_.memory_level, config_.memory_level != MemoryLevel::kSyncToFile
+                                  ? ""
+                                  : wal_ingest_allocator_prefix(work_dir_, i)));
   }
 }
 

--- a/src/storages/graph/edge_table.cc
+++ b/src/storages/graph/edge_table.cc
@@ -548,80 +548,46 @@ void load_statistic_file(const std::string& work_dir,
   table_idx_atomic.store(size);
 }
 
-void EdgeTable::Open(const std::string& work_dir) {
+void EdgeTable::Open(const std::string& work_dir, MemoryLevel memory_level) {
   work_dir_ = work_dir;
-  memory_level_ = 0;
-  auto checkpoint_dir_path = checkpoint_dir(work_dir);
-  in_csr_->open(ie_prefix(meta_->src_label_name, meta_->dst_label_name,
-                          meta_->edge_label_name),
-                checkpoint_dir_path, work_dir);
-  out_csr_->open(oe_prefix(meta_->src_label_name, meta_->dst_label_name,
-                           meta_->edge_label_name),
-                 checkpoint_dir_path, work_dir);
-  if (!meta_->is_bundled()) {
-    table_->open(edata_prefix(meta_->src_label_name, meta_->dst_label_name,
-                              meta_->edge_label_name),
-                 work_dir, meta_->property_names, meta_->properties,
-                 meta_->strategies);
-    assert(table_->col_num() > 0);
-    size_t table_cap = table_->get_column_by_id(0)->size();
-    load_statistic_file(work_dir, meta_->src_label_name, meta_->dst_label_name,
-                        meta_->edge_label_name, capacity_, table_idx_);
-    if (table_cap != capacity_.load()) {
-      THROW_INVALID_ARGUMENT_EXCEPTION(
-          "capacity in statistic file not match actual table capacity, maybe "
-          "the graph is not dumped properly");
-    }
+  memory_level_ = memory_level;
+  auto ckp_dir_path = checkpoint_dir(work_dir);
+  auto ie_prefix_path = ie_prefix(meta_->src_label_name, meta_->dst_label_name,
+                                  meta_->edge_label_name);
+  auto oe_prefix_path = oe_prefix(meta_->src_label_name, meta_->dst_label_name,
+                                  meta_->edge_label_name);
+  auto edata_prefix_path = edata_prefix(
+      meta_->src_label_name, meta_->dst_label_name, meta_->edge_label_name);
+  if (memory_level == MemoryLevel::kSyncToFile) {
+    in_csr_->open(ie_prefix_path, ckp_dir_path, work_dir);
+    out_csr_->open(oe_prefix_path, ckp_dir_path, work_dir);
+  } else if (memory_level == MemoryLevel::kInMemory) {
+    in_csr_->open_in_memory(ckp_dir_path + "/" + ie_prefix_path);
+    out_csr_->open_in_memory(ckp_dir_path + "/" + oe_prefix_path);
+  } else if (memory_level == MemoryLevel::kHugePagePrefered) {
+    in_csr_->open_with_hugepages(ckp_dir_path + "/" + ie_prefix_path);
+    out_csr_->open_with_hugepages(ckp_dir_path + "/" + oe_prefix_path);
+  } else {
+    THROW_INVALID_ARGUMENT_EXCEPTION(
+        "unsupported memory level: " +
+        std::to_string(static_cast<int>(memory_level)));
   }
-}
 
-void EdgeTable::OpenInMemory(const std::string& work_dir) {
-  work_dir_ = work_dir;
-  memory_level_ = 1;
-  auto checkpoint_dir_path = checkpoint_dir(work_dir);
-  in_csr_->open_in_memory(checkpoint_dir_path + "/" +
-                          ie_prefix(meta_->src_label_name,
-                                    meta_->dst_label_name,
-                                    meta_->edge_label_name));
-  out_csr_->open_in_memory(checkpoint_dir_path + "/" +
-                           oe_prefix(meta_->src_label_name,
-                                     meta_->dst_label_name,
-                                     meta_->edge_label_name));
   if (!meta_->is_bundled()) {
-    table_->open_in_memory(
-        edata_prefix(meta_->src_label_name, meta_->dst_label_name,
-                     meta_->edge_label_name),
-        work_dir_, meta_->property_names, meta_->properties, meta_->strategies);
-    assert(table_->col_num() > 0);
-    size_t table_cap = table_->get_column_by_id(0)->size();
-    load_statistic_file(work_dir, meta_->src_label_name, meta_->dst_label_name,
-                        meta_->edge_label_name, capacity_, table_idx_);
-    if (table_cap != capacity_.load()) {
+    if (memory_level == MemoryLevel::kSyncToFile) {
+      table_->open(edata_prefix_path, work_dir_, meta_->property_names,
+                   meta_->properties);
+    } else if (memory_level == MemoryLevel::kInMemory) {
+      table_->open_in_memory(edata_prefix_path, work_dir_,
+                             meta_->property_names, meta_->properties);
+    } else if (memory_level == MemoryLevel::kHugePagePrefered) {
+      table_->open_with_hugepages(edata_prefix_path, work_dir_,
+                                  meta_->property_names, meta_->properties);
+    } else {
       THROW_INVALID_ARGUMENT_EXCEPTION(
-          "capacity in statistic file not match actual table capacity, maybe "
-          "the graph is not dumped properly");
+          "unsupported memory level: " +
+          std::to_string(static_cast<int>(memory_level)));
     }
-  }
-}
-
-void EdgeTable::OpenWithHugepages(const std::string& work_dir) {
-  work_dir_ = work_dir;
-  memory_level_ = 2;  // 2 or 3?
-  auto checkpoint_dir_path = checkpoint_dir(work_dir);
-  in_csr_->open_with_hugepages(checkpoint_dir_path + "/" +
-                               ie_prefix(meta_->src_label_name,
-                                         meta_->dst_label_name,
-                                         meta_->edge_label_name));
-  out_csr_->open_with_hugepages(checkpoint_dir_path + "/" +
-                                oe_prefix(meta_->src_label_name,
-                                          meta_->dst_label_name,
-                                          meta_->edge_label_name));
-  if (!meta_->is_bundled()) {
-    table_->open_with_hugepages(
-        edata_prefix(meta_->src_label_name, meta_->dst_label_name,
-                     meta_->edge_label_name),
-        work_dir_, meta_->property_names, meta_->properties, meta_->strategies,
-        (memory_level_ > 2));
     assert(table_->col_num() > 0);
     size_t table_cap = table_->get_column_by_id(0)->size();
     load_statistic_file(work_dir, meta_->src_label_name, meta_->dst_label_name,
@@ -819,8 +785,7 @@ EdgeDataAccessor EdgeTable::get_edge_data_accessor(
 
 void EdgeTable::AddProperties(const std::vector<std::string>& prop_names,
                               const std::vector<DataType>& prop_types,
-                              const std::vector<Property>& default_values,
-                              const std::vector<StorageStrategy>& strategies) {
+                              const std::vector<Property>& default_values) {
   if (prop_names.empty()) {
     return;
   }
@@ -837,7 +802,7 @@ void EdgeTable::AddProperties(const std::vector<std::string>& prop_names,
   } else {
     size_t property_size = table_->get_column_by_id(0)->size();
     table_->add_columns(prop_names, prop_types, default_values, property_size,
-                        strategies, memory_level_);
+                        memory_level_);
   }
 }
 
@@ -1074,7 +1039,7 @@ void EdgeTable::dropAndCreateNewBundledCSR(
         std::get<1>(edges), std::get<0>(edges), property_type,
         meta_->default_property_values[0], new_in_csr.get());
   } else {
-    auto row_id_col = std::make_shared<ULongColumn>(StorageStrategy::kMem);
+    auto row_id_col = std::make_shared<ULongColumn>();
     auto edges = out_csr_->batch_export(row_id_col);
     std::vector<Property> remaining_data;
     remaining_data.reserve(row_id_col->size());
@@ -1122,7 +1087,7 @@ void EdgeTable::dropAndCreateNewUnbundledCSR(bool delete_property) {
     LOG(INFO) << "rebuild unbundled edge csr with edge properties: "
               << meta_->property_names.size();
     table_->open_in_memory(next_table_prefix, work_dir_, meta_->property_names,
-                           meta_->properties, meta_->strategies);
+                           meta_->properties);
   }
 
   std::shared_ptr<ColumnBase> prev_data_col = nullptr;

--- a/src/storages/graph/property_graph.cc
+++ b/src/storages/graph/property_graph.cc
@@ -39,7 +39,7 @@ namespace neug {
 PropertyGraph::PropertyGraph()
     : vertex_label_total_count_(0),
       edge_label_total_count_(0),
-      memory_level_(1) {}
+      memory_level_(MemoryLevel::kInMemory) {}
 
 PropertyGraph::~PropertyGraph() { Clear(); }
 
@@ -218,12 +218,11 @@ Status PropertyGraph::CreateVertexType(
     default_property_values.erase(default_property_values.begin() +
                                   primary_key_inds[i]);
   }
-  std::vector<StorageStrategy> strategies(property_types.size(),
-                                          StorageStrategy::kMem);
+
   std::string description;
   schema_.AddVertexLabel(vertex_type_name, property_types, property_names,
-                         primary_keys, strategies, Schema::MAX_VNUM,
-                         description, default_property_values);
+                         primary_keys, Schema::MAX_VNUM, description,
+                         default_property_values);
   label_t vertex_label_id = schema_.get_vertex_label_id(vertex_type_name);
   if (vertex_label_id < vertex_tables_.size()) {
     auto& vtable = vertex_tables_[vertex_label_id];
@@ -309,7 +308,7 @@ Status PropertyGraph::CreateEdgeType(
   bool cur_sort_on_compaction = false;
   std::string description;
   schema_.AddEdgeLabel(src_vertex_type, dst_vertex_type, edge_type_name,
-                       property_types, property_names, {}, cur_oe, cur_ie,
+                       property_types, property_names, cur_oe, cur_ie,
                        oe_mutable, ie_mutable, cur_sort_on_compaction,
                        description, default_property_values);
   edge_label_total_count_ = schema_.edge_label_frontier();
@@ -330,7 +329,7 @@ Status PropertyGraph::CreateEdgeType(
       vertex_tables_[src_label_i].get_indexer().capacity(), (size_t) 4096);
   auto dst_v_capacity = std::max(
       vertex_tables_[dst_label_i].get_indexer().capacity(), (size_t) 4096);
-  edge_tables_.at(index).OpenInMemory(work_dir_);
+  edge_tables_.at(index).Open(work_dir_, memory_level_);
   edge_tables_.at(index).EnsureCapacity(src_v_capacity, dst_v_capacity, 4096);
 
   return neug::Status::OK();
@@ -345,7 +344,6 @@ Status PropertyGraph::AddVertexProperties(
                             error_on_conflict);
   std::vector<std::string> add_property_names;
   std::vector<DataType> add_property_types;
-  std::vector<StorageStrategy> add_property_storages;
   std::vector<Property> add_default_property_values;
   for (size_t i = 0; i < add_properties.size(); i++) {
     auto [property_type, property_name, default_value] = add_properties[i];
@@ -365,18 +363,10 @@ Status PropertyGraph::AddVertexProperties(
     }
     add_property_names.emplace_back(property_name);
     add_property_types.emplace_back(property_type);
-    if (memory_level_ == 0) {
-      add_property_storages.emplace_back(StorageStrategy::kDisk);
-    } else if (memory_level_ >= 1) {
-      add_property_storages.emplace_back(StorageStrategy::kMem);
-    } else {
-      add_property_storages.emplace_back(StorageStrategy::kNone);
-    }
     add_default_property_values.emplace_back(default_value);
   }
   schema_.AddVertexProperties(vertex_type_name, add_property_names,
-                              add_property_types, add_property_storages,
-                              add_default_property_values);
+                              add_property_types, add_default_property_values);
   label_t v_label = schema_.get_vertex_label_id(vertex_type_name);
   vertex_tables_[v_label].AddProperties(add_property_names, add_property_types,
                                         add_default_property_values);
@@ -795,12 +785,13 @@ void PropertyGraph::DumpSchema() {
 }
 
 void PropertyGraph::Open(const Schema& schema, const std::string& work_dir,
-                         int memory_level) {
+                         MemoryLevel memory_level) {
   schema_ = schema;
   Open(work_dir, memory_level);
 }
 
-void PropertyGraph::Open(const std::string& work_dir, int memory_level) {
+void PropertyGraph::Open(const std::string& work_dir,
+                         MemoryLevel memory_level) {
   // copy work_dir to work_dir_
   memory_level_ = memory_level;
   work_dir_.assign(work_dir);
@@ -818,11 +809,6 @@ void PropertyGraph::Open(const std::string& work_dir, int memory_level) {
     if (!schema_.vertex_label_valid(i)) {
       THROW_INTERNAL_EXCEPTION("Invalid vertex label id: " + std::to_string(i));
     }
-    std::string v_label_name = schema_.get_vertex_label_name(i);
-    auto properties = schema_.get_vertex_properties(i);
-    auto property_names = schema_.get_vertex_property_names(i);
-    auto property_strategies =
-        schema_.get_vertex_storage_strategies(v_label_name);
     vertex_tables_.emplace_back(schema_.get_vertex_schema(i));
   }
 
@@ -881,13 +867,7 @@ void PropertyGraph::Open(const std::string& work_dir, int memory_level) {
 
         EdgeTable edge_table(
             schema_.get_edge_schema(src_label_i, dst_label_i, e_label_i));
-        if (memory_level == 0) {
-          edge_table.Open(work_dir_);
-        } else if (memory_level >= 2) {
-          edge_table.OpenWithHugepages(work_dir_);
-        } else {
-          edge_table.OpenInMemory(work_dir_);
-        }
+        edge_table.Open(work_dir_, memory_level_);
         auto e_size = edge_table.Size();
         size_t e_capacity = e_size < 4096 ? 4096 : e_size + (e_size + 4) / 5;
         edge_table.EnsureCapacity(vertex_capacities[src_label_i],

--- a/src/storages/graph/schema.cc
+++ b/src/storages/graph/schema.cc
@@ -64,20 +64,17 @@ void VertexSchema::clear() {
   property_types.clear();
   property_names.clear();
   primary_keys.clear();
-  storage_strategies.clear();
   default_property_values.clear();
   default_property_strings.clear();
   vprop_soft_deleted.clear();
 }
 
-void VertexSchema::add_properties(
-    const std::vector<std::string>& names, const std::vector<DataType>& types,
-    const std::vector<StorageStrategy>& strategies,
-    const std::vector<Property>& default_values) {
+void VertexSchema::add_properties(const std::vector<std::string>& names,
+                                  const std::vector<DataType>& types,
+                                  const std::vector<Property>& default_values) {
   for (size_t i = 0; i < names.size(); i++) {
     property_names.emplace_back(names[i]);
     property_types.emplace_back(types[i]);
-    storage_strategies.emplace_back(strategies[i]);
     vprop_soft_deleted.emplace_back(false);
     if (default_values.size() > i)
       default_property_values.emplace_back(default_values[i]);
@@ -88,13 +85,9 @@ void VertexSchema::add_properties(
   process_default_values(default_property_values, default_property_strings);
 }
 
-void VertexSchema::set_properties(
-    const std::vector<DataType>& types,
-    const std::vector<StorageStrategy>& strategies,
-    const std::vector<Property>& default_values) {
+void VertexSchema::set_properties(const std::vector<DataType>& types,
+                                  const std::vector<Property>& default_values) {
   property_types = types;
-  storage_strategies = strategies;
-  storage_strategies.resize(types.size(), StorageStrategy::kMem);
   default_property_values = default_values;
   process_default_values(default_property_values, default_property_strings);
   vprop_soft_deleted.resize(property_types.size(), false);
@@ -134,7 +127,6 @@ void VertexSchema::delete_properties(const std::vector<std::string>& names,
       if (!is_soft) {
         property_names.erase(property_names.begin() + j);
         property_types.erase(property_types.begin() + j);
-        storage_strategies.erase(storage_strategies.begin() + j);
         default_property_values.erase(default_property_values.begin() + j);
         vprop_soft_deleted.erase(vprop_soft_deleted.begin() + j);
       } else {
@@ -264,10 +256,9 @@ bool EdgeSchema::has_property(const std::string& prop) const {
   return false;
 }
 
-void EdgeSchema::add_properties(
-    const std::vector<std::string>& names, const std::vector<DataType>& types,
-    const std::vector<StorageStrategy>& new_strategies,
-    const std::vector<Property>& default_values) {
+void EdgeSchema::add_properties(const std::vector<std::string>& names,
+                                const std::vector<DataType>& types,
+                                const std::vector<Property>& default_values) {
   for (size_t i = 0; i < names.size(); i++) {
     if (std::find(property_names.begin(), property_names.end(), names[i]) !=
         property_names.end()) {
@@ -277,8 +268,6 @@ void EdgeSchema::add_properties(
     }
     property_names.emplace_back(names[i]);
     properties.emplace_back(types[i]);
-    strategies.emplace_back(new_strategies.size() > i ? new_strategies[i]
-                                                      : StorageStrategy::kMem);
     if (default_values.size() > i)
       default_property_values.emplace_back(default_values[i]);
     else {
@@ -319,7 +308,6 @@ void EdgeSchema::delete_properties(const std::vector<std::string>& names,
       if (!is_soft) {
         property_names.erase(property_names.begin() + j);
         properties.erase(properties.begin() + j);
-        strategies.erase(strategies.begin() + j);
         default_property_values.erase(default_property_values.begin() + j);
         eprop_soft_deleted.erase(eprop_soft_deleted.begin() + j);
       } else {
@@ -407,8 +395,7 @@ void Schema::AddVertexLabel(
     const std::string& label, const std::vector<DataType>& property_types,
     const std::vector<std::string>& property_names,
     const std::vector<std::tuple<DataType, std::string, size_t>>& primary_key,
-    const std::vector<StorageStrategy>& strategies, size_t max_vnum,
-    const std::string& description,
+    size_t max_vnum, const std::string& description,
     const std::vector<Property>& default_property_values) {
   label_t v_label_id = vertex_label_to_index(label);
   if (vlabel_tomb_.get(v_label_id)) {  // Add back a deleted label
@@ -416,7 +403,7 @@ void Schema::AddVertexLabel(
   }
   v_schemas_.resize(v_label_id + 1);
   v_schemas_[v_label_id] = std::make_shared<VertexSchema>(
-      label, property_types, property_names, primary_key, strategies,
+      label, property_types, property_names, primary_key,
       default_property_values, description, max_vnum);
   VLOG(10) << "Add vertex label: " << label << ", id: " << (int) v_label_id
            << ", prop size: " << v_schemas_[v_label_id]->property_names.size();
@@ -425,8 +412,7 @@ void Schema::AddVertexLabel(
 void Schema::AddEdgeLabel(
     const std::string& src_label, const std::string& dst_label,
     const std::string& edge_label, const std::vector<DataType>& properties,
-    const std::vector<std::string>& prop_names,
-    const std::vector<StorageStrategy>& strategies, EdgeStrategy oe,
+    const std::vector<std::string>& prop_names, EdgeStrategy oe,
     EdgeStrategy ie, bool oe_mutable, bool ie_mutable, bool sort_on_compaction,
     const std::string& description,
     const std::vector<Property>& default_property_values) {
@@ -443,7 +429,7 @@ void Schema::AddEdgeLabel(
       label_id, std::make_shared<EdgeSchema>(
                     src_label, dst_label, edge_label, sort_on_compaction,
                     description, ie_mutable, oe_mutable, oe, ie, properties,
-                    prop_names, strategies, default_property_values));
+                    prop_names, default_property_values));
   if (label_id >= elabel_triplet_tomb_.size()) {
     elabel_triplet_tomb_.resize(label_id + 1);
   }
@@ -533,11 +519,9 @@ std::vector<label_t> Schema::get_edge_label_ids() const {
 
 void Schema::set_vertex_properties(
     label_t label_id, const std::vector<DataType>& types,
-    const std::vector<StorageStrategy>& strategies,
     const std::vector<Property>& default_property_values) {
   ensure_vertex_label_valid(label_id);
-  v_schemas_[label_id]->set_properties(types, strategies,
-                                       default_property_values);
+  v_schemas_[label_id]->set_properties(types, default_property_values);
 }
 
 std::vector<DataType> Schema::get_vertex_properties(
@@ -596,14 +580,6 @@ const std::string& Schema::get_vertex_description(
 const std::string& Schema::get_vertex_description(label_t label) const {
   ensure_vertex_label_valid(label);
   return v_schemas_[label]->description;
-}
-
-std::vector<StorageStrategy> Schema::get_vertex_storage_strategies(
-    const std::string& label) const {
-  label_t index = get_vertex_label_id(label);
-  ensure_vertex_label_valid(index);
-  return extract_with_invalid_flags(v_schemas_[index]->storage_strategies,
-                                    v_schemas_[index]->vprop_soft_deleted);
 }
 
 size_t Schema::get_max_vnum(const std::string& label) const {
@@ -946,13 +922,6 @@ bool Schema::Equals(const Schema& other) const {
         return false;
       }
     }
-    {
-      const auto& lhs = get_vertex_storage_strategies(label_name);
-      const auto& rhs = other.get_vertex_storage_strategies(label_name);
-      if (lhs != rhs) {
-        return false;
-      }
-    }
     if (get_max_vnum(label_name) != other.get_max_vnum(label_name)) {
       return false;
     }
@@ -1043,18 +1012,6 @@ void RelationToEdgeStrategy(const std::string& rel_str,
   }
 }
 
-StorageStrategy StringToStorageStrategy(const std::string& str) {
-  if (str == "None") {
-    return StorageStrategy::kNone;
-  } else if (str == "Mem") {
-    return StorageStrategy::kMem;
-  } else if (str == "Disk") {
-    return StorageStrategy::kDisk;
-  } else {
-    return StorageStrategy::kMem;
-  }
-}
-
 static bool parse_property_type(YAML::Node node, DataType& type) {
   try {
     type = node.as<neug::DataType>();
@@ -1065,10 +1022,10 @@ static bool parse_property_type(YAML::Node node, DataType& type) {
   }
 }
 
-static Status parse_vertex_properties(
-    YAML::Node node, const std::string& label_name,
-    std::vector<DataType>& types, std::vector<std::string>& names,
-    std::vector<StorageStrategy>& strategies) {
+static Status parse_vertex_properties(YAML::Node node,
+                                      const std::string& label_name,
+                                      std::vector<DataType>& types,
+                                      std::vector<std::string>& names) {
   if (!node || node.IsNull()) {
     VLOG(10) << "Found no vertex properties specified for vertex: "
              << label_name;
@@ -1088,7 +1045,7 @@ static Status parse_vertex_properties(
   }
 
   for (int i = 0; i < prop_num; ++i) {
-    std::string strategy_str, prop_name_str;
+    std::string prop_name_str;
     if (!get_scalar(node[i], "property_name", prop_name_str)) {
       LOG(ERROR) << "Name of vertex-" << label_name << " prop-" << i - 1
                  << " is not specified...";
@@ -1112,16 +1069,9 @@ static Status parse_vertex_properties(
                     "Fail to parse property type of vertex-" + label_name +
                         " prop-" + std::to_string(i - 1));
     }
-    {
-      if (node[i]["x_csr_params"]) {
-        get_scalar(node[i]["x_csr_params"], "storage_strategy", strategy_str);
-      }
-    }
     types.push_back(prop_type);
-    strategies.push_back(StringToStorageStrategy(strategy_str));
     VLOG(10) << "prop-" << i - 1 << " name: " << prop_name_str
-             << " type: " << prop_type.ToString()
-             << " strategy: " << strategy_str;
+             << " type: " << prop_type.ToString();
     names.push_back(prop_name_str);
   }
 
@@ -1131,8 +1081,7 @@ static Status parse_vertex_properties(
 static Status parse_edge_properties(YAML::Node node,
                                     const std::string& label_name,
                                     std::vector<DataType>& types,
-                                    std::vector<std::string>& names,
-                                    std::vector<StorageStrategy>& strategies) {
+                                    std::vector<std::string>& names) {
   if (!node || node.IsNull()) {
     VLOG(10) << "Found no edge properties specified for edge: " << label_name;
     return Status::OK();
@@ -1148,7 +1097,7 @@ static Status parse_edge_properties(YAML::Node node,
   int prop_num = node.size();
 
   for (int i = 0; i < prop_num; ++i) {
-    std::string strategy_str, prop_name_str;
+    std::string prop_name_str;
     if (!node[i]["property_type"]) {
       LOG(ERROR) << "type of edge-" << label_name << " prop-" << i - 1
                  << " is not specified...";
@@ -1165,11 +1114,6 @@ static Status parse_edge_properties(YAML::Node node,
                     "type of edge-" + label_name + " prop-" +
                         std::to_string(i - 1) + " is not specified...");
     }
-    {
-      if (node[i]["x_csr_params"]) {
-        get_scalar(node[i]["x_csr_params"], "storage_strategy", strategy_str);
-      }
-    }
 
     if (!get_scalar(node[i], "property_name", prop_name_str)) {
       LOG(ERROR) << "name of edge-" << label_name << " prop-" << i - 1
@@ -1181,7 +1125,6 @@ static Status parse_edge_properties(YAML::Node node,
 
     types.push_back(prop_type);
     names.push_back(prop_name_str);
-    strategies.push_back(StringToStorageStrategy(strategy_str));
   }
 
   return Status::OK();
@@ -1207,7 +1150,6 @@ static Status parse_vertex_schema(YAML::Node node, Schema& schema) {
   }
   std::vector<DataType> property_types;
   std::vector<std::string> property_names;
-  std::vector<StorageStrategy> strategies;
   std::string description;  // default is empty string
 
   if (node["description"]) {
@@ -1227,8 +1169,7 @@ static Status parse_vertex_schema(YAML::Node node, Schema& schema) {
   }
 
   RETURN_IF_NOT_OK(parse_vertex_properties(node["properties"], label_name,
-                                           property_types, property_names,
-                                           strategies));
+                                           property_types, property_names));
   if (!node["primary_keys"]) {
     LOG(ERROR) << "Expect field primary_keys for " << label_name;
     return Status(StatusCode::ERR_INVALID_SCHEMA,
@@ -1279,11 +1220,10 @@ static Status parse_vertex_schema(YAML::Node node, Schema& schema) {
     // remove primary key from properties.
     property_names.erase(property_names.begin() + primary_key_inds[i]);
     property_types.erase(property_types.begin() + primary_key_inds[i]);
-    strategies.erase(strategies.begin() + primary_key_inds[i]);
   }
 
   schema.AddVertexLabel(label_name, property_types, property_names,
-                        primary_keys, strategies, max_num, description);
+                        primary_keys, max_num, description);
   // check the type_id equals to storage's label_id
   int32_t type_id;
   if (!get_scalar(node, "type_id", type_id)) {
@@ -1323,11 +1263,9 @@ static Status parse_edge_schema(YAML::Node node, Schema& schema) {
 
   std::vector<DataType> property_types;
   std::vector<std::string> prop_names;
-  std::vector<StorageStrategy> strategies;
   std::string description;  // default is empty string
   RETURN_IF_NOT_OK(parse_edge_properties(node["properties"], edge_label_name,
-                                         property_types, prop_names,
-                                         strategies));
+                                         property_types, prop_names));
 
   if (node["description"]) {
     description = node["description"].as<std::string>();
@@ -1511,9 +1449,8 @@ static Status parse_edge_schema(YAML::Node node, Schema& schema) {
              << " to " << dst_label_name << " with " << property_types.size()
              << " properties";
     schema.AddEdgeLabel(src_label_name, dst_label_name, edge_label_name,
-                        property_types, prop_names, strategies, cur_oe, cur_ie,
-                        oe_mutable, ie_mutable, cur_sort_on_compaction,
-                        description);
+                        property_types, prop_names, cur_oe, cur_ie, oe_mutable,
+                        ie_mutable, cur_sort_on_compaction, description);
   }
 
   // check the type_id equals to storage's label_id
@@ -1826,12 +1763,10 @@ neug::result<YAML::Node> Schema::DumpToYaml(const Schema& schema) {
 void Schema::AddVertexProperties(
     const std::string& label, const std::vector<std::string>& properties_names,
     const std::vector<DataType>& properties_types,
-    const std::vector<StorageStrategy>& storage_strategies,
     const std::vector<Property>& properties_default_values) {
   auto v_label_id = get_vertex_label_id(label);
   assert(v_label_id < v_schemas_.size());
   v_schemas_[v_label_id]->add_properties(properties_names, properties_types,
-                                         storage_strategies,
                                          properties_default_values);
 }
 
@@ -2003,7 +1938,7 @@ void Schema::AddEdgeProperties(
   uint32_t index = generate_edge_label(src, dst, edge);
   // Check if the property name already exists
   assert(e_schemas_.count(index) > 0);
-  e_schemas_.at(index)->add_properties(properties_names, properties_types, {},
+  e_schemas_.at(index)->add_properties(properties_names, properties_types,
                                        properties_default_values);
 }
 
@@ -2295,17 +2230,16 @@ OutArchive& operator>>(OutArchive& out_archive, DataType& type) {
 InArchive& operator<<(InArchive& archive, const VertexSchema& v_schema) {
   archive << v_schema.label_name << v_schema.property_types
           << v_schema.property_names << v_schema.primary_keys
-          << v_schema.storage_strategies << v_schema.default_property_values
-          << v_schema.description << v_schema.max_num
-          << v_schema.vprop_soft_deleted;
+          << v_schema.default_property_values << v_schema.description
+          << v_schema.max_num << v_schema.vprop_soft_deleted;
   return archive;
 }
 
 OutArchive& operator>>(OutArchive& archive, VertexSchema& v_schema) {
   archive >> v_schema.label_name >> v_schema.property_types >>
       v_schema.property_names >> v_schema.primary_keys >>
-      v_schema.storage_strategies >> v_schema.default_property_values >>
-      v_schema.description >> v_schema.max_num >> v_schema.vprop_soft_deleted;
+      v_schema.default_property_values >> v_schema.description >>
+      v_schema.max_num >> v_schema.vprop_soft_deleted;
   process_default_values(v_schema.default_property_values,
                          v_schema.default_property_strings);
   return archive;
@@ -2316,8 +2250,8 @@ InArchive& operator<<(InArchive& archive, const EdgeSchema& e_schema) {
           << e_schema.edge_label_name << e_schema.sort_on_compaction
           << e_schema.description << e_schema.ie_mutable << e_schema.oe_mutable
           << e_schema.ie_strategy << e_schema.oe_strategy << e_schema.properties
-          << e_schema.property_names << e_schema.strategies
-          << e_schema.default_property_values << e_schema.eprop_soft_deleted;
+          << e_schema.property_names << e_schema.default_property_values
+          << e_schema.eprop_soft_deleted;
   return archive;
 }
 
@@ -2326,8 +2260,8 @@ OutArchive& operator>>(OutArchive& archive, EdgeSchema& e_schema) {
       e_schema.edge_label_name >> e_schema.sort_on_compaction >>
       e_schema.description >> e_schema.ie_mutable >> e_schema.oe_mutable >>
       e_schema.ie_strategy >> e_schema.oe_strategy >> e_schema.properties >>
-      e_schema.property_names >> e_schema.strategies >>
-      e_schema.default_property_values >> e_schema.eprop_soft_deleted;
+      e_schema.property_names >> e_schema.default_property_values >>
+      e_schema.eprop_soft_deleted;
   process_default_values(e_schema.default_property_values,
                          e_schema.default_property_strings);
   return archive;

--- a/src/storages/graph/vertex_table.cc
+++ b/src/storages/graph/vertex_table.cc
@@ -19,7 +19,7 @@
 
 namespace neug {
 
-void VertexTable::Open(const std::string& work_dir, int memory_level) {
+void VertexTable::Open(const std::string& work_dir, MemoryLevel memory_level) {
   memory_level_ = memory_level;
   work_dir_ = work_dir;
   std::string tmp_dir_path = tmp_dir(work_dir_);
@@ -30,29 +30,26 @@ void VertexTable::Open(const std::string& work_dir, int memory_level) {
       checkpoint_dir_path + "/" + vertex_tracker_file(label_name);
   auto indexer_filename =
       IndexerType::prefix() + "_" + vertex_map_prefix(label_name);
-  if (memory_level_ == 0) {
+  if (memory_level_ == MemoryLevel::kSyncToFile) {
     indexer_.open(indexer_filename, checkpoint_dir_path, work_dir_);
     table_->open(vertex_table_prefix(label_name), work_dir_,
-                 vertex_schema_->property_names, vertex_schema_->property_types,
-                 vertex_schema_->storage_strategies);
+                 vertex_schema_->property_names,
+                 vertex_schema_->property_types);
 
-  } else if (memory_level_ == 1) {
+  } else if (memory_level_ == MemoryLevel::kInMemory) {
     indexer_.open_in_memory(checkpoint_dir_path + "/" + indexer_filename);
     table_->open_in_memory(vertex_table_prefix(label_name), work_dir_,
                            vertex_schema_->property_names,
-                           vertex_schema_->property_types,
-                           vertex_schema_->storage_strategies);
+                           vertex_schema_->property_types);
 
-  } else if (memory_level_ >= 2) {
-    indexer_.open_with_hugepages(checkpoint_dir_path + "/" + indexer_filename,
-                                 (memory_level_ > 2));
-    table_->open_with_hugepages(
-        vertex_table_prefix(label_name), work_dir_,
-        vertex_schema_->property_names, vertex_schema_->property_types,
-        vertex_schema_->storage_strategies, (memory_level_ > 2));
+  } else if (memory_level_ == MemoryLevel::kHugePagePrefered) {
+    indexer_.open_with_hugepages(checkpoint_dir_path + "/" + indexer_filename);
+    table_->open_with_hugepages(vertex_table_prefix(label_name), work_dir_,
+                                vertex_schema_->property_names,
+                                vertex_schema_->property_types);
   } else {
-    THROW_INTERNAL_EXCEPTION("Invalid memory level: " +
-                             std::to_string(memory_level_));
+    THROW_INVALID_ARGUMENT_EXCEPTION("Invalid memory level: " +
+                                     std::to_string(memory_level_));
   }
   v_ts_.Open(vertex_tracker_filename);
 }
@@ -243,13 +240,11 @@ void VertexTable::DeleteProperties(const std::vector<std::string>& properties) {
   }
 }
 
-void VertexTable::AddProperties(
-    const std::vector<std::string>& properties,
-    const std::vector<DataType>& types,
-    const std::vector<Property>& default_values,
-    const std::vector<StorageStrategy>& strategies) {
+void VertexTable::AddProperties(const std::vector<std::string>& properties,
+                                const std::vector<DataType>& types,
+                                const std::vector<Property>& default_values) {
   table_->add_columns(properties, types, default_values, indexer_.capacity(),
-                      strategies, memory_level_);
+                      memory_level_);
 }
 
 void VertexTable::Drop() {

--- a/src/utils/property/column.cc
+++ b/src/utils/property/column.cc
@@ -52,126 +52,32 @@ std::string_view truncate_utf8(std::string_view str, size_t length) {
   return str.substr(0, byte_count);
 }
 
-template <typename T>
-class TypedEmptyColumn : public ColumnBase {
- public:
-  TypedEmptyColumn() {}
-  ~TypedEmptyColumn() {}
-
-  void open(const std::string& name, const std::string& snapshot_dir,
-            const std::string& work_dir) override {}
-  void open_in_memory(const std::string& name) override {}
-  void open_with_hugepages(const std::string& name, bool force) override {}
-  void dump(const std::string& filename) override {}
-  void close() override {}
-  size_t size() const override { return 0; }
-  void resize(size_t size) override {}
-  void resize(size_t size, const Property& default_value) override {}
-
-  DataTypeId type() const override { return PropUtils<T>::prop_type(); }
-
-  void set_value(size_t index, const T& val) {}
-
-  void set_any(size_t index, const Property& value, bool insert_safe) override {
-  }
-
-  T get_view(size_t index) const { return T{}; }
-
-  Property get_prop(size_t index) const override { return Property(); }
-
-  void ingest(uint32_t index, OutArchive& arc) override {
-    T val;
-    arc >> val;
-  }
-
-  StorageStrategy storage_strategy() const override {
-    return StorageStrategy::kNone;
-  }
-
-  void ensure_writable(const std::string& work_dir) override {}
-};
-
-template <>
-class TypedEmptyColumn<std::string_view> : public ColumnBase {
- public:
-  TypedEmptyColumn() {}
-  ~TypedEmptyColumn() {}
-
-  void open(const std::string& name, const std::string& snapshot_dir,
-            const std::string& work_dir) override {}
-  void open_in_memory(const std::string& name) override {}
-  void open_with_hugepages(const std::string& name, bool force) override {}
-  void dump(const std::string& filename) override {}
-  void close() override {}
-  size_t size() const override { return 0; }
-  void resize(size_t size) override {}
-  void resize(size_t size, const Property& default_value) override {}
-
-  DataTypeId type() const override { return DataTypeId::kVarchar; }
-
-  void set_value(size_t index, const std::string_view& val) {}
-
-  void set_any(size_t index, const Property& value, bool insert_safe) override {
-  }
-
-  std::string_view get_view(size_t index) const { return std::string_view{}; }
-
-  Property get_prop(size_t index) const override { return Property(); }
-
-  void ingest(uint32_t index, OutArchive& arc) override {
-    std::string_view val;
-    arc >> val;
-  }
-
-  StorageStrategy storage_strategy() const override {
-    return StorageStrategy::kNone;
-  }
-
-  void ensure_writable(const std::string& work_dir) override {}
-};
-
-std::shared_ptr<ColumnBase> CreateColumn(DataType type,
-                                         StorageStrategy strategy) {
+std::shared_ptr<ColumnBase> CreateColumn(DataType type) {
   auto type_id = type.id();
   auto extra_type_info = type.RawExtraTypeInfo();
-  if (strategy == StorageStrategy::kNone) {
-    switch (type_id) {
+  switch (type_id) {
 #define TYPE_DISPATCHER(enum_val, type) \
   case DataTypeId::enum_val:            \
-    return std::make_shared<TypedEmptyColumn<type>>();
-      FOR_EACH_DATA_TYPE_NO_STRING(TYPE_DISPATCHER)
+    return std::make_shared<TypedColumn<type>>();
+    FOR_EACH_DATA_TYPE_NO_STRING(TYPE_DISPATCHER)
 #undef TYPE_DISPATCHER
-    case DataTypeId::kVarchar:
-      return std::make_shared<TypedEmptyColumn<std::string_view>>();
-    default:
-      THROW_NOT_SUPPORTED_EXCEPTION("Unsupported type for empty column: " +
-                                    type.ToString());
-    }
-  } else {
-    switch (type_id) {
-#define TYPE_DISPATCHER(enum_val, type) \
-  case DataTypeId::enum_val:            \
-    return std::make_shared<TypedColumn<type>>(strategy);
-      FOR_EACH_DATA_TYPE_NO_STRING(TYPE_DISPATCHER)
-#undef TYPE_DISPATCHER
-    case DataTypeId::kVarchar: {
-      uint16_t max_length = STRING_DEFAULT_MAX_LENGTH;
-      if (extra_type_info) {
-        auto str_info = dynamic_cast<const StringTypeInfo*>(extra_type_info);
-        if (str_info) {
-          max_length = str_info->max_length;
-        }
+  case DataTypeId::kVarchar: {
+    uint16_t max_length = STRING_DEFAULT_MAX_LENGTH;
+    if (extra_type_info) {
+      auto str_info = dynamic_cast<const StringTypeInfo*>(extra_type_info);
+      if (str_info) {
+        max_length = str_info->max_length;
       }
-      return std::make_shared<StringColumn>(strategy, max_length);
     }
-    case DataTypeId::kEmpty: {
-      return std::make_shared<TypedColumn<EmptyType>>(strategy);
-    }
-    default: {
-      THROW_NOT_SUPPORTED_EXCEPTION("Unsupported type for column: " +
-                                    type.ToString());
-    }
-    }
+    return std::make_shared<StringColumn>(max_length);
+  }
+  case DataTypeId::kEmpty: {
+    return std::make_shared<TypedColumn<EmptyType>>();
+  }
+  default: {
+    THROW_NOT_SUPPORTED_EXCEPTION("Unsupported type for column: " +
+                                  type.ToString());
+  }
   }
 }
 

--- a/src/utils/property/table.cc
+++ b/src/utils/property/table.cc
@@ -32,15 +32,12 @@ Table::Table() : touched_(false) {}
 Table::~Table() { close(); }
 
 void Table::initColumns(const std::vector<std::string>& col_name,
-                        const std::vector<DataType>& property_types,
-                        const std::vector<StorageStrategy>& strategies_) {
+                        const std::vector<DataType>& property_types) {
   size_t col_num = col_name.size();
   columns_.clear();
   col_names_.clear();
   col_id_map_.clear();
   columns_.resize(col_num, nullptr);
-  auto strategies = strategies_;
-  strategies.resize(col_num, StorageStrategy::kMem);
 
   for (size_t i = 0; i < col_num; ++i) {
     int col_id = col_names_.size();
@@ -54,12 +51,11 @@ void Table::initColumns(const std::vector<std::string>& col_name,
 
 void Table::open(const std::string& name, const std::string& work_dir,
                  const std::vector<std::string>& col_name,
-                 const std::vector<DataType>& property_types,
-                 const std::vector<StorageStrategy>& strategies_) {
+                 const std::vector<DataType>& property_types) {
   name_ = name;
   work_dir_ = work_dir;
   snapshot_dir_ = checkpoint_dir(work_dir_);
-  initColumns(col_name, property_types, strategies_);
+  initColumns(col_name, property_types);
   for (size_t i = 0; i < columns_.size(); ++i) {
     columns_[i]->open(name + ".col_" + std::to_string(i), snapshot_dir_,
                       tmp_dir(work_dir));
@@ -70,12 +66,11 @@ void Table::open(const std::string& name, const std::string& work_dir,
 
 void Table::open_in_memory(const std::string& name, const std::string& work_dir,
                            const std::vector<std::string>& col_name,
-                           const std::vector<DataType>& property_types,
-                           const std::vector<StorageStrategy>& strategies_) {
+                           const std::vector<DataType>& property_types) {
   name_ = name;
   work_dir_ = work_dir;
   snapshot_dir_ = checkpoint_dir(work_dir_);
-  initColumns(col_name, property_types, strategies_);
+  initColumns(col_name, property_types);
   for (size_t i = 0; i < columns_.size(); ++i) {
     columns_[i]->open_in_memory(snapshot_dir_ + "/" + name + ".col_" +
                                 std::to_string(i));
@@ -87,16 +82,14 @@ void Table::open_in_memory(const std::string& name, const std::string& work_dir,
 void Table::open_with_hugepages(const std::string& name,
                                 const std::string& work_dir,
                                 const std::vector<std::string>& col_name,
-                                const std::vector<DataType>& property_types,
-                                const std::vector<StorageStrategy>& strategies_,
-                                bool force) {
+                                const std::vector<DataType>& property_types) {
   name_ = name;
   work_dir_ = work_dir;
   snapshot_dir_ = checkpoint_dir(work_dir);
-  initColumns(col_name, property_types, strategies_);
+  initColumns(col_name, property_types);
   for (size_t i = 0; i < columns_.size(); ++i) {
-    columns_[i]->open_with_hugepages(
-        snapshot_dir_ + "/" + name + ".col_" + std::to_string(i), force);
+    columns_[i]->open_with_hugepages(snapshot_dir_ + "/" + name + ".col_" +
+                                     std::to_string(i));
   }
   touched_ = true;
   buildColumnPtrs();
@@ -125,9 +118,7 @@ void Table::reset_header(const std::vector<std::string>& col_name) {
 void Table::add_columns(const std::vector<std::string>& col_names,
                         const std::vector<DataType>& col_types,
                         const std::vector<Property>& default_property_values,
-                        size_t capacity,
-                        const std::vector<StorageStrategy>& strategies_,
-                        int memory_level) {
+                        size_t capacity, MemoryLevel memory_level) {
   if (default_property_values.size() != col_names.size()) {
     THROW_RUNTIME_ERROR("default_property_values size mismatch: expected " +
                         std::to_string(col_names.size()) + " but got " +
@@ -146,19 +137,22 @@ void Table::add_columns(const std::vector<std::string>& col_names,
     int col_id = col_names_.size();
     col_id_map_.insert({col_names[i], col_id});
     col_names_.emplace_back(col_names[i]);
-    columns_[col_id] = CreateColumn(col_types[i], i < strategies_.size()
-                                                      ? strategies_[i]
-                                                      : StorageStrategy::kMem);
+    columns_[col_id] = CreateColumn(col_types[i]);
   }
   for (size_t i = old_size; i < columns_.size(); ++i) {
-    if (memory_level == 0) {
+    if (memory_level == MemoryLevel::kSyncToFile) {
       columns_[i]->open(name_ + ".col_" + std::to_string(i), "",
                         tmp_dir(work_dir_));
-    } else if (memory_level == 1) {
+    } else if (memory_level == MemoryLevel::kInMemory) {
       columns_[i]->open_in_memory(tmp_dir(work_dir_) + "/" + name_ + ".col_" +
                                   std::to_string(i));
+    } else if (memory_level == MemoryLevel::kHugePagePrefered) {
+      columns_[i]->open_with_hugepages(tmp_dir(work_dir_) + "/" + name_ +
+                                       ".col_" + std::to_string(i));
     } else {
-      THROW_NOT_IMPLEMENTED_EXCEPTION("Unsupported memory level");
+      THROW_NOT_IMPLEMENTED_EXCEPTION(
+          "Unsupported memory level: " +
+          std::to_string(static_cast<int>(memory_level)));
     }
     columns_[i]->resize(capacity, default_property_values[i - old_size]);
   }

--- a/src/utils/property/types.cc
+++ b/src/utils/property/types.cc
@@ -682,4 +682,24 @@ std::string to_string(neug::DataTypeId type) {
   }
   }
 }
+
+std::string to_string(neug::MemoryLevel level) {
+  switch (level) {
+  case neug::MemoryLevel::kUnSet: {
+    return "Unset";
+  }
+  case neug::MemoryLevel::kSyncToFile: {
+    return "SyncToFile";
+  }
+  case neug::MemoryLevel::kInMemory: {
+    return "InMemory";
+  }
+  case neug::MemoryLevel::kHugePagePrefered: {
+    return "HugePagePrefered";
+  }
+  default: {
+    return "Unknown";
+  }
+  }
+}
 }  // namespace std

--- a/tests/storage/alter_property_test.cc
+++ b/tests/storage/alter_property_test.cc
@@ -269,7 +269,7 @@ void testLoadEdgeBatch(PropertyGraph& graph, std::string src_vertex_type,
 void testOpenEmptyGraph(const std::string& graph_dir,
                         const std::string& data_dir) {
   PropertyGraph graph;
-  graph.Open(graph_dir, 0);
+  graph.Open(graph_dir, MemoryLevel::kSyncToFile);
 
   // Create vertex type PERSON
   {

--- a/tests/storage/test_csr_stream_ops.cc
+++ b/tests/storage/test_csr_stream_ops.cc
@@ -110,7 +110,7 @@ class CsrStreamTest : public ::testing::Test {
     std::vector<std::thread> threads;
     if (this->allocators.size() < static_cast<size_t>(thread_num)) {
       this->allocators.resize(
-          thread_num, neug::Allocator(neug::MemoryStrategy::kMemoryOnly, ""));
+          thread_num, neug::Allocator(neug::MemoryLevel::kInMemory, ""));
     }
     std::atomic<size_t> counter(0);
     for (int i = 0; i < thread_num; ++i) {

--- a/tests/storage/test_edge_table.cc
+++ b/tests/storage/test_edge_table.cc
@@ -65,33 +65,28 @@ class EdgeTableTest : public ::testing::Test {
 
     schema_.AddVertexLabel("person", {}, {},
                            {std::make_tuple(neug::DataTypeId::kInt64, "id", 0)},
-                           {neug::StorageStrategy::kMem},
+
                            static_cast<size_t>(1) << 32, "person vertex label");
     schema_.AddVertexLabel(
         "comment", {}, {}, {std::make_tuple(neug::DataTypeId::kInt64, "id", 0)},
-        {neug::StorageStrategy::kMem}, static_cast<size_t>(1) << 32,
-        "comment vertex label");
-    schema_.AddEdgeLabel("person", "comment", "create0", {}, {}, {},
+        static_cast<size_t>(1) << 32, "comment vertex label");
+    schema_.AddEdgeLabel("person", "comment", "create0", {}, {},
                          neug::EdgeStrategy::kMultiple,
                          neug::EdgeStrategy::kMultiple, true, true, false,
                          "person creates comment edge without properties");
     schema_.AddEdgeLabel(
         "person", "comment", "create1", {neug::DataTypeId::kInt32}, {"data"},
-        {neug::StorageStrategy::kMem}, neug::EdgeStrategy::kMultiple,
-        neug::EdgeStrategy::kMultiple, true, true, false,
-        "person creates comment edge");
+        neug::EdgeStrategy::kMultiple, neug::EdgeStrategy::kMultiple, true,
+        true, false, "person creates comment edge");
     schema_.AddEdgeLabel(
         "person", "comment", "create2", {neug::DataTypeId::kVarchar}, {"data"},
-        {neug::StorageStrategy::kMem}, neug::EdgeStrategy::kMultiple,
-        neug::EdgeStrategy::kMultiple, true, true, false,
-        "person creates comment edge");
-    schema_.AddEdgeLabel(
-        "person", "comment", "create3",
-        {neug::DataTypeId::kVarchar, neug::DataTypeId::kInt32},
-        {"data0", "data1"},
-        {neug::StorageStrategy::kMem, neug::StorageStrategy::kMem},
         neug::EdgeStrategy::kMultiple, neug::EdgeStrategy::kMultiple, true,
-        true, false, "person creates comment edge with two properties");
+        true, false, "person creates comment edge");
+    schema_.AddEdgeLabel("person", "comment", "create3",
+                         {neug::DataTypeId::kVarchar, neug::DataTypeId::kInt32},
+                         {"data0", "data1"}, neug::EdgeStrategy::kMultiple,
+                         neug::EdgeStrategy::kMultiple, true, true, false,
+                         "person creates comment edge with two properties");
     src_label_ = schema_.get_vertex_label_id("person");
     dst_label_ = schema_.get_vertex_label_id("comment");
     edge_label_empty_ = schema_.get_edge_label_id("create0");
@@ -139,10 +134,12 @@ class EdgeTableTest : public ::testing::Test {
         schema_.get_edge_schema(src_label, dst_label, edge_label));
   }
 
-  void OpenEdgeTable() { edge_table->Open(WorkDirectory().string()); }
+  void OpenEdgeTable() {
+    edge_table->Open(WorkDirectory().string(), MemoryLevel::kSyncToFile);
+  }
 
   void OpenEdgeTableInMemory(size_t src_v_cap, size_t dst_v_cap) {
-    edge_table->OpenInMemory(SnapshotDirectory().string());
+    edge_table->Open(SnapshotDirectory().string(), MemoryLevel::kInMemory);
     edge_table->EnsureCapacity(src_v_cap, dst_v_cap);
   }
 
@@ -816,7 +813,7 @@ TEST_F(EdgeTableTest, TestAddEdgeAndDelete) {
     edge_data.push_back({neug::Property::from_int32(static_cast<int>(i))});
   }
 
-  neug::Allocator allocator(neug::MemoryStrategy::kMemoryOnly, allocator_dir_);
+  neug::Allocator allocator(neug::MemoryLevel::kInMemory, allocator_dir_);
 
   size_t edge_count = 0;
   for (size_t i = 0; i < src_lids.size(); ++i) {
@@ -971,7 +968,7 @@ TEST_F(EdgeTableTest, TestAddEdgeDeleteUnbundled) {
                          neug::Property::from_int32(static_cast<int>(i))});
   }
 
-  neug::Allocator allocator(neug::MemoryStrategy::kMemoryOnly, allocator_dir_);
+  neug::Allocator allocator(neug::MemoryLevel::kInMemory, allocator_dir_);
 
   size_t edge_count = 0;
   this->edge_table->EnsureCapacity(edge_data.size());
@@ -1057,7 +1054,7 @@ TEST_F(EdgeTableTest, TestEdgeTableCompaction) {
     edge_data.push_back({neug::Property::from_int32(static_cast<int>(i))});
   }
 
-  neug::Allocator allocator(neug::MemoryStrategy::kMemoryOnly, allocator_dir_);
+  neug::Allocator allocator(neug::MemoryLevel::kInMemory, allocator_dir_);
   for (size_t i = 0; i < src_lids.size(); ++i) {
     this->edge_table->AddEdge(src_lids[i], dst_lids[i], edge_data[i], 0,
                               allocator);
@@ -1135,7 +1132,7 @@ TEST_F(EdgeTableTest, TestUpdateEdgeData) {
 
   this->edge_table->EnsureCapacity(edge_data.size());
   this->ExpectUnbundledStats(0, 4096);
-  neug::Allocator allocator(neug::MemoryStrategy::kMemoryOnly, allocator_dir_);
+  neug::Allocator allocator(neug::MemoryLevel::kInMemory, allocator_dir_);
   for (size_t i = 0; i < src_lids.size(); ++i) {
     this->edge_table->AddEdge(src_lids[i], dst_lids[i], edge_data[i], 0,
                               allocator);
@@ -1253,12 +1250,12 @@ TEST_F(EdgeTableTest, TestAddStringPropertyTransitionFromEmptyToUnbundled) {
   this->edge_table->SetEdgeSchema(
       schema_.get_edge_schema(src_label_, dst_label_, edge_label_empty_));
   schema_.get_edge_schema(src_label_, dst_label_, edge_label_empty_)
-      ->add_properties({"tag"}, {neug::DataTypeId::kVarchar}, {},
+      ->add_properties({"tag"}, {neug::DataTypeId::kVarchar},
                        {neug::Property::from_string_view("seed")});
   this->edge_table->AddProperties({"tag"}, {neug::DataTypeId::kVarchar},
                                   {neug::Property::from_string_view("seed")});
   schema_.get_edge_schema(src_label_, dst_label_, edge_label_empty_)
-      ->add_properties({"desc"}, {neug::DataTypeId::kVarchar}, {},
+      ->add_properties({"desc"}, {neug::DataTypeId::kVarchar},
                        {neug::Property::from_string_view("unknown")});
   this->edge_table->AddProperties(
       {"desc"}, {neug::DataTypeId::kVarchar},
@@ -1289,7 +1286,7 @@ TEST_F(EdgeTableTest,
 
   std::vector<std::tuple<int64_t, int64_t, std::string, int>> input = {
       {0, 1, "a", 11}, {1, 2, "b", 22}, {2, 3, "c", 33}};
-  neug::Allocator allocator(neug::MemoryStrategy::kMemoryOnly, allocator_dir_);
+  neug::Allocator allocator(neug::MemoryLevel::kInMemory, allocator_dir_);
   for (const auto& [src_oid, dst_oid, data0, data1] : input) {
     this->edge_table->AddEdge(
         this->GetSrcLid(neug::Property::from_int64(src_oid)),
@@ -1358,7 +1355,7 @@ TEST_F(EdgeTableTest, TestDeletePropertiesTransitionFromUnbundledToBundled) {
 
   std::vector<std::tuple<int64_t, int64_t, std::string, int>> input = {
       {0, 1, "a", 11}, {1, 2, "b", 22}, {2, 3, "c", 33}};
-  neug::Allocator allocator(neug::MemoryStrategy::kMemoryOnly, allocator_dir_);
+  neug::Allocator allocator(neug::MemoryLevel::kInMemory, allocator_dir_);
   for (const auto& [src_oid, dst_oid, data0, data1] : input) {
     this->edge_table->AddEdge(
         this->GetSrcLid(neug::Property::from_int64(src_oid)),
@@ -1415,7 +1412,7 @@ TEST_F(EdgeTableTest, TestAddAndDeletePropertiesStayUnbundled) {
 
   std::vector<std::tuple<int64_t, int64_t, std::string, int>> input = {
       {0, 1, "a", 11}, {1, 2, "b", 22}, {2, 3, "c", 33}};
-  neug::Allocator allocator(neug::MemoryStrategy::kMemoryOnly, allocator_dir_);
+  neug::Allocator allocator(neug::MemoryLevel::kInMemory, allocator_dir_);
   for (const auto& [src_oid, dst_oid, data0, data1] : input) {
     this->edge_table->AddEdge(
         this->GetSrcLid(neug::Property::from_int64(src_oid)),
@@ -1500,7 +1497,6 @@ TYPED_TEST(EdgeTableToolsTest, TestBatchAddEdges) {
   edge_schema->ie_strategy = EdgeStrategy::kMultiple;
   edge_schema->oe_strategy = EdgeStrategy::kMultiple;
   std::vector<std::string> property_name = {"test_property"};
-  std::vector<StorageStrategy> storage_strategy = {StorageStrategy::kMem};
 
   std::string file_path;
   std::vector<DataType> column_types = {DataTypeId::kUInt32,
@@ -1512,63 +1508,63 @@ TYPED_TEST(EdgeTableToolsTest, TestBatchAddEdges) {
     file_path = resource_path + "/edges_i32.csv";
     std::vector<DataType> property_type = {DataTypeId::kInt32};
     column_types.emplace_back(DataTypeId::kInt32);
-    edge_schema->add_properties(property_name, property_type, storage_strategy);
+    edge_schema->add_properties(property_name, property_type);
     suppliers = execution::ops::create_csv_record_suppliers(
         file_path, column_types, csv_options);
   } else if constexpr (std::is_same_v<EdType, int64_t>) {
     file_path = resource_path + "/edges_i64.csv";
     std::vector<DataType> property_type = {DataTypeId::kInt64};
     column_types.emplace_back(DataTypeId::kInt64);
-    edge_schema->add_properties(property_name, property_type, storage_strategy);
+    edge_schema->add_properties(property_name, property_type);
     suppliers = execution::ops::create_csv_record_suppliers(
         file_path, column_types, csv_options);
   } else if constexpr (std::is_same_v<EdType, uint32_t>) {
     file_path = resource_path + "/edges_u32.csv";
     std::vector<DataType> property_type = {DataTypeId::kUInt32};
     column_types.emplace_back(DataTypeId::kUInt32);
-    edge_schema->add_properties(property_name, property_type, storage_strategy);
+    edge_schema->add_properties(property_name, property_type);
     suppliers = execution::ops::create_csv_record_suppliers(
         file_path, column_types, csv_options);
   } else if constexpr (std::is_same_v<EdType, uint64_t>) {
     file_path = resource_path + "/edges_u64.csv";
     std::vector<DataType> property_type = {DataTypeId::kUInt64};
     column_types.emplace_back(DataTypeId::kUInt64);
-    edge_schema->add_properties(property_name, property_type, storage_strategy);
+    edge_schema->add_properties(property_name, property_type);
     suppliers = execution::ops::create_csv_record_suppliers(
         file_path, column_types, csv_options);
   } else if constexpr (std::is_same_v<EdType, float>) {
     file_path = resource_path + "/edges_float.csv";
     std::vector<DataType> property_type = {DataTypeId::kFloat};
     column_types.emplace_back(DataTypeId::kFloat);
-    edge_schema->add_properties(property_name, property_type, storage_strategy);
+    edge_schema->add_properties(property_name, property_type);
     suppliers = execution::ops::create_csv_record_suppliers(
         file_path, column_types, csv_options);
   } else if constexpr (std::is_same_v<EdType, double>) {
     file_path = resource_path + "/edges_double.csv";
     std::vector<DataType> property_type = {DataTypeId::kDouble};
     column_types.emplace_back(DataTypeId::kDouble);
-    edge_schema->add_properties(property_name, property_type, storage_strategy);
+    edge_schema->add_properties(property_name, property_type);
     suppliers = execution::ops::create_csv_record_suppliers(
         file_path, column_types, csv_options);
   } else if constexpr (std::is_same_v<EdType, Date>) {
     file_path = resource_path + "/edges_date.csv";
     std::vector<DataType> property_type = {DataTypeId::kDate};
     column_types.emplace_back(DataTypeId::kDate);
-    edge_schema->add_properties(property_name, property_type, storage_strategy);
+    edge_schema->add_properties(property_name, property_type);
     suppliers = execution::ops::create_csv_record_suppliers(
         file_path, column_types, csv_options);
   } else if constexpr (std::is_same_v<EdType, DateTime>) {
     file_path = resource_path + "/edges_datetime.csv";
     std::vector<DataType> property_type = {DataTypeId::kTimestampMs};
     column_types.emplace_back(DataTypeId::kTimestampMs);
-    edge_schema->add_properties(property_name, property_type, storage_strategy);
+    edge_schema->add_properties(property_name, property_type);
     suppliers = execution::ops::create_csv_record_suppliers(
         file_path, column_types, csv_options);
   } else if constexpr (std::is_same_v<EdType, Interval>) {
     file_path = resource_path + "/edges_interval.csv";
     std::vector<DataType> property_type = {DataTypeId::kInterval};
     column_types.emplace_back(DataTypeId::kInterval);
-    edge_schema->add_properties(property_name, property_type, storage_strategy);
+    edge_schema->add_properties(property_name, property_type);
     suppliers = execution::ops::create_csv_record_suppliers(
         file_path, column_types, csv_options);
   } else {
@@ -1609,7 +1605,6 @@ TYPED_TEST(EdgeTableToolsTest, TestAddProperties) {
   edge_schema->oe_mutable = true;
   edge_schema->ie_strategy = EdgeStrategy::kMultiple;
   edge_schema->oe_strategy = EdgeStrategy::kMultiple;
-  std::vector<StorageStrategy> storage_strategy = {StorageStrategy::kMem};
 
   std::string file_path = resource_path + "/edges_empty.csv";
   std::vector<DataType> column_types = {DataTypeId::kUInt32,

--- a/tests/storage/test_memory_level.cc
+++ b/tests/storage/test_memory_level.cc
@@ -22,10 +22,11 @@
 #include "column_assertions.h"
 #include "neug/main/neug_db.h"
 
-class MemoryLevelPersistenceTest : public ::testing::TestWithParam<int> {
+class MemoryLevelPersistenceTest
+    : public ::testing::TestWithParam<neug::MemoryLevel> {
  protected:
   std::string db_dir;
-  int memory_level;
+  neug::MemoryLevel memory_level;
 
   void SetUp() override {
     memory_level = GetParam();
@@ -43,8 +44,11 @@ class MemoryLevelPersistenceTest : public ::testing::TestWithParam<int> {
   }
 };
 
-INSTANTIATE_TEST_SUITE_P(AllMemoryLevels, MemoryLevelPersistenceTest,
-                         ::testing::Values(0, 1, 2, 3));
+INSTANTIATE_TEST_SUITE_P(
+    AllMemoryLevels, MemoryLevelPersistenceTest,
+    ::testing::Values(neug::MemoryLevel::kSyncToFile,
+                      neug::MemoryLevel::kInMemory,
+                      neug::MemoryLevel::kHugePagePrefered));
 
 TEST_P(MemoryLevelPersistenceTest, DDLAndDMLPersistence) {
   // 1. Open DB, do DDL and DML

--- a/tests/storage/test_mutable_csr.cc
+++ b/tests/storage/test_mutable_csr.cc
@@ -79,7 +79,7 @@ class MutableCsrTest : public ::testing::Test {
   static constexpr const char* TEST_DIR = "/tmp/mutable_csr_test";
 
   void SetUp() override {
-    allocators.resize(1, Allocator(neug::MemoryStrategy::kMemoryOnly, ""));
+    allocators.resize(1, Allocator(neug::MemoryLevel::kInMemory, ""));
   }
 
   size_t count_edge_num(MutableCsr<EDATA_T>& csr) {
@@ -94,15 +94,15 @@ class MutableCsrTest : public ::testing::Test {
     return edge_num;
   }
 
-  void load_csr_data(MutableCsr<EDATA_T>& csr, int memory_level) {
+  void load_csr_data(MutableCsr<EDATA_T>& csr, MemoryLevel memory_level) {
     if (std::filesystem::exists(TEST_DIR)) {
       std::filesystem::remove_all(TEST_DIR);
     }
     std::filesystem::create_directories(TEST_DIR);
 
-    if (memory_level == 0) {
+    if (memory_level == MemoryLevel::kSyncToFile) {
       csr.open("csr_data", "", TEST_DIR);
-    } else if (memory_level == 1) {
+    } else if (memory_level == MemoryLevel::kInMemory) {
       csr.open_in_memory("csr_data");
     }
     csr.resize(src_v_num);
@@ -131,15 +131,16 @@ class MutableCsrTest : public ::testing::Test {
     }
   }
 
-  void load_single_csr_data(SingleMutableCsr<EDATA_T>& csr, int memory_level) {
+  void load_single_csr_data(SingleMutableCsr<EDATA_T>& csr,
+                            MemoryLevel memory_level) {
     if (std::filesystem::exists(TEST_DIR)) {
       std::filesystem::remove_all(TEST_DIR);
     }
     std::filesystem::create_directories(TEST_DIR);
 
-    if (memory_level == 0) {
+    if (memory_level == MemoryLevel::kSyncToFile) {
       csr.open("single_csr_data", "", TEST_DIR);
-    } else if (memory_level == 1) {
+    } else if (memory_level == MemoryLevel::kInMemory) {
       csr.open_in_memory("single_csr_data");
     }
     csr.resize(single_src_v_num);
@@ -359,12 +360,12 @@ TYPED_TEST(MutableCsrTest, TestUnsortedSince) {
 
 TYPED_TEST(MutableCsrTest, TestBasicFunction) {
   MutableCsr<TypeParam> mutable_csr;
-  this->load_csr_data(mutable_csr, 1);
+  this->load_csr_data(mutable_csr, MemoryLevel::kInMemory);
   EXPECT_EQ(mutable_csr.size(), src_v_num);
   EXPECT_EQ(mutable_csr.edge_num(), edge_num);
   mutable_csr.compact();
   SingleMutableCsr<TypeParam> single_mutable_csr;
-  this->load_single_csr_data(single_mutable_csr, 1);
+  this->load_single_csr_data(single_mutable_csr, MemoryLevel::kInMemory);
   EXPECT_EQ(single_mutable_csr.size(), single_src_v_num);
   EXPECT_EQ(single_mutable_csr.edge_num(), edge_num);
   single_mutable_csr.compact();
@@ -377,7 +378,7 @@ TYPED_TEST(MutableCsrTest, TestBasicFunction) {
 
 TYPED_TEST(MutableCsrTest, TestDumpAndOpen) {
   MutableCsr<TypeParam> mutable_csr;
-  this->load_csr_data(mutable_csr, 1);
+  this->load_csr_data(mutable_csr, MemoryLevel::kInMemory);
   mutable_csr.dump("dumped_csr_data", this->TEST_DIR);
   std::filesystem::create_directories(tmp_dir(this->TEST_DIR));
   MutableCsr<TypeParam> fmap_mutable_csr, memory_mutable_csr,
@@ -392,7 +393,7 @@ TYPED_TEST(MutableCsrTest, TestDumpAndOpen) {
   EXPECT_EQ(hugepage_mutable_csr.edge_num(), edge_num);
 
   SingleMutableCsr<TypeParam> single_mutable_csr;
-  this->load_single_csr_data(single_mutable_csr, 1);
+  this->load_single_csr_data(single_mutable_csr, MemoryLevel::kInMemory);
   single_mutable_csr.dump("dumped_csr_data", this->TEST_DIR);
   std::filesystem::create_directories(tmp_dir(this->TEST_DIR));
   SingleMutableCsr<TypeParam> fmap_single_mutable_csr,
@@ -419,13 +420,13 @@ TYPED_TEST(MutableCsrTest, TestDumpAndOpen) {
 
 TYPED_TEST(MutableCsrTest, TestResize) {
   MutableCsr<TypeParam> mutable_csr;
-  this->load_csr_data(mutable_csr, 1);
+  this->load_csr_data(mutable_csr, MemoryLevel::kInMemory);
   mutable_csr.resize(src_v_num - 2);
   EXPECT_EQ(mutable_csr.size(), src_v_num - 2);
   mutable_csr.close();
 
   SingleMutableCsr<TypeParam> single_mutable_csr;
-  this->load_single_csr_data(single_mutable_csr, 1);
+  this->load_single_csr_data(single_mutable_csr, MemoryLevel::kInMemory);
   single_mutable_csr.resize(single_src_v_num - 2);
   EXPECT_EQ(single_mutable_csr.size(), single_src_v_num - 2);
   single_mutable_csr.close();
@@ -439,7 +440,7 @@ TYPED_TEST(MutableCsrTest, TestSortByEdgeData) {
   timestamp_t sort_ts = 10;
 
   MutableCsr<TypeParam> mutable_csr;
-  this->load_csr_data(mutable_csr, 1);
+  this->load_csr_data(mutable_csr, MemoryLevel::kInMemory);
   mutable_csr.batch_sort_by_edge_data(sort_ts);
   GenericView mutable_view = mutable_csr.get_generic_view(sort_ts);
   EXPECT_EQ(mutable_view.type(), CsrViewType::kMultipleMutable);
@@ -447,7 +448,7 @@ TYPED_TEST(MutableCsrTest, TestSortByEdgeData) {
   mutable_csr.close();
 
   SingleMutableCsr<TypeParam> single_mutable_csr;
-  this->load_single_csr_data(single_mutable_csr, 1);
+  this->load_single_csr_data(single_mutable_csr, MemoryLevel::kInMemory);
   single_mutable_csr.batch_sort_by_edge_data(sort_ts);
   GenericView single_mutable_view =
       single_mutable_csr.get_generic_view(sort_ts);
@@ -460,12 +461,12 @@ TYPED_TEST(MutableCsrTest, TestSortByEdgeData) {
 
 TYPED_TEST(MutableCsrTest, TestBatchDeleteVertices) {
   MutableCsr<TypeParam> mutable_csr;
-  this->load_csr_data(mutable_csr, 1);
+  this->load_csr_data(mutable_csr, MemoryLevel::kInMemory);
   mutable_csr.batch_delete_vertices(delete_src_vertices, delete_dst_vertices);
   EXPECT_EQ(mutable_csr.edge_num(), enum_after_delete_vertex);
 
   SingleMutableCsr<TypeParam> single_mutable_csr;
-  this->load_single_csr_data(single_mutable_csr, 1);
+  this->load_single_csr_data(single_mutable_csr, MemoryLevel::kInMemory);
   single_mutable_csr.batch_delete_vertices(delete_src_vertices,
                                            delete_dst_vertices);
   EXPECT_EQ(single_mutable_csr.edge_num(), enum_after_delete_vertex_single);
@@ -476,7 +477,7 @@ TYPED_TEST(MutableCsrTest, TestBatchDeleteVertices) {
 
 TYPED_TEST(MutableCsrTest, TestBatchDeleteEdges) {
   MutableCsr<TypeParam> mutable_csr;
-  this->load_csr_data(mutable_csr, 1);
+  this->load_csr_data(mutable_csr, MemoryLevel::kInMemory);
   std::vector<std::pair<vid_t, int32_t>> edges_to_delete;
   auto view = mutable_csr.get_generic_view(1);
   for (size_t i = 0; i < delete_src_edges.size(); ++i) {
@@ -496,7 +497,7 @@ TYPED_TEST(MutableCsrTest, TestBatchDeleteEdges) {
   EXPECT_EQ(mutable_csr.edge_num(), enum_after_delete_edge);
 
   SingleMutableCsr<TypeParam> single_mutable_csr;
-  this->load_single_csr_data(single_mutable_csr, 1);
+  this->load_single_csr_data(single_mutable_csr, MemoryLevel::kInMemory);
   edges_to_delete.clear();
   view = single_mutable_csr.get_generic_view(1);
   for (size_t i = 0; i < delete_src_edges.size(); ++i) {
@@ -522,7 +523,7 @@ TYPED_TEST(MutableCsrTest, TestBatchDeleteEdges) {
 
 TYPED_TEST(MutableCsrTest, TestBatchDeleteEdgesById) {
   MutableCsr<TypeParam> mutable_csr;
-  this->load_csr_data(mutable_csr, 1);
+  this->load_csr_data(mutable_csr, MemoryLevel::kInMemory);
   std::vector<vid_t> src_ids, dst_ids;
   auto view = mutable_csr.get_generic_view(1);
   for (vid_t i = 0; i < mutable_csr.size(); i++) {
@@ -539,7 +540,7 @@ TYPED_TEST(MutableCsrTest, TestBatchDeleteEdgesById) {
   EXPECT_EQ(mutable_csr.edge_num(), 10 - src_ids.size());
 
   SingleMutableCsr<TypeParam> single_mutable_csr;
-  this->load_single_csr_data(single_mutable_csr, 1);
+  this->load_single_csr_data(single_mutable_csr, MemoryLevel::kInMemory);
   src_ids.clear();
   dst_ids.clear();
   view = single_mutable_csr.get_generic_view(1);
@@ -558,10 +559,10 @@ TYPED_TEST(MutableCsrTest, TestBatchDeleteEdgesById) {
 
 TYPED_TEST(MutableCsrTest, TestPutEdge) {
   MutableCsr<TypeParam> mutable_csr;
-  this->load_csr_data(mutable_csr, 1);
+  this->load_csr_data(mutable_csr, MemoryLevel::kInMemory);
 
   SingleMutableCsr<TypeParam> single_mutable_csr;
-  this->load_single_csr_data(single_mutable_csr, 1);
+  this->load_single_csr_data(single_mutable_csr, MemoryLevel::kInMemory);
   std::set<vid_t> delete_src_id = {insert_src_vid};
   std::set<vid_t> empty_set;
   single_mutable_csr.batch_delete_vertices(delete_src_id, empty_set);
@@ -595,7 +596,7 @@ TEST(CsrToolTest, OpenNonExistFile) {
 
 TYPED_TEST(MutableCsrTest, TestDeleteEdge) {
   MutableCsr<TypeParam> mutable_csr;
-  this->load_csr_data(mutable_csr, 1);
+  this->load_csr_data(mutable_csr, MemoryLevel::kInMemory);
   std::vector<std::tuple<vid_t, vid_t, int32_t>> edges_to_delete;
   auto oe_view = mutable_csr.get_generic_view(0);
   std::set<size_t> deleted_indices;
@@ -655,7 +656,7 @@ TYPED_TEST(MutableCsrTest, TestDeleteEdge) {
   mutable_csr.close();
 
   SingleMutableCsr<TypeParam> single_mutable_csr;
-  this->load_single_csr_data(single_mutable_csr, 1);
+  this->load_single_csr_data(single_mutable_csr, MemoryLevel::kInMemory);
   size_t edge_num = single_mutable_csr.edge_num();
   edges_to_delete.clear();
   oe_view = single_mutable_csr.get_generic_view(0);

--- a/tests/storage/test_property_graph.cc
+++ b/tests/storage/test_property_graph.cc
@@ -32,7 +32,7 @@ class PropertyGraphTest : public ::testing::Test {
     }
     std::filesystem::create_directories(work_dir_);
     graph_ = std::make_unique<PropertyGraph>();
-    graph_->Open(work_dir_, 1);
+    graph_->Open(work_dir_, MemoryLevel::kInMemory);
   }
 
   void TearDown() override {
@@ -124,7 +124,7 @@ TEST_F(PropertyGraphTest, TestOpenAndBulkInsert) {
                       vid4097, 0)
           .ok());
 
-  Allocator allocator(MemoryStrategy::kMemoryOnly, "");
+  Allocator allocator(MemoryLevel::kInMemory, "");
   for (vid_t i = 0; i < 4094; ++i) {
     graph_->AddEdge(person_label, i, person_label, i + 1, knows_label,
                     {Property::from_double(1.0)}, MAX_TIMESTAMP, allocator);

--- a/tests/storage/test_vertex_table.cc
+++ b/tests/storage/test_vertex_table.cc
@@ -35,7 +35,7 @@ class VertexTableTest : public ::testing::Test {
  protected:
   void SetUp() override {
     dir_ = "/tmp/test_vertex_table";
-    memory_level_ = 1;
+    memory_level_ = neug::MemoryLevel::kInMemory;
     // remove the directory if it exists
     if (std::filesystem::exists(dir_)) {
       std::filesystem::remove_all(dir_);
@@ -51,16 +51,13 @@ class VertexTableTest : public ::testing::Test {
     property_values_ = {neug::Property::from_string_view("Alice"),
                         neug::Property::from_int32(30),
                         neug::Property::from_double(88.5)};
-    storage_strategies_ = {neug::StorageStrategy::kMem,
-                           neug::StorageStrategy::kMem,
-                           neug::StorageStrategy::kMem};
     default_prop_values_ = {neug::Property::from_string_view(""),
                             neug::Property::from_int32(0),
                             neug::Property::from_double(0.0)};
     vertex_count_ = 1000000;
     schema_.AddVertexLabel(v_label_name_, property_types_, property_names_,
-                           {std::make_tuple(pk_type_, "id", 0)},
-                           storage_strategies_, 4096, "", default_prop_values_);
+                           {std::make_tuple(pk_type_, "id", 0)}, 4096, "",
+                           default_prop_values_);
     v_label_id_ = schema_.get_vertex_label_id(v_label_name_);
   }
   void TearDown() override {
@@ -96,13 +93,12 @@ class VertexTableTest : public ::testing::Test {
   }
 
   std::string dir_;
-  int32_t memory_level_;
+  neug::MemoryLevel memory_level_;
   std::string v_label_name_;
   neug::DataTypeId pk_type_;
   std::vector<std::string> property_names_;
   std::vector<neug::DataType> property_types_;
   std::vector<neug::Property> property_values_;
-  std::vector<neug::StorageStrategy> storage_strategies_;
   std::vector<neug::Property> default_prop_values_;
   std::mt19937 generator_;
   neug::Schema schema_;

--- a/tests/storage/vertex_table_benchmark.cc
+++ b/tests/storage/vertex_table_benchmark.cc
@@ -49,14 +49,11 @@ class VertexTableBenchmark : public ::testing::Test {
     property_values_ = {neug::Property::from_string_view("Alice"),
                         neug::Property::from_int32(30),
                         neug::Property::from_double(88.5)};
-    storage_strategies_ = {neug::StorageStrategy::kMem,
-                           neug::StorageStrategy::kMem,
-                           neug::StorageStrategy::kMem};
     pk_types_ = {{neug::DataTypeId::kVarchar, "name", 0}};
     description = "Person vertex label";
     v_schema_ = std::make_shared<neug::VertexSchema>(
         v_label_name_, property_types_, property_names_, pk_types_,
-        storage_strategies_, default_prop_values_, description);
+        default_prop_values_, description);
     // Initialize random number generator
     generator_.seed(42);  // Fixed seed for reproducible results
   }
@@ -70,7 +67,7 @@ class VertexTableBenchmark : public ::testing::Test {
 
   void CreateAndOpenVertexTable(neug::VertexTable& table) {
     // Open the vertex table
-    table.Open(test_dir_, 1);  // memory_level=1 for in-memory
+    table.Open(test_dir_, neug::MemoryLevel::kInMemory);
   }
 
   void AddVerticesWithProperties(neug::VertexTable& table, size_t count) {
@@ -163,7 +160,6 @@ class VertexTableBenchmark : public ::testing::Test {
   std::vector<std::string> property_names_;
   std::vector<neug::DataType> property_types_;
   std::vector<neug::Property> property_values_;
-  std::vector<neug::StorageStrategy> storage_strategies_;
   std::vector<neug::Property> default_prop_values_;
   std::shared_ptr<neug::VertexSchema> v_schema_;
   std::vector<std::tuple<neug::DataType, std::string, size_t>> pk_types_;

--- a/tests/transaction/test_acid.cc
+++ b/tests/transaction/test_acid.cc
@@ -37,9 +37,9 @@
 namespace fs = std::filesystem;
 using namespace neug;
 using neug::EdgeStrategy;
+using neug::MemoryLevel;
 using neug::NeugDB;
 using neug::NeugDBSession;
-using neug::StorageStrategy;
 using oid_t = int64_t;
 using neug::DataTypeId;
 using neug::Schema;

--- a/tests/transaction/test_insert_transaction.cc
+++ b/tests/transaction/test_insert_transaction.cc
@@ -26,7 +26,7 @@
 class InsertTransactionTest : public ::testing::Test {
  protected:
   std::string db_dir;
-  int memory_level;
+  neug::MemoryLevel memory_level;
 
   void SetUp() override {
     db_dir = "/tmp/test_insert_transaction_db";
@@ -37,7 +37,7 @@ class InsertTransactionTest : public ::testing::Test {
 
     neug::NeugDB db;
     neug::NeugDBConfig config(db_dir);
-    config.memory_level = 1;
+    config.memory_level = neug::MemoryLevel::kInMemory;
     config.checkpoint_on_close = true;
     db.Open(db_dir);
     auto conn = db.Connect();
@@ -91,7 +91,7 @@ class InsertTransactionTest : public ::testing::Test {
 TEST_F(InsertTransactionTest, InsertTransactionBasic) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
   {
@@ -105,7 +105,7 @@ TEST_F(InsertTransactionTest, InsertTransactionBasic) {
 TEST_F(InsertTransactionTest, AddVertex) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
   {
@@ -133,7 +133,7 @@ TEST_F(InsertTransactionTest, AddVertex) {
 TEST_F(InsertTransactionTest, AddEdge) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
   {
@@ -183,7 +183,7 @@ TEST_F(InsertTransactionTest, AddEdge) {
 TEST_F(InsertTransactionTest, TestUnsupportedInterface) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
 

--- a/tests/transaction/test_update_transaction.cc
+++ b/tests/transaction/test_update_transaction.cc
@@ -29,7 +29,7 @@
 class UpdateTransactionTest : public ::testing::Test {
  protected:
   std::string db_dir;
-  int memory_level;
+  neug::MemoryLevel memory_level;
 
   void SetUp() override {
     db_dir = "/tmp/test_update_transaction_db";
@@ -40,7 +40,7 @@ class UpdateTransactionTest : public ::testing::Test {
 
     neug::NeugDB db;
     neug::NeugDBConfig config(db_dir);
-    config.memory_level = 1;
+    config.memory_level = neug::MemoryLevel::kInMemory;
     config.checkpoint_on_close = true;
     db.Open(db_dir);
     auto conn = db.Connect();
@@ -264,7 +264,7 @@ class UpdateTransactionTest : public ::testing::Test {
 TEST_F(UpdateTransactionTest, AddVertex) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
   {
@@ -293,7 +293,7 @@ TEST_F(UpdateTransactionTest, AddVertexBatch) {
   // we add a batch of vertices.
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
   {
@@ -322,7 +322,7 @@ TEST_F(UpdateTransactionTest, AddVertexBatch) {
 TEST_F(UpdateTransactionTest, AddEdge) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
   {
@@ -371,7 +371,7 @@ TEST_F(UpdateTransactionTest, AddEdge) {
 TEST_F(UpdateTransactionTest, AddVertexEdge) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
   {
@@ -438,7 +438,7 @@ TEST_F(UpdateTransactionTest, AddVertexEdge) {
 TEST_F(UpdateTransactionTest, AddVertexEdgeAbort) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
   {
@@ -488,7 +488,7 @@ TEST_F(UpdateTransactionTest, AddVertexEdgeAbort) {
 TEST_F(UpdateTransactionTest, UpdateVertexProperty) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
   {
@@ -524,7 +524,7 @@ TEST_F(UpdateTransactionTest, UpdateVertexProperty) {
 TEST_F(UpdateTransactionTest, UpdateEdgeProperty) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
   {
@@ -575,7 +575,7 @@ TEST_F(UpdateTransactionTest, UpdateEdgeProperty) {
 TEST_F(UpdateTransactionTest, AddVertexAbort) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
   {
@@ -608,7 +608,7 @@ TEST_F(UpdateTransactionTest, AddVertexAbort) {
 TEST_F(UpdateTransactionTest, AddEdgeAbort) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
   {
@@ -655,7 +655,7 @@ TEST_F(UpdateTransactionTest, AddEdgeAbort) {
 TEST_F(UpdateTransactionTest, UpdateVertexAbort) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
   {
@@ -700,7 +700,7 @@ TEST_F(UpdateTransactionTest, UpdateVertexAbort) {
 TEST_F(UpdateTransactionTest, UpdateEdgeAbort) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
   {
@@ -756,7 +756,7 @@ TEST_F(UpdateTransactionTest, UpdateEdgeAbort) {
   {
     neug::NeugDB db2;
     neug::NeugDBConfig config2(db_dir);
-    config2.memory_level = 1;
+    config2.memory_level = neug::MemoryLevel::kInMemory;
     db2.Open(config2);
     auto conn = db2.Connect();
     auto result = conn->Query(
@@ -773,7 +773,7 @@ TEST_F(UpdateTransactionTest, UpdateEdgeAbort2) {
   // Update a bundled edge property and abort the transaction
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
   {
@@ -821,7 +821,7 @@ TEST_F(UpdateTransactionTest, UpdateEdgeAbort2) {
   {
     neug::NeugDB db2;
     neug::NeugDBConfig config2(db_dir);
-    config2.memory_level = 1;
+    config2.memory_level = neug::MemoryLevel::kInMemory;
     db2.Open(config2);
     auto conn = db2.Connect();
     auto result = conn->Query(
@@ -838,7 +838,7 @@ TEST_F(UpdateTransactionTest, AddEdgeAndUpdateAndAbort) {
       << "Currently not support update bundled edge property and abort";
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
   {
@@ -906,7 +906,7 @@ TEST_F(UpdateTransactionTest, AddEdgeAndUpdateAndAbort) {
 TEST_F(UpdateTransactionTest, DeleteVertex) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
 
@@ -953,7 +953,7 @@ TEST_F(UpdateTransactionTest, DeleteVertex) {
 TEST_F(UpdateTransactionTest, DeleteEdgeAbort) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
 
@@ -1047,7 +1047,7 @@ TEST_F(UpdateTransactionTest, DeleteEdgeAbort) {
 TEST_F(UpdateTransactionTest, AddDeleteVertexAbort) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
 
@@ -1108,7 +1108,7 @@ TEST_F(UpdateTransactionTest, AddDeleteVertexAbort) {
 TEST_F(UpdateTransactionTest, CreteEdgeTypeAndAbort) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
 
@@ -1148,7 +1148,7 @@ TEST_F(UpdateTransactionTest, CreteEdgeTypeAndCommit) {
   GTEST_SKIP() << "Enable this test after in-place AddEdge is supported";
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
 
@@ -1179,7 +1179,7 @@ TEST_F(UpdateTransactionTest, CreteEdgeTypeAndCommit) {
 TEST_F(UpdateTransactionTest, DeleteEdgeTypeAbort) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
 
@@ -1211,7 +1211,7 @@ TEST_F(UpdateTransactionTest, DeleteEdgeTypeAbort) {
 TEST_F(UpdateTransactionTest, AddVertexProperties) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
 
@@ -1274,7 +1274,7 @@ TEST_F(UpdateTransactionTest, AddVertexProperties) {
 TEST_F(UpdateTransactionTest, AddEdgeProperties) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
 
@@ -1336,7 +1336,7 @@ TEST_F(UpdateTransactionTest, AddEdgeProperties) {
 TEST_F(UpdateTransactionTest, RenameVertexProperty) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
 
@@ -1375,7 +1375,7 @@ TEST_F(UpdateTransactionTest, RenameVertexProperty) {
 TEST_F(UpdateTransactionTest, RenameEdgeProperty) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
 
@@ -1428,7 +1428,7 @@ TEST_F(UpdateTransactionTest, RenameEdgeProperty) {
 TEST_F(UpdateTransactionTest, DeleteEdgeProperties) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
 
@@ -1499,7 +1499,7 @@ TEST_F(UpdateTransactionTest, DeleteEdgeProperties) {
 TEST_F(UpdateTransactionTest, DeleteVertexProperties) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
 
@@ -1544,7 +1544,7 @@ TEST_F(UpdateTransactionTest, DeleteVertexProperties) {
 
 TEST_F(UpdateTransactionTest, TestReplayWal) {
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   config.checkpoint_on_close = false;
   config.compact_on_close = false;
   config.checkpoint_after_recovery = true;
@@ -1659,7 +1659,7 @@ TEST_F(UpdateTransactionTest, TestReplayWal) {
 TEST_F(UpdateTransactionTest, TestAPIAfterDeleteVertexLabel) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
 
@@ -1721,7 +1721,7 @@ TEST_F(UpdateTransactionTest, TestAPIAfterDeleteVertexLabel) {
 TEST_F(UpdateTransactionTest, TestAPIAfterDeleteEdgeLabel) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
 
@@ -1782,7 +1782,7 @@ TEST_F(UpdateTransactionTest, TestAPIAfterDeleteEdgeLabel) {
 TEST_F(UpdateTransactionTest, DeleteVertexWithOutgoingEdges) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
   {
@@ -1820,7 +1820,7 @@ TEST_F(UpdateTransactionTest, DeleteVertexWithOutgoingEdges) {
 TEST_F(UpdateTransactionTest, DeleteVertexWithBidirectionalEdges) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
   {
@@ -1875,7 +1875,7 @@ TEST_F(UpdateTransactionTest, DeleteVertexWithBidirectionalEdges) {
 TEST_F(UpdateTransactionTest, DeleteVertexAbortRestoresEdges) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
   size_t initial_created_count, initial_knows_count;
@@ -1962,7 +1962,7 @@ TEST_F(UpdateTransactionTest, DeleteVertexAbortRestoresEdges) {
 TEST_F(UpdateTransactionTest, DeleteVertexWithMultipleEdgeTypes) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
 
@@ -2021,7 +2021,7 @@ TEST_F(UpdateTransactionTest, DeleteVertexWithMultipleEdgeTypes) {
 TEST_F(UpdateTransactionTest, TestCheckpoint) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
 
@@ -2036,7 +2036,7 @@ TEST_F(UpdateTransactionTest, TestCheckpoint) {
 TEST_F(UpdateTransactionTest, TestUnsupportedInterface) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
 
@@ -2057,7 +2057,7 @@ TEST_F(UpdateTransactionTest, TestUnsupportedInterface) {
 TEST_F(UpdateTransactionTest, BatchDeleteVertices) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
 
@@ -2089,7 +2089,7 @@ TEST_F(UpdateTransactionTest, BatchDeleteVertices) {
 TEST_F(UpdateTransactionTest, BatchDeleteEdges) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
 
@@ -2135,7 +2135,7 @@ TEST_F(UpdateTransactionTest, BatchDeleteEdges) {
 TEST_F(UpdateTransactionTest, BatchDeleteVerticesFailure) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
 
@@ -2166,7 +2166,7 @@ TEST_F(UpdateTransactionTest, BatchDeleteVerticesFailure) {
 TEST_F(UpdateTransactionTest, BatchDeleteEdgesFailure) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
 
@@ -2204,7 +2204,7 @@ TEST_F(UpdateTransactionTest, TestUpdateStringProperty) {
   // By default, the string property has max length: STRING_DEFAULT_MAX_LENGTH.
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
   {
@@ -2252,7 +2252,7 @@ TEST_F(UpdateTransactionTest, TestUpdateStringProperty) {
 TEST_F(UpdateTransactionTest, TestUpdateEdgeStringPropertyCompact) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   config.checkpoint_on_close = true;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
@@ -2366,7 +2366,7 @@ TEST_F(UpdateTransactionTest, TestUpdateEdgeStringPropertyCompact) {
 TEST_F(UpdateTransactionTest, TestTPServiceStart) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
-  config.memory_level = 1;
+  config.memory_level = neug::MemoryLevel::kInMemory;
   db.Open(config);
   auto conn = db.Connect();
   auto svc = std::make_shared<neug::NeugDBService>(db);
@@ -2428,7 +2428,7 @@ TEST_F(UpdateTransactionTest, TestTPServiceStart) {
   {
     neug::NeugDB db2;
     neug::NeugDBConfig config2(db_dir);
-    config2.memory_level = 1;
+    config2.memory_level = neug::MemoryLevel::kInMemory;
     db2.Open(config2);
     auto conn2 = db2.Connect();
     auto result = conn2->Query(

--- a/tests/unittest/logical_delete_test.cc
+++ b/tests/unittest/logical_delete_test.cc
@@ -32,7 +32,7 @@ class PropertyGraphLogicalDeleteTest : public ::testing::Test {
       std::filesystem::remove_all(test_dir_);
     }
     std::filesystem::create_directories(test_dir_);
-    graph_.Open(test_dir_, 1);
+    graph_.Open(test_dir_, MemoryLevel::kInMemory);
   }
 
   void TearDown() override {

--- a/tests/unittest/schema_test.cc
+++ b/tests/unittest/schema_test.cc
@@ -26,7 +26,7 @@
 using neug::DataType;
 using neug::DataTypeId;
 using neug::EdgeStrategy;
-using neug::StorageStrategy;
+using neug::MemoryLevel;
 
 // Small helpers to construct common inputs
 std::vector<DataType> VProps(std::initializer_list<DataType> il) {
@@ -37,9 +37,6 @@ std::vector<std::string> VNames(std::initializer_list<const char*> il) {
   for (auto* s : il)
     out.emplace_back(s);
   return out;
-}
-std::vector<StorageStrategy> VStrats(size_t n, StorageStrategy s) {
-  return std::vector<StorageStrategy>(n, s);
 }
 
 std::vector<std::tuple<DataType, std::string, size_t>> VPk(
@@ -54,12 +51,10 @@ TEST(SchemaTest, AddVertexLabel_AddRenameDeleteVertexProperties_Physical) {
   auto v_types = VProps({DataType::VARCHAR});
   auto v_names = VNames({"name"});
   auto v_pk = VPk(DataType::INT64, "id", /*idx in props*/ 0);
-  auto v_strats = VStrats(v_types.size(), StorageStrategy::kMem);
 
   schema.AddVertexLabel("Person", v_types,
                         /*property_names*/ {v_names.begin(), v_names.end()},
                         v_pk,
-                        /*strategies*/ {v_strats.begin(), v_strats.end()},
                         /*max_vnum*/ 1024, /*desc*/ "person vertex");
 
   // Check basics
@@ -79,11 +74,8 @@ TEST(SchemaTest, AddVertexLabel_AddRenameDeleteVertexProperties_Physical) {
   // 2) Add vertex properties
   std::vector<std::string> add_names = {"age", "score"};
   std::vector<DataType> add_types = {DataTypeId::kInt32, DataTypeId::kDouble};
-  std::vector<StorageStrategy> add_strats = {StorageStrategy::kMem,
-                                             StorageStrategy::kMem};
   std::vector<neug::Property> add_defaults;  // not used currently
-  schema.AddVertexProperties("Person", add_names, add_types, add_strats,
-                             add_defaults);
+  schema.AddVertexProperties("Person", add_names, add_types, add_defaults);
 
   ASSERT_EQ(schema.get_vertex_properties("Person").size(), 3);
   auto names_after_add = schema.get_vertex_property_names("Person");
@@ -120,17 +112,14 @@ TEST(SchemaTest, AddEdgeLabel_AddRenameDeleteEdgeProperties_Physical) {
     auto t = VProps({DataTypeId::kVarchar});
     auto n = VNames({"name"});
     auto pk = VPk(DataTypeId::kInt64, "id", 0);
-    auto s = VStrats(t.size(), StorageStrategy::kMem);
-    schema.AddVertexLabel("Person", t, {n.begin(), n.end()}, pk,
-                          {s.begin(), s.end()}, 1024, "");
-    schema.AddVertexLabel("Company", t, {n.begin(), n.end()}, pk,
-                          {s.begin(), s.end()}, 1024, "");
+    schema.AddVertexLabel("Person", t, {n.begin(), n.end()}, pk, 1024, "");
+    schema.AddVertexLabel("Company", t, {n.begin(), n.end()}, pk, 1024, "");
   }
 
   // 1) Add an edge label Person -[WorksAt]-> Company
   std::vector<DataType> e_types = {DataTypeId::kInt32};
   std::vector<std::string> e_names = {"since"};
-  schema.AddEdgeLabel("Person", "Company", "WorksAt", e_types, e_names, {},
+  schema.AddEdgeLabel("Person", "Company", "WorksAt", e_types, e_names,
                       /*oe*/ EdgeStrategy::kMultiple,
                       /*ie*/ EdgeStrategy::kSingle,
                       /*oe_mutable*/ true, /*ie_mutable*/ false,
@@ -203,9 +192,7 @@ TEST(SchemaTest, DeleteVertexLabel_LogicalThenReAddActsAsRevert) {
   auto t = VProps({DataTypeId::kVarchar});
   auto n = VNames({"name"});
   auto pk = VPk(DataTypeId::kInt64, "id", 0);
-  auto s = VStrats(t.size(), StorageStrategy::kMem);
-  schema.AddVertexLabel("City", t, {n.begin(), n.end()}, pk,
-                        {s.begin(), s.end()}, 100, "");
+  schema.AddVertexLabel("City", t, {n.begin(), n.end()}, pk, 100, "");
   ASSERT_TRUE(schema.contains_vertex_label("City"));
 
   schema.DeleteVertexLabel("City", true);
@@ -213,7 +200,7 @@ TEST(SchemaTest, DeleteVertexLabel_LogicalThenReAddActsAsRevert) {
 
   schema.AddVertexLabel("City", {DataTypeId::kVarchar}, {"name"},
                         VPk(DataTypeId::kVarchar, "name", 0),
-                        /*strategies*/ {}, /*max_vnum*/ 100, "");
+                        /*max_vnum*/ 100, "");
   EXPECT_TRUE(schema.contains_vertex_label("City"));
   EXPECT_EQ(schema.get_vertex_property_names("City")[0], "name");
 }
@@ -223,16 +210,15 @@ TEST(SchemaTest, DeleteVertexLabel_PhysicalThenReAdd) {
   auto t = VProps({DataTypeId::kVarchar});
   auto n = VNames({"name"});
   auto pk = VPk(DataTypeId::kInt64, "id", 0);
-  auto s = VStrats(t.size(), StorageStrategy::kMem);
-  schema.AddVertexLabel("Project", t, {n.begin(), n.end()}, pk,
-                        {s.begin(), s.end()}, 100, "");
+  schema.AddVertexLabel("Project", t, {n.begin(), n.end()}, pk, 100, "");
   ASSERT_TRUE(schema.contains_vertex_label("Project"));
 
   schema.DeleteVertexLabel("Project");
   EXPECT_FALSE(schema.contains_vertex_label("Project"));
 
   schema.AddVertexLabel("Project", {DataTypeId::kVarchar}, {"name"},
-                        VPk(DataTypeId::kVarchar, "name", 0), {}, 100, "");
+                        VPk(DataTypeId::kVarchar, "name", 0),
+                        /*max_vnum*/ 100, "");
   EXPECT_TRUE(schema.contains_vertex_label("Project"));
 }
 
@@ -242,14 +228,11 @@ TEST(SchemaTest, DeleteEdgeLabel_LogicalAndPhysicalAndReAdd) {
     auto t = VProps({DataTypeId::kInt64, DataTypeId::kVarchar});
     auto n = VNames({"id", "name"});
     auto pk = VPk(DataTypeId::kInt64, "id", 0);
-    auto s = VStrats(t.size(), StorageStrategy::kMem);
-    schema.AddVertexLabel("A", t, {n.begin(), n.end()}, pk,
-                          {s.begin(), s.end()}, 100, "");
-    schema.AddVertexLabel("B", t, {n.begin(), n.end()}, pk,
-                          {s.begin(), s.end()}, 100, "");
+    schema.AddVertexLabel("A", t, {n.begin(), n.end()}, pk, 100, "");
+    schema.AddVertexLabel("B", t, {n.begin(), n.end()}, pk, 100, "");
   }
 
-  schema.AddEdgeLabel("A", "B", "Link", {DataTypeId::kInt32}, {"w"}, {},
+  schema.AddEdgeLabel("A", "B", "Link", {DataTypeId::kInt32}, {"w"},
                       EdgeStrategy::kMultiple, EdgeStrategy::kMultiple, true,
                       true, false, "");
 
@@ -262,7 +245,7 @@ TEST(SchemaTest, DeleteEdgeLabel_LogicalAndPhysicalAndReAdd) {
   EXPECT_FALSE(schema.exist(src, dst, el));
   EXPECT_FALSE(schema.exist(src, dst, el));
 
-  schema.AddEdgeLabel("A", "B", "Link", {DataTypeId::kInt32}, {"w"}, {},
+  schema.AddEdgeLabel("A", "B", "Link", {DataTypeId::kInt32}, {"w"},
                       EdgeStrategy::kMultiple, EdgeStrategy::kMultiple, true,
                       true, false, "");
   EXPECT_TRUE(schema.edge_triplet_valid(src, dst, el));
@@ -270,7 +253,7 @@ TEST(SchemaTest, DeleteEdgeLabel_LogicalAndPhysicalAndReAdd) {
   schema.DeleteEdgeLabel(src, dst, el);
   EXPECT_FALSE(schema.exist(src, dst, el));
 
-  schema.AddEdgeLabel("A", "B", "Link", {DataTypeId::kInt32}, {"w"}, {},
+  schema.AddEdgeLabel("A", "B", "Link", {DataTypeId::kInt32}, {"w"},
                       EdgeStrategy::kMultiple, EdgeStrategy::kMultiple, true,
                       true, false, "");
   EXPECT_TRUE(schema.exist(src, dst, el));
@@ -286,10 +269,9 @@ TEST(SchemaTest, LogicalDeleteVertexProperties_HidesProperty) {
   auto types = VProps({DataTypeId::kVarchar, DataTypeId::kInt32});
   auto names = VNames({"name", "age"});
   auto pk = VPk(DataTypeId::kInt64, "id", 0);
-  auto strats = VStrats(types.size(), StorageStrategy::kMem);
   // Only non-PK properties go into vproperties_/vprop_names_
-  schema.AddVertexLabel("Person", types, {names.begin(), names.end()}, pk,
-                        {strats.begin(), strats.end()}, 1024, "");
+  schema.AddVertexLabel("Person", types, {names.begin(), names.end()}, pk, 1024,
+                        "");
 
   // Pre-condition
   ASSERT_TRUE(schema.vertex_has_property("Person", "name"));
@@ -310,15 +292,12 @@ TEST(SchemaTest, LogicalDeleteEdgeProperties_HidesProperty) {
   auto vt = VProps({DataTypeId::kVarchar});
   auto vn = VNames({"name"});
   auto vpk = VPk(DataTypeId::kInt64, "id", 0);
-  auto vs = VStrats(vt.size(), StorageStrategy::kMem);
-  schema.AddVertexLabel("A", vt, {vn.begin(), vn.end()}, vpk,
-                        {vs.begin(), vs.end()}, 100, "");
-  schema.AddVertexLabel("B", vt, {vn.begin(), vn.end()}, vpk,
-                        {vs.begin(), vs.end()}, 100, "");
+  schema.AddVertexLabel("A", vt, {vn.begin(), vn.end()}, vpk, 100, "");
+  schema.AddVertexLabel("B", vt, {vn.begin(), vn.end()}, vpk, 100, "");
 
   std::vector<DataType> e_types = {DataTypeId::kInt32, DataTypeId::kVarchar};
   std::vector<std::string> e_names = {"w", "tag"};
-  schema.AddEdgeLabel("A", "B", "Link", e_types, e_names, {},
+  schema.AddEdgeLabel("A", "B", "Link", e_types, e_names,
                       EdgeStrategy::kMultiple, EdgeStrategy::kMultiple, true,
                       true, false, "");
 
@@ -339,9 +318,7 @@ TEST(SchemaTest, RevertDeleteVertexLabel_ClearsTombstone) {
   auto t = VProps({DataTypeId::kVarchar});
   auto n = VNames({"name"});
   auto pk = VPk(DataTypeId::kInt64, "id", 0);
-  auto s = VStrats(t.size(), StorageStrategy::kMem);
-  schema.AddVertexLabel("City", t, {n.begin(), n.end()}, pk,
-                        {s.begin(), s.end()}, 100, "");
+  schema.AddVertexLabel("City", t, {n.begin(), n.end()}, pk, 100, "");
   ASSERT_TRUE(schema.contains_vertex_label("City"));
 
   schema.DeleteVertexLabel("City", true);
@@ -357,13 +334,10 @@ TEST(SchemaTest, RevertDeleteEdgeLabel_ByName_ClearsTombstone) {
   auto t = VProps({DataTypeId::kVarchar});
   auto n = VNames({"name"});
   auto pk = VPk(DataTypeId::kInt64, "id", 0);
-  auto s = VStrats(t.size(), StorageStrategy::kMem);
-  schema.AddVertexLabel("A", t, {n.begin(), n.end()}, pk, {s.begin(), s.end()},
-                        100, "");
-  schema.AddVertexLabel("B", t, {n.begin(), n.end()}, pk, {s.begin(), s.end()},
-                        100, "");
+  schema.AddVertexLabel("A", t, {n.begin(), n.end()}, pk, 100, "");
+  schema.AddVertexLabel("B", t, {n.begin(), n.end()}, pk, 100, "");
 
-  schema.AddEdgeLabel("A", "B", "Link", {DataTypeId::kInt32}, {"w"}, {},
+  schema.AddEdgeLabel("A", "B", "Link", {DataTypeId::kInt32}, {"w"},
                       EdgeStrategy::kMultiple, EdgeStrategy::kMultiple, true,
                       true, false, "");
   ASSERT_TRUE(schema.contains_edge_label("Link"));
@@ -381,13 +355,10 @@ TEST(SchemaTest, RevertDeleteEdgeLabel_ByTriplet_ClearsTombstone) {
   auto t = VProps({DataTypeId::kVarchar});
   auto n = VNames({"name"});
   auto pk = VPk(DataTypeId::kInt64, "id", 0);
-  auto s = VStrats(t.size(), StorageStrategy::kMem);
-  schema.AddVertexLabel("A", t, {n.begin(), n.end()}, pk, {s.begin(), s.end()},
-                        100, "");
-  schema.AddVertexLabel("B", t, {n.begin(), n.end()}, pk, {s.begin(), s.end()},
-                        100, "");
+  schema.AddVertexLabel("A", t, {n.begin(), n.end()}, pk, 100, "");
+  schema.AddVertexLabel("B", t, {n.begin(), n.end()}, pk, 100, "");
 
-  schema.AddEdgeLabel("A", "B", "Link", {DataTypeId::kInt32}, {"w"}, {},
+  schema.AddEdgeLabel("A", "B", "Link", {DataTypeId::kInt32}, {"w"},
                       EdgeStrategy::kMultiple, EdgeStrategy::kMultiple, true,
                       true, false, "");
   auto src = schema.get_vertex_label_id("A");
@@ -410,40 +381,32 @@ TEST(SchemaDumpTest, SchemaDumpWithMultipleEdgeTriplet) {
       VProps({DataTypeId::kVarchar, DataTypeId::kInt32, DataTypeId::kDouble});
   auto person_property_names_ = VNames({"name", "age", "score"});
   auto person_pk_ = VPk(DataTypeId::kInt64, "id", 0);
-  auto person_strategies_ =
-      VStrats(person_property_types_.size(), StorageStrategy::kMem);
   schema.AddVertexLabel("person", person_property_types_,
-                        person_property_names_, person_pk_, person_strategies_,
-                        4096, "person vertex");
+                        person_property_names_, person_pk_, 4096,
+                        "person vertex");
 
   // Add vertex label "company"
   auto company_property_types_ =
       VProps({DataTypeId::kVarchar, DataTypeId::kInt32});
   auto company_property_names_ = VNames({"company_name", "employee_count"});
   auto company_pk_ = VPk(DataTypeId::kInt64, "id", 0);
-  auto company_strategies_ =
-      VStrats(company_property_types_.size(), StorageStrategy::kMem);
 
   schema.AddVertexLabel("company", company_property_types_,
-                        company_property_names_, company_pk_,
-                        company_strategies_, 2048, "company vertex");
+                        company_property_names_, company_pk_, 2048,
+                        "company vertex");
 
   // Add edge label "knows"
   auto edge_property_types_ = VProps({DataTypeId::kInt64});
   auto edge_property_names_ = VNames({"since"});
-  auto edge_strategies_ =
-      VStrats(edge_property_types_.size(), StorageStrategy::kMem);
 
   schema.AddEdgeLabel("person", "person", "knows", edge_property_types_,
-                      edge_property_names_, edge_strategies_,
-                      EdgeStrategy::kMultiple, EdgeStrategy::kMultiple, true,
-                      true, false, "knows edge");
+                      edge_property_names_, EdgeStrategy::kMultiple,
+                      EdgeStrategy::kMultiple, true, true, false, "knows edge");
 
   // Add edge label "worksAt"
   schema.AddEdgeLabel("person", "company", "knows", edge_property_types_,
-                      edge_property_names_, edge_strategies_,
-                      EdgeStrategy::kMultiple, EdgeStrategy::kMultiple, true,
-                      true, false, "knows edge");
+                      edge_property_names_, EdgeStrategy::kMultiple,
+                      EdgeStrategy::kMultiple, true, true, false, "knows edge");
 
   auto yaml = neug::Schema::DumpToYaml(schema);
   EXPECT_TRUE(yaml);
@@ -463,41 +426,35 @@ class SchemaDeleteTest : public ::testing::Test {
                               neug::DataTypeId::kDouble};
     person_property_names_ = {"name", "age", "score"};
     person_pk_ = {std::make_tuple(neug::DataTypeId::kInt64, "id", 0)};
-    person_strategies_ = {neug::StorageStrategy::kMem,
-                          neug::StorageStrategy::kMem,
-                          neug::StorageStrategy::kMem};
 
     schema_->AddVertexLabel("person", person_property_types_,
-                            person_property_names_, person_pk_,
-                            person_strategies_, 4096, "person vertex");
+                            person_property_names_, person_pk_, 4096,
+                            "person vertex");
 
     // Add vertex label "company"
     company_property_types_ = {neug::DataTypeId::kVarchar,
                                neug::DataTypeId::kInt32};
     company_property_names_ = {"company_name", "employee_count"};
     company_pk_ = {std::make_tuple(neug::DataTypeId::kInt64, "id", 0)};
-    company_strategies_ = {neug::StorageStrategy::kMem,
-                           neug::StorageStrategy::kMem};
 
     schema_->AddVertexLabel("company", company_property_types_,
-                            company_property_names_, company_pk_,
-                            company_strategies_, 2048, "company vertex");
+                            company_property_names_, company_pk_, 2048,
+                            "company vertex");
 
     // Add edge label "knows"
     edge_property_types_ = {neug::DataTypeId::kInt64};
     edge_property_names_ = {"since"};
-    edge_strategies_ = {neug::StorageStrategy::kMem};
 
-    schema_->AddEdgeLabel(
-        "person", "person", "knows", edge_property_types_, edge_property_names_,
-        edge_strategies_, neug::EdgeStrategy::kMultiple,
-        neug::EdgeStrategy::kMultiple, true, true, false, "knows edge");
+    schema_->AddEdgeLabel("person", "person", "knows", edge_property_types_,
+                          edge_property_names_, neug::EdgeStrategy::kMultiple,
+                          neug::EdgeStrategy::kMultiple, true, true, false,
+                          "knows edge");
 
     // Add edge label "worksAt"
-    schema_->AddEdgeLabel(
-        "person", "company", "worksAt", edge_property_types_,
-        edge_property_names_, edge_strategies_, neug::EdgeStrategy::kMultiple,
-        neug::EdgeStrategy::kMultiple, true, true, false, "worksAt edge");
+    schema_->AddEdgeLabel("person", "company", "worksAt", edge_property_types_,
+                          edge_property_names_, neug::EdgeStrategy::kMultiple,
+                          neug::EdgeStrategy::kMultiple, true, true, false,
+                          "worksAt edge");
   }
 
   void TearDown() override { schema_.reset(); }
@@ -507,16 +464,13 @@ class SchemaDeleteTest : public ::testing::Test {
   std::vector<neug::DataType> person_property_types_;
   std::vector<std::string> person_property_names_;
   std::vector<std::tuple<neug::DataType, std::string, size_t>> person_pk_;
-  std::vector<neug::StorageStrategy> person_strategies_;
 
   std::vector<neug::DataType> company_property_types_;
   std::vector<std::string> company_property_names_;
   std::vector<std::tuple<neug::DataType, std::string, size_t>> company_pk_;
-  std::vector<neug::StorageStrategy> company_strategies_;
 
   std::vector<neug::DataType> edge_property_types_;
   std::vector<std::string> edge_property_names_;
-  std::vector<neug::StorageStrategy> edge_strategies_;
 };
 
 // Test VertexSchema::is_property_soft_deleted
@@ -860,15 +814,13 @@ TEST_F(SchemaDeleteTest, SchemaEdgeHasPropertyWithSoftDelete) {
 }
 
 TEST(VertexSchemaTest, TestVertexSchemaIndex) {
-  neug::VertexSchema schema(
-      "test",
-      {
-          neug::DataType::VARCHAR,  // name
-          neug::DataType::DOUBLE    // score
-      },
-      {"name", "score"}, VPk(neug::DataType::INT64, "id", 1),
-      {neug::StorageStrategy::kMem, neug::StorageStrategy::kMem,
-       neug::StorageStrategy::kMem});
+  neug::VertexSchema schema("test",
+                            {
+                                neug::DataType::VARCHAR,  // name
+                                neug::DataType::DOUBLE    // score
+                            },
+                            {"name", "score"},
+                            VPk(neug::DataType::INT64, "id", 1));
   // id is at index 1
 
   EXPECT_THROW(schema.get_property_index("id"), neug::exception::Exception);
@@ -888,16 +840,13 @@ TEST(SchemaTest, TestSchemaEqual) {
   auto t = VProps({DataType::VARCHAR});
   auto n = VNames({"name"});
   auto pk = VPk(DataType::INT64, "id", 0);
-  auto s = VStrats(t.size(), StorageStrategy::kMem);
-  schema.AddVertexLabel("Person", t, {n.begin(), n.end()}, pk,
-                        {s.begin(), s.end()}, 1024, "");
-  schema.AddVertexLabel("Company", t, {n.begin(), n.end()}, pk,
-                        {s.begin(), s.end()}, 1024, "");
+  schema.AddVertexLabel("Person", t, {n.begin(), n.end()}, pk, 1024, "");
+  schema.AddVertexLabel("Company", t, {n.begin(), n.end()}, pk, 1024, "");
 
   // 1) Add an edge label Person -[WorksAt]-> Company
   std::vector<DataType> e_types = {DataType::INT32};
   std::vector<std::string> e_names = {"since"};
-  schema.AddEdgeLabel("Person", "Company", "WorksAt", e_types, e_names, {},
+  schema.AddEdgeLabel("Person", "Company", "WorksAt", e_types, e_names,
                       /*oe*/ EdgeStrategy::kMultiple,
                       /*ie*/ EdgeStrategy::kSingle,
                       /*oe_mutable*/ true, /*ie_mutable*/ false,

--- a/tests/utils/test_table.cc
+++ b/tests/utils/test_table.cc
@@ -80,19 +80,9 @@ TEST(TableTest, TestTableBasic) {
       {DataTypeId::kTimestampMs}, {DataTypeId::kInterval},
       {DataTypeId::kVarchar}};
 
-  std::vector<StorageStrategy> disk_strategies(col_name.size(),
-                                               StorageStrategy::kDisk);
-  std::vector<StorageStrategy> mem_strategies(col_name.size(),
-                                              StorageStrategy::kMem);
-  std::vector<StorageStrategy> none_strategies(col_name.size(),
-                                               StorageStrategy::kNone);
-
-  disk_table.open("test_dist", TEST_DIR, col_name, property_types,
-                  disk_strategies);
-  mem_table.open("test_dist", TEST_DIR, col_name, property_types,
-                 mem_strategies);
-  none_table.open("test_dist", TEST_DIR, col_name, property_types,
-                  none_strategies);
+  disk_table.open("test_dist", TEST_DIR, col_name, property_types);
+  mem_table.open("test_dist", TEST_DIR, col_name, property_types);
+  none_table.open("test_dist", TEST_DIR, col_name, property_types);
 
   disk_table.resize(10);
   mem_table.resize(10);
@@ -302,8 +292,8 @@ TEST(TableTest, TestTableBasic) {
   disk_table.drop();
   mem_table.drop();
 
-  disk_table.open("disk_table", std::string(TEST_DIR), col_name, property_types,
-                  disk_strategies);
+  disk_table.open("disk_table", std::string(TEST_DIR), col_name,
+                  property_types);
   EXPECT_EQ(disk_table.col_num(), 11);
   EXPECT_EQ(disk_table.get_column_by_id(0)->size(), 10);
   disk_table.reset_header(col_name);
@@ -315,7 +305,7 @@ TEST(TableTest, TestTableBasic) {
   disk_table.drop();
 
   mem_table.open_in_memory("disk_table", std::string(TEST_DIR), col_name,
-                           property_types, mem_strategies);
+                           property_types);
   EXPECT_EQ(mem_table.col_num(), 11);
   EXPECT_EQ(mem_table.get_column_by_id(0)->size(), 10);
   const Table& mem_table_ref = mem_table;
@@ -335,11 +325,8 @@ TEST(TableTest, StringColumnDistinguishesUnsetFromEmptyString) {
   Table table;
   std::vector<std::string> col_name = {"string_column"};
   std::vector<DataType> property_types = {{DataTypeId::kVarchar}};
-  std::vector<StorageStrategy> mem_strategies(col_name.size(),
-                                              StorageStrategy::kMem);
 
-  table.open("test_string_validity", TEST_DIR, col_name, property_types,
-             mem_strategies);
+  table.open("test_string_validity", TEST_DIR, col_name, property_types);
   table.resize(2, {Property::from_string_view("default_value")});
 
   auto string_column = std::dynamic_pointer_cast<StringColumn>(
@@ -358,7 +345,7 @@ TEST(TableTest, StringColumnDistinguishesUnsetFromEmptyString) {
   std::string path = std::string(TEST_DIR) + "/string_column";
   string_column->dump(path);
 
-  StringColumn new_string_column(StorageStrategy::kMem);
+  StringColumn new_string_column;
   new_string_column.open_in_memory(path);
   EXPECT_EQ(new_string_column.get_prop(0).as_string_view(), "default_value");
   EXPECT_EQ(new_string_column.get_prop(1).as_string_view(),


### PR DESCRIPTION
Fix #100 

This pull request introduces a new strongly-typed `MemoryLevel` enum for memory usage configuration throughout the codebase, replacing the previous use of raw integer values. It also removes the per-property `StorageStrategy` configuration from schemas and related APIs, simplifying property management for vertices and edges. The changes update constructors, member variables, and method signatures to use the new types and remove now-unnecessary parameters.

**Memory configuration improvements:**

* Introduced a new `MemoryLevel` enum class (with values like `kUnSet`, `kInMemory`, `kSyncToFile`, `kHugePagePrefered`) to replace integer-based memory level configuration in `NeugDBConfig`, `VertexTable`, `EdgeTable`, and `PropertyGraph`, and updated all relevant constructors, member variables, and documentation accordingly. [[1]](diffhunk://#diff-532dfd9a7b0e3151eec5e5c652c053d49b191ee05db7832803a8c6018273049aR40-R54) [[2]](diffhunk://#diff-532dfd9a7b0e3151eec5e5c652c053d49b191ee05db7832803a8c6018273049aL83-R99) [[3]](diffhunk://#diff-532dfd9a7b0e3151eec5e5c652c053d49b191ee05db7832803a8c6018273049aL103-R119) [[4]](diffhunk://#diff-532dfd9a7b0e3151eec5e5c652c053d49b191ee05db7832803a8c6018273049aL134-R151) [[5]](diffhunk://#diff-e4af7448b2130cc2e28cfcb97217446cfd90cab878f7bac1da53fc0e5a72b718L143-R142) [[6]](diffhunk://#diff-ca0b2344754e05e932c780324554dfcfd96455ccd98516af2fb5913023282eeeL105-R105) [[7]](diffhunk://#diff-ca0b2344754e05e932c780324554dfcfd96455ccd98516af2fb5913023282eeeL130-R133) [[8]](diffhunk://#diff-ca0b2344754e05e932c780324554dfcfd96455ccd98516af2fb5913023282eeeL629-R629) [[9]](diffhunk://#diff-b054f54c06b26216fc69507ea91e56c9819d7bfc0e4dff2f3554188964730c6fL86-R86) [[10]](diffhunk://#diff-b054f54c06b26216fc69507ea91e56c9819d7bfc0e4dff2f3554188964730c6fL114-R114) [[11]](diffhunk://#diff-b054f54c06b26216fc69507ea91e56c9819d7bfc0e4dff2f3554188964730c6fL319-R317)

* Updated documentation and usage examples to reflect the new `MemoryLevel` enum and its values, clarifying the meaning and order of memory levels. [[1]](diffhunk://#diff-532dfd9a7b0e3151eec5e5c652c053d49b191ee05db7832803a8c6018273049aL52-R68) [[2]](diffhunk://#diff-532dfd9a7b0e3151eec5e5c652c053d49b191ee05db7832803a8c6018273049aL61-R80)

**Schema and property management simplification:**

* Removed the `StorageStrategy` per-property configuration from `VertexSchema`, `EdgeSchema`, and related APIs, including constructors, member variables, and methods. This simplifies property management and reduces API complexity. [[1]](diffhunk://#diff-9ffa540554daddc73e886896367d65ae2e6489afd317560a3375c67126c7b0bbL61) [[2]](diffhunk://#diff-9ffa540554daddc73e886896367d65ae2e6489afd317560a3375c67126c7b0bbL93) [[3]](diffhunk://#diff-9ffa540554daddc73e886896367d65ae2e6489afd317560a3375c67126c7b0bbL105-L118) [[4]](diffhunk://#diff-9ffa540554daddc73e886896367d65ae2e6489afd317560a3375c67126c7b0bbL136-L140) [[5]](diffhunk://#diff-9ffa540554daddc73e886896367d65ae2e6489afd317560a3375c67126c7b0bbL178) [[6]](diffhunk://#diff-9ffa540554daddc73e886896367d65ae2e6489afd317560a3375c67126c7b0bbL200) [[7]](diffhunk://#diff-9ffa540554daddc73e886896367d65ae2e6489afd317560a3375c67126c7b0bbL243) [[8]](diffhunk://#diff-9ffa540554daddc73e886896367d65ae2e6489afd317560a3375c67126c7b0bbL256) [[9]](diffhunk://#diff-9ffa540554daddc73e886896367d65ae2e6489afd317560a3375c67126c7b0bbL269-L274) [[10]](diffhunk://#diff-9ffa540554daddc73e886896367d65ae2e6489afd317560a3375c67126c7b0bbL283) [[11]](diffhunk://#diff-9ffa540554daddc73e886896367d65ae2e6489afd317560a3375c67126c7b0bbL295) [[12]](diffhunk://#diff-9ffa540554daddc73e886896367d65ae2e6489afd317560a3375c67126c7b0bbL325) [[13]](diffhunk://#diff-9ffa540554daddc73e886896367d65ae2e6489afd317560a3375c67126c7b0bbL470) [[14]](diffhunk://#diff-9ffa540554daddc73e886896367d65ae2e6489afd317560a3375c67126c7b0bbL479) [[15]](diffhunk://#diff-9ffa540554daddc73e886896367d65ae2e6489afd317560a3375c67126c7b0bbL510) [[16]](diffhunk://#diff-9ffa540554daddc73e886896367d65ae2e6489afd317560a3375c67126c7b0bbL614) [[17]](diffhunk://#diff-9ffa540554daddc73e886896367d65ae2e6489afd317560a3375c67126c7b0bbL636-L638) [[18]](diffhunk://#diff-b054f54c06b26216fc69507ea91e56c9819d7bfc0e4dff2f3554188964730c6fL183-R185) [[19]](diffhunk://#diff-e4af7448b2130cc2e28cfcb97217446cfd90cab878f7bac1da53fc0e5a72b718L107-R107)

**API consistency:**

* Updated method signatures in `VertexTable`, `EdgeTable`, and `PropertyGraph` to use the new `MemoryLevel` enum and removed `StorageStrategy` parameters, ensuring consistency across the codebase. [[1]](diffhunk://#diff-b054f54c06b26216fc69507ea91e56c9819d7bfc0e4dff2f3554188964730c6fL114-R114) [[2]](diffhunk://#diff-b054f54c06b26216fc69507ea91e56c9819d7bfc0e4dff2f3554188964730c6fL183-R185) [[3]](diffhunk://#diff-e4af7448b2130cc2e28cfcb97217446cfd90cab878f7bac1da53fc0e5a72b718L107-R107) [[4]](diffhunk://#diff-ca0b2344754e05e932c780324554dfcfd96455ccd98516af2fb5913023282eeeL130-R133)

These changes improve type safety, make memory configuration more explicit, and streamline property management throughout the system.

