### PR TITLE
refactor: Avoid unnecessary MD5 computation 

### DIFF
--- a/src/storages/container/file_mmap_container.cc
+++ b/src/storages/container/file_mmap_container.cc
@@ -68,9 +68,6 @@ void FileSharedMMap::Resize(size_t size) {
   if (size == size_) {
     return;
   }
-  if (mmap_data_ && size_ > 0) {
-    Sync();  // Ensure changes are flushed before resizing
-  }
   size_t real_size = size + sizeof(FileHeader);
   if (mmap_data_ && mmap_size_ > 0) {
     munmapImpl(mmap_data_, mmap_size_);
@@ -98,10 +95,6 @@ void FileSharedMMap::Resize(size_t size) {
   }
   data_ = static_cast<char*>(mmap_data_) + sizeof(FileHeader);
   size_ = mmap_size_ - sizeof(FileHeader);
-  // Recompute and persist the MD5 for the new payload (including any
-  // zero-extended region from ftruncate), so that a subsequent Open()
-  // passes the integrity check.
-  Sync();
 }
 
 void* FileSharedMMap::mmapImpl(const std::string& path, size_t mmap_size) {

--- a/src/storages/container/file_mmap_container.cc
+++ b/src/storages/container/file_mmap_container.cc
@@ -95,10 +95,6 @@ void FileSharedMMap::Resize(size_t size) {
   }
   data_ = static_cast<char*>(mmap_data_) + sizeof(FileHeader);
   size_ = mmap_size_ - sizeof(FileHeader);
-  // Recompute and persist the MD5 for the new payload (including any
-  // zero-extended region from ftruncate), so that a subsequent Open()
-  // passes the integrity check.
-  Sync();
 }
 
 void* FileSharedMMap::mmapImpl(const std::string& path, size_t mmap_size) {

--- a/src/storages/container/file_mmap_container.cc
+++ b/src/storages/container/file_mmap_container.cc
@@ -68,6 +68,10 @@ void FileSharedMMap::Resize(size_t size) {
   if (size == size_) {
     return;
   }
+  if (mmap_data_ && size_ > 0) {
+    // Avoid MD5 recomputation here.
+    msync(mmap_data_, mmap_size_, MS_SYNC);
+  }
   size_t real_size = size + sizeof(FileHeader);
   if (mmap_data_ && mmap_size_ > 0) {
     munmapImpl(mmap_data_, mmap_size_);
@@ -95,6 +99,10 @@ void FileSharedMMap::Resize(size_t size) {
   }
   data_ = static_cast<char*>(mmap_data_) + sizeof(FileHeader);
   size_ = mmap_size_ - sizeof(FileHeader);
+  // Recompute and persist the MD5 for the new payload (including any
+  // zero-extended region from ftruncate), so that a subsequent Open()
+  // passes the integrity check.
+  Sync();
 }
 
 void* FileSharedMMap::mmapImpl(const std::string& path, size_t mmap_size) {
@@ -152,7 +160,16 @@ void FileSharedMMap::Dump(const std::string& path) {
                  << "), falling back to fwrite for " << path;
     MMapContainer::Dump(path);
   }
-  Close();
+  // Sync() has already been executed above, so avoid Close() here to prevent
+  // an extra full-payload MD5 pass.
+  if (mmap_data_ && mmap_size_ > 0) {
+    munmapImpl(mmap_data_, mmap_size_);
+  }
+  path_.clear();
+  mmap_data_ = nullptr;
+  mmap_size_ = 0;
+  data_ = nullptr;
+  size_ = 0;
 }
 
 }  // namespace neug

--- a/src/storages/container/file_mmap_container.cc
+++ b/src/storages/container/file_mmap_container.cc
@@ -68,10 +68,6 @@ void FileSharedMMap::Resize(size_t size) {
   if (size == size_) {
     return;
   }
-  if (mmap_data_ && size_ > 0) {
-    // Avoid MD5 recomputation here.
-    msync(mmap_data_, mmap_size_, MS_SYNC);
-  }
   size_t real_size = size + sizeof(FileHeader);
   if (mmap_data_ && mmap_size_ > 0) {
     munmapImpl(mmap_data_, mmap_size_);

--- a/src/storages/container/file_mmap_container.cc
+++ b/src/storages/container/file_mmap_container.cc
@@ -157,11 +157,7 @@ void FileSharedMMap::Dump(const std::string& path) {
   if (mmap_data_ && mmap_size_ > 0) {
     munmapImpl(mmap_data_, mmap_size_);
   }
-  path_.clear();
-  mmap_data_ = nullptr;
-  mmap_size_ = 0;
-  data_ = nullptr;
-  size_ = 0;
+  Close();
 }
 
 }  // namespace neug

--- a/src/storages/container/mmap_container.cc
+++ b/src/storages/container/mmap_container.cc
@@ -69,9 +69,6 @@ void MMapContainer::Open(const std::string& path) {
 }
 
 void MMapContainer::Close() {
-  // Flush MD5 header to the backing file before unmapping.
-  // For non-file containers the base Sync() is a no-op, so this is free.
-  Sync();
   if (mmap_data_ && mmap_size_ > 0) {
     munmapImpl(mmap_data_, mmap_size_);
   }

--- a/src/storages/container/mmap_container.cc
+++ b/src/storages/container/mmap_container.cc
@@ -69,6 +69,9 @@ void MMapContainer::Open(const std::string& path) {
 }
 
 void MMapContainer::Close() {
+  // Flush MD5 header to the backing file before unmapping.
+  // For non-file containers the base Sync() is a no-op, so this is free.
+  Sync();
   if (mmap_data_ && mmap_size_ > 0) {
     munmapImpl(mmap_data_, mmap_size_);
   }


### PR DESCRIPTION
Fix #168 