### PR TITLE
docs: Clean up Java API reference doc

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,6 @@ on:
         - main
       paths:
         - 'doc/**'
-        - 'tools/java_driver/**'
         - '.github/workflows/docs.yml'
 
 
@@ -33,18 +32,10 @@ jobs:
       with:
         python-version: '3.10'
 
-    - name: Setup Java and Maven
-      uses: s4u/setup-maven-action@v1.19.0
-      with:
-        java-version: '17'
-        maven-version: '3.9.6'
-
     - name: Build Documentation
       run: |
         sudo apt update
         sudo apt install -y doxygen graphviz
-        cd ${GITHUB_WORKSPACE}/tools/java_driver
-        mvn -DskipTests javadoc:javadoc
         cd ${GITHUB_WORKSPACE}/tools/python_bind
         python3 -m pip  install -r requirements.txt
         python3 -m pip  install -r requirements_dev.txt
@@ -52,5 +43,3 @@ jobs:
         . /home/neug/.neug_env
         make dependencies
         make html
-        mkdir -p ${GITHUB_WORKSPACE}/doc/build/html/reference/java_api
-        cp -r ${GITHUB_WORKSPACE}/tools/java_driver/target/site/apidocs ${GITHUB_WORKSPACE}/doc/build/html/reference/java_api/

--- a/doc/source/reference/java_api/index.md
+++ b/doc/source/reference/java_api/index.md
@@ -2,17 +2,6 @@
 
 The NeuG Java API provides a Java-native driver for connecting to NeuG servers, executing Cypher queries, and consuming typed query results.
 
-```{toctree}
-:maxdepth: 1
-:hidden:
-
-driver
-config
-session
-result_set
-result_set_metadata
-```
-
 ## Overview
 
 The Java driver is designed for application integration and service-side usage:
@@ -186,7 +175,7 @@ These dependencies are managed automatically by Maven.
 
 ## API Documentation
 
-- <a href="apidocs/index.html">Generated Javadoc</a>
+The generated Javadoc can be built locally. See [Build Javadoc Locally](#build-javadoc-locally) below.
 
 ## Build Javadoc Locally
 


### PR DESCRIPTION
- Remove Sphinx-specific toctree directive (not supported by Nextra)
- Replace non-existent Javadoc link with build instructions

