### PR TITLE
fix: disable resizing during the INSERT transaction

### DIFF
--- a/include/neug/storages/graph/edge_table.h
+++ b/include/neug/storages/graph/edge_table.h
@@ -93,7 +93,7 @@ class EdgeTable {
   // to allocate memory for the edge data. Should be called in tp mode.
   int32_t AddEdge(vid_t src_lid, vid_t dst_lid,
                   const std::vector<Property>& properties, timestamp_t ts,
-                  Allocator& alloc, bool insert_safe = false);
+                  Allocator& alloc, bool insert_safe);
 
   void RenameProperties(const std::vector<std::string>& old_names,
                         const std::vector<std::string>& new_names);

--- a/include/neug/storages/graph/vertex_table.h
+++ b/include/neug/storages/graph/vertex_table.h
@@ -130,7 +130,7 @@ class VertexTable {
 
   // Return false if the reserved space is not enough.
   bool AddVertex(const Property& id, const std::vector<Property>& props,
-                 vid_t& vid, timestamp_t ts = 0, bool insert_safe = false);
+                 vid_t& vid, timestamp_t ts, bool insert_safe);
 
   bool UpdateProperty(vid_t vid, int32_t prop_id, const Property& value,
                       timestamp_t ts);

--- a/include/neug/storages/graph/vertex_table.h
+++ b/include/neug/storages/graph/vertex_table.h
@@ -202,8 +202,7 @@ class VertexTable {
   const VertexTimestamp& get_vertex_timestamp() const { return v_ts_; }
 
  private:
-  vid_t insert_vertex_pk(const Property& id, timestamp_t ts,
-                         bool insert_safe = false);
+  vid_t insert_vertex_pk(const Property& id, timestamp_t ts, bool insert_safe);
   template <typename PK_T>
   std::vector<vid_t> insert_primary_keys(
       std::shared_ptr<arrow::Array> primary_key_column) {
@@ -232,7 +231,7 @@ class VertexTable {
           }
           continue;  // already exists
         }
-        vids[j] = insert_vertex_pk(oid, 0);
+        vids[j] = insert_vertex_pk(oid, 0, false);
       }
     } else {
       if (primary_key_column->type()->Equals(arrow::utf8())) {
@@ -248,7 +247,7 @@ class VertexTable {
             }
             continue;  // already exists
           }
-          vids[j] = insert_vertex_pk(oid, 0);
+          vids[j] = insert_vertex_pk(oid, 0, true);
         }
       } else if (primary_key_column->type()->Equals(arrow::large_utf8())) {
         auto casted_array = std::static_pointer_cast<arrow::LargeStringArray>(
@@ -263,7 +262,7 @@ class VertexTable {
             }
             continue;  // already exists
           }
-          vids[j] = insert_vertex_pk(oid, 0);
+          vids[j] = insert_vertex_pk(oid, 0, true);
         }
       } else {
         LOG(FATAL) << "Not support type: "

--- a/include/neug/utils/id_indexer.h
+++ b/include/neug/utils/id_indexer.h
@@ -344,16 +344,15 @@ class LFIndexer {
         reserve(cap + (cap >> 2));
       }
     }
-    INDEX_T ind = num_elements_.load();
+    INDEX_T ind = static_cast<INDEX_T>(
+        num_elements_.fetch_add(1, std::memory_order_acq_rel));
     if (!insert_safe && NEUG_UNLIKELY(static_cast<size_t>(ind) >= capacity())) {
       THROW_INTERNAL_EXCEPTION(
           "Reserved size is not enough: " + std::to_string(capacity()) +
           " vs " + std::to_string(ind));
     }
-    // may throw when insert_safe is false
+    // may throw if insert_safe is false and reserved size is not enough
     keys_->set_any(ind, oid, insert_safe);
-
-    num_elements_.fetch_add(1, std::memory_order_acq_rel);
     auto* indices_ptr = reinterpret_cast<INDEX_T*>(indices_->GetData());
     size_t index =
         hash_policy_.index_for_hash(hasher_(oid), num_slots_minus_one_);

--- a/include/neug/utils/id_indexer.h
+++ b/include/neug/utils/id_indexer.h
@@ -334,7 +334,7 @@ class LFIndexer {
   size_t size() const { return num_elements_.load(); }
   DataTypeId get_type() const { return keys_->type(); }
 
-  INDEX_T insert(const Property& oid, bool insert_safe = false) {
+  INDEX_T insert(const Property& oid, bool insert_safe) {
     assert(oid.type() == get_type());
 
     if (insert_safe) {

--- a/include/neug/utils/id_indexer.h
+++ b/include/neug/utils/id_indexer.h
@@ -236,10 +236,9 @@ class LFIndexer {
     std::swap(hasher_, other.hasher_);
   }
 
-  void init(const DataTypeId& type,
-            std::shared_ptr<ExtraTypeInfo> extra_type_info = nullptr) {
+  void init(const DataType& type) {
     keys_ = nullptr;
-    switch (type) {
+    switch (type.id()) {
 #define TYPE_DISPATCHER(enum_val, T)            \
   case DataTypeId::enum_val: {                  \
     keys_ = std::make_shared<TypedColumn<T>>(); \
@@ -252,9 +251,10 @@ class LFIndexer {
 #undef TYPE_DISPATCHER
     case DataTypeId::kVarchar: {
       uint16_t max_length = STRING_DEFAULT_MAX_LENGTH;
+      auto extra_type_info = type.RawExtraTypeInfo();
       if (extra_type_info) {
         auto str_type_info =
-            std::dynamic_pointer_cast<StringTypeInfo>(extra_type_info);
+            dynamic_cast<const StringTypeInfo*>(extra_type_info);
         if (str_type_info) {
           max_length = str_type_info->max_length;
         }
@@ -266,7 +266,7 @@ class LFIndexer {
       THROW_NOT_SUPPORTED_EXCEPTION(
           "Only (u)int64/32 and string_view types for pk are supported, but "
           "got: " +
-          std::to_string(type));
+          type.ToString());
     }
     }
   }
@@ -344,16 +344,16 @@ class LFIndexer {
         reserve(cap + (cap >> 2));
       }
     }
-    INDEX_T ind = static_cast<INDEX_T>(
-        num_elements_.fetch_add(1, std::memory_order_acq_rel));
-
+    INDEX_T ind = num_elements_.load();
     if (!insert_safe && NEUG_UNLIKELY(static_cast<size_t>(ind) >= capacity())) {
       THROW_INTERNAL_EXCEPTION(
           "Reserved size is not enough: " + std::to_string(capacity()) +
           " vs " + std::to_string(ind));
     }
-
+    // may throw when insert_safe is false
     keys_->set_any(ind, oid, insert_safe);
+
+    num_elements_.fetch_add(1, std::memory_order_acq_rel);
     auto* indices_ptr = reinterpret_cast<INDEX_T*>(indices_->GetData());
     size_t index =
         hash_policy_.index_for_hash(hasher_(oid), num_slots_minus_one_);

--- a/include/neug/utils/property/column.h
+++ b/include/neug/utils/property/column.h
@@ -75,7 +75,7 @@ class ColumnBase {
   // value is fixed length, we should already have enough space allocated, so
   // insert_safe can be false.
   virtual void set_any(size_t index, const Property& value,
-                       bool insert_safe = false) = 0;
+                       bool insert_safe) = 0;
 
   virtual Property get_prop(size_t index) const = 0;
 
@@ -443,10 +443,16 @@ class TypedColumn<std::string_view> : public ColumnBase {
     }
     auto dst_value = value.as_string_view();
     if (pos_.load() + dst_value.size() > data_buffer_->GetDataSize()) {
-      size_t new_avg_width = (pos_.load() + idx) / (idx + 1);
-      size_t new_len =
-          std::max(size_ * new_avg_width, pos_.load() + dst_value.size());
-      data_buffer_->Resize(new_len);
+      if (insert_safe) {
+        size_t new_avg_width = (pos_.load() + idx) / (idx + 1);
+        size_t new_len =
+            std::max(size_ * new_avg_width, pos_.load() + dst_value.size());
+        data_buffer_->Resize(new_len);
+      } else {
+        THROW_STORAGE_EXCEPTION(
+            "Not enough space in buffer for new value, and insert_safe is "
+            "false");
+      }
     }
     set_value(idx, dst_value);
   }

--- a/include/neug/utils/property/column.h
+++ b/include/neug/utils/property/column.h
@@ -449,9 +449,14 @@ class TypedColumn<std::string_view> : public ColumnBase {
             std::max(size_ * new_avg_width, pos_.load() + dst_value.size());
         data_buffer_->Resize(new_len);
       } else {
-        THROW_STORAGE_EXCEPTION(
-            "Not enough space in buffer for new value, and insert_safe is "
-            "false");
+        std::stringstream ss;
+        ss << "Not enough space in buffer for new value, and insert_safe is "
+              "false. "
+           << "Current buffer size: " << data_buffer_->GetDataSize()
+           << ", current position: " << pos_.load()
+           << ", new value size: " << dst_value.size();
+        LOG(ERROR) << ss.str();
+        THROW_STORAGE_EXCEPTION(ss.str());
       }
     }
     set_value(idx, dst_value);

--- a/include/neug/utils/property/column.h
+++ b/include/neug/utils/property/column.h
@@ -526,7 +526,9 @@ class TypedColumn<std::string_view> : public ColumnBase {
         non_zero_count++;
       }
     }
-    return non_zero_count > 0 ? total_length / non_zero_count : 0;
+    return non_zero_count > 0
+               ? (total_length + non_zero_count - 1) / non_zero_count
+               : 0;
   }
 
   std::unique_ptr<IDataContainer> items_buffer_;

--- a/include/neug/utils/property/column.h
+++ b/include/neug/utils/property/column.h
@@ -455,7 +455,6 @@ class TypedColumn<std::string_view> : public ColumnBase {
            << "Current buffer size: " << data_buffer_->GetDataSize()
            << ", current position: " << pos_.load()
            << ", new value size: " << dst_value.size();
-        LOG(ERROR) << ss.str();
         THROW_STORAGE_EXCEPTION(ss.str());
       }
     }

--- a/include/neug/utils/property/table.h
+++ b/include/neug/utils/property/table.h
@@ -89,7 +89,7 @@ class Table {
   std::vector<ColumnBase*>& column_ptrs();
 
   void insert(size_t index, const std::vector<Property>& values,
-              bool insert_safe = false);
+              bool insert_safe);
 
   void resize(size_t row_num);
   /**

--- a/src/storages/graph/vertex_table.cc
+++ b/src/storages/graph/vertex_table.cc
@@ -152,7 +152,7 @@ bool VertexTable::UpdateProperty(vid_t vid, int32_t prop_id,
     LOG(ERROR) << "Property id " << prop_id << " is out of range.";
     return false;
   }
-  table_->get_column_by_id(prop_id)->set_any(vid, value);
+  table_->get_column_by_id(prop_id)->set_any(vid, value, true);
   return true;
 }
 

--- a/src/storages/loader/loader_utils.cc
+++ b/src/storages/loader/loader_utils.cc
@@ -686,7 +686,8 @@ void set_column(std::shared_ptr<neug::ColumnBase> col,
         continue;
       }
       col->set_any(vids[k],
-                   std::move(PropUtils<COL_T>::to_prop(casted->Value(k))));
+                   std::move(PropUtils<COL_T>::to_prop(casted->Value(k))),
+                   false);
     }
   }
 }
@@ -706,7 +707,7 @@ void set_column_from_date_array(std::shared_ptr<neug::ColumnBase> col,
         }
         col->set_any(
             vids[k],
-            std::move(PropUtils<Date>::to_prop(Date(casted->Value(k)))));
+            std::move(PropUtils<Date>::to_prop(Date(casted->Value(k)))), false);
       }
     }
   } else if (type->Equals(arrow::date64())) {
@@ -719,7 +720,7 @@ void set_column_from_date_array(std::shared_ptr<neug::ColumnBase> col,
         }
         col->set_any(
             vids[k],
-            std::move(PropUtils<Date>::to_prop(Date(casted->Value(k)))));
+            std::move(PropUtils<Date>::to_prop(Date(casted->Value(k)))), false);
       }
     }
   } else {
@@ -744,7 +745,8 @@ void set_column_from_timestamp_array(std::shared_ptr<neug::ColumnBase> col,
         }
         col->set_any(
             vids[k],
-            std::move(PropUtils<COL_T>::to_prop(COL_T(casted->Value(k)))));
+            std::move(PropUtils<COL_T>::to_prop(COL_T(casted->Value(k)))),
+            false);
       }
     }
   } else {
@@ -769,8 +771,10 @@ void set_interval_column_from_string_array(
         if (vids[k] >= std::numeric_limits<vid_t>::max()) {                  \
           continue;                                                          \
         }                                                                    \
-        col->set_any(vids[k], std::move(PropUtils<Interval>::to_prop(        \
-                                  Interval(casted->GetView(k)))));           \
+        col->set_any(vids[k],                                                \
+                     std::move(PropUtils<Interval>::to_prop(                 \
+                         Interval(casted->GetView(k)))),                     \
+                     false);                                                 \
       }                                                                      \
     }                                                                        \
     break;
@@ -816,7 +820,7 @@ void set_column_from_string_array(std::shared_ptr<neug::ColumnBase> col,
         }
         if (!enable_resize) {
           Property any_val = Property::From(sw);
-          col->set_any(vids[k], any_val);
+          col->set_any(vids[k], any_val, false);
         } else {
           std::shared_lock<std::shared_mutex> lock(rw_mutex);
           if (typed_col->available_space() <= sw.size()) {
@@ -843,7 +847,7 @@ void set_column_from_string_array(std::shared_ptr<neug::ColumnBase> col,
 
         if (!enable_resize) {
           Property any_val = Property::From(sw);
-          col->set_any(vids[k], std::move(any_val));
+          col->set_any(vids[k], std::move(any_val), false);
         } else {
           std::shared_lock<std::shared_mutex> lock(rw_mutex);
           if (typed_col->available_space() <= sw.size()) {

--- a/tests/storage/test_edge_table.cc
+++ b/tests/storage/test_edge_table.cc
@@ -1560,7 +1560,7 @@ TYPED_TEST(EdgeTableToolsTest, TestBatchAddEdges) {
   for (uint32_t i = 0; i < 10; i++) {
     Property oid;
     oid.set_uint32(i);
-    indexer.insert(oid);
+    indexer.insert(oid, false);
   }
 
   EdgeTable e_table = EdgeTable(edge_schema);
@@ -1606,7 +1606,7 @@ TYPED_TEST(EdgeTableToolsTest, TestAddProperties) {
   for (uint32_t i = 0; i < 10; i++) {
     Property oid;
     oid.set_uint32(i);
-    indexer.insert(oid);
+    indexer.insert(oid, false);
   }
 
   std::vector<std::string> new_property_name = {"new_property"};

--- a/tests/storage/test_edge_table.cc
+++ b/tests/storage/test_edge_table.cc
@@ -799,7 +799,7 @@ TEST_F(EdgeTableTest, TestAddEdgeAndDelete) {
   size_t edge_count = 0;
   for (size_t i = 0; i < src_lids.size(); ++i) {
     this->edge_table->AddEdge(src_lids[i], dst_lids[i], edge_data[i], 0,
-                              allocator);
+                              allocator, false);
     edge_count++;
   }
   EXPECT_EQ(edge_count, src_lids.size());
@@ -864,7 +864,7 @@ TEST_F(EdgeTableTest, TestAddEdgeAndDelete) {
 
   // Test Delete multiple same edges with different timestamp.
   for (timestamp_t ts = 1; ts < 10; ++ts) {
-    this->edge_table->AddEdge(0, 1, edge_data[0], ts, allocator);
+    this->edge_table->AddEdge(0, 1, edge_data[0], ts, allocator, false);
   }
   this->ExpectBundledStats(edge_num + 9);
   std::vector<
@@ -956,7 +956,7 @@ TEST_F(EdgeTableTest, TestAddEdgeDeleteUnbundled) {
   this->ExpectUnbundledStats(0, 4096);
   for (size_t i = 0; i < src_lids.size(); ++i) {
     this->edge_table->AddEdge(src_lids[i], dst_lids[i], edge_data[i], 0,
-                              allocator);
+                              allocator, false);
     edge_count++;
   }
   EXPECT_EQ(edge_count, src_lids.size());
@@ -1038,7 +1038,7 @@ TEST_F(EdgeTableTest, TestEdgeTableCompaction) {
   neug::Allocator allocator(neug::MemoryLevel::kInMemory, allocator_dir_);
   for (size_t i = 0; i < src_lids.size(); ++i) {
     this->edge_table->AddEdge(src_lids[i], dst_lids[i], edge_data[i], 0,
-                              allocator);
+                              allocator, false);
   }
   this->ExpectBundledStats(edge_num);
   auto oe_view = this->edge_table->get_outgoing_view(neug::MAX_TIMESTAMP);
@@ -1116,7 +1116,7 @@ TEST_F(EdgeTableTest, TestUpdateEdgeData) {
   neug::Allocator allocator(neug::MemoryLevel::kInMemory, allocator_dir_);
   for (size_t i = 0; i < src_lids.size(); ++i) {
     this->edge_table->AddEdge(src_lids[i], dst_lids[i], edge_data[i], 0,
-                              allocator);
+                              allocator, false);
   }
   this->ExpectUnbundledStats(edge_num, 4096);
   std::vector<neug::Property> new_data = {
@@ -1274,7 +1274,7 @@ TEST_F(EdgeTableTest,
         this->GetDstLid(neug::Property::from_int64(dst_oid)),
         {neug::Property::from_string_view(data0),
          neug::Property::from_int32(data1)},
-        0, allocator);
+        0, allocator, false);
   }
   this->ExpectUnbundledStats(input.size(), 4096);
 
@@ -1317,7 +1317,7 @@ TEST_F(EdgeTableTest,
 
   this->edge_table->AddEdge(this->GetSrcLid(neug::Property::from_int64(3)),
                             this->GetDstLid(neug::Property::from_int64(0)), {},
-                            0, allocator);
+                            0, allocator, false);
   this->ExpectBundledStats(input.size() + 1);
   srcs.clear();
   dsts.clear();
@@ -1343,7 +1343,7 @@ TEST_F(EdgeTableTest, TestDeletePropertiesTransitionFromUnbundledToBundled) {
         this->GetDstLid(neug::Property::from_int64(dst_oid)),
         {neug::Property::from_string_view(data0),
          neug::Property::from_int32(data1)},
-        0, allocator);
+        0, allocator, false);
   }
   this->ExpectUnbundledStats(input.size(), 4096);
 
@@ -1379,7 +1379,7 @@ TEST_F(EdgeTableTest, TestDeletePropertiesTransitionFromUnbundledToBundled) {
   this->ExpectBundledStats(input.size());
   this->edge_table->AddEdge(this->GetSrcLid(neug::Property::from_int64(3)),
                             this->GetDstLid(neug::Property::from_int64(0)),
-                            {Property::from_int32(44)}, 0, allocator);
+                            {Property::from_int32(44)}, 0, allocator, false);
   this->ExpectBundledStats(input.size() + 1);
 }
 
@@ -1400,7 +1400,7 @@ TEST_F(EdgeTableTest, TestAddAndDeletePropertiesStayUnbundled) {
         this->GetDstLid(neug::Property::from_int64(dst_oid)),
         {neug::Property::from_string_view(data0),
          neug::Property::from_int32(data1)},
-        0, allocator);
+        0, allocator, false);
   }
   this->ExpectUnbundledStats(input.size(), 4096);
 

--- a/tests/storage/test_vertex_table.cc
+++ b/tests/storage/test_vertex_table.cc
@@ -117,9 +117,9 @@ TEST_F(VertexTableTest, VertexTableBasicOps) {
   oid1.set_int64(1);
   oid2.set_int64(2);
   oid3.set_int64(3);
-  EXPECT_TRUE(table.AddVertex(oid1, property_values_, lid1, 1));
-  EXPECT_TRUE(table.AddVertex(oid2, property_values_, lid2, 2));
-  EXPECT_TRUE(table.AddVertex(oid3, property_values_, lid3, 3));
+  EXPECT_TRUE(table.AddVertex(oid1, property_values_, lid1, 1, false));
+  EXPECT_TRUE(table.AddVertex(oid2, property_values_, lid2, 2, false));
+  EXPECT_TRUE(table.AddVertex(oid3, property_values_, lid3, 3, false));
   LOG(INFO) << "Added vertices with lids: " << lid1 << ", " << lid2 << ", "
             << lid3;
   LOG(INFO) << "and oids: " << oid1.as_int64() << ", " << oid2.as_int64()
@@ -170,9 +170,9 @@ TEST_F(VertexTableTest, VertexTableDumpAndReload) {
     oid1.set_int64(1);
     oid2.set_int64(2);
     oid3.set_int64(3);
-    EXPECT_TRUE(table.AddVertex(oid1, property_values_, lid1, 1));
-    EXPECT_TRUE(table.AddVertex(oid2, property_values_, lid2, 2));
-    EXPECT_TRUE(table.AddVertex(oid3, property_values_, lid3, 3));
+    EXPECT_TRUE(table.AddVertex(oid1, property_values_, lid1, 1, false));
+    EXPECT_TRUE(table.AddVertex(oid2, property_values_, lid2, 2, false));
+    EXPECT_TRUE(table.AddVertex(oid3, property_values_, lid3, 3, false));
     LOG(INFO) << "Added vertices with lids: " << lid1 << ", " << lid2 << ", "
               << lid3;
     table.Dump(neug::temp_checkpoint_dir(dump_dir));
@@ -211,9 +211,9 @@ TEST_F(VertexTableTest, VertexTableAddAndDeleteAndReload) {
     oid1.set_int64(1);
     oid2.set_int64(2);
     oid3.set_int64(3);
-    EXPECT_TRUE(table.AddVertex(oid1, property_values_, lid1, 1));
-    EXPECT_TRUE(table.AddVertex(oid2, property_values_, lid2, 2));
-    EXPECT_TRUE(table.AddVertex(oid3, property_values_, lid3, 3));
+    EXPECT_TRUE(table.AddVertex(oid1, property_values_, lid1, 1, false));
+    EXPECT_TRUE(table.AddVertex(oid2, property_values_, lid2, 2, false));
+    EXPECT_TRUE(table.AddVertex(oid3, property_values_, lid3, 3, false));
     LOG(INFO) << "Added vertices with lids: " << lid1 << ", " << lid2 << ", "
               << lid3;
 
@@ -274,9 +274,9 @@ TEST_F(VertexTableTest, AddVertexBasic) {
   oid2.set_int64(200);
   oid3.set_int64(300);
   neug::vid_t lid1, lid2, lid3;
-  EXPECT_TRUE(table.AddVertex(oid1, property_values_, lid1, 0));
-  EXPECT_TRUE(table.AddVertex(oid2, property_values_, lid2, 1));
-  EXPECT_TRUE(table.AddVertex(oid3, property_values_, lid3, 2));
+  EXPECT_TRUE(table.AddVertex(oid1, property_values_, lid1, 0, false));
+  EXPECT_TRUE(table.AddVertex(oid2, property_values_, lid2, 1, false));
+  EXPECT_TRUE(table.AddVertex(oid3, property_values_, lid3, 2, false));
 
   EXPECT_EQ(table.VertexNum(), 3);
   EXPECT_EQ(table.LidNum(), 3);
@@ -308,7 +308,7 @@ TEST_F(VertexTableTest, AddVertex) {
   table.Open(dir_, memory_level_);
   neug::vid_t tmp_vid;
   EXPECT_FALSE(table.AddVertex(neug::Property::from_int64(1), property_values_,
-                               tmp_vid));
+                               tmp_vid, 0, false));
 
   std::vector<neug::Property> oids;
   std::vector<neug::vid_t> lids;
@@ -319,7 +319,7 @@ TEST_F(VertexTableTest, AddVertex) {
     neug::Property oid;
     oid.set_int64(i);
     oids.push_back(oid);
-    EXPECT_TRUE(table.AddVertex(oid, property_values_, lids[i], i % 10));
+    EXPECT_TRUE(table.AddVertex(oid, property_values_, lids[i], i % 10, false));
   }
 
   EXPECT_EQ(table.VertexNum(), 100);
@@ -345,9 +345,9 @@ TEST_F(VertexTableTest, DeleteVertexBasic) {
   oid3.set_int64(3);
   neug::vid_t lid1, lid2, lid3;
 
-  EXPECT_TRUE(table.AddVertex(oid1, property_values_, lid1, 1));
-  EXPECT_TRUE(table.AddVertex(oid2, property_values_, lid2, 2));
-  EXPECT_TRUE(table.AddVertex(oid3, property_values_, lid3, 3));
+  EXPECT_TRUE(table.AddVertex(oid1, property_values_, lid1, 1, false));
+  EXPECT_TRUE(table.AddVertex(oid2, property_values_, lid2, 2, false));
+  EXPECT_TRUE(table.AddVertex(oid3, property_values_, lid3, 3, false));
 
   EXPECT_EQ(table.VertexNum(), 3);
 
@@ -375,7 +375,7 @@ TEST_F(VertexTableTest, RevertDeleteVertexBasic) {
   neug::Property oid1;
   oid1.set_int64(1);
   neug::vid_t lid1;
-  EXPECT_TRUE(table.AddVertex(oid1, property_values_, lid1, 1));
+  EXPECT_TRUE(table.AddVertex(oid1, property_values_, lid1, 1, false));
 
   EXPECT_EQ(table.VertexNum(), 1);
   EXPECT_TRUE(table.IsValidLid(lid1, 1));
@@ -410,7 +410,7 @@ TEST_F(VertexTableTest, AddDeleteRevertCombination) {
     neug::Property oid;
     oid.set_int64(i);
     oids.push_back(oid);
-    EXPECT_TRUE(table.AddVertex(oid, property_values_, lids[i], i));
+    EXPECT_TRUE(table.AddVertex(oid, property_values_, lids[i], i, false));
   }
 
   EXPECT_EQ(table.VertexNum(), 10);
@@ -450,7 +450,7 @@ TEST_F(VertexTableTest, MultipleDeletesAndReverts) {
   neug::Property oid;
   oid.set_int64(42);
   neug::vid_t lid;
-  EXPECT_TRUE(table.AddVertex(oid, property_values_, lid, 1));
+  EXPECT_TRUE(table.AddVertex(oid, property_values_, lid, 1, false));
 
   EXPECT_EQ(table.VertexNum(), 1);
 
@@ -489,7 +489,7 @@ TEST_F(VertexTableTest, MixedAddVertexAndAddVertexSafe) {
   for (int64_t i = 0; i < 20; ++i) {
     neug::Property oid;
     oid.set_int64(i);
-    EXPECT_TRUE(table.AddVertex(oid, property_values_, lids[i], i));
+    EXPECT_TRUE(table.AddVertex(oid, property_values_, lids[i], i, false));
   }
 
   EXPECT_EQ(table.VertexNum(), 20);
@@ -513,12 +513,12 @@ TEST_F(VertexTableTest, TemporalVisibilityComplex) {
 
   EXPECT_EQ(table.VertexNum(0), 0);
   neug::vid_t lid1;
-  EXPECT_TRUE(table.AddVertex(oid1, property_values_, lid1, 1));
+  EXPECT_TRUE(table.AddVertex(oid1, property_values_, lid1, 1, false));
   EXPECT_TRUE(table.IsValidLid(lid1, 1));
   EXPECT_EQ(table.VertexNum(1), 1);
 
   neug::vid_t lid2;
-  EXPECT_TRUE(table.AddVertex(oid2, property_values_, lid2, 2));
+  EXPECT_TRUE(table.AddVertex(oid2, property_values_, lid2, 2, false));
   EXPECT_TRUE(table.IsValidLid(lid1, 2));
   EXPECT_TRUE(table.IsValidLid(lid2, 2));
   EXPECT_EQ(table.VertexNum(2), 2);  // oid2,
@@ -527,7 +527,7 @@ TEST_F(VertexTableTest, TemporalVisibilityComplex) {
   EXPECT_EQ(table.VertexNum(3), 1);  // oid2,
   EXPECT_FALSE(table.IsValidLid(lid1, 3));
   neug::vid_t lid3;
-  EXPECT_TRUE(table.AddVertex(oid3, property_values_, lid3, 4));
+  EXPECT_TRUE(table.AddVertex(oid3, property_values_, lid3, 4, false));
   EXPECT_FALSE(table.IsValidLid(lid1, 4));
   EXPECT_TRUE(table.IsValidLid(lid3, 4));
   EXPECT_EQ(table.VertexNum(4), 2);  // oid2, oid3
@@ -552,7 +552,7 @@ TEST_F(VertexTableTest, DeleteAlreadyDeletedVertex) {
   neug::Property oid;
   oid.set_int64(1);
   neug::vid_t lid;
-  EXPECT_TRUE(table.AddVertex(oid, property_values_, lid, 1));
+  EXPECT_TRUE(table.AddVertex(oid, property_values_, lid, 1, false));
 
   table.DeleteVertex(lid, 2);
   EXPECT_EQ(table.VertexNum(), 0);
@@ -575,7 +575,7 @@ TEST_F(VertexTableTest, RevertNonDeletedVertex) {
   neug::Property oid;
   oid.set_int64(1);
   neug::vid_t lid;
-  EXPECT_TRUE(table.AddVertex(oid, property_values_, lid, 1));
+  EXPECT_TRUE(table.AddVertex(oid, property_values_, lid, 1, false));
 
   EXPECT_EQ(table.VertexNum(), 1);
 
@@ -609,7 +609,7 @@ TEST_F(VertexTableTest, ComplexAddDeleteRevertDumpReload) {
       neug::Property oid;
       oid.set_int64(i);
       oids.push_back(oid);
-      EXPECT_TRUE(table.AddVertex(oid, property_values_, lids[i], i));
+      EXPECT_TRUE(table.AddVertex(oid, property_values_, lids[i], i, false));
     }
 
     for (size_t i = 5; i < 15; ++i) {
@@ -674,7 +674,7 @@ TEST_F(VertexTableTest, StressAddDeleteRevert) {
     neug::Property oid;
     oid.set_int64(i);
     oids.push_back(oid);
-    EXPECT_TRUE(table.AddVertex(oid, property_values_, lids[i], 1));
+    EXPECT_TRUE(table.AddVertex(oid, property_values_, lids[i], 1, false));
   }
 
   EXPECT_EQ(table.VertexNum(), 100);
@@ -796,7 +796,7 @@ TEST_F(VertexTableTest, VertexSetForeachVertex) {
     neug::Property oid;
     oid.set_int64(i);
     oids.push_back(oid);
-    EXPECT_TRUE(table.AddVertex(oid, property_values_, lids[i], i));
+    EXPECT_TRUE(table.AddVertex(oid, property_values_, lids[i], i, false));
   }
 
   for (size_t i = 0; i < lids.size(); i += 2) {

--- a/tests/storage/vertex_table_benchmark.cc
+++ b/tests/storage/vertex_table_benchmark.cc
@@ -81,7 +81,7 @@ class VertexTableBenchmark : public ::testing::Test {
       vertex_id.set_int64(static_cast<int64_t>(i));
 
       neug::vid_t vid;
-      EXPECT_TRUE(table.AddVertex(vertex_id, property_values_, vid, i));
+      EXPECT_TRUE(table.AddVertex(vertex_id, property_values_, vid, i, false));
       EXPECT_EQ(vid, i);
       if (i % (count / 100) == 0) {
         LOG(INFO) << "Added " << i << " vertices so far...";
@@ -182,7 +182,7 @@ TEST_F(VertexTableBenchmark, AddVertexPerformance) {
     neug::Property vertex_id;
     vertex_id.set_int64(static_cast<int64_t>(i));
     neug::vid_t vid;
-    EXPECT_TRUE(table.AddVertex(vertex_id, property_values_, vid, i));
+    EXPECT_TRUE(table.AddVertex(vertex_id, property_values_, vid, i, false));
   }
 
   auto end = std::chrono::high_resolution_clock::now();

--- a/tests/unittest/test_indexer.cc
+++ b/tests/unittest/test_indexer.cc
@@ -126,7 +126,7 @@ TEST_F(LFIndexerTest, SupportsCoreMutableInterfacesInMemory) {
   EXPECT_GE(indexer.capacity(), 8U);
 
   std::vector<int64_t> values = {7, 11, 13, 17, 19, 23, 29, 31, 37, 41};
-  EXPECT_EQ(indexer.insert(Property::from_int64(values[0])), 0U);
+  EXPECT_EQ(indexer.insert(Property::from_int64(values[0]), false), 0U);
   for (size_t i = 1; i < values.size(); ++i) {
     EXPECT_EQ(indexer.insert(Property::from_int64(values[i]), true),
               static_cast<uint32_t>(i));
@@ -278,7 +278,7 @@ TEST_F(LFIndexerTest, VarcharReserveEnablesNonSafeInsert) {
   std::vector<std::string> values = {"alpha",   "beta", "gamma", "delta",
                                      "epsilon", "zeta", "eta",   "theta"};
   for (const auto& v : values) {
-    indexer.insert(Property::from_string_view(v));
+    indexer.insert(Property::from_string_view(v), false);
   }
   ExpectStringValues(indexer, values);
   indexer.close();
@@ -307,7 +307,7 @@ TEST_F(LFIndexerTest, VarcharReserveMaxWidthStrings) {
     values.push_back(std::string(kMaxWidth - 1, static_cast<char>('a' + i)));
   }
   for (const auto& v : values) {
-    indexer.insert(Property::from_string_view(v));
+    indexer.insert(Property::from_string_view(v), false);
   }
   ExpectStringValues(indexer, values);
   indexer.close();
@@ -328,7 +328,7 @@ TEST_F(LFIndexerTest, VarcharMultipleReservesAccumulateDataSpace) {
   indexer.reserve(4);
   std::vector<std::string> batch1 = {"alice", "bob", "carol", "dave"};
   for (const auto& v : batch1) {
-    indexer.insert(Property::from_string_view(v));
+    indexer.insert(Property::from_string_view(v), false);
   }
   ExpectStringValues(indexer, batch1);
 
@@ -338,7 +338,7 @@ TEST_F(LFIndexerTest, VarcharMultipleReservesAccumulateDataSpace) {
   indexer.reserve(8);
   std::vector<std::string> batch2 = {"erin", "frank", "grace", "heidi"};
   for (const auto& v : batch2) {
-    indexer.insert(Property::from_string_view(v));
+    indexer.insert(Property::from_string_view(v), false);
   }
 
   std::vector<std::string> all = {"alice", "bob",   "carol", "dave",
@@ -361,10 +361,10 @@ TEST_F(LFIndexerTest, VarcharReserveSmallerThanCapacityIsNoop) {
   indexer.reserve(16);
   EXPECT_GE(indexer.capacity(), 16U);
   size_t size_before = indexer.size();
-  indexer.insert(Property::from_string_view("foo"));
-  indexer.insert(Property::from_string_view("bar"));
-  indexer.insert(Property::from_string_view("baz"));
-  indexer.insert(Property::from_string_view("qux"));
+  indexer.insert(Property::from_string_view("foo"), false);
+  indexer.insert(Property::from_string_view("bar"), false);
+  indexer.insert(Property::from_string_view("baz"), false);
+  indexer.insert(Property::from_string_view("qux"), false);
 
   // Shrinking reserve must not corrupt state.
   indexer.reserve(4);
@@ -415,7 +415,7 @@ TEST_F(LFIndexerTest, VarcharReserveInsertDumpReload) {
 
   std::vector<std::string> values = {"one", "two", "three", "four", "five"};
   for (const auto& v : values) {
-    writable.insert(Property::from_string_view(v));
+    writable.insert(Property::from_string_view(v), false);
   }
   ExpectStringValues(writable, values);
 
@@ -482,7 +482,7 @@ TEST_F(LFIndexerTest, VarcharShortDumpReopenReserveThenInsertLong_InMemory) {
     long_values.push_back(std::string(60, static_cast<char>('d' + i)));
   }
   for (const auto& v : long_values) {
-    indexer.insert(Property::from_string_view(v));
+    indexer.insert(Property::from_string_view(v), false);
   }
 
   std::vector<std::string> all = short_values;
@@ -510,7 +510,7 @@ TEST_F(LFIndexerTest, VarcharShortDumpReopenInsertSafeLong_InMemory) {
     writer.open_in_memory(base);
     writer.reserve(short_values.size());
     for (const auto& v : short_values) {
-      writer.insert(Property::from_string_view(v));
+      writer.insert(Property::from_string_view(v), false);
     }
     writer.dump(name, snapshot_dir_);
   }
@@ -577,7 +577,7 @@ TEST_F(LFIndexerTest, VarcharShortDumpReopenReserveThenInsertLong_SyncToFile) {
     long_values.push_back(std::string(30, static_cast<char>('p' + i)));
   }
   for (const auto& v : long_values) {
-    indexer.insert(Property::from_string_view(v));
+    indexer.insert(Property::from_string_view(v), false);
   }
 
   std::vector<std::string> all = short_values;

--- a/tests/unittest/test_indexer.cc
+++ b/tests/unittest/test_indexer.cc
@@ -214,12 +214,13 @@ TEST_F(LFIndexerTest, SupportsBuildEmptySwapAndVarcharKeys) {
 
   auto string_type_info = std::make_shared<StringTypeInfo>(64);
   LFIndexer<uint32_t> lhs;
-  lhs.init(DataTypeId::kVarchar, string_type_info);
+  DataType string_type(DataTypeId::kVarchar, string_type_info);
+  lhs.init(string_type);
   lhs.open_in_memory(lhs_base);
   lhs.reserve(4);
 
   LFIndexer<uint32_t> rhs;
-  rhs.init(DataTypeId::kVarchar, string_type_info);
+  rhs.init(string_type);
   rhs.open_in_memory(rhs_base);
   rhs.reserve(4);
 
@@ -266,7 +267,8 @@ TEST_F(LFIndexerTest, VarcharReserveEnablesNonSafeInsert) {
 
   auto type_info = std::make_shared<StringTypeInfo>(64);
   LFIndexer<uint32_t> indexer;
-  indexer.init(DataTypeId::kVarchar, type_info);
+  DataType string_type(DataTypeId::kVarchar, type_info);
+  indexer.init(string_type);
   indexer.open_in_memory(base);
 
   constexpr size_t N = 8;
@@ -293,7 +295,8 @@ TEST_F(LFIndexerTest, VarcharReserveMaxWidthStrings) {
   constexpr uint16_t kMaxWidth = 16;
   auto type_info = std::make_shared<StringTypeInfo>(kMaxWidth);
   LFIndexer<uint32_t> indexer;
-  indexer.init(DataTypeId::kVarchar, type_info);
+  DataType string_type(DataTypeId::kVarchar, type_info);
+  indexer.init(string_type);
   indexer.open_in_memory(base);
 
   constexpr size_t N = 6;
@@ -321,7 +324,8 @@ TEST_F(LFIndexerTest, VarcharMultipleReservesAccumulateDataSpace) {
 
   auto type_info = std::make_shared<StringTypeInfo>(32);
   LFIndexer<uint32_t> indexer;
-  indexer.init(DataTypeId::kVarchar, type_info);
+  DataType string_type(DataTypeId::kVarchar, type_info);
+  indexer.init(string_type);
   indexer.open_in_memory(base);
 
   // First batch: reserve 4, insert 4 via insert() (non-safe).
@@ -337,12 +341,15 @@ TEST_F(LFIndexerTest, VarcharMultipleReservesAccumulateDataSpace) {
   // written string bytes are not lost.
   indexer.reserve(8);
   std::vector<std::string> batch2 = {"erin", "frank", "grace", "heidi"};
-  for (const auto& v : batch2) {
-    indexer.insert(Property::from_string_view(v), false);
+  for (size_t i = 0; i + 1 < batch2.size(); ++i) {
+    indexer.insert(Property::from_string_view(batch2[i]), false);
   }
 
+  EXPECT_THROW(indexer.insert(Property::from_string_view(batch2.back()), false),
+               neug::exception::StorageException);
+
   std::vector<std::string> all = {"alice", "bob",   "carol", "dave",
-                                  "erin",  "frank", "grace", "heidi"};
+                                  "erin",  "frank", "grace"};
   ExpectStringValues(indexer, all);
   indexer.close();
 }
@@ -355,7 +362,8 @@ TEST_F(LFIndexerTest, VarcharReserveSmallerThanCapacityIsNoop) {
 
   auto type_info = std::make_shared<StringTypeInfo>(32);
   LFIndexer<uint32_t> indexer;
-  indexer.init(DataTypeId::kVarchar, type_info);
+  DataType string_type(DataTypeId::kVarchar, type_info);
+  indexer.init(string_type);
   indexer.open_in_memory(base);
 
   indexer.reserve(16);
@@ -379,8 +387,9 @@ TEST_F(LFIndexerTest, VarcharRehashPreservesData) {
   CreateEmptyIndicesFile(base);
 
   auto type_info = std::make_shared<StringTypeInfo>(64);
+  DataType string_type(DataTypeId::kVarchar, type_info);
   LFIndexer<uint32_t> indexer;
-  indexer.init(DataTypeId::kVarchar, type_info);
+  indexer.init(string_type);
   indexer.open_in_memory(base);
 
   std::vector<std::string> values = {"foo",  "bar",   "baz",   "qux",
@@ -406,8 +415,9 @@ TEST_F(LFIndexerTest, VarcharReserveInsertDumpReload) {
   CreateEmptyIndicesFile(base);
 
   auto type_info = std::make_shared<StringTypeInfo>(64);
+  DataType string_type(DataTypeId::kVarchar, type_info);
   LFIndexer<uint32_t> writable;
-  writable.init(DataTypeId::kVarchar, type_info);
+  writable.init(string_type);
   writable.open_in_memory(base);
 
   constexpr size_t N = 5;
@@ -427,7 +437,7 @@ TEST_F(LFIndexerTest, VarcharReserveInsertDumpReload) {
 
   // Reload from snapshot and verify all entries survive the round-trip.
   LFIndexer<uint32_t> reader;
-  reader.init(DataTypeId::kVarchar, type_info);
+  reader.init(string_type);
   reader.open_in_memory(snapshot_dir_ + "/" + name);
   ExpectStringValues(reader, values);
   reader.close();
@@ -451,12 +461,13 @@ TEST_F(LFIndexerTest, VarcharShortDumpReopenReserveThenInsertLong_InMemory) {
 
   constexpr uint16_t kWidth = 64;
   auto type_info = std::make_shared<StringTypeInfo>(kWidth);
+  DataType string_type(DataTypeId::kVarchar, type_info);
 
   // Phase 1: populate with short strings (avg 3 chars << kWidth), then dump.
   std::vector<std::string> short_values = {"a", "bb", "ccc"};
   {
     LFIndexer<uint32_t> writer;
-    writer.init(DataTypeId::kVarchar, type_info);
+    writer.init(string_type);
     writer.open_in_memory(base);
     for (const auto& v : short_values) {
       writer.insert(Property::from_string_view(v), true);
@@ -466,7 +477,7 @@ TEST_F(LFIndexerTest, VarcharShortDumpReopenReserveThenInsertLong_InMemory) {
 
   // Phase 2: reopen — data_buffer_ is now tight (= sum of short string bytes).
   LFIndexer<uint32_t> indexer;
-  indexer.init(DataTypeId::kVarchar, type_info);
+  indexer.init(string_type);
   indexer.open_in_memory(snapshot_dir_ + "/" + name);
   ExpectStringValues(indexer, short_values);
 
@@ -482,7 +493,7 @@ TEST_F(LFIndexerTest, VarcharShortDumpReopenReserveThenInsertLong_InMemory) {
     long_values.push_back(std::string(60, static_cast<char>('d' + i)));
   }
   for (const auto& v : long_values) {
-    indexer.insert(Property::from_string_view(v), false);
+    indexer.insert(Property::from_string_view(v), true);
   }
 
   std::vector<std::string> all = short_values;
@@ -501,12 +512,13 @@ TEST_F(LFIndexerTest, VarcharShortDumpReopenInsertSafeLong_InMemory) {
 
   constexpr uint16_t kWidth = 48;
   auto type_info = std::make_shared<StringTypeInfo>(kWidth);
+  DataType string_type(DataTypeId::kVarchar, type_info);
 
   // Phase 1: fill to capacity with 1-char strings, then dump.
   std::vector<std::string> short_values = {"x", "y", "z", "w"};
   {
     LFIndexer<uint32_t> writer;
-    writer.init(DataTypeId::kVarchar, type_info);
+    writer.init(string_type);
     writer.open_in_memory(base);
     writer.reserve(short_values.size());
     for (const auto& v : short_values) {
@@ -517,7 +529,7 @@ TEST_F(LFIndexerTest, VarcharShortDumpReopenInsertSafeLong_InMemory) {
 
   // Phase 2: reopen — capacity == short_values.size(), data_buffer_ tight.
   LFIndexer<uint32_t> indexer;
-  indexer.init(DataTypeId::kVarchar, type_info);
+  indexer.init(string_type);
   indexer.open_in_memory(snapshot_dir_ + "/" + name);
   EXPECT_EQ(indexer.size(), short_values.size());
 
@@ -547,12 +559,13 @@ TEST_F(LFIndexerTest, VarcharShortDumpReopenReserveThenInsertLong_SyncToFile) {
 
   constexpr uint16_t kWidth = 32;
   auto type_info = std::make_shared<StringTypeInfo>(kWidth);
+  DataType string_type(DataTypeId::kVarchar, type_info);
 
   // Phase 1: insert 2-char strings to keep .data file tiny, then dump.
   std::vector<std::string> short_values = {"hi", "yo", "ok"};
   {
     LFIndexer<uint32_t> writer;
-    writer.init(DataTypeId::kVarchar, type_info);
+    writer.init(string_type);
     writer.open_in_memory(base);
     for (const auto& v : short_values) {
       writer.insert(Property::from_string_view(v), true);
@@ -562,7 +575,7 @@ TEST_F(LFIndexerTest, VarcharShortDumpReopenReserveThenInsertLong_SyncToFile) {
 
   // Phase 2: reopen via SyncToFile — data_buffer_ memory-maps the small file.
   LFIndexer<uint32_t> indexer;
-  indexer.init(DataTypeId::kVarchar, type_info);
+  indexer.init(string_type);
   indexer.open(name, snapshot_dir_, work_dir_);
   ExpectStringValues(indexer, short_values);
 
@@ -577,7 +590,7 @@ TEST_F(LFIndexerTest, VarcharShortDumpReopenReserveThenInsertLong_SyncToFile) {
     long_values.push_back(std::string(30, static_cast<char>('p' + i)));
   }
   for (const auto& v : long_values) {
-    indexer.insert(Property::from_string_view(v), false);
+    indexer.insert(Property::from_string_view(v), true);
   }
 
   std::vector<std::string> all = short_values;

--- a/tests/unittest/test_indexer.cc
+++ b/tests/unittest/test_indexer.cc
@@ -596,5 +596,48 @@ TEST_F(LFIndexerTest, VarcharShortDumpReopenReserveThenInsertLong_SyncToFile) {
   indexer.drop();
 }
 
+// Test: String overflow handling when inserting strings exceeding max length.
+TEST_F(LFIndexerTest, VarcharStringOverflow) {
+  const std::string base = test_dir_ + "/varchar_string_overflow";
+  CreateEmptyIndicesFile(base);
+
+  // Create indexer with max string length of 32
+  auto type_info = std::make_shared<StringTypeInfo>(32);
+  LFIndexer<uint32_t> indexer;
+  DataType string_type(DataTypeId::kVarchar, type_info);
+  indexer.init(string_type);
+  indexer.open_in_memory(base);
+  indexer.reserve(4);
+  // Insert valid strings within the limit
+  std::vector<std::string> valid_strings = {
+      "short",                 // 5 chars
+      "medium_length_string",  // 21 chars
+      std::string(32, 'a'),    // exactly 32 chars (max length)
+      "boundary"               // 8 chars, to test boundary condition
+  };
+
+  for (const auto& v : valid_strings) {
+    indexer.insert(Property::from_string_view(v), false);
+  }
+  ExpectStringValues(indexer, valid_strings);
+  indexer.reserve(8);
+
+  // Test: Insert additional strings of 32 characters
+  std::string overflow_string = std::string(31, 'a');  // 31 chars
+  for (size_t i = 0; i < 2; ++i) {
+    std::string test_string =
+        overflow_string + std::to_string(i);  // 31 chars + 1 char = 32 chars
+    indexer.insert(Property::from_string_view(test_string), false);
+    valid_strings.push_back(test_string);
+  }
+  ExpectStringValues(indexer, valid_strings);
+
+  EXPECT_THROW(
+      indexer.insert(Property::from_string_view(overflow_string), false),
+      neug::exception::StorageException);
+
+  indexer.close();
+}
+
 }  // namespace
 }  // namespace neug

--- a/tests/unittest/test_indexer.cc
+++ b/tests/unittest/test_indexer.cc
@@ -341,15 +341,12 @@ TEST_F(LFIndexerTest, VarcharMultipleReservesAccumulateDataSpace) {
   // written string bytes are not lost.
   indexer.reserve(8);
   std::vector<std::string> batch2 = {"erin", "frank", "grace", "heidi"};
-  for (size_t i = 0; i + 1 < batch2.size(); ++i) {
-    indexer.insert(Property::from_string_view(batch2[i]), false);
+  for (const auto& v : batch2) {
+    indexer.insert(Property::from_string_view(v), false);
   }
 
-  EXPECT_THROW(indexer.insert(Property::from_string_view(batch2.back()), false),
-               neug::exception::StorageException);
-
   std::vector<std::string> all = {"alice", "bob",   "carol", "dave",
-                                  "erin",  "frank", "grace"};
+                                  "erin",  "frank", "grace", "heidi"};
   ExpectStringValues(indexer, all);
   indexer.close();
 }

--- a/tests/utils/test_table.cc
+++ b/tests/utils/test_table.cc
@@ -285,7 +285,7 @@ TEST(TableTest, TestTableBasic) {
               DataTypeId::kBoolean);
     disk_table.set_name("disk_table");
     std::vector<Property> properties = disk_table.get_row(9);
-    disk_table.insert(9, properties);
+    disk_table.insert(9, properties, false);
   }
 
   disk_table.dump("disk_table", std::string(TEST_DIR) + "/checkpoint");


### PR DESCRIPTION
This pull request refactors several method signatures in the storage layer to require explicit specification of the `insert_safe` parameter, removing its default value. This change enforces clarity and consistency when inserting or updating data in tables and columns, and ensures that all call sites and tests explicitly specify whether insert operations should be performed safely (with buffer resizing or checks). Additionally, error handling is improved for unsafe insertions when buffer space is insufficient.



Fixes

