### PR TITLE
refactor: Remove `wal_uri` from config and remove dummy work_dir parameter

### DIFF
--- a/bin/rt_server.cc
+++ b/bin/rt_server.cc
@@ -59,10 +59,7 @@ int main(int argc, char** argv) {
       cxxopts::value<int>()->default_value("1"))(
       "sharding-mode", "Sharding mode (exclusive or cooperative)",
       cxxopts::value<std::string>()->default_value("cooperative"))(
-      "wal-uri", "URI for Write-Ahead Logging storage",
-      cxxopts::value<std::string>()->default_value(
-          "file://{GRAPH_DATA_DIR}/wal"))("host", "Host address",
-                                          cxxopts::value<std::string>());
+      "host", "Host address", cxxopts::value<std::string>());
 
   google::InitGoogleLogging(argv[0]);
   FLAGS_logtostderr = true;
@@ -100,7 +97,6 @@ int main(int argc, char** argv) {
   neug::NeugDB db;
   neug::NeugDBConfig config(data_path, shard_num);
   config.memory_level = memory_level;
-  config.wal_uri = vm["wal-uri"].as<std::string>();
   if (config.memory_level == neug::MemoryLevel::kHugePagePreferred) {
     config.enable_auto_compaction = true;
   }

--- a/include/neug/config.h.in
+++ b/include/neug/config.h.in
@@ -97,7 +97,6 @@ struct NeugDBConfig {
         thread_num(1),
         enable_auto_compaction(false),
         memory_level(MemoryLevel::kInMemory),
-        wal_uri("{GRAPH_DATA_DIR}/wal"),
         compact_csr(true),
         compact_on_close(true),
         checkpoint_on_close(false),
@@ -117,7 +116,6 @@ struct NeugDBConfig {
         thread_num(thread_num_),
         enable_auto_compaction(false),
         memory_level(MemoryLevel::kInMemory),
-        wal_uri("{GRAPH_DATA_DIR}/wal"),
         compact_csr(true),
         compact_on_close(true),
         checkpoint_on_close(false),
@@ -149,9 +147,6 @@ struct NeugDBConfig {
    * - 2: Prefer hugepages
    */
   MemoryLevel memory_level;
-
-  /// WAL (Write-Ahead Log) storage URI. Use {GRAPH_DATA_DIR} as placeholder.
-  std::string wal_uri;
 
   /// Compact CSR structures during compaction
   bool compact_csr;

--- a/include/neug/main/neug_db.h
+++ b/include/neug/main/neug_db.h
@@ -297,9 +297,8 @@ class NeugDB {
  private:
   void preprocessConfig();
   void initAllocators();
-  void openGraphAndSchema();
-  void ingestWals();
-  void ingestWals(IWalParser& parser, const std::string& work_dir);
+  void openGraphAndIngestWals();
+  void ingestWals(IWalParser& parser);
   void initPlannerAndQueryProcessor();
   /**
    * @brief Create a checkpoint of the current graph.

--- a/include/neug/server/session_pool.h
+++ b/include/neug/server/session_pool.h
@@ -31,8 +31,7 @@ struct SessionLocalContext {
       PropertyGraph& graph_, std::shared_ptr<IGraphPlanner> planner,
       std::shared_ptr<execution::GlobalQueryCache> global_query_cache,
       std::shared_ptr<Allocator> alloc,
-      std::shared_ptr<IVersionManager> version_manager,
-      const std::string& work_dir, int thread_id,
+      std::shared_ptr<IVersionManager> version_manager, int thread_id,
       std::unique_ptr<IWalWriter> in_logger, const NeugDBConfig& config_)
       : allocator(alloc),
         logger(std::move(in_logger)),
@@ -144,16 +143,15 @@ class SessionPool {
       std::shared_ptr<execution::GlobalQueryCache> global_query_cache,
       std::shared_ptr<IVersionManager> version_manager,
       std::vector<std::shared_ptr<Allocator>>& allocators,
-      const NeugDBConfig& config, const std::string& work_dir) {
+      const NeugDBConfig& config, const std::string& wal_uri) {
     session_num_ = config.thread_num;
-    auto wal_uri = parse_wal_uri(config.wal_uri, work_dir);
     WalWriterFactory::Init();
     contexts_ = static_cast<SessionLocalContext*>(
         aligned_alloc(4096, sizeof(SessionLocalContext) * config.thread_num));
     for (int i = 0; i < config.thread_num; ++i) {
       new (&contexts_[i]) SessionLocalContext(
-          graph, planner, global_query_cache, allocators[i], version_manager,
-          work_dir, i, WalWriterFactory::CreateWalWriter(wal_uri, i), config);
+          graph, planner, global_query_cache, allocators[i], version_manager, i,
+          WalWriterFactory::CreateWalWriter(wal_uri, i), config);
     }
     bthread_cond_init(&cond_, nullptr);
     bthread_mutex_init(&mutex_, nullptr);

--- a/include/neug/transaction/update_transaction.h
+++ b/include/neug/transaction/update_transaction.h
@@ -276,9 +276,8 @@ class UpdateTransaction {
                                               edge_label, timestamp_);
   }
 
-  static void IngestWal(PropertyGraph& graph, const std::string& work_dir,
-                        uint32_t timestamp, char* data, size_t length,
-                        Allocator& alloc);
+  static void IngestWal(PropertyGraph& graph, uint32_t timestamp, char* data,
+                        size_t length, Allocator& alloc);
   Property GetVertexId(label_t label, vid_t lid) const;
 
   bool GetVertexIndex(label_t label, const Property& id, vid_t& index) const;

--- a/include/neug/transaction/wal/wal.h
+++ b/include/neug/transaction/wal/wal.h
@@ -46,7 +46,6 @@ struct UpdateWalUnit {
   size_t size{0};
 };
 
-std::string parse_wal_uri(std::string uri, const std::string& work_dir);
 std::string get_wal_uri_scheme(const std::string& uri);
 std::string get_wal_uri_path(const std::string& uri);
 

--- a/src/main/neug_db.cc
+++ b/src/main/neug_db.cc
@@ -49,8 +49,8 @@ namespace neug {
 class Connection;
 static void IngestWalRange(PropertyGraph& graph,
                            std::vector<std::shared_ptr<Allocator>>& allocators,
-                           const IWalParser& parser, uint32_t from, uint32_t to,
-                           const std::string& work_dir) {
+                           const IWalParser& parser, uint32_t from,
+                           uint32_t to) {
   if (from >= to) {
     return;
   }
@@ -117,8 +117,7 @@ bool NeugDB::Open(const NeugDBConfig& config) {
   }
   neug::execution::PlanParser::get().init();
   initAllocators();
-  openGraphAndSchema();
-  ingestWals();
+  openGraphAndIngestWals();
   initPlannerAndQueryProcessor();
 
   LOG(INFO) << "NeugDB opened successfully";
@@ -211,7 +210,7 @@ void NeugDB::initAllocators() {
   }
 }
 
-void NeugDB::openGraphAndSchema() {
+void NeugDB::openGraphAndIngestWals() {
   if (!std::filesystem::exists(work_dir_)) {
     std::filesystem::create_directories(work_dir_);
   }
@@ -219,41 +218,36 @@ void NeugDB::openGraphAndSchema() {
   thread_num_ = config_.thread_num;
   try {
     graph_.Open(work_dir_, config_.memory_level);
+    neug::WalParserFactory::Init();
+    auto wal_parser = WalParserFactory::CreateWalParser(wal_dir(work_dir_));
+    ingestWals(*wal_parser);
   } catch (std::exception& e) {
     LOG(ERROR) << "Exception: " << e.what();
     THROW_INTERNAL_EXCEPTION(e.what());
   }
 }
 
-void NeugDB::ingestWals() {
-  auto wal_uri = parse_wal_uri(config_.wal_uri, work_dir_);
-  neug::WalParserFactory::Init();
-  auto wal_parser = WalParserFactory::CreateWalParser(wal_uri);
-  ingestWals(*wal_parser, work_dir_);
-}
-
-void NeugDB::ingestWals(IWalParser& parser, const std::string& work_dir) {
+void NeugDB::ingestWals(IWalParser& parser) {
   uint32_t from_ts = 1;
   LOG(INFO) << "Ingesting update wals size: "
             << parser.get_update_wals().size();
   for (auto& update_wal : parser.get_update_wals()) {
     uint32_t to_ts = update_wal.timestamp;
     if (from_ts < to_ts) {
-      IngestWalRange(graph_, allocators_, parser, from_ts, to_ts, work_dir);
+      IngestWalRange(graph_, allocators_, parser, from_ts, to_ts);
     }
     if (update_wal.size == 0) {
       graph_.Compact(config_.compact_csr, config_.csr_reserve_ratio,
                      update_wal.timestamp);
       last_compaction_ts_ = update_wal.timestamp;
     } else {
-      UpdateTransaction::IngestWal(graph_, work_dir, to_ts, update_wal.ptr,
+      UpdateTransaction::IngestWal(graph_, to_ts, update_wal.ptr,
                                    update_wal.size, *allocators_[0]);
     }
     from_ts = to_ts + 1;
   }
   if (from_ts <= parser.last_ts()) {
-    IngestWalRange(graph_, allocators_, parser, from_ts, parser.last_ts() + 1,
-                   work_dir);
+    IngestWalRange(graph_, allocators_, parser, from_ts, parser.last_ts() + 1);
   }
   LOG(INFO) << "Finish ingesting wals up to timestamp: " << parser.last_ts();
   last_ts_ = parser.last_ts();

--- a/src/server/neug_db_service.cc
+++ b/src/server/neug_db_service.cc
@@ -42,7 +42,7 @@ void NeugDBService::init(const ServiceConfig& config) {
 
   session_pool_ = std::make_unique<neug::SessionPool>(
       db_.graph(), db_.GetPlanner(), db_.GetQueryCache(), version_manager_,
-      db_.allocators_, db_config_, db_.work_dir());
+      db_.allocators_, db_config_, wal_dir(db_.work_dir()));
 
   hdl_mgr_ = std::make_unique<BrpcServiceManager>(db_, *session_pool_);
   hdl_mgr_->Init(config);

--- a/src/transaction/update_transaction.cc
+++ b/src/transaction/update_transaction.cc
@@ -1028,10 +1028,8 @@ bool UpdateTransaction::UpdateEdgeProperty(label_t src_label, vid_t src,
   return true;
 }
 
-void UpdateTransaction::IngestWal(PropertyGraph& graph,
-                                  const std::string& work_dir,
-                                  uint32_t timestamp, char* data, size_t length,
-                                  Allocator& alloc) {
+void UpdateTransaction::IngestWal(PropertyGraph& graph, uint32_t timestamp,
+                                  char* data, size_t length, Allocator& alloc) {
   OutArchive arc;
   arc.SetSlice(data, length);
   while (!arc.Empty()) {

--- a/src/transaction/wal/wal.cc
+++ b/src/transaction/wal/wal.cc
@@ -28,19 +28,6 @@
 
 namespace neug {
 
-std::string parse_wal_uri(std::string wal_uri, const std::string& work_dir) {
-  if (wal_uri.empty()) {
-    VLOG(1) << "wal_uri is not set, use default wal_uri";
-    wal_uri = wal_dir(work_dir);
-  } else if (wal_uri.find("{GRAPH_DATA_DIR}") != std::string::npos) {
-    VLOG(1) << "Template {GRAPH_DATA_DIR} found in wal_uri, replace it with "
-               "data_dir";
-    wal_uri = std::regex_replace(wal_uri, std::regex("\\{GRAPH_DATA_DIR\\}"),
-                                 work_dir);
-  }
-  return wal_uri;
-}
-
 std::string get_wal_uri_scheme(const std::string& uri) {
   std::string scheme;
   auto pos = uri.find("://");


### PR DESCRIPTION
This pull request simplifies and standardizes how the Write-Ahead Log (WAL) directory is handled throughout the codebase. The main changes remove the `wal_uri` configuration from `NeugDBConfig`, eliminate the `parse_wal_uri` function, and update related interfaces and method signatures to use a direct `wal_dir` approach. This reduces configuration complexity and potential sources of error related to WAL path resolution.

**Configuration Simplification**
* Removed the `wal_uri` field and related logic from `NeugDBConfig`, so WAL directory handling is now standardized and no longer configurable via template strings. [[1]](diffhunk://#diff-532dfd9a7b0e3151eec5e5c652c053d49b191ee05db7832803a8c6018273049aL100) [[2]](diffhunk://#diff-532dfd9a7b0e3151eec5e5c652c053d49b191ee05db7832803a8c6018273049aL120) [[3]](diffhunk://#diff-532dfd9a7b0e3151eec5e5c652c053d49b191ee05db7832803a8c6018273049aL153-L155)
* Deleted the `parse_wal_uri` function and all calls to it, removing support for `{GRAPH_DATA_DIR}` template expansion. [[1]](diffhunk://#diff-9b7a0430f66bbe3805d746356417d1928e5ba0795124602f71723d7974d37b1aL49) [[2]](diffhunk://#diff-948afb5676fcd807dbf142b1e1264b5b73fdfc41db6ffd0cec6eb7dfab3b5d2eL31-L43)

**Interface and Method Updates**
* Updated constructors and methods in `SessionLocalContext`, `SessionPool`, and `UpdateTransaction` to remove `work_dir` and `wal_uri` parameters in favor of directly passing the resolved WAL directory. [[1]](diffhunk://#diff-3383e571b98a2e81609e26d82627b6923e98af964c8d2d036b6d0ce1064933dfL34-R34) [[2]](diffhunk://#diff-3383e571b98a2e81609e26d82627b6923e98af964c8d2d036b6d0ce1064933dfL147-R154) [[3]](diffhunk://#diff-a68bd0cc716f740f4017577bb3a904d6ad19fed7c839f475463c6770eb43f307L279-R280)
* Refactored `NeugDB` to combine WAL ingestion and graph opening into `openGraphAndIngestWals`, and updated related method signatures to remove `work_dir` parameters. [[1]](diffhunk://#diff-1211c13a9bd5812585bb603d036b5ddd641235026858c3050bf007ca1af3730fL300-R301) [[2]](diffhunk://#diff-478b33080820e5bc0f34544c7c19738919d15492ef20301d7492e4a52794a71eL120-R120) [[3]](diffhunk://#diff-478b33080820e5bc0f34544c7c19738919d15492ef20301d7492e4a52794a71eL214-R250) [[4]](diffhunk://#diff-478b33080820e5bc0f34544c7c19738919d15492ef20301d7492e4a52794a71eL52-R53)

**Service and Transaction Logic**
* Updated service initialization and WAL ingestion logic to use the new direct WAL directory approach, ensuring consistency across the codebase. [[1]](diffhunk://#diff-79be07cd2d484444a5a7dd9dfbb4a3400e6b74221ab331f752c80ca8de056450L45-R45) [[2]](diffhunk://#diff-860867eeb692a98e826c7417ab2fc6d9380f35009636640383e1c94ff7748cb6L1031-R1032)

These changes make WAL handling more robust and less error-prone by removing unnecessary configuration indirection.