### PR TITLE
fix: skip filter push-down for bare node/rel predicates

### DIFF
--- a/src/compiler/optimizer/filter_push_down_pattern.cpp
+++ b/src/compiler/optimizer/filter_push_down_pattern.cpp
@@ -15,10 +15,32 @@
  */
 
 #include "neug/compiler/optimizer/filter_push_down_pattern.h"
+#include "neug/compiler/binder/expression_visitor.h"
 #include "neug/compiler/gopt/g_alias_manager.h"
 
 namespace neug {
 namespace optimizer {
+
+namespace {
+// Detects whole-node / whole-rel references (ExpressionType::PATTERN) in the
+// predicate, e.g. "WHERE a IS NOT NULL" or "WHERE a IS NULL" on a bound alias.
+// Pushing such predicates into SCAN/EXTEND/GET_V embeds a Variable without
+// `property` in the scan predicate; execution parses that with VarType::kVertex
+// and aborts in parse_vertex_var ("vertex variable missing property"). Keeping
+// the filter above the scan uses VarType::kRecord (select.cc) and is correct.
+class BarePatternDetector final : public binder::ExpressionVisitor {
+ public:
+  bool hasBarePattern() const { return found_; }
+
+ protected:
+  void visitNodeRelExpr(std::shared_ptr<binder::Expression>) override {
+    found_ = true;
+  }
+
+ private:
+  bool found_ = false;
+};
+}  // namespace
 
 void FilterPushDownPattern::rewrite(planner::LogicalPlan* plan) {
   auto root = plan->getLastOperator();
@@ -110,6 +132,13 @@ bool FilterPushDownPattern::canPushDown(
   if (childType != planner::LogicalOperatorType::SCAN_NODE_TABLE &&
       childType != planner::LogicalOperatorType::EXTEND &&
       childType != planner::LogicalOperatorType::GET_V) {
+    return false;
+  }
+  // Do not fuse bare PATTERN null checks into scan predicates; see
+  // BarePatternDetector.
+  BarePatternDetector patternDetector;
+  patternDetector.visit(predicate);
+  if (patternDetector.hasBarePattern()) {
     return false;
   }
   auto uniqueName = getUniqueName(child);

--- a/tools/python_bind/tests/test_db_query.py
+++ b/tools/python_bind/tests/test_db_query.py
@@ -2876,6 +2876,27 @@ def test_is_not_null_on_node_variable(tmp_path):
     assert len(records) == 1
     assert records[0][0] == 1
 
+    conn.execute("CREATE NODE TABLE person(id INT64 PRIMARY KEY);")
+    conn.execute("CREATE REL TABLE knows(FROM person TO person);")
+    conn.execute("CREATE (a:person {id: 1});")
+    conn.execute("CREATE (a:person {id: 2});")
+    conn.execute(
+        "MATCH (a:person {id: 1}), (b:person {id: 2}) CREATE (a)-[:knows]->(b);"
+    )
+    # Current OPTIONAL + WHERE semantics: the planner pushes WHERE into the
+    # OPTIONAL MATCH branch (as part of that optional pattern), rather than
+    # applying it as a filter after the left-outer-join-style row extension.
+    # That differs from Cypher-style semantics where filtering runs after the
+    # optional match, so row counts / null handling may not match a strict LOJ.
+    result = conn.execute(
+        "MATCH (a:person) OPTIONAL MATCH (a)-[:knows]->(b:person) "
+        "WHERE b IS NULL RETURN a, b;",
+        access_mode="read",
+    )
+    records = list(result)
+    ids = sorted(row[0]["id"] for row in records)
+    assert ids == [1, 2]
+
     conn.close()
     db.close()
 

--- a/tools/python_bind/tests/test_db_query.py
+++ b/tools/python_bind/tests/test_db_query.py
@@ -2852,6 +2852,34 @@ def test_optional_match_on_edge(tmp_path):
     db.close()
 
 
+def test_is_not_null_on_node_variable(tmp_path):
+    """IS NOT NULL on a bound node variable should not abort.
+
+    Reproducer: MATCH (a:Node) WHERE a IS NOT NULL RETURN 1
+    Previously aborted in variable.cc with 'vertex variable missing property'
+    because the physical plan emitted a Variable without a property field
+    for the whole-node null check.
+    """
+    db_dir = tmp_path / "is_not_null_node"
+    db_dir.mkdir()
+    db = Database(db_path=str(db_dir), mode="w")
+    conn = db.connect()
+
+    conn.execute("CREATE NODE TABLE Node(id INT64, PRIMARY KEY(id));")
+    conn.execute("CREATE (a:Node {id: 1});")
+
+    result = conn.execute(
+        "MATCH (a:Node) WHERE a IS NOT NULL RETURN 1;",
+        access_mode="read",
+    )
+    records = list(result)
+    assert len(records) == 1
+    assert records[0][0] == 1
+
+    conn.close()
+    db.close()
+
+
 def test_drop_and_recreate_table_same_name(tmp_path):
     """Test that dropping node tables with relationships and recreating
     with the same name but different schema does not crash (SIGSEGV)."""


### PR DESCRIPTION

## What do these changes do?

Predicates like WHERE a IS NOT NULL embed a PATTERN without a property; scan predicates are parsed with VarType::kVertex and abort in parse_vertex_var. Detect bare PATTERN in canPushDown and keep the filter on the record path.

Add Python regression test test_is_not_null_on_node_variable.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #191 

