### PR TITLE
refactor: Replace some dangerous `LOG(FATAL)` with exception throw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,5 +140,8 @@ tools/python_bind/neug/extensions/
 # aone copilot
 .aone_copilot/
 
-# claude cod
+# claude code
 .claude/
+
+# qoder ide
+.qoder/

--- a/src/execution/common/columns/arrow_context_column.cc
+++ b/src/execution/common/columns/arrow_context_column.cc
@@ -18,6 +18,7 @@
 #include <arrow/array/array_binary.h>
 #include <arrow/array/builder_binary.h>
 #include <arrow/array/builder_primitive.h>
+#include "neug/utils/exception/exception.h"
 #include <arrow/array/builder_time.h>
 #include <arrow/type.h>
 #include <glog/logging.h>
@@ -42,7 +43,7 @@ std::pair<size_t, size_t> locate_array_and_offset(
     }
     accumulated_size += array_length;
   }
-  LOG(FATAL) << "Should not reach here";
+  THROW_INTERNAL_EXCEPTION("Should not reach here");
   return {0, 0};
 }
 
@@ -249,9 +250,9 @@ void ArrowArrayContextColumnBuilder::push_back(
       columns_.push_back(column);
       return;
     } else {
-      LOG(FATAL) << "Expect the same type of columns, but got "
-                 << columns_[0]->type()->ToString() << " and "
-                 << column->type()->ToString();
+      THROW_INTERNAL_EXCEPTION("Expect the same type of columns, but got " +
+                               columns_[0]->type()->ToString() + " and " +
+                               column->type()->ToString());
     }
   }
   columns_.push_back(column);

--- a/src/execution/common/columns/columns_utils.cc
+++ b/src/execution/common/columns/columns_utils.cc
@@ -18,6 +18,7 @@
 #include "neug/execution/common/columns/list_columns.h"
 #include "neug/execution/common/columns/path_columns.h"
 #include "neug/execution/common/columns/struct_columns.h"
+#include "neug/utils/exception/exception.h"
 #include "neug/execution/common/columns/value_columns.h"
 #include "neug/execution/common/columns/vertex_columns.h"
 
@@ -52,8 +53,8 @@ std::shared_ptr<IContextColumnBuilder> ColumnsUtils::create_builder(
     return std::make_shared<ValueColumnBuilder<std::string>>();
   }
   default:
-    LOG(FATAL) << "Unsupported data type for column builder: "
-               << static_cast<int>(type.id());
+    THROW_NOT_SUPPORTED_EXCEPTION("Unsupported data type for column builder: " +
+                                  std::to_string(static_cast<int>(type.id())));
     return nullptr;
   }
 }

--- a/src/execution/common/columns/list_columns.cc
+++ b/src/execution/common/columns/list_columns.cc
@@ -17,6 +17,7 @@
 #include "neug/execution/common/columns/edge_columns.h"
 #include "neug/execution/common/columns/struct_columns.h"
 #include "neug/execution/common/columns/vertex_columns.h"
+#include "neug/utils/exception/exception.h"
 
 namespace neug {
 namespace execution {
@@ -89,8 +90,8 @@ ListColumn::unfold() const {
     return {builder.finish(), offsets};
   }
   default:
-    LOG(FATAL) << "not implemented for " << this->column_info() << " "
-               << static_cast<int>(elem_type_.id());
+    THROW_NOT_IMPLEMENTED_EXCEPTION("not implemented for " + this->column_info() + " " +
+                                    std::to_string(static_cast<int>(elem_type_.id())));
     return {nullptr, std::vector<size_t>()};
   }
 }

--- a/src/execution/common/operators/retrieve/join.cc
+++ b/src/execution/common/operators/retrieve/join.cc
@@ -18,6 +18,7 @@
 #include "neug/common/types.h"
 #include "neug/execution/common/columns/vertex_columns.h"
 #include "neug/execution/common/context.h"
+#include "neug/utils/exception/exception.h"
 #include "neug/execution/utils/params.h"
 #include "neug/storages/graph/graph_interface.h"
 #include "neug/utils/encoder.h"
@@ -645,7 +646,8 @@ neug::result<Context> Join::join(Context&& ctx, Context&& ctx2,
   } else if (params.join_type == JoinKind::kTimesJoin) {
     return default_times_join(std::move(ctx), std::move(ctx2), params);
   }
-  LOG(FATAL) << "Unsupported join type" << static_cast<int>(params.join_type);
+  THROW_NOT_SUPPORTED_EXCEPTION("Unsupported join type" +
+                                std::to_string(static_cast<int>(params.join_type)));
   return ctx;
 }
 

--- a/src/execution/execute/ops/batch/batch_insert_edge.cc
+++ b/src/execution/execute/ops/batch/batch_insert_edge.cc
@@ -18,6 +18,7 @@
 #include "neug/execution/execute/ops/batch/batch_update_utils.h"
 #include "neug/storages/graph/graph_interface.h"
 #include "neug/utils/result.h"
+#include "neug/utils/exception/exception.h"
 
 #include <glog/logging.h>
 #include <string>
@@ -159,7 +160,7 @@ neug::result<OpBuildResultT> BatchInsertEdgeOprBuilder::Build(
   const auto& opr = plan.plan(op_idx).opr().load_edge();
 
   if (!opr.has_edge_type()) {
-    LOG(FATAL) << "BatchInsertEdgeOprBuilder::Build: edge type is not set";
+    THROW_INTERNAL_EXCEPTION("BatchInsertEdgeOprBuilder::Build: edge type is not set");
   }
 
   std::vector<std::pair<int32_t, std::string>> prop_mappings,

--- a/src/execution/execute/ops/batch/batch_insert_vertex.cc
+++ b/src/execution/execute/ops/batch/batch_insert_vertex.cc
@@ -18,6 +18,7 @@
 #include "neug/execution/execute/ops/batch/batch_update_utils.h"
 #include "neug/storages/graph/graph_interface.h"
 #include "neug/utils/result.h"
+#include "neug/utils/exception/exception.h"
 
 #include <glog/logging.h>
 #include <string>
@@ -72,8 +73,8 @@ neug::result<Context> BatchInsertVertexOpr::Eval(
     break;
   }
   default:
-    LOG(FATAL) << "BatchInsertVertexOpr: invalid vertex_type: "
-               << vertex_type_.DebugString();
+    THROW_INVALID_ARGUMENT_EXCEPTION("BatchInsertVertexOpr: invalid vertex_type: " +
+                                     vertex_type_.DebugString());
   }
   auto suppliers = create_record_batch_supplier(ctx, prop_mappings_);
   for (auto supplier : suppliers) {
@@ -91,7 +92,7 @@ neug::result<OpBuildResultT> BatchInsertVertexOprBuilder::Build(
   const auto& opr = plan.plan(op_idx).opr().load_vertex();
 
   if (!opr.has_vertex_type()) {
-    LOG(FATAL) << "BatchInsertVertexOpr must have vertex type";
+    THROW_INTERNAL_EXCEPTION("BatchInsertVertexOpr must have vertex type");
   }
   std::vector<std::pair<int32_t, std::string>> prop_mappings;
   parse_property_mappings(opr.property_mappings(), prop_mappings);

--- a/src/execution/execute/ops/batch/batch_update_utils.cc
+++ b/src/execution/execute/ops/batch/batch_update_utils.cc
@@ -23,6 +23,8 @@
 #include <rapidjson/document.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
+
+#include "neug/utils/exception/exception.h"
 #include <stddef.h>
 #include <cstdint>
 #include <ostream>
@@ -332,12 +334,14 @@ create_record_batch_supplier_from_arrow_array_column(
     auto prop_name = mapping.second;
     auto column = ctx.get(tag_id);
     if (column == nullptr) {
-      LOG(FATAL) << "Column not found for tag id: " << tag_id;
+      THROW_INTERNAL_EXCEPTION("Column not found for tag id: " +
+                               std::to_string(tag_id));
     }
     auto arrow_column =
         std::dynamic_pointer_cast<ArrowArrayContextColumn>(column);
     if (!arrow_column) {
-      LOG(FATAL) << "Invalid column type for tag id: " << tag_id;
+      THROW_INTERNAL_EXCEPTION("Invalid column type for tag id: " +
+                               std::to_string(tag_id));
     }
 
     auto& column_arrays = arrow_column->GetColumns();
@@ -353,8 +357,8 @@ create_record_batch_supplier_from_arrow_array_column(
     for (size_t i = 1; i < arrays.size(); ++i) {
       auto& array = arrays[i];
       if (array.size() != batch_size) {
-        LOG(FATAL) << "Array size mismatch for tag id: "
-                   << prop_mappings[i].first;
+        THROW_INTERNAL_EXCEPTION("Array size mismatch for tag id: " +
+                                 std::to_string(prop_mappings[i].first));
       }
     }
   }
@@ -610,7 +614,7 @@ void parse_property_mappings(
       auto prop_name = mapping.property().key().name();
       if (mapping.data().operators_size() != 1 ||
           !mapping.data().operators(0).has_var()) {
-        LOG(FATAL) << "Invalid property mapping: " << prop_name;
+        THROW_INVALID_ARGUMENT_EXCEPTION("Invalid property mapping: " + prop_name);
       }
       auto tag_id = mapping.data().operators(0).var().tag().id();
       prop_mappings.emplace_back(tag_id, prop_name);

--- a/src/execution/execute/ops/insert/create_vertex.cc
+++ b/src/execution/execute/ops/insert/create_vertex.cc
@@ -18,6 +18,7 @@
 #include "neug/storages/graph/graph_interface.h"
 
 #include "neug/execution/expression/expr.h"
+#include "neug/utils/exception/exception.h"
 
 namespace neug {
 namespace execution {
@@ -88,8 +89,8 @@ neug::result<OpBuildResultT> CreateVertexOprBuilder::Build(
       break;
     }
     default:
-      LOG(FATAL) << "Unknown vertex type: "
-                 << entry.vertex_type().DebugString();
+      THROW_NOT_SUPPORTED_EXCEPTION("Unknown vertex type: " +
+                                    entry.vertex_type().DebugString());
     }
     labels.push_back(label);
     alias.push_back(entry.alias().id());
@@ -98,10 +99,10 @@ neug::result<OpBuildResultT> CreateVertexOprBuilder::Build(
     std::vector<std::pair<std::string, std::unique_ptr<ExprBase>>> props;
     for (const auto& prop : entry.property_mappings()) {
       if (!prop.has_property()) {
-        LOG(FATAL) << "PropertyMapping has no property: " << prop.DebugString();
+        THROW_INTERNAL_EXCEPTION("PropertyMapping has no property: " + prop.DebugString());
       }
       if (!prop.has_data()) {
-        LOG(FATAL) << "PropertyMapping has no data: " << prop.DebugString();
+        THROW_INTERNAL_EXCEPTION("PropertyMapping has no data: " + prop.DebugString());
       }
       auto expr = parse_expression(prop.data(), ctx_meta, VarType::kRecord);
       props.emplace_back(prop.property().key().name(), std::move(expr));

--- a/src/execution/execute/ops/retrieve/group_by.cc
+++ b/src/execution/execute/ops/retrieve/group_by.cc
@@ -18,6 +18,7 @@
 #include "neug/execution/common/context.h"
 #include "neug/execution/common/operators/retrieve/group_by.h"
 #include "neug/execution/common/operators/retrieve/project.h"
+#include "neug/utils/exception/exception.h"
 #include "neug/execution/execute/ops/retrieve/group_by_utils.h"
 #include "neug/storages/graph/graph_interface.h"
 #include "neug/utils/property/types.h"
@@ -73,7 +74,7 @@ neug::result<OpBuildResultT> GroupByOprBuilder::Build(
                parse_from_ir_data_type(plan.plan(op_idx).meta_data(i).type()));
     }
   } else {
-    LOG(FATAL) << "GroupBy metadata number mismatch.";
+    THROW_INTERNAL_EXCEPTION("GroupBy metadata number mismatch.");
   }
   auto opr = plan.plan(op_idx).opr().group_by();
   std::vector<std::pair<int, int>> mappings;

--- a/src/execution/execute/ops/retrieve/group_by_utils.cc
+++ b/src/execution/execute/ops/retrieve/group_by_utils.cc
@@ -18,6 +18,7 @@
 #include "neug/execution/common/columns/list_columns.h"
 #include "neug/execution/common/columns/value_columns.h"
 #include "neug/execution/common/columns/vertex_columns.h"
+#include "neug/utils/exception/exception.h"
 
 namespace neug {
 namespace execution {
@@ -596,7 +597,7 @@ std::unique_ptr<ReducerBase> create_typed_reducer(EXPR&& expr, AggrKind kind) {
     if constexpr (std::is_arithmetic<typename EXPR::V>::value) {
       return std::make_unique<SumReducer<EXPR, IS_OPTIONAL>>(std::move(expr));
     } else {
-      LOG(FATAL) << "unsupport" << static_cast<int>(kind);
+      THROW_NOT_SUPPORTED_EXCEPTION("unsupport" + std::to_string(static_cast<int>(kind)));
       return nullptr;
     }
   }
@@ -609,21 +610,21 @@ std::unique_ptr<ReducerBase> create_typed_reducer(EXPR&& expr, AggrKind kind) {
   }
   case AggrKind::kMin: {
     if constexpr (std::is_same<typename EXPR::V, VertexRecord>::value) {
-      LOG(FATAL) << "Min not support VertexRecord";
+      THROW_NOT_SUPPORTED_EXCEPTION("Min not support VertexRecord");
     } else {
       return std::make_unique<MinReducer<EXPR, IS_OPTIONAL>>(std::move(expr));
     }
   }
   case AggrKind::kMax: {
     if constexpr (std::is_same<typename EXPR::V, VertexRecord>::value) {
-      LOG(FATAL) << "Max not support VertexRecord";
+      THROW_NOT_SUPPORTED_EXCEPTION("Max not support VertexRecord");
     } else {
       return std::make_unique<MaxReducer<EXPR, IS_OPTIONAL>>(std::move(expr));
     }
   }
   case AggrKind::kFirst: {
     if constexpr (std::is_same<typename EXPR::V, VertexRecord>::value) {
-      LOG(FATAL) << "First not support VertexRecord";
+      THROW_NOT_SUPPORTED_EXCEPTION("First not support VertexRecord");
     } else {
       return std::make_unique<FirstReducer<EXPR, IS_OPTIONAL>>(std::move(expr));
     }
@@ -640,12 +641,12 @@ std::unique_ptr<ReducerBase> create_typed_reducer(EXPR&& expr, AggrKind kind) {
     if constexpr (std::is_arithmetic<typename EXPR::V>::value) {
       return std::make_unique<AvgReducer<EXPR, IS_OPTIONAL>>(std::move(expr));
     } else {
-      LOG(FATAL) << "unsupport" << static_cast<int>(kind);
+      THROW_NOT_SUPPORTED_EXCEPTION("unsupport" + std::to_string(static_cast<int>(kind)));
       return nullptr;
     }
   }
   default:
-    LOG(FATAL) << "unsupport" << static_cast<int>(kind);
+    THROW_NOT_SUPPORTED_EXCEPTION("unsupport" + std::to_string(static_cast<int>(kind)));
     return nullptr;
   }
 }
@@ -678,9 +679,11 @@ static std::unique_ptr<ReducerBase> create_general_reducer(
           std::move(var_wrap), var->elem_type());
     }
   } else {
-    LOG(FATAL) << "not support var reduce " << static_cast<int>(kind)
-               << var->elem_type().ToString() << " " << var->is_optional()
-               << " " << var->column_info();
+    THROW_NOT_SUPPORTED_EXCEPTION("not support var reduce " +
+                                  std::to_string(static_cast<int>(kind)) +
+                                  var->elem_type().ToString() + " " +
+                                  std::to_string(var->is_optional()) + " " +
+                                  var->column_info());
   }
   return nullptr;  // This line is unreachable but avoids compiler warning.
 }
@@ -695,7 +698,7 @@ static std::unique_ptr<ReducerBase> create_pair_reducer(
           std::move(var_wrap));
       return reducer;
     } else {
-      LOG(FATAL) << "not support optional count\n";
+      THROW_NOT_SUPPORTED_EXCEPTION("not support optional count\n");
     }
   } else if (kind == AggrKind::kCountDistinct) {
     VarPairWrapper var_wrap(std::move(fst), std::move(snd));
@@ -705,10 +708,10 @@ static std::unique_ptr<ReducerBase> create_pair_reducer(
               std::move(var_wrap));
       return reducer;
     } else {
-      LOG(FATAL) << "not support optional count\n";
+      THROW_NOT_SUPPORTED_EXCEPTION("not support optional count\n");
     }
   } else {
-    LOG(FATAL) << "not support var reduce\n";
+    THROW_NOT_SUPPORTED_EXCEPTION("not support var reduce\n");
   }
   return nullptr;
 }

--- a/src/execution/execute/ops/retrieve/scan_utils.cc
+++ b/src/execution/execute/ops/retrieve/scan_utils.cc
@@ -18,6 +18,7 @@
 #include "neug/execution/execute/ops/retrieve/scan_utils.h"
 #include "neug/execution/common/types/value.h"
 #include "neug/execution/utils/pb_parse_utils.h"
+#include "neug/utils/exception/exception.h"
 
 namespace neug {
 namespace execution {
@@ -123,7 +124,8 @@ std::vector<Property> ScanUtils::parse_ids_with_type(
     return parse_ids_from_idx_predicate(triplet, params);
   }
   default:
-    LOG(FATAL) << "unsupported type" << static_cast<int>(type);
+    THROW_NOT_SUPPORTED_EXCEPTION("unsupported type" +
+                                  std::to_string(static_cast<int>(type)));
     break;
   }
   return {};

--- a/src/execution/expression/accessors/edge_accessor.cc
+++ b/src/execution/expression/accessors/edge_accessor.cc
@@ -14,6 +14,7 @@
  */
 
 #include "neug/execution/expression/accessors/edge_accessor.h"
+#include "neug/utils/exception/exception.h"
 
 namespace neug {
 namespace execution {
@@ -146,8 +147,8 @@ std::unique_ptr<BindedExprBase> EdgeAccessor::bind(
     return std::make_unique<BindedEdgeIdentityAccessor>();
   }
   default:
-    LOG(FATAL) << "Unknown GraphAccessorType: "
-               << static_cast<int>(access_type_);
+    THROW_NOT_SUPPORTED_EXCEPTION("Unknown GraphAccessorType: " +
+                                  std::to_string(static_cast<int>(access_type_)));
     break;
   }
   return nullptr;

--- a/src/execution/expression/accessors/record_accessor.cc
+++ b/src/execution/expression/accessors/record_accessor.cc
@@ -14,6 +14,7 @@
  */
 
 #include "neug/execution/expression/accessors/record_accessor.h"
+#include "neug/utils/exception/exception.h"
 #include "neug/execution/common/columns/i_context_column.h"
 
 namespace neug {
@@ -139,8 +140,8 @@ std::unique_ptr<BindedExprBase> RecordVertexAccessor::bind(
   case GraphAccessType::kGid:
     return std::make_unique<BindedRecordVertexGIdExpr>(tag_);
   default:
-    LOG(FATAL) << "Unknown RecordVertexAccessor GraphAccessType: "
-               << static_cast<int>(access_type_);
+    THROW_NOT_SUPPORTED_EXCEPTION("Unknown RecordVertexAccessor GraphAccessType: " +
+                                  std::to_string(static_cast<int>(access_type_)));
     break;
   }
   return nullptr;
@@ -262,8 +263,8 @@ std::unique_ptr<BindedExprBase> RecordEdgeAccessor::bind(
   case GraphAccessType::kGid:
     return std::make_unique<BindedEdgeRecordGIdExpr>(tag_);
   default:
-    LOG(FATAL) << "Unknown RecordEdgeAccessor GraphAccessType: "
-               << static_cast<int>(access_type_);
+    THROW_NOT_SUPPORTED_EXCEPTION("Unknown RecordEdgeAccessor GraphAccessType: " +
+                                  std::to_string(static_cast<int>(access_type_)));
     break;
   }
   return nullptr;
@@ -314,7 +315,7 @@ std::unique_ptr<BindedExprBase> RecordPathAccessor::bind(
   } else if (property_ == "cost") {
     return std::make_unique<BindedPathWeightExpr>(tag_);
   }
-  LOG(FATAL) << "Unknown RecordPathAccessor property: " << property_;
+  THROW_NOT_SUPPORTED_EXCEPTION("Unknown RecordPathAccessor property: " + property_);
   return nullptr;
 }
 

--- a/src/execution/expression/accessors/vertex_accessor.cc
+++ b/src/execution/expression/accessors/vertex_accessor.cc
@@ -14,6 +14,7 @@
  */
 
 #include "neug/execution/expression/accessors/vertex_accessor.h"
+#include "neug/utils/exception/exception.h"
 
 namespace neug {
 namespace execution {
@@ -116,7 +117,8 @@ std::unique_ptr<BindedExprBase> VertexAccessor::bind(
     return std::make_unique<BindedVertexIdentityAccessor>();
   }
   default:
-    LOG(FATAL) << "Unknown GraphAccessType: " << static_cast<int>(access_type_);
+    THROW_NOT_SUPPORTED_EXCEPTION("Unknown GraphAccessType: " +
+                                  std::to_string(static_cast<int>(access_type_)));
     break;
   }
   return nullptr;

--- a/src/execution/expression/expr.cc
+++ b/src/execution/expression/expr.cc
@@ -18,6 +18,7 @@
 
 #include "neug/compiler/function/neug_scalar_function.h"
 #include "neug/compiler/function/scalar_function.h"
+#include "neug/utils/exception/exception.h"
 #include "neug/compiler/main/metadata_registry.h"
 #include "neug/execution/expression/accessors/const_accessor.h"
 #include "neug/execution/expression/exprs/arith_expr.h"
@@ -194,7 +195,7 @@ static std::unique_ptr<ExprBase> build_expr(
       } else if (name == "gs.function.endNode") {
         return std::make_unique<StartEndNodeExpr>(std::move(expr), false);
       } else {
-        LOG(FATAL) << "not support udf" << opr.DebugString();
+        THROW_NOT_SUPPORTED_EXCEPTION("not support udf" + opr.DebugString());
       }
     }
     case ::common::ExprOpr::kPathFunc: {
@@ -203,7 +204,7 @@ static std::unique_ptr<ExprBase> build_expr(
       int tag = opr.path_func().has_tag() ? opr.path_func().tag().id() : -1;
       if (opr.node_type().data_type().item_case() !=
           ::common::DataType::kArray) {
-        LOG(FATAL) << "path function node_type is not array type";
+        THROW_INVALID_ARGUMENT_EXCEPTION("path function node_type is not array type");
         return nullptr;
       }
       auto type = parse_from_data_type(
@@ -215,13 +216,13 @@ static std::unique_ptr<ExprBase> build_expr(
                  ::common::PathFunction_FuncOpt::PathFunction_FuncOpt_EDGE) {
         return std::make_unique<PathPropsExpr>(tag, name, type, false);
       } else {
-        LOG(FATAL) << "unsupport path function opt" << opr.DebugString();
+        THROW_NOT_SUPPORTED_EXCEPTION("unsupport path function opt" + opr.DebugString());
       }
 
       break;
     }
     default:
-      LOG(FATAL) << "not support" << opr.DebugString();
+      THROW_NOT_SUPPORTED_EXCEPTION("not support" + opr.DebugString());
       break;
     }
   }

--- a/src/execution/expression/exprs/arith_expr.cc
+++ b/src/execution/expression/exprs/arith_expr.cc
@@ -15,6 +15,8 @@
 
 #include "neug/execution/expression/exprs/arith_expr.h"
 
+#include "neug/utils/exception/exception.h"
+
 namespace neug {
 namespace execution {
 class BindedArithExpr : public VertexExprBase,
@@ -69,8 +71,8 @@ class BindedArithExpr : public VertexExprBase,
     case ::common::Arithmetic::MOD:
       return lhs % rhs;
     default:
-      LOG(FATAL) << "Unsupported arithmetic operation: "
-                 << static_cast<int>(arith);
+      THROW_NOT_SUPPORTED_EXCEPTION("Unsupported arithmetic operation: " +
+                                    std::to_string(static_cast<int>(arith)));
       return Value(type_);
     }
   }

--- a/src/execution/expression/exprs/extract_expr.cc
+++ b/src/execution/expression/exprs/extract_expr.cc
@@ -14,6 +14,8 @@
  */
 
 #include "neug/execution/expression/exprs/extract_expr.h"
+
+#include "neug/utils/exception/exception.h"
 #include "neug/generated/proto/plan/expr.pb.h"
 
 namespace neug {
@@ -66,7 +68,8 @@ class BindedExtractExpr : public VertexExprBase,
       case ::common::Extract::DAY:
         return Value::INT64(val.GetValue<date_t>().day());
       default:
-        LOG(FATAL) << "not support: " << extract_type.DebugString();
+        THROW_NOT_SUPPORTED_EXCEPTION("not support: " +
+                                      extract_type.DebugString());
         return Value(DataType::INT64);
       }
     } else if (val.type().id() == DataTypeId::kInterval) {
@@ -87,11 +90,13 @@ class BindedExtractExpr : public VertexExprBase,
       case ::common::Extract::MILLISECOND:
         return Value::INT64(interval.millisecond());
       default:
-        LOG(FATAL) << "not support: " << extract_type.DebugString();
+        THROW_NOT_SUPPORTED_EXCEPTION("not support: " +
+                                      extract_type.DebugString());
         return Value(DataType::INT64);
       }
     } else {
-      LOG(FATAL) << "not support: " << val.type().id();
+      THROW_NOT_SUPPORTED_EXCEPTION("not support: " +
+                                    std::to_string(static_cast<int>(val.type().id())));
       return Value(DataType::INT64);
     }
   }
@@ -112,7 +117,7 @@ class BindedExtractExpr : public VertexExprBase,
     case ::common::Extract::SECOND:
       return extract_second(ms);
     default:
-      LOG(FATAL) << "not support";
+      THROW_NOT_SUPPORTED_EXCEPTION("not support");
     }
     return 0;
   }

--- a/src/execution/expression/exprs/logical_expr.cc
+++ b/src/execution/expression/exprs/logical_expr.cc
@@ -17,6 +17,8 @@
 
 #include <regex>
 
+#include "neug/utils/exception/exception.h"
+
 namespace neug {
 namespace execution {
 class BindedUnaryLogicalExpr : public VertexExprBase,
@@ -61,8 +63,8 @@ class BindedUnaryLogicalExpr : public VertexExprBase,
       return Value::BOOLEAN(val.IsNull());
     }
     default:
-      LOG(FATAL) << "Unsupported unary logical operation: "
-                 << static_cast<int>(logical);
+      THROW_NOT_SUPPORTED_EXCEPTION("Unsupported unary logical operation: " +
+                                    std::to_string(static_cast<int>(logical)));
       return Value(type_);
     }
   }
@@ -112,8 +114,9 @@ class BindedBinaryLogicalExpr : public VertexExprBase,
       return Value::BOOLEAN(std::regex_match(lhs_str, std::regex(rhs_str)));
     }
     default:
-      LOG(FATAL) << "Unsupported binary logical operation: "
-                 << static_cast<int>(logical_);
+      THROW_NOT_SUPPORTED_EXCEPTION(
+          "Unsupported binary logical operation: " +
+          std::to_string(static_cast<int>(logical_)));
       return Value(type_);
     }
   }

--- a/src/execution/expression/exprs/variable.cc
+++ b/src/execution/expression/exprs/variable.cc
@@ -20,6 +20,7 @@
 #include "neug/execution/expression/accessors/record_accessor.h"
 #include "neug/execution/expression/accessors/vertex_accessor.h"
 #include "neug/generated/proto/plan/common.pb.h"
+#include "neug/utils/exception/exception.h"
 namespace neug {
 namespace execution {
 
@@ -229,13 +230,14 @@ static std::unique_ptr<ExprBase> parse_record_var(const ::common::Variable& var,
           return std::make_unique<RecordPathAccessor>(tag, DataType::DOUBLE,
                                                       "cost");
         }
-        LOG(FATAL) << "unsupported record path property key: "
-                   << prop.key().name();
+        THROW_NOT_SUPPORTED_EXCEPTION("unsupported record path property key: " +
+                                      prop.key().name());
         return nullptr;
       } else {
-        LOG(FATAL) << "unsupported record variable tag type: "
-                   << static_cast<int>(ctx_meta.get(tag).id()) << " "
-                   << var.DebugString();
+        THROW_NOT_SUPPORTED_EXCEPTION(
+            "unsupported record variable tag type: " +
+            std::to_string(static_cast<int>(ctx_meta.get(tag).id())) + " " +
+            var.DebugString());
       }
     } else if (prop.has_label()) {
       if (ctx_meta.get(tag).id() == DataTypeId::kVertex) {
@@ -243,8 +245,9 @@ static std::unique_ptr<ExprBase> parse_record_var(const ::common::Variable& var,
       } else if (ctx_meta.get(tag).id() == DataTypeId::kEdge) {
         return RecordEdgeAccessor::create_label_accessor(tag);
       } else {
-        LOG(FATAL) << "unsupported record variable tag type: "
-                   << static_cast<int>(ctx_meta.get(tag).id());
+        THROW_NOT_SUPPORTED_EXCEPTION(
+            "unsupported record variable tag type: " +
+            std::to_string(static_cast<int>(ctx_meta.get(tag).id())));
       }
     } else if (prop.has_id()) {
       if (ctx_meta.get(tag).id() == DataTypeId::kVertex) {
@@ -252,8 +255,9 @@ static std::unique_ptr<ExprBase> parse_record_var(const ::common::Variable& var,
       } else if (ctx_meta.get(tag).id() == DataTypeId::kEdge) {
         return RecordEdgeAccessor::create_gid_accessor(tag);
       } else {
-        LOG(FATAL) << "unsupported record variable tag type: "
-                   << static_cast<int>(ctx_meta.get(tag).id());
+        THROW_NOT_SUPPORTED_EXCEPTION(
+            "unsupported record variable tag type: " +
+            std::to_string(static_cast<int>(ctx_meta.get(tag).id())));
       }
     } else if (prop.has_len()) {
       if (ctx_meta.get(tag).id() == DataTypeId::kPath) {
@@ -261,7 +265,8 @@ static std::unique_ptr<ExprBase> parse_record_var(const ::common::Variable& var,
                                                     "length");
       }
     } else {
-      LOG(FATAL) << "unsupported property access: " << prop.DebugString();
+      THROW_NOT_SUPPORTED_EXCEPTION("unsupported property access: " +
+                                    prop.DebugString());
     }
   }
   return nullptr;
@@ -282,8 +287,8 @@ static std::unique_ptr<ExprBase> parse_vertex_var(const common::Variable& var,
     } else if (prop.has_id()) {
       return VertexAccessor::create_gid_accessor();
     } else {
-      LOG(FATAL) << "unsupported vertex variable property access: "
-                 << var.DebugString();
+      THROW_NOT_SUPPORTED_EXCEPTION(
+          "unsupported vertex variable property access: " + var.DebugString());
     }
   }
   return nullptr;
@@ -302,8 +307,8 @@ static std::unique_ptr<ExprBase> parse_edge_var(const common::Variable& var,
     } else if (prop.has_id()) {
       return EdgeAccessor::create_gid_accessor();
     } else {
-      LOG(FATAL) << "unsupported edge variable property access: "
-                 << var.DebugString();
+      THROW_NOT_SUPPORTED_EXCEPTION(
+          "unsupported edge variable property access: " + var.DebugString());
     }
   }
   return nullptr;
@@ -313,7 +318,7 @@ std::unique_ptr<ExprBase> parse_variable(const common::Variable& var,
                                          const ContextMeta& ctx_meta,
                                          VarType var_type) {
   if (!var.has_node_type()) {
-    LOG(FATAL) << "variable missing node_type: " << var.DebugString();
+    THROW_INTERNAL_EXCEPTION("variable missing node_type: " + var.DebugString());
   }
   DataType type = parse_from_ir_data_type(var.node_type());
   int tag = var.has_tag() ? var.tag().id() : -1;

--- a/src/execution/utils/pb_parse_utils.cc
+++ b/src/execution/utils/pb_parse_utils.cc
@@ -18,6 +18,8 @@
 #include <google/protobuf/wrappers.pb.h>
 #include <cstdint>
 
+#include "neug/utils/exception/exception.h"
+
 #include <ostream>
 #include <set>
 #include <string_view>
@@ -46,7 +48,7 @@ VOpt parse_opt(const physical::GetV_VOpt& opt) {
   } else if (opt == physical::GetV_VOpt::GetV_VOpt_ITSELF) {
     return VOpt::kItself;
   } else {
-    LOG(FATAL) << "unexpected GetV::Opt";
+    THROW_NOT_SUPPORTED_EXCEPTION("unexpected GetV::Opt");
     return VOpt::kItself;
   }
 }
@@ -59,7 +61,7 @@ Direction parse_direction(const physical::EdgeExpand_Direction& dir) {
   } else if (dir == physical::EdgeExpand_Direction_BOTH) {
     return Direction::kBoth;
   }
-  LOG(FATAL) << "not support..." << dir;
+  THROW_NOT_SUPPORTED_EXCEPTION("not support..." + std::to_string(static_cast<int>(dir)));
   return Direction::kOut;
 }
 
@@ -136,7 +138,7 @@ PathOpt parse_path_opt(const physical::PathExpand_PathOpt& path_opt_pb) {
                                 PathExpand_PathOpt_ANY_WEIGHTED_SHORTEST) {
     return PathOpt::kAnyWeightedShortest;
   } else {
-    LOG(FATAL) << "unexpected PathOpt";
+    THROW_NOT_SUPPORTED_EXCEPTION("unexpected PathOpt");
     return PathOpt::kArbitrary;
   }
 }
@@ -161,7 +163,7 @@ AggrKind parse_aggregate(physical::GroupBy_AggFunc::Aggregate v) {
   } else if (v == physical::GroupBy_AggFunc::AVG) {
     return AggrKind::kAvg;
   } else {
-    LOG(FATAL) << "unsupport" << static_cast<int>(v);
+    THROW_NOT_SUPPORTED_EXCEPTION("unsupport" + std::to_string(static_cast<int>(v)));
     return AggrKind::kSum;
   }
 }

--- a/src/storages/graph/edge_table.cc
+++ b/src/storages/graph/edge_table.cc
@@ -287,7 +287,8 @@ static void parse_endpoint_column(const IndexerType& indexer,
       lids.push_back(vid);
     }
   } else {
-    LOG(FATAL) << "not support type " << array->type()->ToString();
+    THROW_NOT_SUPPORTED_EXCEPTION("not support type " +
+                                  array->type()->ToString());
   }
 }
 
@@ -376,7 +377,8 @@ static std::vector<Property> get_row_from_recordbatch(
         auto str = casted->GetView(row_idx);
         row.push_back(Property::from_string_view(str));
       } else {
-        LOG(FATAL) << "not support type " << array->type()->ToString();
+        THROW_NOT_SUPPORTED_EXCEPTION("not support type " +
+                                      array->type()->ToString());
       }
       break;
     }
@@ -408,7 +410,8 @@ static std::vector<Property> get_row_from_recordbatch(
       break;
     }
     default:
-      LOG(FATAL) << "not support type " << array->type()->ToString();
+      THROW_NOT_SUPPORTED_EXCEPTION("not support type " +
+                                    array->type()->ToString());
     }
   }
   return row;

--- a/src/storages/graph/vertex_table.cc
+++ b/src/storages/graph/vertex_table.cc
@@ -68,9 +68,9 @@ void VertexTable::insert_vertices(
   } else if (pk_type_id == DataTypeId::kVarchar) {
     insert_vertices_impl<std::string_view>(supplier);
   } else {
-    LOG(FATAL) << "Unsupported primary key type for vertex, type: "
-               << pk_type_.ToString()
-               << ", label: " << vertex_schema_->label_name;
+    THROW_NOT_SUPPORTED_EXCEPTION(
+        "Unsupported primary key type for vertex, type: " +
+        pk_type_.ToString() + ", label: " + vertex_schema_->label_name);
   }
 }
 

--- a/src/storages/loader/abstract_property_graph_loader.cc
+++ b/src/storages/loader/abstract_property_graph_loader.cc
@@ -16,6 +16,7 @@
 #include "neug/storages/loader/abstract_property_graph_loader.h"
 #include "neug/storages/loader/loader_utils.h"
 #include "neug/utils/arrow_utils.h"
+#include "neug/utils/exception/exception.h"
 
 namespace neug {
 
@@ -39,9 +40,9 @@ void AbstractPropertyGraphLoader::addVertices(
     label_t v_label_id, const std::vector<std::string>& v_files) {
   auto pks = schema_.get_vertex_primary_key(v_label_id);
   if (pks.size() != 1) {
-    LOG(FATAL) << "Only support one primary key for vertex label: "
-               << schema_.get_vertex_label_name(v_label_id);
-    return;
+    THROW_INVALID_ARGUMENT_EXCEPTION(
+        "Only support one primary key for vertex label: " +
+        schema_.get_vertex_label_name(v_label_id));
   }
   auto primary_key = pks[0];
   auto pk_type = std::get<0>(primary_key);
@@ -51,10 +52,9 @@ void AbstractPropertyGraphLoader::addVertices(
   if (pk_type_id != DataTypeId::kInt64 && pk_type_id != DataTypeId::kVarchar &&
       pk_type_id != DataTypeId::kInt32 && pk_type_id != DataTypeId::kUInt32 &&
       pk_type_id != DataTypeId::kUInt64) {
-    LOG(FATAL)
-        << "Only support int64_t, uint64_t, int32_t, uint32_t and string "
-           "primary key for vertex.";
-    return;
+    THROW_INVALID_ARGUMENT_EXCEPTION(
+        "Only support int64_t, uint64_t, int32_t, uint32_t and string "
+        "primary key for vertex.");
   }
 
   return addVerticesToVertexTable(v_label_id,

--- a/src/storages/loader/loader_factory.cc
+++ b/src/storages/loader/loader_factory.cc
@@ -23,6 +23,8 @@
 #include <utility>         // for pair
 #include <vector>          // for vector
 
+#include "neug/utils/exception/exception.h"
+
 #include <glog/logging.h>
 
 #include "neug/utils/string_utils.h"
@@ -73,8 +75,9 @@ std::shared_ptr<IFragmentLoader> LoaderFactory::CreateFragmentLoader(
     for (const auto& loader : known_loaders_) {
       ss << "[" << loader.first << "] ";
     }
-    LOG(FATAL) << "Unsupported format: " << format << " with scheme: " << scheme
-               << ", supported loaders are: " << ss.str();
+    THROW_NOT_SUPPORTED_EXCEPTION("Unsupported format: " + format +
+                                  " with scheme: " + scheme +
+                                  ", supported loaders are: " + ss.str());
   }
   return std::shared_ptr<IFragmentLoader>();
 }

--- a/src/storages/loader/loader_utils.cc
+++ b/src/storages/loader/loader_utils.cc
@@ -28,6 +28,7 @@
 #include <ostream>
 
 #include "neug/utils/arrow_utils.h"
+#include "neug/utils/exception/exception.h"
 #include "neug/utils/string_utils.h"
 
 namespace neug {
@@ -54,7 +55,7 @@ static void put_block_size_option(const LoadingConfig& loading_config,
                                   arrow::csv::ReadOptions& read_options) {
   auto batch_size = loading_config.GetBatchSize();
   if (batch_size <= 0) {
-    LOG(FATAL) << "Block size should be positive";
+    THROW_INVALID_ARGUMENT_EXCEPTION("Block size should be positive");
   }
   read_options.block_size = batch_size;
 }
@@ -87,12 +88,14 @@ void printDiskRemaining(const std::string& path) {
 void put_delimiter_option(const std::string& delimiter_str,
                           arrow::csv::ParseOptions& parse_options) {
   if (delimiter_str.size() != 1 && delimiter_str[0] != '\\') {
-    LOG(FATAL) << "Delimiter should be a single character, or a escape "
-                  "character, like '\\t'";
+    THROW_INVALID_ARGUMENT_EXCEPTION(
+        "Delimiter should be a single character, or a escape "
+        "character, like '\\t'");
   }
   if (delimiter_str[0] == '\\') {
     if (delimiter_str.size() != 2) {
-      LOG(FATAL) << "Delimiter should be a single character";
+      THROW_INVALID_ARGUMENT_EXCEPTION(
+          "Delimiter should be a single character");
     }
     // escape the special character
     switch (delimiter_str[1]) {
@@ -100,7 +103,8 @@ void put_delimiter_option(const std::string& delimiter_str,
       parse_options.delimiter = '\t';
       break;
     default:
-      LOG(FATAL) << "Unsupported escape character: " << delimiter_str[1];
+      THROW_INVALID_ARGUMENT_EXCEPTION("Unsupported escape character: " +
+                                       std::string(1, delimiter_str[1]));
     }
   } else {
     parse_options.delimiter = delimiter_str[0];
@@ -301,8 +305,8 @@ CSVTableRecordBatchSupplier::CSVTableRecordBatchSupplier(
     : file_path_(path) {
   auto read_result = arrow::io::ReadableFile::Open(path);
   if (!read_result.ok()) {
-    LOG(FATAL) << "Failed to open file: " << path
-               << " error: " << read_result.status().message();
+    THROW_IO_EXCEPTION("Failed to open file: " + path +
+                       " error: " + read_result.status().message());
   }
   std::shared_ptr<arrow::io::ReadableFile> file = read_result.ValueOrDie();
   auto res = arrow::csv::TableReader::Make(arrow::io::default_io_context(),
@@ -310,16 +314,16 @@ CSVTableRecordBatchSupplier::CSVTableRecordBatchSupplier(
                                            convert_options);
 
   if (!res.ok()) {
-    LOG(FATAL) << "Failed to create table reader for file: " << path
-               << " error: " << res.status().message();
+    THROW_IO_EXCEPTION("Failed to create table reader for file: " + path +
+                       " error: " + res.status().message());
   }
   auto reader = res.ValueOrDie();
 
   auto result = reader->Read();
   auto status = result.status();
   if (!status.ok()) {
-    LOG(FATAL) << "Failed to read table from file: " << path
-               << " error: " << status.message();
+    THROW_IO_EXCEPTION("Failed to read table from file: " + path +
+                       " error: " + status.message());
   }
   table_ = result.ValueOrDie();
   reader_ = std::make_shared<arrow::TableBatchReader>(*table_);
@@ -349,7 +353,7 @@ ArrowRecordBatchArraySupplier::GetNextBatch() {
       num_rows = arrays_[i][current_batch_index_]->length();
     } else {
       if (num_rows != arrays_[i][current_batch_index_]->length()) {
-        LOG(FATAL) << "The length of columns is not equal";
+        THROW_INTERNAL_EXCEPTION("The length of columns is not equal");
       }
     }
   }
@@ -439,17 +443,19 @@ void fillVertexReaderMeta(
       auto& [col_id, col_name, property_name] = cur_label_col_mapping[i];
       if (col_name.empty()) {
         if (col_id >= read_options.column_names.size() || col_id < 0) {
-          LOG(FATAL) << "The specified column index: " << col_id
-                     << " is out of range, please check your configuration";
+          THROW_INVALID_ARGUMENT_EXCEPTION(
+              "The specified column index: " + std::to_string(col_id) +
+              " is out of range, please check your configuration");
         }
         col_name = read_options.column_names[col_id];
       }
       // check whether index match to the name if col_id is valid
       if (col_id >= 0 && col_id < read_options.column_names.size()) {
         if (col_name != read_options.column_names[col_id]) {
-          LOG(FATAL) << "The specified column name: " << col_name
-                     << " does not match the column name in the file: "
-                     << read_options.column_names[col_id];
+          THROW_INVALID_ARGUMENT_EXCEPTION(
+              "The specified column name: " + col_name +
+              " does not match the column name in the file: " +
+              read_options.column_names[col_id]);
         }
       }
       included_col_names.emplace_back(col_name);
@@ -477,12 +483,13 @@ void fillVertexReaderMeta(
         }
       }
       if (ind == mapped_property_names.size()) {
-        LOG(FATAL) << "The specified property name: " << property_name
-                   << " does not exist in the vertex column mapping for "
-                      "vertex label: "
-                   << v_label_name
-                   << " please "
-                      "check your configuration";
+        THROW_INVALID_ARGUMENT_EXCEPTION(
+            "The specified property name: " + property_name +
+            " does not exist in the vertex column mapping for "
+            "vertex label: " +
+            v_label_name +
+            " please "
+            "check your configuration");
       }
       auto arrow_type = PropertyTypeToArrowType(property_type);
       VLOG(10) << "vertex_label: " << v_label_name
@@ -501,9 +508,10 @@ void fillVertexReaderMeta(
         }
       }
       if (ind == mapped_property_names.size()) {
-        LOG(FATAL) << "The specified property name: " << pk_name
-                   << " does not exist in the vertex column mapping, please "
-                      "check your configuration";
+        THROW_INVALID_ARGUMENT_EXCEPTION(
+            "The specified property name: " + pk_name +
+            " does not exist in the vertex column mapping, please "
+            "check your configuration");
       }
       arrow_types.insert(
           {included_col_names[ind], PropertyTypeToArrowType(pk_type)});
@@ -593,17 +601,19 @@ void fillEdgeReaderMeta(label_t src_label_id, label_t dst_label_id,
       auto& [col_id, col_name, property_name] = cur_label_col_mapping[i];
       if (col_name.empty()) {
         if (col_id >= read_options.column_names.size() || col_id < 0) {
-          LOG(FATAL) << "The specified column index: " << col_id
-                     << " is out of range, please check your configuration";
+          THROW_INVALID_ARGUMENT_EXCEPTION(
+              "The specified column index: " + std::to_string(col_id) +
+              " is out of range, please check your configuration");
         }
         col_name = read_options.column_names[col_id];
       }
       // check whether index match to the name if col_id is valid
       if (col_id >= 0 && col_id < read_options.column_names.size()) {
         if (col_name != read_options.column_names[col_id]) {
-          LOG(FATAL) << "The specified column name: " << col_name
-                     << " does not match the column name in the file: "
-                     << read_options.column_names[col_id];
+          THROW_INVALID_ARGUMENT_EXCEPTION(
+              "The specified column name: " + col_name +
+              " does not match the column name in the file: " +
+              read_options.column_names[col_id]);
         }
       }
       if (loading_config.GetHasHeaderRow()) {
@@ -635,9 +645,10 @@ void fillEdgeReaderMeta(label_t src_label_id, label_t dst_label_id,
         }
       }
       if (ind == mapped_property_names.size()) {
-        LOG(FATAL) << "The specified property name: " << property_name
-                   << " does not exist in the vertex column mapping, please "
-                      "check your configuration";
+        THROW_INVALID_ARGUMENT_EXCEPTION(
+            "The specified property name: " + property_name +
+            " does not exist in the vertex column mapping, please "
+            "check your configuration");
       }
       VLOG(10) << "edge_label: " << edge_label_name
                << " property_name: " << property_name
@@ -697,6 +708,7 @@ void set_column_from_date_array(std::shared_ptr<neug::ColumnBase> col,
                                 const std::vector<vid_t>& vids) {
   auto type = array->type();
   auto col_type = col->type();
+  auto col_data_type = DataType(col_type);
   if (type->Equals(arrow::date32())) {
     for (auto j = 0; j < array->num_chunks(); ++j) {
       auto casted =
@@ -724,8 +736,9 @@ void set_column_from_date_array(std::shared_ptr<neug::ColumnBase> col,
       }
     }
   } else {
-    LOG(FATAL) << "Not implemented: converting " << type->ToString() << " to "
-               << col_type;
+    THROW_NOT_IMPLEMENTED_EXCEPTION("Not implemented: converting " +
+                                    type->ToString() + " to " +
+                                    col_data_type.ToString());
   }
 }
 
@@ -735,6 +748,7 @@ void set_column_from_timestamp_array(std::shared_ptr<neug::ColumnBase> col,
                                      const std::vector<vid_t>& vids) {
   auto type = array->type();
   auto col_type = col->type();
+  auto col_data_type = DataType(col_type);
   if (type->Equals(arrow::timestamp(arrow::TimeUnit::type::MILLI))) {
     for (auto j = 0; j < array->num_chunks(); ++j) {
       auto casted =
@@ -750,8 +764,9 @@ void set_column_from_timestamp_array(std::shared_ptr<neug::ColumnBase> col,
       }
     }
   } else {
-    LOG(FATAL) << "Not implemented: converting " << type->ToString() << " to "
-               << col_type;
+    THROW_NOT_IMPLEMENTED_EXCEPTION("Not implemented: converting " +
+                                    type->ToString() + " to " +
+                                    col_data_type.ToString());
   }
 }
 
@@ -761,6 +776,7 @@ void set_interval_column_from_string_array(
     const std::vector<vid_t>& vids) {
   auto type = array->type();
   auto col_type = col->type();
+  auto col_data_type = DataType(col_type);
   switch (type->id()) {
 #define SET_ANY_FOR_INTERVAL_FROM_STRING_ARRAY(ARROW_TYPE, ARROW_ARRAY_TYPE) \
   case ARROW_TYPE:                                                           \
@@ -783,8 +799,9 @@ void set_interval_column_from_string_array(
     SET_ANY_FOR_INTERVAL_FROM_STRING_ARRAY(arrow::Type::STRING,
                                            arrow::StringArray)
   default:
-    LOG(FATAL) << "Not implemented: converting " << type->ToString() << " to "
-               << col_type;
+    THROW_NOT_IMPLEMENTED_EXCEPTION("Not implemented: converting " +
+                                    type->ToString() + " to " +
+                                    col_data_type.ToString());
 #undef SET_ANY_FOR_INTERVAL_FROM_STRING_ARRAY
   }
 }
@@ -892,7 +909,7 @@ void set_properties_column(std::shared_ptr<neug::ColumnBase> col,
     set_column_from_string_array(col, array, vids, mutex, true);
     break;
   default:
-    LOG(FATAL) << "Not support type: " << type->ToString();
+    THROW_NOT_SUPPORTED_EXCEPTION("Not support type: " + type->ToString());
   }
 }
 

--- a/src/transaction/insert_transaction.cc
+++ b/src/transaction/insert_transaction.cc
@@ -15,6 +15,8 @@
 
 #include "neug/transaction/insert_transaction.h"
 
+#include "neug/utils/exception/exception.h"
+
 #include <glog/logging.h>
 #include <chrono>
 
@@ -203,7 +205,8 @@ void InsertTransaction::IngestWal(PropertyGraph& graph, uint32_t timestamp,
       graph.AddEdge(redo.src_label, src_lid, redo.dst_label, dst_lid,
                     redo.edge_label, redo.properties, timestamp, alloc);
     } else {
-      LOG(FATAL) << "Unexpected op-" << static_cast<int>(op_type);
+      THROW_INTERNAL_EXCEPTION("Unexpected op-" +
+                               std::to_string(static_cast<int>(op_type)));
     }
   }
 }

--- a/src/transaction/wal/local_wal_parser.cc
+++ b/src/transaction/wal/local_wal_parser.cc
@@ -15,6 +15,8 @@
 
 #include "neug/transaction/wal/local_wal_parser.h"
 
+#include "neug/utils/exception/exception.h"
+
 #include <fcntl.h>
 #include <glog/logging.h>
 #include <sys/mman.h>
@@ -49,7 +51,7 @@ void LocalWalParser::open(const std::string& wal_uri) {
     int fd = ::open(path.c_str(), O_RDONLY);
     void* mmapped_buffer = mmap(NULL, file_size, PROT_READ, MAP_PRIVATE, fd, 0);
     if (mmapped_buffer == MAP_FAILED) {
-      LOG(FATAL) << "mmap failed...";
+      THROW_IO_EXCEPTION("mmap failed...");
     }
 
     fds_.push_back(fd);

--- a/src/transaction/wal/local_wal_parser.cc
+++ b/src/transaction/wal/local_wal_parser.cc
@@ -15,8 +15,6 @@
 
 #include "neug/transaction/wal/local_wal_parser.h"
 
-#include "neug/utils/exception/exception.h"
-
 #include <fcntl.h>
 #include <glog/logging.h>
 #include <sys/mman.h>
@@ -51,7 +49,7 @@ void LocalWalParser::open(const std::string& wal_uri) {
     int fd = ::open(path.c_str(), O_RDONLY);
     void* mmapped_buffer = mmap(NULL, file_size, PROT_READ, MAP_PRIVATE, fd, 0);
     if (mmapped_buffer == MAP_FAILED) {
-      THROW_IO_EXCEPTION("mmap failed...");
+      LOG(FATAL) << "mmap failed...";
     }
 
     fds_.push_back(fd);

--- a/src/transaction/wal/local_wal_writer.cc
+++ b/src/transaction/wal/local_wal_writer.cc
@@ -15,6 +15,8 @@
 
 #include "neug/transaction/wal/local_wal_writer.h"
 
+#include "neug/utils/exception/exception.h"
+
 #include <errno.h>
 #include <fcntl.h>
 #include <glog/logging.h>
@@ -49,10 +51,10 @@ void LocalWalWriter::open() {
     break;
   }
   if (fd_ == -1) {
-    LOG(FATAL) << "Failed to open wal file " << strerror(errno);
+    THROW_IO_EXCEPTION("Failed to open wal file " + std::string(strerror(errno)));
   }
   if (ftruncate(fd_, TRUNC_SIZE) != 0) {
-    LOG(FATAL) << "Failed to truncate wal file " << strerror(errno);
+    THROW_IO_EXCEPTION("Failed to truncate wal file " + std::string(strerror(errno)));
   }
   file_size_ = TRUNC_SIZE;
   file_used_ = 0;
@@ -61,7 +63,7 @@ void LocalWalWriter::open() {
 void LocalWalWriter::close() {
   if (fd_ != -1) {
     if (::close(fd_) != 0) {
-      LOG(FATAL) << "Failed to close file" << strerror(errno);
+      THROW_IO_EXCEPTION("Failed to close file" + std::string(strerror(errno)));
     }
     fd_ = -1;
     file_size_ = 0;
@@ -77,7 +79,7 @@ bool LocalWalWriter::append(const char* data, size_t length) {
   if (expected_size > file_size_) {
     size_t new_file_size = (expected_size / TRUNC_SIZE + 1) * TRUNC_SIZE;
     if (ftruncate(fd_, new_file_size) != 0) {
-      LOG(FATAL) << "Failed to truncate wal file " << strerror(errno);
+      THROW_IO_EXCEPTION("Failed to truncate wal file " + std::string(strerror(errno)));
     }
     file_size_ = new_file_size;
   }
@@ -85,22 +87,22 @@ bool LocalWalWriter::append(const char* data, size_t length) {
   file_used_ += length;
 
   if (static_cast<size_t>(write(fd_, data, length)) != length) {
-    LOG(FATAL) << "Failed to write wal file " << strerror(errno);
+    THROW_IO_EXCEPTION("Failed to write wal file " + std::string(strerror(errno)));
   }
 
 #if 1
 #ifdef F_FULLFSYNC
   if (fcntl(fd_, F_FULLFSYNC) != 0) {
 #ifdef __APPLE__
-    LOG(FATAL) << "Failed to fcntl sync wal file " << strerror(errno);
+    THROW_IO_EXCEPTION("Failed to fcntl sync wal file " + std::string(strerror(errno)));
 #else
-    LOG(FATAL) << "Failed to fcntl sync wal file " << strerrno(errno);
+    THROW_IO_EXCEPTION("Failed to fcntl sync wal file " + std::string(strerrno(errno)));
 #endif
   }
 #else
   // if (fsync(fd_) != 0) {
   if (fdatasync(fd_) != 0) {
-    LOG(FATAL) << "Failed to fsync wal file " << strerror(errno);
+    THROW_IO_EXCEPTION("Failed to fsync wal file " + std::string(strerror(errno)));
   }
 #endif
 #endif

--- a/src/transaction/wal/wal.cc
+++ b/src/transaction/wal/wal.cc
@@ -15,6 +15,8 @@
 
 #include "neug/transaction/wal/wal.h"
 
+#include "neug/utils/exception/exception.h"
+
 #include <glog/logging.h>
 #include <memory>
 #include <regex>
@@ -69,8 +71,9 @@ std::unique_ptr<IWalWriter> WalWriterFactory::CreateWalWriter(
     for (const auto& writer : known_writers_) {
       ss << "[" << writer.first << "] ";
     }
-    LOG(FATAL) << "Unknown wal writer: " << scheme << " for uri: " << wal_uri
-               << ", supported writers are: " << ss.str();
+    THROW_NOT_SUPPORTED_EXCEPTION("Unknown wal writer: " + scheme +
+                                  " for uri: " + wal_uri +
+                                  ", supported writers are: " + ss.str());
     return nullptr;  // to suppress warning
   }
 }
@@ -113,8 +116,9 @@ std::unique_ptr<IWalParser> WalParserFactory::CreateWalParser(
     for (const auto& parser : know_parsers_) {
       ss << "[" << parser.first << "] ";
     }
-    LOG(FATAL) << "Unknown wal parser: " << scheme << " for uri: " << wal_uri
-               << ", supported parsers are: " << ss.str();
+    THROW_NOT_SUPPORTED_EXCEPTION("Unknown wal parser: " + scheme +
+                                  " for uri: " + wal_uri +
+                                  ", supported parsers are: " + ss.str());
     return nullptr;  // to suppress warning
   }
 }

--- a/src/utils/pb_utils.cc
+++ b/src/utils/pb_utils.cc
@@ -14,6 +14,8 @@
  */
 
 #include "neug/utils/pb_utils.h"
+
+#include "neug/utils/exception/exception.h"
 #include <glog/logging.h>
 #include <google/protobuf/stubs/port.h>
 #include <google/protobuf/util/json_util.h>
@@ -347,7 +349,8 @@ bool conflict_action_to_bool(const physical::ConflictAction& action) {
   } else if (action == physical::ConflictAction::ON_CONFLICT_DO_NOTHING) {
     return false;
   } else {
-    LOG(FATAL) << "invalid action: " << action;
+    THROW_INVALID_ARGUMENT_EXCEPTION("invalid action: " +
+                                     std::to_string(static_cast<int>(action)));
     return false;  // to suppress warning
   }
 }


### PR DESCRIPTION
Fix #361 
For the error encountered at runtime, we should throw exception rather than abort the process.