### PR TITLE
fix: configurable WAL pre-allocation size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,13 @@ if(NOT NEUG_NODE_GROUP_SIZE_LOG2)
     set(NEUG_NODE_GROUP_SIZE_LOG2 17)
 endif()
 message(STATUS "NEUG_NODE_GROUP_SIZE_LOG2: ${NEUG_NODE_GROUP_SIZE_LOG2}")
+
+# 1ul << 30 = 1GB WAL file size by default
+option(NEUG_DEFAULT_WAL_SIZE_LOG2 "Log2 of the default WAL pre-allocation size per thread." 30)
+if(NOT NEUG_DEFAULT_WAL_SIZE_LOG2)
+    set(NEUG_DEFAULT_WAL_SIZE_LOG2 30)
+endif()
+message(STATUS "NEUG_DEFAULT_WAL_SIZE_LOG2: ${NEUG_DEFAULT_WAL_SIZE_LOG2}")
 option(ENABLE_WERROR "Treat all warnings as errors" FALSE)
 option(ENABLE_ADDRESS_SANITIZER "Enable address sanitizer." FALSE)
 option(ENABLE_THREAD_SANITIZER "Enable thread sanitizer." FALSE)

--- a/cmake/templates/system_config.h.in
+++ b/cmake/templates/system_config.h.in
@@ -83,6 +83,14 @@ struct CopyConfig {
       50 * DEFAULT_VECTOR_CAPACITY;
 };
 
+struct WalConfig {
+  // clang-format off
+  static constexpr uint64_t DEFAULT_WAL_SIZE_LOG2 = @NEUG_DEFAULT_WAL_SIZE_LOG2@;
+  // clang-format on
+  static constexpr uint64_t DEFAULT_WAL_SIZE = static_cast<uint64_t>(1)
+                                               << DEFAULT_WAL_SIZE_LOG2;
+};
+
 }  // namespace common
 }  // namespace neug
 

--- a/include/neug/transaction/wal/local_wal_writer.h
+++ b/include/neug/transaction/wal/local_wal_writer.h
@@ -18,6 +18,7 @@
 #include <memory>
 #include <string>
 
+#include "neug/compiler/common/system_config.h"
 #include "neug/transaction/wal/wal.h"
 
 namespace neug {
@@ -27,7 +28,8 @@ class LocalWalWriter : public IWalWriter {
   static std::unique_ptr<IWalWriter> Make(const std::string& wal_uri,
                                           int thread_id);
 
-  static constexpr size_t TRUNC_SIZE = 1ul << 30;
+  // 1ul << 30 = 1GB by default
+  static constexpr size_t TRUNC_SIZE = common::WalConfig::DEFAULT_WAL_SIZE;
   LocalWalWriter(const std::string& wal_uri, int thread_id)
       : wal_uri_(wal_uri),
         thread_id_(thread_id),


### PR DESCRIPTION
## Summary

Makes per-thread WAL pre-allocation size configurable at build time via `NEUG_DEFAULT_WAL_SIZE_LOG2`, instead of a hard-coded `1 << 30` (1 GiB) in `LocalWalWriter`.

This addresses the operational issue described in #286 where default service mode on high-core machines creates very large apparent WAL footprints.

## Changes

- Add CMake option `NEUG_DEFAULT_WAL_SIZE_LOG2` (default `30`, preserving previous behavior).
- Expose `common::WalConfig::DEFAULT_WAL_SIZE` through generated `system_config.h`.
- Use it as `LocalWalWriter::TRUNC_SIZE`.

Fixes #286.

Made with [Cursor](https://cursor.com)