### PR TITLE
fix: Fix the performance issue of query ic5.

### DIFF
--- a/src/execution/execute/ops/retrieve/tc_fuse.cc
+++ b/src/execution/execute/ops/retrieve/tc_fuse.cc
@@ -175,12 +175,12 @@ bool tc_fusable(const physical::PhysicalPlan& plan, int op_idx) {
   int alias7 = ee_opr2.alias().value();
   // select_opr
   const auto& select_opr = plan.plan(op_idx + 7).opr().select();
-  if (select_opr.predicate().operators_size() != 7) {
+  if (select_opr.predicate().operators_size() != 3) {
     return false;
   }
-  auto& var = select_opr.predicate().operators(1);
-  auto& within = select_opr.predicate().operators(3);
-  auto& v_set = select_opr.predicate().operators(5);
+  auto& var = select_opr.predicate().operators(0);
+  auto& within = select_opr.predicate().operators(1);
+  auto& v_set = select_opr.predicate().operators(2);
   if ((!var.has_var()) || (!var.var().has_tag()) || var.var().has_property()) {
     return false;
   }


### PR DESCRIPTION
This pull request updates the logic in the `tc_fusable` function to correctly handle the structure of the select operator's predicate. The main change is adjusting the expected number and positions of operators in the predicate, ensuring the function matches the updated query plan structure.

Predicate structure validation:

* Changed the check for the number of operators in `select_opr.predicate()` from 7 to 3, and updated the indices used to access `var`, `within`, and `v_set` accordingly. This ensures compatibility with the new predicate structure in the query plan.

Fixes

