### PR TITLE
fix: Fix string dump issue

### DIFF
--- a/include/neug/execution/common/types/value.h
+++ b/include/neug/execution/common/types/value.h
@@ -632,8 +632,7 @@ bool Value::ApplyComparisonOp(const Value& lhs, const Value& rhs) {
 }
 
 Property value_to_property(const Value& value);
-Value property_to_value(const Property& property,
-                        const DataType& type = DataType::UNKNOWN);
+Value property_to_value(const Property& property);
 
 template <typename T>
 Value performCast(const Value& input) {

--- a/include/neug/utils/property/column.h
+++ b/include/neug/utils/property/column.h
@@ -311,7 +311,7 @@ class TypedColumn<std::string_view> : public ColumnBase {
     MD5_CTX data_ctx, item_ctx;
     MD5_Init(&data_ctx);
     MD5_Init(&item_ctx);
-    string_item cur_item;
+    string_item cur_item = {0, 0};
     size_t offset = 0;
     size_t count_no_empty = 0;
     string_item pre_item = {0, 0};
@@ -364,7 +364,7 @@ class TypedColumn<std::string_view> : public ColumnBase {
       LOG(ERROR) << ss.str();
       THROW_IO_EXCEPTION(ss.str());
     }
-    size_t pos_val = pos_.load();
+    size_t pos_val = offset;
     // No-compaction path: dump containers as-is.
     write_file(filename + ".pos", &pos_val, sizeof(pos_val), 1);
   }

--- a/src/execution/common/types/value.cc
+++ b/src/execution/common/types/value.cc
@@ -772,7 +772,7 @@ Property value_to_property(const Value& value) {
   }
 }
 
-Value property_to_value(const Property& property, const DataType& type) {
+Value property_to_value(const Property& property) {
   switch (property.type()) {
   case DataTypeId::kBoolean:
     return Value::BOOLEAN(property.as_bool());
@@ -789,11 +789,7 @@ Value property_to_value(const Property& property, const DataType& type) {
   case DataTypeId::kDouble:
     return Value::DOUBLE(property.as_double());
   case DataTypeId::kVarchar: {
-    auto str_type_info = type.RawExtraTypeInfo();
-    auto max_length = str_type_info
-                          ? str_type_info->Cast<StringTypeInfo>().max_length
-                          : STRING_DEFAULT_MAX_LENGTH;
-    return Value::VARCHAR(std::string(property.as_string_view()), max_length);
+    return Value::STRING(std::string(property.as_string_view()));
   }
   case DataTypeId::kDate:
     return Value::DATE(property.as_date());

--- a/src/utils/pb_utils.cc
+++ b/src/utils/pb_utils.cc
@@ -309,8 +309,18 @@ property_defs_to_value(
                  << property.default_value().DebugString();
       }
     } else {
-      default_value =
-          execution::property_to_value(get_default_value(type.id()), type);
+      if (type.id() == DataTypeId::kVarchar) {
+        int32_t width =
+            type.RawExtraTypeInfo()
+                ? type.RawExtraTypeInfo()->Cast<StringTypeInfo>().max_length
+                : STRING_DEFAULT_MAX_LENGTH;
+        default_value = execution::Value::VARCHAR(
+            std::string(get_default_value(type.id()).as_string_view()), width);
+      } else {
+        default_value =
+            execution::property_to_value(get_default_value(type.id()));
+      }
+
       VLOG(1) << "No default value, use type default:"
               << default_value.to_string()
               << " type: " << default_value.type().ToString();


### PR DESCRIPTION
This pull request focuses on simplifying and clarifying the conversion logic between `Property` and `Value` types, particularly for string types, and fixes a bug in the serialization logic of string columns. The changes remove unnecessary parameters, make the interface more consistent, and address an issue with how position values are saved during column dumps.



