### PR TITLE
refactor: Disable auto checkpoint for read-only mode

### DIFF
--- a/include/neug/utils/id_indexer.h
+++ b/include/neug/utils/id_indexer.h
@@ -987,27 +987,4 @@ class IdIndexer : public IdIndexerBase<INDEX_T> {
   GHash<KEY_T> hasher_;
 };
 
-template <typename KEY_T, typename INDEX_T>
-struct _move_data {
-  using key_buffer_t = typename id_indexer_impl::KeyBuffer<KEY_T>::type;
-  void operator()(const key_buffer_t& input, ColumnBase& col, size_t size) {
-    auto& keys = dynamic_cast<TypedColumn<KEY_T>&>(col);
-    for (size_t idx = 0; idx < size; ++idx) {
-      keys.set_value(idx, input[idx]);
-    }
-  }
-};
-
-template <typename INDEX_T>
-struct _move_data<std::string_view, INDEX_T> {
-  using key_buffer_t =
-      typename id_indexer_impl::KeyBuffer<std::string_view>::type;
-  void operator()(const key_buffer_t& input, ColumnBase& col, size_t size) {
-    auto& keys = dynamic_cast<StringColumn&>(col);
-    for (size_t idx = 0; idx < size; ++idx) {
-      keys.set_value(idx, input[idx]);
-    }
-  }
-};
-
 }  // namespace neug

--- a/src/main/neug_db.cc
+++ b/src/main/neug_db.cc
@@ -142,7 +142,6 @@ void NeugDB::Close() {
   if (closed_.exchange(true)) {
     return;
   }
-  closed_.store(true);
   if (connection_manager_) {
     connection_manager_->Close();
     connection_manager_.reset();
@@ -154,7 +153,8 @@ void NeugDB::Close() {
     query_processor_.reset();
   }
   // -----------Create checkpoint if needed----------------
-  if (config_.checkpoint_on_close) {
+  if (config_.checkpoint_on_close && config_.mode == DBMode::READ_WRITE) {
+    VLOG(1) << "Creating checkpoint on close...";
     createCheckpoint(false, false);
   }
   graph_.Clear();
@@ -162,6 +162,7 @@ void NeugDB::Close() {
   if (file_lock_) {
     file_lock_->unlock();
   }
+  closed_.store(true);
 }
 
 std::shared_ptr<Connection> NeugDB::Connect() {

--- a/src/main/neug_db.cc
+++ b/src/main/neug_db.cc
@@ -138,7 +138,6 @@ bool NeugDB::Open(const NeugDBConfig& config) {
 }
 
 void NeugDB::Close() {
-  // atomic flag to avoid double close
   if (closed_.exchange(true)) {
     return;
   }
@@ -146,23 +145,29 @@ void NeugDB::Close() {
     connection_manager_->Close();
     connection_manager_.reset();
   }
-  if (planner_) {
-    planner_.reset();
-  }
+
   if (query_processor_) {
     query_processor_.reset();
   }
-  // -----------Create checkpoint if needed----------------
+  if (planner_) {
+    planner_.reset();
+  }
+
   if (config_.checkpoint_on_close && config_.mode == DBMode::READ_WRITE) {
     VLOG(1) << "Creating checkpoint on close...";
-    createCheckpoint(false, false);
+    try {
+      createCheckpoint(false, false);
+    } catch (const std::exception& e) {
+      LOG(ERROR) << "Checkpoint on close failed: " << e.what();
+    }
   }
+
   graph_.Clear();
 
   if (file_lock_) {
     file_lock_->unlock();
+    file_lock_.reset();
   }
-  closed_.store(true);
 }
 
 std::shared_ptr<Connection> NeugDB::Connect() {

--- a/src/server/neug_db_session.cc
+++ b/src/server/neug_db_session.cc
@@ -93,7 +93,15 @@ inline bool is_insert_only(const physical::ExecutionFlag flags) {
                              flags.checkpoint() || flags.procedure_call());
 }
 
-Status validate_flags(AccessMode mode, const physical::ExecutionFlag& flags) {
+Status validate_flags(AccessMode mode, const physical::ExecutionFlag& flags,
+                      const NeugDBConfig& db_config) {
+  if (db_config.mode == DBMode::READ_ONLY) {
+    if (!is_read_only(flags) || mode != AccessMode::kRead) {
+      return neug::Status(
+          neug::StatusCode::ERR_INVALID_ARGUMENT,
+          "Database is in read-only mode; write operations are not allowed.");
+    }
+  }
   if (mode == neug::AccessMode::kRead) {
     if (!is_read_only(flags)) {
       return neug::Status(neug::StatusCode::ERR_INVALID_ARGUMENT,
@@ -117,13 +125,14 @@ Status validate_flags(AccessMode mode, const physical::ExecutionFlag& flags) {
 template <typename Transaction>
 inline neug::result<execution::Context> ExecutePipelineInTransaction(
     execution::LocalQueryCache& pipeline_cache, const Schema& schema,
-    const std::string& query, AccessMode mode,
+    const std::string& query, AccessMode mode, const NeugDBConfig& db_config,
     const rapidjson::Document& param_json_obj, execution::OprTimer* timer,
     neug::MetaDatas& result_schema, Transaction& txn,
     IStorageInterface& storage_interface) {
   GS_AUTO(cache_value, pipeline_cache.Get(schema, query));
   assert(cache_value != nullptr);
-  RETURN_STATUS_ERROR_IF_NOT_OK(validate_flags(mode, cache_value->flags));
+  RETURN_STATUS_ERROR_IF_NOT_OK(
+      validate_flags(mode, cache_value->flags, db_config));
 
   auto params_map =
       ParamsParser::ParseFromJsonObj(cache_value->params_type, param_json_obj);
@@ -168,24 +177,27 @@ neug::result<std::string> NeugDBSession::Eval(const std::string& req) {
     auto read_txn = GetReadTransaction();
     neug::StorageReadInterface gri(read_txn.graph(), read_txn.timestamp());
     GS_AUTO(ctx, ExecutePipelineInTransaction(pipeline_cache_, schema(), query,
-                                              mode, param_json_obj, timer.get(),
-                                              result_schema, read_txn, gri));
+                                              mode, db_config_, param_json_obj,
+                                              timer.get(), result_schema,
+                                              read_txn, gri));
     response->mutable_schema()->CopyFrom(result_schema);
     neug::execution::Sink::sink_results(ctx, gri, response);
   } else if (mode == AccessMode::kInsert) {
     auto insert_txn = GetInsertTransaction();
     neug::StorageTPInsertInterface gii(insert_txn);
     GS_AUTO(ctx, ExecutePipelineInTransaction(pipeline_cache_, schema(), query,
-                                              mode, param_json_obj, timer.get(),
-                                              result_schema, insert_txn, gii));
+                                              mode, db_config_, param_json_obj,
+                                              timer.get(), result_schema,
+                                              insert_txn, gii));
   } else if (mode == AccessMode::kUpdate ||
              mode == AccessMode::kSchema) {  // Update mode
     CHECK(planner_ != nullptr);
     auto update_txn = GetUpdateTransaction();
     neug::StorageTPUpdateInterface gui(update_txn);
     GS_AUTO(ctx, ExecutePipelineInTransaction(pipeline_cache_, schema(), query,
-                                              mode, param_json_obj, timer.get(),
-                                              result_schema, update_txn, gui));
+                                              mode, db_config_, param_json_obj,
+                                              timer.get(), result_schema,
+                                              update_txn, gui));
     response->mutable_schema()->CopyFrom(result_schema);
     neug::execution::Sink::sink_results(ctx, gui, response);
   } else {

--- a/tools/python_bind/tests/conftest.py
+++ b/tools/python_bind/tests/conftest.py
@@ -18,6 +18,8 @@
 
 import pytest
 
+from neug.session import Session
+
 
 def ensure_result_cnt_gt_zero(result):
     """
@@ -63,3 +65,29 @@ def submit_cypher_query(conn, query, lambda_func=None):
 
     if lambda_func:
         lambda_func(result)
+
+
+def wait_for_server_ready(uri, timeout=10):
+    """
+    Wait until the service at the given URI is ready, or until the timeout is reached.
+    """
+    import time
+
+    session = None
+    last_error = None
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            session = Session(uri, timeout="10s")
+            session.execute("MATCH (n) RETURN 1;")
+            return
+        except Exception as exc:
+            last_error = exc
+            if session is not None:
+                try:
+                    session.close()
+                except Exception:
+                    pass
+                session = None
+        time.sleep(1)
+    pytest.fail(f"Timed out waiting for read-only server readiness: {last_error}")

--- a/tools/python_bind/tests/test_lsqb.py
+++ b/tools/python_bind/tests/test_lsqb.py
@@ -60,7 +60,6 @@ class TestLsqb(unittest.TestCase):
             self.db.close()
 
     def test_queries(self):
-
         submit_cypher_query(
             conn=self.conn,
             query="MATCH (n:Country) return n limit 10;",

--- a/tools/python_bind/tests/test_tp_service.py
+++ b/tools/python_bind/tests/test_tp_service.py
@@ -29,6 +29,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
 
 from neug.database import Database
 from neug.session import Session
+from conftest import wait_for_server_ready
 
 logger = logging.getLogger(__name__)
 
@@ -1083,7 +1084,7 @@ def test_readonly_db_rejects_write_queries_via_session():
     # Step 2: reopen in read-only mode and start serving.
     db_ro = Database(db_dir, "r")
     uri = db_ro.serve(10006, "localhost", False)
-    time.sleep(1)
+    wait_for_server_ready(uri)
 
     session = Session(uri, timeout="10s")
 

--- a/tools/python_bind/tests/test_tp_service.py
+++ b/tools/python_bind/tests/test_tp_service.py
@@ -27,9 +27,10 @@ import pytest
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
 
+from conftest import wait_for_server_ready
+
 from neug.database import Database
 from neug.session import Session
-from conftest import wait_for_server_ready
 
 logger = logging.getLogger(__name__)
 

--- a/tools/python_bind/tests/test_tp_service.py
+++ b/tools/python_bind/tests/test_tp_service.py
@@ -1055,3 +1055,57 @@ def test_insert_string_column_exaustion():
                 e,
             )
         logging.disable(logging.NOTSET)
+
+
+def test_readonly_db_rejects_write_queries_via_session():
+    """A database opened in read-only mode must reject INSERT/UPDATE queries
+    submitted through a Session, while still serving read queries correctly."""
+    db_dir = "/tmp/test_readonly_db_rejects_write_queries_via_session"
+    shutil.rmtree(db_dir, ignore_errors=True)
+    os.makedirs(db_dir, exist_ok=True)
+
+    # Step 1: create the database and populate it in write mode.
+    db = Database(db_dir, "w")
+    conn = db.connect()
+    conn.execute(
+        "CREATE NODE TABLE person(id INT64, name STRING, age INT64, PRIMARY KEY(id));"
+    )
+    conn.execute("CREATE REL TABLE knows(FROM person TO person, weight DOUBLE);")
+    conn.execute("CREATE (p:person {id: 1, name: 'marko', age: 29});")
+    conn.execute("CREATE (p:person {id: 2, name: 'vadas', age: 27});")
+    conn.execute(
+        "MATCH (a:person), (b:person) WHERE a.id = 1 AND b.id = 2"
+        " CREATE (a)-[:knows {weight: 0.5}]->(b);"
+    )
+    conn.close()
+    db.close()
+
+    # Step 2: reopen in read-only mode and start serving.
+    db_ro = Database(db_dir, "r")
+    uri = db_ro.serve(10006, "localhost", False)
+    time.sleep(1)
+
+    session = Session(uri, timeout="10s")
+
+    # Read queries must succeed.
+    res = session.execute("MATCH (n:person) WHERE n.id = 1 RETURN n.name;")
+    assert len(res) == 1
+    assert res[0][0] == "marko"
+
+    # INSERT must be rejected by the server.
+    with pytest.raises(Exception):
+        session.execute("CREATE (p:person {id: 3, name: 'josh', age: 32});")
+
+    # UPDATE must be rejected by the server.
+    with pytest.raises(Exception):
+        session.execute("MATCH (n:person) WHERE n.id = 1 SET n.age = 99;")
+
+    # The read-only data must be unchanged after the failed writes.
+    res = session.execute("MATCH (n:person) RETURN n.id ORDER BY n.id;")
+    assert len(res) == 2
+    assert res[0][0] == 1
+    assert res[1][0] == 2
+
+    session.close()
+    db_ro.stop_serving()
+    db_ro.close()


### PR DESCRIPTION
When the database is opened in read-only mode, there is no need for us to auto checkpoint on close.

Fix #239 
Fix #240 