### PR TITLE
refactor: Remove some unused log

### DIFF
--- a/src/storages/graph/property_graph.cc
+++ b/src/storages/graph/property_graph.cc
@@ -1061,7 +1061,6 @@ void PropertyGraph::DumpSchema() {
   out.flush();
   out.close();
 
-  LOG(INFO) << "Dump schema to file: " << get_schema_yaml_path();
   std::string filename = get_schema_yaml_path();
   auto schema_res = schema_.to_yaml();
   if (!schema_res) {
@@ -1072,7 +1071,7 @@ void PropertyGraph::DumpSchema() {
   if (!write_yaml_file(schema_res.value(), filename)) {
     THROW_IO_EXCEPTION("Failed to write schema yaml file: " + filename);
   }
-  LOG(INFO) << "Dump schema to yaml file: " << filename;
+  VLOG(1) << "Dump schema to yaml file: " << filename;
 }
 
 const Schema& PropertyGraph::schema() const { return schema_; }

--- a/src/utils/pb_utils.cc
+++ b/src/utils/pb_utils.cc
@@ -271,8 +271,6 @@ bool common_value_to_value(const DataType& type, const common::Value& value,
       uint16_t max_length =
           str_type_info ? str_type_info->Cast<StringTypeInfo>().max_length
                         : STRING_DEFAULT_MAX_LENGTH;
-      LOG(INFO) << "Setting string value: " << value.str()
-                << " for type: " << type.ToString();
       out_value = execution::Value::VARCHAR(value.str(), max_length);
     }
     break;


### PR DESCRIPTION
Fix #161 
This pull request makes minor improvements to logging in the codebase by reducing the verbosity of certain log messages. Informational logs related to schema dumping and string value setting have been either removed or downgraded to a lower log level.

Logging changes:

* Downgraded the log level from `LOG(INFO)` to `VLOG(1)` for the message indicating that the schema was dumped to a YAML file in `PropertyGraph::DumpSchema()` (`src/storages/graph/property_graph.cc`).
* Removed the `LOG(INFO)` message that logged the setting of string values in `common_value_to_value()` (`src/utils/pb_utils.cc`).
* Removed a redundant `LOG(INFO)` message after dumping the schema to a file in `PropertyGraph::DumpSchema()` (`src/storages/graph/property_graph.cc`).