### PR TITLE
refactor: Disable `compact_on_close` by default

### DIFF
--- a/include/neug/config.h.in
+++ b/include/neug/config.h.in
@@ -98,7 +98,7 @@ struct NeugDBConfig {
         enable_auto_compaction(false),
         memory_level(MemoryLevel::kInMemory),
         compact_csr(true),
-        compact_on_close(true),
+        compact_on_close(false),
         checkpoint_on_close(false),
         checkpoint_after_recovery(false) {}
 
@@ -117,7 +117,7 @@ struct NeugDBConfig {
         enable_auto_compaction(false),
         memory_level(MemoryLevel::kInMemory),
         compact_csr(true),
-        compact_on_close(true),
+        compact_on_close(false),
         checkpoint_on_close(false),
         checkpoint_after_recovery(false) {}
 

--- a/tests/transaction/test_update_transaction.cc
+++ b/tests/transaction/test_update_transaction.cc
@@ -2254,6 +2254,7 @@ TEST_F(UpdateTransactionTest, TestUpdateEdgeStringPropertyCompact) {
   neug::NeugDBConfig config(db_dir);
   config.memory_level = neug::MemoryLevel::kInMemory;
   config.checkpoint_on_close = true;
+  config.compact_on_close = true;
   db.Open(config);
   auto svc = std::make_shared<neug::NeugDBService>(db);
   std::vector<std::string> reviews;


### PR DESCRIPTION
Fix #255 