### PR TITLE
refactor: Remove dummy method  `copy_to_tmp` for Column and Table 

### DIFF
--- a/include/neug/utils/property/column.h
+++ b/include/neug/utils/property/column.h
@@ -59,8 +59,6 @@ class ColumnBase {
 
   virtual size_t size() const = 0;
 
-  virtual void copy_to_tmp(const std::string& cur_path,
-                           const std::string& tmp_path) = 0;
   virtual void resize(size_t size) = 0;
   virtual void resize(size_t size, const Property& default_value) = 0;
 
@@ -136,19 +134,6 @@ class TypedColumn : public ColumnBase {
   }
 
   void close() override { buffer_.reset(); }
-
-  void copy_to_tmp(const std::string& cur_path,
-                   const std::string& tmp_path) override {
-    mmap_array<T> tmp;
-    if (!std::filesystem::exists(cur_path)) {
-      return;
-    }
-    copy_file(cur_path, tmp_path);
-    tmp.open(tmp_path, true);
-    buffer_.reset();
-    buffer_.swap(tmp);
-    tmp.reset();
-  }
 
   void dump(const std::string& filename) override { buffer_.dump(filename); }
 
@@ -247,8 +232,6 @@ class TypedColumn<EmptyType> : public ColumnBase {
   void open_in_memory(const std::string& name) override {}
   void open_with_hugepages(const std::string& name, bool force) override {}
   void dump(const std::string& filename) override {}
-  void copy_to_tmp(const std::string& cur_path,
-                   const std::string& tmp_path) override {}
   void close() override {}
   size_t size() const override { return 0; }
   void resize(size_t size) override {}
@@ -341,23 +324,6 @@ class TypedColumn<std::string_view> : public ColumnBase {
   }
 
   void close() override { buffer_.reset(); }
-
-  void copy_to_tmp(const std::string& cur_path,
-                   const std::string& tmp_path) override {
-    mmap_array<std::string_view> tmp;
-    if (!std::filesystem::exists(cur_path + ".data")) {
-      return;
-    }
-    copy_file(cur_path + ".data", tmp_path + ".data");
-    copy_file(cur_path + ".items", tmp_path + ".items");
-    copy_file(cur_path + ".pos", tmp_path + ".pos");
-
-    buffer_.reset();
-    tmp.open(tmp_path, true);
-    buffer_.swap(tmp);
-    tmp.reset();
-    init_pos(tmp_path + ".pos");
-  }
 
   void dump(const std::string& filename) override {
     size_t pos_val = pos_.load();

--- a/include/neug/utils/property/table.h
+++ b/include/neug/utils/property/table.h
@@ -32,11 +32,6 @@ class Table {
   Table();
   ~Table();
 
-  void init(const std::string& name, const std::string& work_dir,
-            const std::vector<std::string>& col_name,
-            const std::vector<DataType>& types,
-            const std::vector<StorageStrategy>& strategies_);
-
   void open(const std::string& name, const std::string& work_dir,
             const std::vector<std::string>& col_name,
             const std::vector<DataType>& property_types,

--- a/include/neug/utils/property/table.h
+++ b/include/neug/utils/property/table.h
@@ -53,9 +53,6 @@ class Table {
                            const std::vector<StorageStrategy>& strategies_,
                            bool force = false);
 
-  void copy_to_tmp(const std::string& name, const std::string& snapshot_dir,
-                   const std::string& work_dir);
-
   void dump(const std::string& name, const std::string& snapshot_dir);
 
   void reset_header(const std::vector<std::string>& col_name);

--- a/src/storages/graph/vertex_table.cc
+++ b/src/storages/graph/vertex_table.cc
@@ -156,6 +156,7 @@ bool VertexTable::UpdateProperty(vid_t vid, int32_t prop_id,
     LOG(ERROR) << "Property id " << prop_id << " is out of range.";
     return false;
   }
+  table_->ensure_writable(prop_id);
   table_->get_column_by_id(prop_id)->set_any(vid, value);
   return true;
 }

--- a/src/utils/property/column.cc
+++ b/src/utils/property/column.cc
@@ -63,8 +63,6 @@ class TypedEmptyColumn : public ColumnBase {
   void open_in_memory(const std::string& name) override {}
   void open_with_hugepages(const std::string& name, bool force) override {}
   void dump(const std::string& filename) override {}
-  void copy_to_tmp(const std::string& cur_path,
-                   const std::string& tmp_path) override {}
   void close() override {}
   size_t size() const override { return 0; }
   void resize(size_t size) override {}
@@ -104,8 +102,6 @@ class TypedEmptyColumn<std::string_view> : public ColumnBase {
   void open_in_memory(const std::string& name) override {}
   void open_with_hugepages(const std::string& name, bool force) override {}
   void dump(const std::string& filename) override {}
-  void copy_to_tmp(const std::string& cur_path,
-                   const std::string& tmp_path) override {}
   void close() override {}
   size_t size() const override { return 0; }
   void resize(size_t size) override {}

--- a/src/utils/property/table.cc
+++ b/src/utils/property/table.cc
@@ -301,6 +301,7 @@ void Table::insert(size_t index, const std::vector<Property>& values,
   CHECK_EQ(values.size(), columns_.size());
   size_t col_num = columns_.size();
   for (size_t i = 0; i < col_num; ++i) {
+    columns_[i]->ensure_writable(work_dir_);
     columns_[i]->set_any(index, values[i], insert_safe);
   }
 }
@@ -368,5 +369,13 @@ void Table::drop() {
 void Table::set_name(const std::string& name) { name_ = name; }
 
 void Table::set_work_dir(const std::string& work_dir) { work_dir_ = work_dir; }
+
+void Table::ensure_writable(size_t col_id) {
+  if (col_id >= columns_.size()) {
+    THROW_INVALID_ARGUMENT_EXCEPTION("Column id out of range: " +
+                                     std::to_string(col_id));
+  }
+  columns_[col_id]->ensure_writable(work_dir_);
+}
 
 }  // namespace neug

--- a/src/utils/property/table.cc
+++ b/src/utils/property/table.cc
@@ -116,17 +116,6 @@ void Table::open_with_hugepages(const std::string& name,
   buildColumnPtrs();
 }
 
-void Table::copy_to_tmp(const std::string& name,
-                        const std::string& snapshot_dir,
-                        const std::string& work_dir) {
-  int i = 0;
-  for (auto& col : columns_) {
-    col->copy_to_tmp(snapshot_dir + "/" + name + ".col_" + std::to_string(i),
-                     work_dir + "/" + name + ".col_" + std::to_string(i));
-    ++i;
-  }
-}
-
 void Table::dump(const std::string& name, const std::string& snapshot_dir) {
   int i = 0;
   for (auto col : columns_) {

--- a/src/utils/property/table.cc
+++ b/src/utils/property/table.cc
@@ -52,20 +52,6 @@ void Table::initColumns(const std::vector<std::string>& col_name,
   columns_.resize(col_id_map_.size());
 }
 
-void Table::init(const std::string& name, const std::string& work_dir,
-                 const std::vector<std::string>& col_name,
-                 const std::vector<DataType>& property_types,
-                 const std::vector<StorageStrategy>& strategies_) {
-  name_ = name;
-  work_dir_ = work_dir;
-  initColumns(col_name, property_types, strategies_);
-  for (size_t i = 0; i < columns_.size(); ++i) {
-    columns_[i]->open(name + ".col_" + std::to_string(i), "", work_dir);
-  }
-  touched_ = true;
-  buildColumnPtrs();
-}
-
 void Table::open(const std::string& name, const std::string& work_dir,
                  const std::vector<std::string>& col_name,
                  const std::vector<DataType>& property_types,
@@ -301,7 +287,6 @@ void Table::insert(size_t index, const std::vector<Property>& values,
   CHECK_EQ(values.size(), columns_.size());
   size_t col_num = columns_.size();
   for (size_t i = 0; i < col_num; ++i) {
-    columns_[i]->ensure_writable(work_dir_);
     columns_[i]->set_any(index, values[i], insert_safe);
   }
 }

--- a/tests/utils/test_table.cc
+++ b/tests/utils/test_table.cc
@@ -87,11 +87,11 @@ TEST(TableTest, TestTableBasic) {
   std::vector<StorageStrategy> none_strategies(col_name.size(),
                                                StorageStrategy::kNone);
 
-  disk_table.init("test_dist", TEST_DIR, col_name, property_types,
+  disk_table.open("test_dist", TEST_DIR, col_name, property_types,
                   disk_strategies);
-  mem_table.init("test_dist", TEST_DIR, col_name, property_types,
+  mem_table.open("test_dist", TEST_DIR, col_name, property_types,
                  mem_strategies);
-  none_table.init("test_dist", TEST_DIR, col_name, property_types,
+  none_table.open("test_dist", TEST_DIR, col_name, property_types,
                   none_strategies);
 
   disk_table.resize(10);
@@ -338,7 +338,7 @@ TEST(TableTest, StringColumnDistinguishesUnsetFromEmptyString) {
   std::vector<StorageStrategy> mem_strategies(col_name.size(),
                                               StorageStrategy::kMem);
 
-  table.init("test_string_validity", TEST_DIR, col_name, property_types,
+  table.open("test_string_validity", TEST_DIR, col_name, property_types,
              mem_strategies);
   table.resize(2, {Property::from_string_view("default_value")});
 

--- a/tests/utils/test_table.cc
+++ b/tests/utils/test_table.cc
@@ -311,8 +311,6 @@ TEST(TableTest, TestTableBasic) {
   EXPECT_EQ(disk_table.get_column_id_by_name("renamed_bool_column"), 0);
   disk_table.delete_column("renamed_bool_column");
   EXPECT_EQ(disk_table.col_num(), 10);
-  disk_table.copy_to_tmp("disk_table", std::string(TEST_DIR) + "/checkpoint",
-                         std::string(TEST_DIR));
   disk_table.set_work_dir(std::string(TEST_DIR));
   disk_table.drop();
 


### PR DESCRIPTION
Fix #116 

We copy files under checkpoint to tmp_dir in a lazy manner implemented by ensure_writable, and `copy_to_tmp` are deprecated but seems not deleted.

Related issue: #118 