### PR TITLE
refactor: Remove dummy method `build_lf_indexer` for `LFIndexer`

### DIFF
--- a/include/neug/utils/id_indexer.h
+++ b/include/neug/utils/id_indexer.h
@@ -195,12 +195,6 @@ class IdIndexer;
 template <typename INDEX_T>
 class LFIndexer;
 
-template <typename KEY_T, typename INDEX_T>
-void build_lf_indexer(const IdIndexer<KEY_T, INDEX_T>& input,
-                      const std::string& filename, LFIndexer<INDEX_T>& lf,
-                      const std::string& snapshot_dir,
-                      const std::string& work_dir, DataTypeId type);
-
 template <typename INDEX_T>
 class LFIndexer {
   static constexpr INDEX_T sentinel = std::numeric_limits<INDEX_T>::max();
@@ -533,14 +527,6 @@ class LFIndexer {
 
   ska::ska::prime_number_hash_policy hash_policy_;
   GHash<Property> hasher_;
-
-  // _KEY_T is defined in sys/_types/_key_t.h on macos
-  template <typename __KEY_T, typename _INDEX_T>
-  friend void build_lf_indexer(const IdIndexer<__KEY_T, _INDEX_T>& input,
-                               const std::string& filename,
-                               LFIndexer<_INDEX_T>& output,
-                               const std::string& snapshot_dir,
-                               const std::string& work_dir, DataTypeId type);
 };
 
 template <typename INDEX_T>
@@ -999,13 +985,6 @@ class IdIndexer : public IdIndexerBase<INDEX_T> {
   size_t num_slots_minus_one_ = 0;
 
   GHash<KEY_T> hasher_;
-
-  template <typename __KEY_T, typename _INDEX_T>
-  friend void build_lf_indexer(const IdIndexer<__KEY_T, _INDEX_T>& input,
-                               const std::string& filename,
-                               LFIndexer<_INDEX_T>& output,
-                               const std::string& snapshot_dir,
-                               const std::string& work_dir, DataTypeId type);
 };
 
 template <typename KEY_T, typename INDEX_T>
@@ -1030,60 +1009,5 @@ struct _move_data<std::string_view, INDEX_T> {
     }
   }
 };
-
-template <typename KEY_T, typename INDEX_T>
-void build_lf_indexer(const IdIndexer<KEY_T, INDEX_T>& input,
-                      const std::string& filename, LFIndexer<INDEX_T>& lf,
-                      const std::string& snapshot_dir,
-                      const std::string& work_dir, DataTypeId type) {
-  size_t size = input.keys_.size();
-  lf.init(type);
-  lf.keys_->open(filename + ".keys", "", work_dir);
-  lf.keys_->resize(size);
-  _move_data<KEY_T, INDEX_T>()(input.keys_, *lf.keys_, size);
-  lf.num_elements_.store(size);
-
-  auto indices_path = work_dir + "/" + filename + ".indices";
-  file_utils::create_file(indices_path, sizeof(FileHeader));
-  lf.indices_ = OpenContainer(indices_path,
-                              tmp_dir(work_dir) + "/" + filename + ".indices",
-                              MemoryLevel::kSyncToFile);
-  lf.indices_->Resize((input.num_slots_minus_one_ + 1) * sizeof(INDEX_T));
-  auto* lf_indices_ptr = reinterpret_cast<INDEX_T*>(lf.indices_->GetData());
-  lf.indices_size_ = lf.indices_->GetDataSize() / sizeof(INDEX_T);
-
-  lf.hash_policy_.set_mod_function_by_index(
-      input.hash_policy_.get_mod_function_index());
-  lf.num_slots_minus_one_ = input.num_slots_minus_one_;
-  memcpy(lf_indices_ptr, input.indices_.data(),
-         lf.indices_size_ * sizeof(INDEX_T));
-
-  std::vector<INDEX_T> residuals;
-  for (INDEX_T idx = 0; idx < input.size(); ++idx) {
-    if (input.indices_[idx] != LFIndexer<INDEX_T>::sentinel) {
-      residuals.push_back(input.indices_[idx]);
-    }
-  }
-  for (const auto& lid : residuals) {
-    auto oid = input.keys_[lid];
-    size_t index = input.hash_policy_.index_for_hash(
-        input.hasher_(oid), input.num_slots_minus_one_);
-    while (true) {
-      if (lf_indices_ptr[index] == lid) {
-        break;
-      } else if (lf_indices_ptr[index] == LFIndexer<INDEX_T>::sentinel) {
-        lf_indices_ptr[index] = lid;
-        break;
-      }
-      index = (index + 1) % (input.num_slots_minus_one_ + 1);
-    }
-  }
-  lf.dump_meta(snapshot_dir + "/" + filename + ".meta");
-
-  lf.keys_->dump(snapshot_dir + "/" + filename + ".keys");
-  std::filesystem::remove(work_dir + "/" + filename + ".meta");
-  lf.keys_->close();
-  lf.keys_->open(filename + ".keys", snapshot_dir, work_dir);
-}
 
 }  // namespace neug

--- a/tests/storage/test_edge_table.cc
+++ b/tests/storage/test_edge_table.cc
@@ -90,22 +90,23 @@ class EdgeTableTest : public ::testing::Test {
     return WorkDirectory() / "checkpoint";
   }
 
+  void build_indexer(neug::LFIndexer<neug::vid_t>& indexer, neug::vid_t num,
+                     const std::string& name, const std::string& snapshot_dir,
+                     const std::string& work_dir) {
+    indexer.drop();
+    indexer.init(DataTypeId::kInt64);
+    indexer.open(name, snapshot_dir, work_dir);
+    indexer.reserve(num);
+    for (neug::vid_t i = 0; i < num; ++i) {
+      indexer.insert(PropUtils<int64_t>::to_prop(i), i);
+    }
+  }
+
   void InitIndexers(neug::vid_t src_num, neug::vid_t dst_num) {
-    neug::IdIndexer<int64_t, neug::vid_t> src_input, dst_input;
-    for (neug::vid_t i = 0; i < src_num; ++i) {
-      neug::vid_t lid;
-      src_input.add(static_cast<int64_t>(i), lid);
-    }
-    for (neug::vid_t i = 0; i < dst_num; ++i) {
-      neug::vid_t lid;
-      dst_input.add(static_cast<int64_t>(i), lid);
-    }
-    neug::build_lf_indexer<int64_t, neug::vid_t>(
-        src_input, "src_indexer", src_indexer, SnapshotDirectory().string(),
-        WorkDirectory().string(), neug::DataTypeId::kInt64);
-    neug::build_lf_indexer<int64_t, neug::vid_t>(
-        dst_input, "dst_indexer", dst_indexer, SnapshotDirectory().string(),
-        WorkDirectory().string(), neug::DataTypeId::kInt64);
+    build_indexer(src_indexer, src_num, "src_indexer",
+                  SnapshotDirectory().string(), WorkDirectory().string());
+    build_indexer(dst_indexer, dst_num, "dst_indexer",
+                  SnapshotDirectory().string(), WorkDirectory().string());
   }
 
   void ConstructEdgeTable(neug::label_t src_label, neug::label_t dst_label,


### PR DESCRIPTION
Fix #225 