### PR TITLE
fix: Fix an issue with path-expand

### DIFF
--- a/src/execution/common/operators/retrieve/path_expand.cc
+++ b/src/execution/common/operators/retrieve/path_expand.cc
@@ -27,206 +27,213 @@ neug::result<Context> PathExpand::edge_expand_v(
     const StorageReadInterface& graph, Context&& ctx,
     const PathExpandParams& params) {
   std::vector<size_t> shuffle_offset;
+
   if (params.labels.size() == 1 &&
-      ctx.get(params.start_tag)->column_type() == ContextColumnType::kVertex &&
-      std::dynamic_pointer_cast<IVertexColumn>(ctx.get(params.start_tag))
-              ->vertex_column_type() == VertexColumnType::kSingle) {
-    auto& input_vertex_list =
-        *std::dynamic_pointer_cast<SLVertexColumn>(ctx.get(params.start_tag));
-    auto pair = path_expand_vertex_without_predicate_impl(
-        graph, input_vertex_list, params.labels, params.dir, params.hop_lower,
-        params.hop_upper);
-    ctx.set_with_reshuffle(params.alias, pair.first, pair.second);
-    return ctx;
-  } else {
-    if (params.dir == Direction::kOut) {
-      auto& input_vertex_list =
-          *std::dynamic_pointer_cast<IVertexColumn>(ctx.get(params.start_tag));
-      std::set<label_t> labels;
-      std::vector<std::vector<LabelTriplet>> out_labels_map(
-          graph.schema().vertex_label_frontier());
-      for (const auto& label : params.labels) {
-        labels.emplace(label.dst_label);
-        if (params.hop_lower == 0) {
-          labels.emplace(label.src_label);
-        }
-        out_labels_map[label.src_label].emplace_back(label);
+      params.labels[0].src_label == params.labels[0].dst_label &&
+      ctx.get(params.start_tag)->column_type() == ContextColumnType::kVertex) {
+    auto vertex_col =
+        dynamic_cast<const IVertexColumn*>(ctx.get(params.start_tag).get());
+    if (vertex_col->vertex_column_type() == VertexColumnType::kSingle) {
+      const auto& input_vertex_list =
+          dynamic_cast<const SLVertexColumn&>(*ctx.get(params.start_tag));
+      if (input_vertex_list.label() == params.labels[0].src_label) {
+        auto pair = path_expand_vertex_without_predicate_impl(
+            graph, input_vertex_list, params.labels, params.dir,
+            params.hop_lower, params.hop_upper);
+        ctx.set_with_reshuffle(params.alias, pair.first, pair.second);
+        return ctx;
       }
-
-      MLVertexColumnBuilderOpt builder(labels);
-      std::vector<std::tuple<label_t, vid_t, size_t>> input;
-      std::vector<std::tuple<label_t, vid_t, size_t>> output;
-      foreach_vertex(input_vertex_list,
-                     [&](size_t index, label_t label, vid_t v) {
-                       output.emplace_back(label, v, index);
-                     });
-      int depth = 0;
-      while (depth < params.hop_upper && (!output.empty())) {
-        input.clear();
-        std::swap(input, output);
-        if (depth >= params.hop_lower) {
-          for (auto& tuple : input) {
-            builder.push_back_vertex({std::get<0>(tuple), std::get<1>(tuple)});
-            shuffle_offset.push_back(std::get<2>(tuple));
-          }
-        }
-
-        if (depth + 1 >= params.hop_upper) {
-          break;
-        }
-
-        for (auto& tuple : input) {
-          auto label = std::get<0>(tuple);
-          auto v = std::get<1>(tuple);
-          auto index = std::get<2>(tuple);
-          for (const auto& label_triplet : out_labels_map[label]) {
-            auto oe_view = graph.GetGenericOutgoingGraphView(
-                label_triplet.src_label, label_triplet.dst_label,
-                label_triplet.edge_label);
-            auto oes = oe_view.get_edges(v);
-            for (auto it = oes.begin(); it != oes.end(); ++it) {
-              output.emplace_back(label_triplet.dst_label, it.get_vertex(),
-                                  index);
-            }
-          }
-        }
-        ++depth;
-      }
-      ctx.set_with_reshuffle(params.alias, builder.finish(), shuffle_offset);
-      return ctx;
-    } else if (params.dir == Direction::kIn) {
-      auto& input_vertex_list =
-          *std::dynamic_pointer_cast<IVertexColumn>(ctx.get(params.start_tag));
-      std::set<label_t> labels;
-      std::vector<std::vector<LabelTriplet>> in_labels_map(
-          graph.schema().vertex_label_frontier());
-      for (auto& label : params.labels) {
-        labels.emplace(label.src_label);
-        if (params.hop_lower == 0) {
-          labels.emplace(label.dst_label);
-        }
-        in_labels_map[label.dst_label].emplace_back(label);
-      }
-
-      MLVertexColumnBuilderOpt builder(labels);
-      std::vector<std::tuple<label_t, vid_t, size_t>> input;
-      std::vector<std::tuple<label_t, vid_t, size_t>> output;
-      foreach_vertex(input_vertex_list,
-                     [&](size_t index, label_t label, vid_t v) {
-                       output.emplace_back(label, v, index);
-                     });
-      int depth = 0;
-      while (depth < params.hop_upper && (!output.empty())) {
-        input.clear();
-        std::swap(input, output);
-        if (depth >= params.hop_lower) {
-          for (const auto& tuple : input) {
-            builder.push_back_vertex({std::get<0>(tuple), std::get<1>(tuple)});
-            shuffle_offset.push_back(std::get<2>(tuple));
-          }
-        }
-
-        if (depth + 1 >= params.hop_upper) {
-          break;
-        }
-
-        for (const auto& tuple : input) {
-          auto label = std::get<0>(tuple);
-          auto v = std::get<1>(tuple);
-          auto index = std::get<2>(tuple);
-          for (const auto& label_triplet : in_labels_map[label]) {
-            auto iview = graph.GetGenericIncomingGraphView(
-                label_triplet.dst_label, label_triplet.src_label,
-                label_triplet.edge_label);
-            auto ies = iview.get_edges(v);
-            for (auto it = ies.begin(); it != ies.end(); ++it) {
-              output.emplace_back(label_triplet.src_label, it.get_vertex(),
-                                  index);
-            }
-          }
-        }
-        ++depth;
-      }
-      ctx.set_with_reshuffle(params.alias, builder.finish(), shuffle_offset);
-      return ctx;
-    } else if (params.dir == Direction::kBoth) {
-      std::set<label_t> labels;
-      std::vector<std::vector<LabelTriplet>> in_labels_map(
-          graph.schema().vertex_label_frontier()),
-          out_labels_map(graph.schema().vertex_label_frontier());
-      for (const auto& label : params.labels) {
-        labels.emplace(label.dst_label);
-        labels.emplace(label.src_label);
-        in_labels_map[label.dst_label].emplace_back(label);
-        out_labels_map[label.src_label].emplace_back(label);
-      }
-
-      MLVertexColumnBuilderOpt builder(labels);
-      std::vector<std::tuple<label_t, vid_t, size_t>> input;
-      std::vector<std::tuple<label_t, vid_t, size_t>> output;
-      auto input_vertex_list =
-          std::dynamic_pointer_cast<IVertexColumn>(ctx.get(params.start_tag));
-      if (input_vertex_list->vertex_column_type() ==
-          VertexColumnType::kMultiple) {
-        auto& input_vertex_list = *std::dynamic_pointer_cast<MLVertexColumn>(
-            ctx.get(params.start_tag));
-
-        input_vertex_list.foreach_vertex(
-            [&](size_t index, label_t label, vid_t v) {
-              output.emplace_back(label, v, index);
-            });
-      } else {
-        foreach_vertex(*input_vertex_list,
-                       [&](size_t index, label_t label, vid_t v) {
-                         output.emplace_back(label, v, index);
-                       });
-      }
-      int depth = 0;
-      while (depth < params.hop_upper && (!output.empty())) {
-        input.clear();
-        std::swap(input, output);
-        if (depth >= params.hop_lower) {
-          for (auto& tuple : input) {
-            builder.push_back_vertex({std::get<0>(tuple), std::get<1>(tuple)});
-            shuffle_offset.push_back(std::get<2>(tuple));
-          }
-        }
-
-        if (depth + 1 >= params.hop_upper) {
-          break;
-        }
-
-        for (auto& tuple : input) {
-          auto label = std::get<0>(tuple);
-          auto v = std::get<1>(tuple);
-          auto index = std::get<2>(tuple);
-          for (const auto& label_triplet : out_labels_map[label]) {
-            auto oview = graph.GetGenericOutgoingGraphView(
-                label_triplet.src_label, label_triplet.dst_label,
-                label_triplet.edge_label);
-            auto oes = oview.get_edges(v);
-            for (auto it = oes.begin(); it != oes.end(); ++it) {
-              output.emplace_back(label_triplet.dst_label, it.get_vertex(),
-                                  index);
-            }
-          }
-          for (const auto& label_triplet : in_labels_map[label]) {
-            auto iview = graph.GetGenericIncomingGraphView(
-                label_triplet.dst_label, label_triplet.src_label,
-                label_triplet.edge_label);
-            auto ies = iview.get_edges(v);
-            for (auto it = ies.begin(); it != ies.end(); ++it) {
-              output.emplace_back(label_triplet.src_label, it.get_vertex(),
-                                  index);
-            }
-          }
-        }
-        depth++;
-      }
-      ctx.set_with_reshuffle(params.alias, builder.finish(), shuffle_offset);
-      return ctx;
     }
   }
+
+  if (params.dir == Direction::kOut) {
+    auto& input_vertex_list =
+        *std::dynamic_pointer_cast<IVertexColumn>(ctx.get(params.start_tag));
+    std::set<label_t> labels;
+    std::vector<std::vector<LabelTriplet>> out_labels_map(
+        graph.schema().vertex_label_frontier());
+    for (const auto& label : params.labels) {
+      labels.emplace(label.dst_label);
+      if (params.hop_lower == 0) {
+        labels.emplace(label.src_label);
+      }
+      out_labels_map[label.src_label].emplace_back(label);
+    }
+
+    MLVertexColumnBuilderOpt builder(labels);
+    std::vector<std::tuple<label_t, vid_t, size_t>> input;
+    std::vector<std::tuple<label_t, vid_t, size_t>> output;
+    foreach_vertex(input_vertex_list,
+                   [&](size_t index, label_t label, vid_t v) {
+                     output.emplace_back(label, v, index);
+                   });
+    int depth = 0;
+    while (depth < params.hop_upper && (!output.empty())) {
+      input.clear();
+      std::swap(input, output);
+      if (depth >= params.hop_lower) {
+        for (auto& tuple : input) {
+          builder.push_back_vertex({std::get<0>(tuple), std::get<1>(tuple)});
+          shuffle_offset.push_back(std::get<2>(tuple));
+        }
+      }
+
+      if (depth + 1 >= params.hop_upper) {
+        break;
+      }
+
+      for (auto& tuple : input) {
+        auto label = std::get<0>(tuple);
+        auto v = std::get<1>(tuple);
+        auto index = std::get<2>(tuple);
+        for (const auto& label_triplet : out_labels_map[label]) {
+          auto oe_view = graph.GetGenericOutgoingGraphView(
+              label_triplet.src_label, label_triplet.dst_label,
+              label_triplet.edge_label);
+          auto oes = oe_view.get_edges(v);
+          for (auto it = oes.begin(); it != oes.end(); ++it) {
+            output.emplace_back(label_triplet.dst_label, it.get_vertex(),
+                                index);
+          }
+        }
+      }
+      ++depth;
+    }
+    ctx.set_with_reshuffle(params.alias, builder.finish(), shuffle_offset);
+    return ctx;
+  } else if (params.dir == Direction::kIn) {
+    auto& input_vertex_list =
+        *std::dynamic_pointer_cast<IVertexColumn>(ctx.get(params.start_tag));
+    std::set<label_t> labels;
+    std::vector<std::vector<LabelTriplet>> in_labels_map(
+        graph.schema().vertex_label_frontier());
+    for (auto& label : params.labels) {
+      labels.emplace(label.src_label);
+      if (params.hop_lower == 0) {
+        labels.emplace(label.dst_label);
+      }
+      in_labels_map[label.dst_label].emplace_back(label);
+    }
+
+    MLVertexColumnBuilderOpt builder(labels);
+    std::vector<std::tuple<label_t, vid_t, size_t>> input;
+    std::vector<std::tuple<label_t, vid_t, size_t>> output;
+    foreach_vertex(input_vertex_list,
+                   [&](size_t index, label_t label, vid_t v) {
+                     output.emplace_back(label, v, index);
+                   });
+    int depth = 0;
+    while (depth < params.hop_upper && (!output.empty())) {
+      input.clear();
+      std::swap(input, output);
+      if (depth >= params.hop_lower) {
+        for (const auto& tuple : input) {
+          builder.push_back_vertex({std::get<0>(tuple), std::get<1>(tuple)});
+          shuffle_offset.push_back(std::get<2>(tuple));
+        }
+      }
+
+      if (depth + 1 >= params.hop_upper) {
+        break;
+      }
+
+      for (const auto& tuple : input) {
+        auto label = std::get<0>(tuple);
+        auto v = std::get<1>(tuple);
+        auto index = std::get<2>(tuple);
+        for (const auto& label_triplet : in_labels_map[label]) {
+          auto iview = graph.GetGenericIncomingGraphView(
+              label_triplet.dst_label, label_triplet.src_label,
+              label_triplet.edge_label);
+          auto ies = iview.get_edges(v);
+          for (auto it = ies.begin(); it != ies.end(); ++it) {
+            output.emplace_back(label_triplet.src_label, it.get_vertex(),
+                                index);
+          }
+        }
+      }
+      ++depth;
+    }
+    ctx.set_with_reshuffle(params.alias, builder.finish(), shuffle_offset);
+    return ctx;
+  } else {
+    std::set<label_t> labels;
+    std::vector<std::vector<LabelTriplet>> in_labels_map(
+        graph.schema().vertex_label_frontier()),
+        out_labels_map(graph.schema().vertex_label_frontier());
+    for (const auto& label : params.labels) {
+      labels.emplace(label.dst_label);
+      labels.emplace(label.src_label);
+      in_labels_map[label.dst_label].emplace_back(label);
+      out_labels_map[label.src_label].emplace_back(label);
+    }
+
+    MLVertexColumnBuilderOpt builder(labels);
+    std::vector<std::tuple<label_t, vid_t, size_t>> input;
+    std::vector<std::tuple<label_t, vid_t, size_t>> output;
+    auto input_vertex_list =
+        std::dynamic_pointer_cast<IVertexColumn>(ctx.get(params.start_tag));
+    if (input_vertex_list->vertex_column_type() ==
+        VertexColumnType::kMultiple) {
+      auto& input_vertex_list =
+          *std::dynamic_pointer_cast<MLVertexColumn>(ctx.get(params.start_tag));
+
+      input_vertex_list.foreach_vertex(
+          [&](size_t index, label_t label, vid_t v) {
+            output.emplace_back(label, v, index);
+          });
+    } else {
+      foreach_vertex(*input_vertex_list,
+                     [&](size_t index, label_t label, vid_t v) {
+                       output.emplace_back(label, v, index);
+                     });
+    }
+    int depth = 0;
+    while (depth < params.hop_upper && (!output.empty())) {
+      input.clear();
+      std::swap(input, output);
+      if (depth >= params.hop_lower) {
+        for (auto& tuple : input) {
+          builder.push_back_vertex({std::get<0>(tuple), std::get<1>(tuple)});
+          shuffle_offset.push_back(std::get<2>(tuple));
+        }
+      }
+
+      if (depth + 1 >= params.hop_upper) {
+        break;
+      }
+
+      for (auto& tuple : input) {
+        auto label = std::get<0>(tuple);
+        auto v = std::get<1>(tuple);
+        auto index = std::get<2>(tuple);
+        for (const auto& label_triplet : out_labels_map[label]) {
+          auto oview = graph.GetGenericOutgoingGraphView(
+              label_triplet.src_label, label_triplet.dst_label,
+              label_triplet.edge_label);
+          auto oes = oview.get_edges(v);
+          for (auto it = oes.begin(); it != oes.end(); ++it) {
+            output.emplace_back(label_triplet.dst_label, it.get_vertex(),
+                                index);
+          }
+        }
+        for (const auto& label_triplet : in_labels_map[label]) {
+          auto iview = graph.GetGenericIncomingGraphView(
+              label_triplet.dst_label, label_triplet.src_label,
+              label_triplet.edge_label);
+          auto ies = iview.get_edges(v);
+          for (auto it = ies.begin(); it != ies.end(); ++it) {
+            output.emplace_back(label_triplet.src_label, it.get_vertex(),
+                                index);
+          }
+        }
+      }
+      depth++;
+    }
+    ctx.set_with_reshuffle(params.alias, builder.finish(), shuffle_offset);
+    return ctx;
+  }
+
   LOG(ERROR) << "not support path expand options";
   RETURN_UNSUPPORTED_ERROR("not support path expand options");
 }

--- a/src/execution/common/operators/retrieve/path_expand_impl.cc
+++ b/src/execution/common/operators/retrieve/path_expand_impl.cc
@@ -163,33 +163,28 @@ path_expand_vertex_without_predicate_impl(
     const StorageReadInterface& graph, const SLVertexColumn& input,
     const std::vector<LabelTriplet>& labels, Direction dir, int lower,
     int upper) {
-  if (labels.size() == 1) {
-    if (labels[0].src_label == labels[0].dst_label &&
-        labels[0].src_label == input.label()) {
-      if (dir == Direction::kBoth) {
-        auto iview = graph.GetGenericIncomingGraphView(
-            labels[0].src_label, labels[0].dst_label, labels[0].edge_label);
-        auto oview = graph.GetGenericOutgoingGraphView(
-            labels[0].src_label, labels[0].dst_label, labels[0].edge_label);
-        return iterative_expand_vertex_on_dual_graph_view(iview, oview, input,
-                                                          lower, upper);
-      } else if (dir == Direction::kIn) {
-        auto iview = graph.GetGenericIncomingGraphView(
-            labels[0].src_label, labels[0].dst_label, labels[0].edge_label);
-        return iterative_expand_vertex_on_graph_view(iview, input, lower,
-                                                     upper);
-      } else {
-        CHECK(dir == Direction::kOut);
-        auto oview = graph.GetGenericOutgoingGraphView(
-            labels[0].src_label, labels[0].dst_label, labels[0].edge_label);
-        return iterative_expand_vertex_on_graph_view(oview, input, lower,
-                                                     upper);
-      }
-    }
+  assert(labels.size() == 1);
+
+  assert(labels[0].src_label == labels[0].dst_label &&
+         labels[0].src_label == input.label());
+
+  if (dir == Direction::kBoth) {
+    auto iview = graph.GetGenericIncomingGraphView(
+        labels[0].src_label, labels[0].dst_label, labels[0].edge_label);
+    auto oview = graph.GetGenericOutgoingGraphView(
+        labels[0].src_label, labels[0].dst_label, labels[0].edge_label);
+    return iterative_expand_vertex_on_dual_graph_view(iview, oview, input,
+                                                      lower, upper);
+  } else if (dir == Direction::kIn) {
+    auto iview = graph.GetGenericIncomingGraphView(
+        labels[0].src_label, labels[0].dst_label, labels[0].edge_label);
+    return iterative_expand_vertex_on_graph_view(iview, input, lower, upper);
+  } else {
+    CHECK(dir == Direction::kOut);
+    auto oview = graph.GetGenericOutgoingGraphView(
+        labels[0].src_label, labels[0].dst_label, labels[0].edge_label);
+    return iterative_expand_vertex_on_graph_view(oview, input, lower, upper);
   }
-  LOG(FATAL) << "not implemented...";
-  std::shared_ptr<IContextColumn> ret(nullptr);
-  return std::make_pair(ret, std::vector<size_t>());
 }
 
 }  // namespace execution

--- a/tools/python_bind/tests/test_db_query.py
+++ b/tools/python_bind/tests/test_db_query.py
@@ -1487,6 +1487,45 @@ def test_tinysnb_path_expand():
     assert records[0][0] == 13
 
 
+def test_path_expand_count_on_typed_rel_table(tmp_path):
+    db_dir = tmp_path / "path_expand_typed_rel"
+    db_dir.mkdir()
+    db = Database(db_path=str(db_dir), mode="w")
+    conn = db.connect()
+
+    setup_queries = [
+        ("CREATE NODE TABLE A(id STRING, p INT32, PRIMARY KEY(id));", "schema"),
+        ("CREATE NODE TABLE B(id STRING, q INT32, PRIMARY KEY(id));", "schema"),
+        ("CREATE REL TABLE R(FROM A TO B, w INT32);", "schema"),
+        ("CREATE (a:A {id:'a1', p:1});", "update"),
+        ("CREATE (a:A {id:'a2', p:2});", "update"),
+        ("CREATE (b:B {id:'b1', q:1});", "update"),
+        (
+            "MATCH (a:A {id:'a1'}), (b:B {id:'b1'}) CREATE (a)-[:R {w:1}]->(b);",
+            "update",
+        ),
+        (
+            "MATCH (a:A {id:'a2'}), (b:B {id:'b1'}) CREATE (a)-[:R {w:2}]->(b);",
+            "update",
+        ),
+    ]
+
+    for query, access_mode in setup_queries:
+        conn.execute(query, access_mode=access_mode)
+
+    result = conn.execute(
+        "MATCH (a:A)-[:R*1..2]->(b:B) RETURN count(*) AS c",
+        access_mode="read",
+    )
+    records = list(result)
+
+    assert len(records) == 1
+    assert records[0][0] == 2
+
+    conn.close()
+    db.close()
+
+
 def test_path_expand_with_filter():
     db_dir = "/tmp/tinysnb"
     db = Database(db_path=db_dir, mode="r")


### PR DESCRIPTION
This pull request refactors the `PathExpand::edge_expand_v` logic to improve type safety and correctness for path expansion operations, particularly for single-label, single-vertex scenarios. Additionally, it strengthens internal assertions and adds a new Python test to verify correct behavior when expanding paths on typed relationship tables.

