### PR TITLE
ci: add parquet extension to CI extension test builds

### DIFF
--- a/.github/workflows/neug-extension-test.yml
+++ b/.github/workflows/neug-extension-test.yml
@@ -73,7 +73,7 @@ jobs:
         python-version: '3.13'
 
     # TODO: After unifying wheel build (neug-manylinux:v0.1.0-x86_64) and dev images (neug-dev:v0.1.0), 
-    # skip the build process and use `pip3 install neug` to test the locally built json extension 
+    # skip the build process and use `pip3 install neug` to test the locally built json/parquet extension 
     # with the released wheel package.
     - name: Build NeuG with extensions
       run: |
@@ -88,7 +88,7 @@ jobs:
         export USE_NINJA=OFF
         export WITH_MIMALLOC=OFF
         export CMAKE_INSTALL_PREFIX=/opt/neug-install/
-        export BUILD_EXTENSIONS="json"
+        export BUILD_EXTENSIONS="json;parquet"
         sudo mkdir -p /opt/neug-install
         sudo chown -R $USER:$USER /opt/neug-install/
         export CC="ccache gcc"
@@ -169,7 +169,7 @@ jobs:
           export CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)
           export BUILD_TYPE=RELEASE
           export PYBIND11_FINDPYTHON=OFF
-          CI_INSTALL_EXTENSIONS="json" python3 -m cibuildwheel ./tools/python_bind --output-dir extension_packages
+          CI_INSTALL_EXTENSIONS="json;parquet" python3 -m cibuildwheel ./tools/python_bind --output-dir extension_packages
 
       - name: Clean all installed python packages
         run: |
@@ -248,7 +248,7 @@ jobs:
           export CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)
           export BUILD_TYPE=RELEASE
           export PYBIND11_FINDPYTHON=OFF
-          CI_INSTALL_EXTENSIONS="json" python3 -m cibuildwheel ./tools/python_bind --output-dir extension_packages
+          CI_INSTALL_EXTENSIONS="json;parquet" python3 -m cibuildwheel ./tools/python_bind --output-dir extension_packages
 
       - name: Clean all installed python packages
         run: |

--- a/extension/parquet/include/parquet_read_function.h
+++ b/extension/parquet/include/parquet_read_function.h
@@ -22,6 +22,7 @@
 #include "parquet_options.h"
 #include "neug/compiler/function/function.h"
 #include "neug/compiler/function/read_function.h"
+#include "neug/compiler/main/metadata_registry.h"
 #include "neug/execution/execute/ops/batch/batch_update_utils.h"
 #include "neug/utils/reader/options.h"
 #include "neug/utils/reader/reader.h"
@@ -48,9 +49,15 @@ struct ParquetReadFunction {
   static execution::Context execFunc(
       std::shared_ptr<reader::ReadSharedState> state) {
     // Get file system from provider
-    LocalFileSystemProvider fsProvider;
-    auto fileInfo = fsProvider.provide(state->schema.file);
-    state->schema.file.paths = fileInfo.resolvedPaths;
+    const auto& vfs = neug::main::MetadataRegistry::getVFS();
+    const auto& fs = vfs->Provide(state->schema.file);
+    auto resolvedPaths = std::vector<std::string>();
+    for (const auto& path : state->schema.file.paths) {
+      const auto& resolved = fs->glob(path);
+      resolvedPaths.insert(resolvedPaths.end(), resolved.begin(),
+                           resolved.end());
+    }
+    state->schema.file.paths = std::move(resolvedPaths);
     
     // Create Parquet-specific options builder
     auto optionsBuilder =
@@ -58,7 +65,7 @@ struct ParquetReadFunction {
     
     // Create Arrow reader with Parquet options
     auto reader = std::make_unique<reader::ArrowReader>(
-        state, std::move(optionsBuilder), fileInfo.fileSystem);
+        state, std::move(optionsBuilder), fs->toArrowFileSystem());
     
     // Execute read operation.
     // ArrowReader::read() throws exceptions (via THROW_IO_EXCEPTION /
@@ -81,9 +88,15 @@ struct ParquetReadFunction {
     externalSchema.file = schema;
     
     // Resolve file paths
-    LocalFileSystemProvider fsProvider;
-    auto fileInfo = fsProvider.provide(state->schema.file);
-    state->schema.file.paths = fileInfo.resolvedPaths;
+    const auto& vfs = neug::main::MetadataRegistry::getVFS();
+    const auto& fs = vfs->Provide(state->schema.file);
+    auto resolvedPaths = std::vector<std::string>();
+    for (const auto& path : state->schema.file.paths) {
+      const auto& resolved = fs->glob(path);
+      resolvedPaths.insert(resolvedPaths.end(), resolved.begin(),
+                           resolved.end());
+    }
+    state->schema.file.paths = std::move(resolvedPaths);
     
     // Create Parquet-specific options builder
     auto optionsBuilder =
@@ -91,7 +104,7 @@ struct ParquetReadFunction {
     
     // Create Arrow reader with Parquet options
     auto reader = std::make_shared<reader::ArrowReader>(
-        state, std::move(optionsBuilder), fileInfo.fileSystem);
+        state, std::move(optionsBuilder), fs->toArrowFileSystem());
     
     // Create sniffer to infer schema from Parquet metadata
     auto sniffer = std::make_shared<reader::ArrowSniffer>(reader);


### PR DESCRIPTION
## Related Issues
fix #110

## What does this PR do?
Adds `parquet` to the extension build targets in `neug-extension-test.yml` so the parquet extension is built and tested in CI alongside the JSON extension.

## What changes in this PR?
- `.github/workflows/neug-extension-test.yml`:
  - `extension_tests_default`: `BUILD_EXTENSIONS="json"` → `"json;parquet"`
  - `extension_tests_wheel_linux_x86_64`: `CI_INSTALL_EXTENSIONS="json"` → `"json;parquet"`
  - `extension_tests_wheel_linux_arm64`: `CI_INSTALL_EXTENSIONS="json"` → `"json;parquet"`
  - Update inline comment to reference json/parquet extension