### PR TITLE
fix: adjust precedence for string/list predicates with NOT

### DIFF
--- a/src/compiler/gopt/g_precedence.cpp
+++ b/src/compiler/gopt/g_precedence.cpp
@@ -58,7 +58,7 @@ int GPrecedence::getPrecedence(const binder::Expression& expr) {
     case ScalarType::ENDS_WITH:
     case ScalarType::CONTAINS:
     case ScalarType::LIST_CONTAINS:
-      return 10;  // Power (exponentiation) - higher precedence
+      return 10;  // Power (exponentiation), STRING Operators, LIST Operators - higher precedence
     default:
       return 11;  // Other function calls - highest precedence
     }

--- a/src/compiler/gopt/g_precedence.cpp
+++ b/src/compiler/gopt/g_precedence.cpp
@@ -54,6 +54,10 @@ int GPrecedence::getPrecedence(const binder::Expression& expr) {
     case ScalarType::MODULO:
       return 9;  // Multiplication, division, modulo (*, /, %)
     case ScalarType::POWER:
+    case ScalarType::STARTS_WITH:
+    case ScalarType::ENDS_WITH:
+    case ScalarType::CONTAINS:
+    case ScalarType::LIST_CONTAINS:
       return 10;  // Power (exponentiation) - higher precedence
     default:
       return 11;  // Other function calls - highest precedence

--- a/tools/python_bind/tests/test_db_query.py
+++ b/tools/python_bind/tests/test_db_query.py
@@ -3018,18 +3018,23 @@ def test_not_starts_with(tmp_path):
     conn.execute("CREATE REL TABLE Knows(FROM Person TO Person, id STRING);")
     conn.execute("CREATE (:Person {id: 'n4'});")
     conn.execute("CREATE (:Person {id: 'n8'});")
-    conn.execute("MATCH (a:Person {id: 'n4'}), (b:Person {id: 'n8'}) CREATE (a)-[:Knows {id: 'e19'}]->(b);")
+    conn.execute(
+        "MATCH (a:Person {id: 'n4'}), (b:Person {id: 'n8'}) CREATE (a)-[:Knows {id: 'e19'}]->(b);"
+    )
 
-    result = conn.execute("""
+    result = conn.execute(
+        """
         MATCH (a:Person {id: 'n4'})-[r0:Knows {id: 'e19'}]->(b:Person {id: 'n8'})
         WHERE NOT ('a' STARTS WITH 'a') OR (r0.id IN [a.id])
         RETURN a.id AS source_id, b.id AS target_id;
-    """)
+    """
+    )
 
     records = list(result)
     assert records == []
     conn.close()
     db.close()
+
 
 def test_not_list_contains(tmp_path):
     db_dir = tmp_path / "test_not_list_contains"
@@ -3046,13 +3051,19 @@ def test_not_list_contains(tmp_path):
     result = conn.execute("MATCH (n:L1) RETURN count(n) AS pair_count;")
     records = list(result)
     assert records == [[3]]
-    result = conn.execute("MATCH (n:L1) WHERE (n.p0 IN ['s3836', 'L1']) RETURN count(n) AS pair_count;")
+    result = conn.execute(
+        "MATCH (n:L1) WHERE (n.p0 IN ['s3836', 'L1']) RETURN count(n) AS pair_count;"
+    )
     records = list(result)
     assert records == [[1]]
-    result = conn.execute("MATCH (n:L1) WHERE NOT (n.p0 IN ['s3836', 'L1']) RETURN count(n) AS pair_count;")
+    result = conn.execute(
+        "MATCH (n:L1) WHERE NOT (n.p0 IN ['s3836', 'L1']) RETURN count(n) AS pair_count;"
+    )
     records = list(result)
     assert records == [[2]]
-    result = conn.execute("MATCH (n:L1) WHERE ((n.p0 IN ['s3836', 'L1'])) IS NULL RETURN count(n) AS pair_count;")
+    result = conn.execute(
+        "MATCH (n:L1) WHERE ((n.p0 IN ['s3836', 'L1'])) IS NULL RETURN count(n) AS pair_count;"
+    )
     records = list(result)
     assert records == [[0]]
     conn.close()

--- a/tools/python_bind/tests/test_db_query.py
+++ b/tools/python_bind/tests/test_db_query.py
@@ -3005,3 +3005,55 @@ def test_duplicate_project_column(tmp_path):
         "ORDER BY node_id LIMIT 100"
     )
     assert list(conn_l0.execute(failing_query, parameters=parameters)) == [[1, 1]]
+
+
+def test_not_starts_with(tmp_path):
+    db_dir = tmp_path / "test_not_starts_with"
+    shutil.rmtree(db_dir, ignore_errors=True)
+    db_dir.mkdir()
+    db = Database(db_path=str(db_dir), mode="w")
+    conn = db.connect()
+
+    conn.execute("CREATE NODE TABLE Person(id STRING, PRIMARY KEY(id));")
+    conn.execute("CREATE REL TABLE Knows(FROM Person TO Person, id STRING);")
+    conn.execute("CREATE (:Person {id: 'n4'});")
+    conn.execute("CREATE (:Person {id: 'n8'});")
+    conn.execute("MATCH (a:Person {id: 'n4'}), (b:Person {id: 'n8'}) CREATE (a)-[:Knows {id: 'e19'}]->(b);")
+
+    result = conn.execute("""
+        MATCH (a:Person {id: 'n4'})-[r0:Knows {id: 'e19'}]->(b:Person {id: 'n8'})
+        WHERE NOT ('a' STARTS WITH 'a') OR (r0.id IN [a.id])
+        RETURN a.id AS source_id, b.id AS target_id;
+    """)
+
+    records = list(result)
+    assert records == []
+    conn.close()
+    db.close()
+
+def test_not_list_contains(tmp_path):
+    db_dir = tmp_path / "test_not_list_contains"
+    shutil.rmtree(db_dir, ignore_errors=True)
+    db_dir.mkdir()
+    db = Database(db_path=str(db_dir), mode="w")
+    conn = db.connect()
+
+    conn.execute("CREATE NODE TABLE L1(id STRING, p0 STRING, PRIMARY KEY(id));")
+    conn.execute("CREATE (:L1 {id: 'n1', p0: 's3836'});")
+    conn.execute("CREATE (:L1 {id: 'n2', p0: 'x'});")
+    conn.execute("CREATE (:L1 {id: 'n3', p0: 'y'});")
+
+    result = conn.execute("MATCH (n:L1) RETURN count(n) AS pair_count;")
+    records = list(result)
+    assert records == [[3]]
+    result = conn.execute("MATCH (n:L1) WHERE (n.p0 IN ['s3836', 'L1']) RETURN count(n) AS pair_count;")
+    records = list(result)
+    assert records == [[1]]
+    result = conn.execute("MATCH (n:L1) WHERE NOT (n.p0 IN ['s3836', 'L1']) RETURN count(n) AS pair_count;")
+    records = list(result)
+    assert records == [[2]]
+    result = conn.execute("MATCH (n:L1) WHERE ((n.p0 IN ['s3836', 'L1'])) IS NULL RETURN count(n) AS pair_count;")
+    records = list(result)
+    assert records == [[0]]
+    conn.close()
+    db.close()


### PR DESCRIPTION
## Summary
- assign `STARTS WITH` / `ENDS WITH` / `CONTAINS` / `IN` scalar expressions a higher precedence bucket so `NOT` combinations parse and evaluate correctly
- add python binding regression tests for `NOT ('a' STARTS WITH 'a')` and `NOT (n.p0 IN [...])`
- keep scope limited to precedence logic and query regression coverage

## Test plan
- [x] Run full test suite
- [x] Code review of precedence mapping and test assertions

Fixes #311
Fixes #321

Made with [Cursor](https://cursor.com)