### PR TITLE
fix: Use atomic for degree_list and use memory fence to ensure thread safety

### DIFF
--- a/include/neug/storages/csr/csr_view.h
+++ b/include/neug/storages/csr/csr_view.h
@@ -422,6 +422,9 @@ struct TypedCsrView<T, CsrViewType::kMultipleMutable> {
     const int deg = reinterpret_cast<const std::atomic<int>*>(degrees)[v].load(
         std::memory_order_acquire);
     const nbr_t* base = adjlists[v];
+    if (deg == 0 || base == nullptr) {
+      return;
+    }
     const nbr_t* ptr = base + deg - 1;
     const nbr_t* end = base - 1;
     while (ptr != end) {
@@ -453,6 +456,9 @@ struct TypedCsrView<T, CsrViewType::kMultipleMutable> {
     const int deg = reinterpret_cast<const std::atomic<int>*>(degrees)[v].load(
         std::memory_order_acquire);
     const nbr_t* base = adjlists[v];
+    if (deg == 0 || base == nullptr) {
+      return;
+    }
     const nbr_t* ptr = base + deg - 1;
     const nbr_t* end = base - 1;
     while (ptr != end) {
@@ -613,10 +619,15 @@ struct CsrView {
       ret.start_ptr = start_ptr;
       ret.end_ptr = start_ptr + cfg_.stride;
     } else {
-      // multiple — use atomic loads for torn-read safety
-      const int deg =
-          reinterpret_cast<const std::atomic<int>*>(degrees_)[v].load(
-              std::memory_order_acquire);
+      int deg;
+      if (cfg_.ts_offset != 0) {
+        // Mutable CSR: atomic load for torn-read safety (concurrent writers)
+        deg = reinterpret_cast<const std::atomic<int>*>(degrees_)[v].load(
+            std::memory_order_acquire);
+      } else {
+        // Immutable CSR: plain read (no concurrent writers)
+        deg = degrees_[v];
+      }
       const char* start_ptr = reinterpret_cast<const char*>(
           reinterpret_cast<const int64_t*>(adjlists_)[v]);
       if (start_ptr == nullptr) {

--- a/include/neug/storages/csr/csr_view.h
+++ b/include/neug/storages/csr/csr_view.h
@@ -418,8 +418,12 @@ struct TypedCsrView<T, CsrViewType::kMultipleMutable> {
 
   template <typename FUNC_T>
   void foreach_nbr_gt(vid_t v, const T& threshold, const FUNC_T& func) const {
-    const nbr_t* ptr = adjlists[v] + degrees[v] - 1;
-    const nbr_t* end = adjlists[v] - 1;
+    // Atomic loads for torn-read safety: snapshot degree and buffer pointer
+    const int deg = reinterpret_cast<const std::atomic<int>*>(degrees)[v].load(
+        std::memory_order_acquire);
+    const nbr_t* base = adjlists[v];
+    const nbr_t* ptr = base + deg - 1;
+    const nbr_t* end = base - 1;
     while (ptr != end) {
       if (ptr->timestamp > timestamp) {
         --ptr;
@@ -445,8 +449,12 @@ struct TypedCsrView<T, CsrViewType::kMultipleMutable> {
 
   template <typename FUNC_T>
   void foreach_nbr_lt(vid_t v, const T& threshold, const FUNC_T& func) const {
-    const nbr_t* ptr = adjlists[v] + degrees[v] - 1;
-    const nbr_t* end = adjlists[v] - 1;
+    // Atomic load for torn-read safety: snapshot degree
+    const int deg = reinterpret_cast<const std::atomic<int>*>(degrees)[v].load(
+        std::memory_order_acquire);
+    const nbr_t* base = adjlists[v];
+    const nbr_t* ptr = base + deg - 1;
+    const nbr_t* end = base - 1;
     while (ptr != end) {
       if (ptr->timestamp > timestamp) {
         --ptr;
@@ -464,7 +472,7 @@ struct TypedCsrView<T, CsrViewType::kMultipleMutable> {
       return;
     }
     ptr = std::lower_bound(
-              adjlists[v], ptr + 1, threshold,
+              base, ptr + 1, threshold,
               [](const nbr_t& b, const T& a) { return b.data < a; }) -
           1;
     while (ptr != end) {
@@ -605,6 +613,10 @@ struct CsrView {
       ret.start_ptr = start_ptr;
       ret.end_ptr = start_ptr + cfg_.stride;
     } else {
+      // multiple — use atomic loads for torn-read safety
+      const int deg =
+          reinterpret_cast<const std::atomic<int>*>(degrees_)[v].load(
+              std::memory_order_acquire);
       const char* start_ptr = reinterpret_cast<const char*>(
           reinterpret_cast<const int64_t*>(adjlists_)[v]);
       if (start_ptr == nullptr) {
@@ -612,7 +624,7 @@ struct CsrView {
         ret.end_ptr = nullptr;
       } else {
         ret.start_ptr = start_ptr;
-        ret.end_ptr = start_ptr + degrees_[v] * cfg_.stride;
+        ret.end_ptr = start_ptr + deg * cfg_.stride;
       }
     }
     ret.cfg = cfg_;

--- a/include/neug/storages/csr/mutable_csr.h
+++ b/include/neug/storages/csr/mutable_csr.h
@@ -114,10 +114,10 @@ class MutableCsr : public TypedCsrBase<EDATA_T> {
           " >= " + std::to_string(vertex_capacity()));
     }
     auto** buffers = reinterpret_cast<nbr_t**>(adj_list_buffer_->GetData());
-    auto* sizes = reinterpret_cast<int*>(degree_list_->GetData());
+    auto* sizes = reinterpret_cast<std::atomic<int>*>(degree_list_->GetData());
     auto* caps = reinterpret_cast<int*>(cap_list_->GetData());
     locks_[src].lock();
-    int sz = sizes[src];
+    int sz = sizes[src].load(std::memory_order_relaxed);
     int cap = caps[src];
     if (sz == cap) {
       cap += (cap >> 1);
@@ -130,7 +130,11 @@ class MutableCsr : public TypedCsrBase<EDATA_T> {
       buffers[src] = new_buffer;
       caps[src] = cap;
     }
-    int32_t prev_size = sizes[src]++;
+    // Release fetch_add: acts as synchronization anchor for readers.
+    // The degree increment is sequenced after any buffer pointer update
+    // above, so an acquire load of degree on the reader side guarantees
+    // visibility of the new buffer pointer.
+    int32_t prev_size = sizes[src].fetch_add(1, std::memory_order_release);
     auto& nbr = buffers[src][prev_size];
     nbr.neighbor = dst;
     nbr.data = data;
@@ -151,9 +155,10 @@ class MutableCsr : public TypedCsrBase<EDATA_T> {
     std::vector<EDATA_T> data_list;
     const nbr_t* const* adjlists =
         reinterpret_cast<const nbr_t* const*>(adj_list_buffer_->GetData());
-    const int* degrees = reinterpret_cast<const int*>(degree_list_->GetData());
+    const auto* degrees =
+        reinterpret_cast<const std::atomic<int>*>(degree_list_->GetData());
     for (vid_t src = 0; src < static_cast<vid_t>(vertex_capacity()); ++src) {
-      auto deg = degrees[src];
+      auto deg = degrees[src].load(std::memory_order_acquire);
       for (int i = 0; i < deg; ++i) {
         const auto& nbr = adjlists[src][i];
         if (nbr.timestamp.load() != std::numeric_limits<timestamp_t>::max()) {
@@ -197,7 +202,7 @@ class MutableCsr : public TypedCsrBase<EDATA_T> {
     if (!degree_list_) {
       return 0;
     }
-    return degree_list_->GetDataSize() / sizeof(int);
+    return degree_list_->GetDataSize() / sizeof(std::atomic<int>);
   }
 };
 

--- a/include/neug/storages/csr/mutable_csr.h
+++ b/include/neug/storages/csr/mutable_csr.h
@@ -42,6 +42,13 @@
 
 namespace neug {
 
+// std::atomic<int> must have the same size as int on supported platforms
+// so that the degree_list buffer (persisted as int[]) can be safely
+// reinterpreted as atomic<int>[] for concurrent access.
+static_assert(
+    sizeof(std::atomic<int>) == sizeof(int),
+    "atomic<int> must have the same size as int on supported platforms");
+
 template <typename EDATA_T>
 class MutableCsr : public TypedCsrBase<EDATA_T> {
  public:
@@ -130,12 +137,7 @@ class MutableCsr : public TypedCsrBase<EDATA_T> {
       buffers[src] = new_buffer;
       caps[src] = cap;
     }
-    // Release fetch_add: acts as synchronization anchor for readers.
-    // The degree increment is sequenced after any buffer pointer update
-    // above, so an acquire load of degree on the reader side guarantees
-    // visibility of the new buffer pointer.
-    int32_t prev_size = sizes[src].fetch_add(1, std::memory_order_release);
-    auto& nbr = buffers[src][prev_size];
+    auto& nbr = buffers[src][sz];
     nbr.neighbor = dst;
     nbr.data = data;
     nbr.timestamp.store(ts);
@@ -145,8 +147,9 @@ class MutableCsr : public TypedCsrBase<EDATA_T> {
       unsorted_since_ = 0;
     }
     const void* data_ptr = static_cast<const void*>(&nbr.data);
+    sizes[src].store(sz + 1, std::memory_order_release);
     locks_[src].unlock();
-    return {prev_size, data_ptr};
+    return {sz, data_ptr};
   }
 
   std::tuple<std::vector<vid_t>, std::vector<vid_t>> batch_export(

--- a/src/storages/csr/mutable_csr.cc
+++ b/src/storages/csr/mutable_csr.cc
@@ -506,7 +506,7 @@ void MutableCsr<EDATA_T>::batch_put_edges(const std::vector<vid_t>& src_list,
     new_offset += old_deg;
     offset += cap_arr[i];
     buf_arr[i] = new_buffer;
-    sz_arr[i].store(old_deg, std::memory_order_relaxed);
+    sz_arr[i].store(old_deg, std::memory_order_release);
   }
   size_t added_edge_num = 0;
   for (size_t i = 0; i < src_list.size(); ++i) {
@@ -516,7 +516,8 @@ void MutableCsr<EDATA_T>::batch_put_edges(const std::vector<vid_t>& src_list,
     }
     vid_t dst = dst_list[i];
     const EDATA_T& data = data_list[i];
-    auto& nbr = buf_arr[src][sz_arr[src].fetch_add(1, std::memory_order_relaxed)];
+    auto& nbr =
+        buf_arr[src][sz_arr[src].fetch_add(1, std::memory_order_relaxed)];
     nbr.neighbor = dst;
     nbr.data = data;
     nbr.timestamp.store(ts);

--- a/src/storages/csr/mutable_csr.cc
+++ b/src/storages/csr/mutable_csr.cc
@@ -163,13 +163,13 @@ template <typename EDATA_T>
 void MutableCsr<EDATA_T>::reset_timestamp() {
   size_t vnum = vertex_capacity();
   auto** buf_arr = reinterpret_cast<nbr_t**>(adj_list_buffer_->GetData());
-  auto* sz_arr = reinterpret_cast<int*>(degree_list_->GetData());
+  auto* sz_arr = reinterpret_cast<std::atomic<int>*>(degree_list_->GetData());
   for (size_t i = 0; i != vnum; ++i) {
     nbr_t* nbrs = buf_arr[i];
     if (nbrs == nullptr) {
       continue;
     }
-    size_t deg = sz_arr[i];
+    size_t deg = sz_arr[i].load(std::memory_order_relaxed);
     for (size_t j = 0; j != deg; ++j) {
       if (nbrs[j].timestamp != INVALID_TIMESTAMP) {
         nbrs[j].timestamp.store(0, std::memory_order_relaxed);
@@ -184,16 +184,16 @@ void MutableCsr<EDATA_T>::compact() {
   // deleted edges.
   size_t vnum = vertex_capacity();
   auto** buf_arr = reinterpret_cast<nbr_t**>(adj_list_buffer_->GetData());
-  auto* sz_arr = reinterpret_cast<int*>(degree_list_->GetData());
+  auto* sz_arr = reinterpret_cast<std::atomic<int>*>(degree_list_->GetData());
   size_t total_edge_num = 0;
   for (size_t i = 0; i != vnum; ++i) {
-    int sz = sz_arr[i];
+    int sz = sz_arr[i].load(std::memory_order_relaxed);
     nbr_t* read_ptr = buf_arr[i];
     if (read_ptr == nullptr) {
       continue;
     }
     nbr_t* read_end = read_ptr + sz;
-    nbr_t* write_ptr = buf_arr[i];
+    nbr_t* write_ptr = read_ptr;
     int removed = 0;
     while (read_ptr != read_end) {
       if (read_ptr->timestamp != INVALID_TIMESTAMP) {
@@ -206,8 +206,8 @@ void MutableCsr<EDATA_T>::compact() {
       }
       ++read_ptr;
     }
-    sz_arr[i] -= removed;
-    total_edge_num += sz_arr[i];
+    sz_arr[i].store(sz - removed, std::memory_order_relaxed);
+    total_edge_num += (sz - removed);
   }
   if (total_edge_num != edge_num_.load()) {
     LOG(WARNING) << "Inconsistent edge count after compaction"
@@ -233,11 +233,11 @@ void MutableCsr<EDATA_T>::resize(vid_t vnum) {
     degree_list_->Resize(vnum * sizeof(int));
     cap_list_->Resize(vnum * sizeof(int));
     auto** buf_arr = reinterpret_cast<nbr_t**>(adj_list_buffer_->GetData());
-    auto* sz_arr = reinterpret_cast<int*>(degree_list_->GetData());
+    auto* sz_arr = reinterpret_cast<std::atomic<int>*>(degree_list_->GetData());
     auto* cap_arr = reinterpret_cast<int*>(cap_list_->GetData());
     for (vid_t i = old_vnum; i < vnum; ++i) {
       buf_arr[i] = nullptr;
-      sz_arr[i] = 0;
+      sz_arr[i].store(0, std::memory_order_relaxed);
       cap_arr[i] = 0;
     }
     locks_ = std::make_unique<SpinLock[]>(vnum);
@@ -268,16 +268,16 @@ void MutableCsr<EDATA_T>::batch_sort_by_edge_data(timestamp_t ts) {
   if (adj_list_buffer_ != nullptr) {
     size_t vnum = vertex_capacity();
     auto** buf_arr = reinterpret_cast<nbr_t**>(adj_list_buffer_->GetData());
-    auto* sz_arr = reinterpret_cast<int*>(degree_list_->GetData());
+    auto* sz_arr = reinterpret_cast<std::atomic<int>*>(degree_list_->GetData());
     for (size_t i = 0; i != vnum; ++i) {
       nbr_t* begin = buf_arr[i];
       if (begin == nullptr) {
         continue;
       }
-      std::sort(begin, begin + sz_arr[i],
-                [](const nbr_t& lhs, const nbr_t& rhs) {
-                  return lhs.data < rhs.data;
-                });
+      int deg = sz_arr[i].load(std::memory_order_relaxed);
+      std::sort(begin, begin + deg, [](const nbr_t& lhs, const nbr_t& rhs) {
+        return lhs.data < rhs.data;
+      });
     }
   }
   unsorted_since_ = ts;
@@ -288,29 +288,32 @@ void MutableCsr<EDATA_T>::batch_delete_vertices(
     const std::set<vid_t>& src_set, const std::set<vid_t>& dst_set) {
   vid_t vnum = static_cast<vid_t>(vertex_capacity());
   auto** buf_arr = reinterpret_cast<nbr_t**>(adj_list_buffer_->GetData());
-  auto* sz_arr = reinterpret_cast<int*>(degree_list_->GetData());
+  auto* sz_arr = reinterpret_cast<std::atomic<int>*>(degree_list_->GetData());
   for (vid_t src : src_set) {
     if (src < vnum) {
       auto* data = buf_arr[src];
-      auto* end = data + sz_arr[src];
+      int deg = sz_arr[src].load(std::memory_order_relaxed);
+      auto* end = data + deg;
       for (auto* ptr = data; ptr != end; ++ptr) {
         if (ptr->timestamp.load() != std::numeric_limits<timestamp_t>::max()) {
           edge_num_.fetch_sub(1, std::memory_order_relaxed);
         }
       }
-      sz_arr[src] = 0;
+      sz_arr[src].store(0, std::memory_order_relaxed);
     }
   }
   for (vid_t src = 0; src < vnum; ++src) {
-    if (sz_arr[src] == 0) {
+    int cur_deg = sz_arr[src].load(std::memory_order_relaxed);
+    if (cur_deg == 0) {
       continue;
     }
-    const nbr_t* read_ptr = buf_arr[src];
-    if (read_ptr == nullptr) {
+    nbr_t* buf = buf_arr[src];
+    if (buf == nullptr) {
       continue;
     }
-    const nbr_t* read_end = read_ptr + sz_arr[src];
-    nbr_t* write_ptr = buf_arr[src];
+    const nbr_t* read_ptr = buf;
+    const nbr_t* read_end = read_ptr + cur_deg;
+    nbr_t* write_ptr = buf;
     int removed = 0;
     while (read_ptr != read_end) {
       vid_t nbr = read_ptr->neighbor;
@@ -329,7 +332,7 @@ void MutableCsr<EDATA_T>::batch_delete_vertices(
       ++read_ptr;
     }
 
-    sz_arr[src] -= removed;
+    sz_arr[src].store(cur_deg - removed, std::memory_order_relaxed);
   }
   unsorted_since_ = 0;
 }
@@ -347,14 +350,15 @@ void MutableCsr<EDATA_T>::batch_delete_edges(
     src_dst_map[src].insert(dst_list[i]);
   }
   auto** buf_arr = reinterpret_cast<nbr_t**>(adj_list_buffer_->GetData());
-  auto* sz_arr = reinterpret_cast<int*>(degree_list_->GetData());
+  auto* sz_arr = reinterpret_cast<std::atomic<int>*>(degree_list_->GetData());
   for (const auto& pair : src_dst_map) {
     vid_t src = pair.first;
     nbr_t* write_ptr = buf_arr[src];
     if (write_ptr == nullptr) {
       continue;
     }
-    const nbr_t* read_end = write_ptr + sz_arr[src];
+    int deg = sz_arr[src].load(std::memory_order_relaxed);
+    const nbr_t* read_end = write_ptr + deg;
     while (write_ptr != read_end) {
       if (pair.second.find(write_ptr->neighbor) != pair.second.end()) {
         write_ptr->timestamp.store(std::numeric_limits<timestamp_t>::max());
@@ -371,10 +375,11 @@ void MutableCsr<EDATA_T>::batch_delete_edges(
     const std::vector<std::pair<vid_t, int32_t>>& edges) {
   std::map<vid_t, std::set<int32_t>> src_offset_map;
   vid_t vnum = static_cast<vid_t>(vertex_capacity());
-  const auto* sz_arr = reinterpret_cast<const int*>(degree_list_->GetData());
+  auto* sz_arr = reinterpret_cast<std::atomic<int>*>(degree_list_->GetData());
   auto** buf_arr = reinterpret_cast<nbr_t**>(adj_list_buffer_->GetData());
   for (const auto& edge : edges) {
-    if (edge.first >= vnum || edge.second >= sz_arr[edge.first]) {
+    if (edge.first >= vnum ||
+        edge.second >= sz_arr[edge.first].load(std::memory_order_relaxed)) {
       continue;
     }
     src_offset_map[edge.first].insert(edge.second);
@@ -401,8 +406,8 @@ template <typename EDATA_T>
 void MutableCsr<EDATA_T>::delete_edge(vid_t src, int32_t offset,
                                       timestamp_t ts) {
   vid_t vnum = static_cast<vid_t>(vertex_capacity());
-  const auto* sz_arr = reinterpret_cast<const int*>(degree_list_->GetData());
-  if (src >= vnum || offset >= sz_arr[src]) {
+  auto* sz_arr = reinterpret_cast<std::atomic<int>*>(degree_list_->GetData());
+  if (src >= vnum || offset >= sz_arr[src].load(std::memory_order_relaxed)) {
     THROW_INVALID_ARGUMENT_EXCEPTION("src out of bound or offset out of bound");
   }
   nbr_t* nbrs = reinterpret_cast<nbr_t**>(adj_list_buffer_->GetData())[src];
@@ -426,8 +431,8 @@ template <typename EDATA_T>
 void MutableCsr<EDATA_T>::revert_delete_edge(vid_t src, vid_t nbr,
                                              int32_t offset, timestamp_t ts) {
   vid_t vnum = static_cast<vid_t>(vertex_capacity());
-  const auto* sz_arr = reinterpret_cast<const int*>(degree_list_->GetData());
-  if (src >= vnum || offset >= sz_arr[src]) {
+  auto* sz_arr = reinterpret_cast<std::atomic<int>*>(degree_list_->GetData());
+  if (src >= vnum || offset >= sz_arr[src].load(std::memory_order_relaxed)) {
     THROW_INVALID_ARGUMENT_EXCEPTION("src out of bound or offset out of bound");
   }
   nbr_t* nbrs = reinterpret_cast<nbr_t**>(adj_list_buffer_->GetData())[src];
@@ -465,12 +470,12 @@ void MutableCsr<EDATA_T>::batch_put_edges(const std::vector<vid_t>& src_list,
   }
 
   auto** buf_arr = reinterpret_cast<nbr_t**>(adj_list_buffer_->GetData());
-  auto* sz_arr = reinterpret_cast<int*>(degree_list_->GetData());
+  auto* sz_arr = reinterpret_cast<std::atomic<int>*>(degree_list_->GetData());
   auto* cap_arr = reinterpret_cast<int*>(cap_list_->GetData());
   size_t total_to_move = 0;
   size_t total_to_allocate = 0;
   for (vid_t i = 0; i < vnum; ++i) {
-    int old_deg = sz_arr[i];
+    int old_deg = sz_arr[i].load(std::memory_order_relaxed);
     total_to_move += old_deg;
     int new_degree = degree[i] + old_deg;
     int new_cap = std::ceil(new_degree * NeugDBConfig::DEFAULT_RESERVE_RATIO);
@@ -481,7 +486,7 @@ void MutableCsr<EDATA_T>::batch_put_edges(const std::vector<vid_t>& src_list,
   std::vector<nbr_t> new_nbr_list(total_to_move);
   size_t offset = 0;
   for (vid_t i = 0; i < vnum; ++i) {
-    int old_deg = sz_arr[i];
+    int old_deg = sz_arr[i].load(std::memory_order_relaxed);
     if (old_deg > 0 && buf_arr[i] != nullptr) {
       memcpy(new_nbr_list.data() + offset, buf_arr[i], sizeof(nbr_t) * old_deg);
     }
@@ -493,7 +498,7 @@ void MutableCsr<EDATA_T>::batch_put_edges(const std::vector<vid_t>& src_list,
   size_t new_offset = 0;
   for (vid_t i = 0; i < vnum; ++i) {
     nbr_t* new_buffer = base_ptr != nullptr ? base_ptr + offset : nullptr;
-    int old_deg = sz_arr[i];
+    int old_deg = sz_arr[i].load(std::memory_order_relaxed);
     if (old_deg > 0 && new_buffer != nullptr) {
       memcpy(new_buffer, new_nbr_list.data() + new_offset,
              sizeof(nbr_t) * old_deg);
@@ -501,7 +506,7 @@ void MutableCsr<EDATA_T>::batch_put_edges(const std::vector<vid_t>& src_list,
     new_offset += old_deg;
     offset += cap_arr[i];
     buf_arr[i] = new_buffer;
-    sz_arr[i] = old_deg;
+    sz_arr[i].store(old_deg, std::memory_order_relaxed);
   }
   size_t added_edge_num = 0;
   for (size_t i = 0; i < src_list.size(); ++i) {
@@ -511,7 +516,7 @@ void MutableCsr<EDATA_T>::batch_put_edges(const std::vector<vid_t>& src_list,
     }
     vid_t dst = dst_list[i];
     const EDATA_T& data = data_list[i];
-    auto& nbr = buf_arr[src][sz_arr[src]++];
+    auto& nbr = buf_arr[src][sz_arr[src].fetch_add(1, std::memory_order_relaxed)];
     nbr.neighbor = dst;
     nbr.data = data;
     nbr.timestamp.store(ts);

--- a/tests/storage/test_mutable_csr.cc
+++ b/tests/storage/test_mutable_csr.cc
@@ -15,11 +15,14 @@
 
 #include <gtest/gtest.h>
 #include <sys/stat.h>
+#include <atomic>
 #include <chrono>
 #include <iostream>
 #include <optional>
 #include <random>
 #include <string>
+#include <thread>
+#include <vector>
 #include "neug/storages/csr/csr_view_utils.h"
 #include "neug/storages/csr/mutable_csr.h"
 #include "unittest/utils.h"
@@ -757,7 +760,7 @@ class MutableCsrDumpDirtyTest : public ::testing::Test {
   // Throws std::runtime_error on stat() failure so that any follow-on
   // inode comparisons are never made against an uninitialized value.
   static ino_t inode_of(const std::string& path) {
-    struct stat st{};
+    struct stat st {};
     if (stat(path.c_str(), &st) != 0) {
       throw std::runtime_error("stat() failed for path: " + path + " — " +
                                std::strerror(errno));
@@ -837,6 +840,158 @@ TEST_F(MutableCsrDumpDirtyTest, VariousMutationsSetDirty) {
       "put_edge", [this](CsrT& c) { c.put_edge(0, 1, 123, 1, *this->alloc_); });
   expect_slow_after("batch_delete_edges",
                     [](CsrT& c) { c.batch_delete_edges({0}, {3}); });
+}
+// Concurrent read-write test: verifies that lock-free readers using
+// get_edges() / foreach_nbr_lt() see consistent (degree, buffer) snapshots
+// even when a concurrent writer triggers CSR buffer reallocation via put_edge.
+// This is a regression test for the torn-read bug fixed by using
+// std::atomic_ref in put_edge / GenericView / TypedView.
+// ---------------------------------------------------------------------------
+
+TYPED_TEST(MutableCsrTest, TestConcurrentPutEdgeAndRead) {
+  // Use int64_t for the typed view test (foreach_nbr_lt requires ordered data)
+  MutableCsr<TypeParam> csr;
+  this->load_csr_data(csr, MemoryLevel::kInMemory);
+
+  // Sort edges so that foreach_nbr_lt can use binary search path
+  csr.batch_sort_by_edge_data(1);
+
+  constexpr int kWriterIterations = 500;
+  constexpr int kReaderIterations = 2000;
+  constexpr int kNumReaders = 4;
+
+  std::atomic<bool> stop_flag{false};
+  std::atomic<int> reader_errors{0};
+
+  // Writer thread: continuously inserts edges to vertex 0, which will trigger
+  // multiple buffer reallocations (initial cap=8, grows by 1.5x each time).
+  std::thread writer([&]() {
+    for (int i = 0; i < kWriterIterations; ++i) {
+      vid_t dst = static_cast<vid_t>(i % 100);
+      timestamp_t ts = 2;  // visible to readers with ts >= 2
+      this->template put_single_edge<MutableCsr>(csr, 0, dst, ts,
+                                                 *(this->allocators[0]));
+    }
+    stop_flag.store(true, std::memory_order_release);
+  });
+
+  // Reader threads: continuously read edges via get_edges() and verify
+  // that the returned NbrList has consistent start/end pointers.
+  std::vector<std::thread> readers;
+  for (int r = 0; r < kNumReaders; ++r) {
+    readers.emplace_back([&, r]() {
+      int local_errors = 0;
+      for (int i = 0; i < kReaderIterations; ++i) {
+        // Test GenericView::get_edges
+        auto view = csr.get_generic_view(2);
+        auto edges = view.get_edges(0);
+
+        // Sanity check: end_ptr must be >= start_ptr
+        if (edges.end_ptr < edges.start_ptr) {
+          local_errors++;
+          continue;
+        }
+
+        // Verify that iteration doesn't crash (the original bug caused SIGSEGV
+        // here due to ptr/end being in different buffers)
+        size_t count = 0;
+        for (auto it = edges.begin(); it != edges.end(); ++it) {
+          ++count;
+          // Safety bound to prevent infinite loop in case of regression
+          if (count > 100000) {
+            local_errors++;
+            break;
+          }
+        }
+
+        // Test TypedView if data type supports comparison (foreach_nbr_lt)
+        if constexpr (!std::is_same_v<TypeParam, EmptyType> &&
+                      !std::is_same_v<TypeParam, Interval>) {
+          auto typed_view =
+              view.template get_typed_view<TypeParam,
+                                           CsrViewType::kMultipleMutable>();
+          size_t lt_count = 0;
+          typed_view.foreach_nbr_lt(0, std::numeric_limits<TypeParam>::max(),
+                                    [&](vid_t nbr, const TypeParam& data) {
+                                      ++lt_count;
+                                      if (lt_count > 100000) {
+                                        local_errors++;
+                                      }
+                                    });
+        }
+      }
+      reader_errors.fetch_add(local_errors, std::memory_order_relaxed);
+    });
+  }
+
+  writer.join();
+  for (auto& t : readers) {
+    t.join();
+  }
+
+  EXPECT_EQ(reader_errors.load(), 0)
+      << "Concurrent readers detected inconsistent state";
+  // Writer should have inserted all edges
+  EXPECT_GE(csr.edge_num(), edge_num + kWriterIterations);
+}
+
+// Test that concurrent readers on different vertices don't interfere with
+// a writer that reallocates a specific vertex's buffer.
+TYPED_TEST(MutableCsrTest, TestConcurrentPutEdgeMultiVertex) {
+  MutableCsr<TypeParam> csr;
+  this->load_csr_data(csr, MemoryLevel::kInMemory);
+
+  constexpr int kEdgesPerVertex = 200;
+  constexpr int kReaderIterations = 1000;
+  constexpr int kNumReaders = 3;
+
+  std::atomic<bool> stop_flag{false};
+  std::atomic<int> reader_errors{0};
+
+  // Writer: insert many edges to vertex 2 (will trigger reallocation)
+  std::thread writer([&]() {
+    for (int i = 0; i < kEdgesPerVertex; ++i) {
+      vid_t dst = static_cast<vid_t>(i % 50);
+      this->template put_single_edge<MutableCsr>(csr, 2, dst, 1,
+                                                 *(this->allocators[0]));
+    }
+    stop_flag.store(true, std::memory_order_release);
+  });
+
+  // Readers: read edges from vertex 2 (same vertex being written to)
+  std::vector<std::thread> readers;
+  for (int r = 0; r < kNumReaders; ++r) {
+    readers.emplace_back([&]() {
+      int local_errors = 0;
+      for (int i = 0; i < kReaderIterations; ++i) {
+        auto view = csr.get_generic_view(1);
+        auto edges = view.get_edges(2);
+
+        if (edges.end_ptr < edges.start_ptr) {
+          local_errors++;
+          continue;
+        }
+
+        size_t count = 0;
+        for (auto it = edges.begin(); it != edges.end(); ++it) {
+          ++count;
+          if (count > 100000) {
+            local_errors++;
+            break;
+          }
+        }
+      }
+      reader_errors.fetch_add(local_errors, std::memory_order_relaxed);
+    });
+  }
+
+  writer.join();
+  for (auto& t : readers) {
+    t.join();
+  }
+
+  EXPECT_EQ(reader_errors.load(), 0)
+      << "Concurrent readers on same vertex detected inconsistent state";
 }
 
 }  // namespace test


### PR DESCRIPTION
FIx #381 

This pull request refactors the mutable CSR (Compressed Sparse Row) graph storage implementation to use `std::atomic<int>` for vertex degree storage, ensuring thread safety and preventing torn reads/writes in concurrent environments. The changes update all relevant code paths to use atomic operations, with appropriate memory orderings, and adjust buffer management accordingly.

The most important changes are:

**Thread Safety and Atomic Degree Management:**
* Replaced all raw `int` degree arrays with `std::atomic<int>` in both the in-memory representation and all access/manipulation code, ensuring atomicity and visibility guarantees for concurrent readers and writers. All reads and writes to degrees now use explicit memory orderings (`acquire` for reads, `release` for writes, and `relaxed` where appropriate). [[1]](diffhunk://#diff-f94c884c9ed46d6ce76cf207babcb87077e3c7db1946112d16f95c74908f9f13L122-R126) [[2]](diffhunk://#diff-f94c884c9ed46d6ce76cf207babcb87077e3c7db1946112d16f95c74908f9f13L138-R144) [[3]](diffhunk://#diff-f94c884c9ed46d6ce76cf207babcb87077e3c7db1946112d16f95c74908f9f13L155-R166) [[4]](diffhunk://#diff-35b4bd50487625c9ddee735b90b1066317fc3a3871ac6cd8a23c88bd8365c092L154-R161) [[5]](diffhunk://#diff-35b4bd50487625c9ddee735b90b1066317fc3a3871ac6cd8a23c88bd8365c092L175-R186) [[6]](diffhunk://#diff-35b4bd50487625c9ddee735b90b1066317fc3a3871ac6cd8a23c88bd8365c092L197-R200) [[7]](diffhunk://#diff-35b4bd50487625c9ddee735b90b1066317fc3a3871ac6cd8a23c88bd8365c092L224-R231) [[8]](diffhunk://#diff-35b4bd50487625c9ddee735b90b1066317fc3a3871ac6cd8a23c88bd8365c092L271-R282) [[9]](diffhunk://#diff-35b4bd50487625c9ddee735b90b1066317fc3a3871ac6cd8a23c88bd8365c092L291-R322) [[10]](diffhunk://#diff-35b4bd50487625c9ddee735b90b1066317fc3a3871ac6cd8a23c88bd8365c092L332-R341) [[11]](diffhunk://#diff-35b4bd50487625c9ddee735b90b1066317fc3a3871ac6cd8a23c88bd8365c092L349-R367) [[12]](diffhunk://#diff-35b4bd50487625c9ddee735b90b1066317fc3a3871ac6cd8a23c88bd8365c092L372-R388) [[13]](diffhunk://#diff-35b4bd50487625c9ddee735b90b1066317fc3a3871ac6cd8a23c88bd8365c092L401-R417) [[14]](diffhunk://#diff-35b4bd50487625c9ddee735b90b1066317fc3a3871ac6cd8a23c88bd8365c092L425-R443) [[15]](diffhunk://#diff-35b4bd50487625c9ddee735b90b1066317fc3a3871ac6cd8a23c88bd8365c092L464-R487) [[16]](diffhunk://#diff-35b4bd50487625c9ddee735b90b1066317fc3a3871ac6cd8a23c88bd8365c092L480-R498) [[17]](diffhunk://#diff-35b4bd50487625c9ddee735b90b1066317fc3a3871ac6cd8a23c88bd8365c092L492-R518) [[18]](diffhunk://#diff-35b4bd50487625c9ddee735b90b1066317fc3a3871ac6cd8a23c88bd8365c092L510-R533)

**Reader/Writer Synchronization:**
* Updated all code that reads or writes the degree array (e.g., edge insertions, deletions, compaction, batch operations, and neighbor iteration) to use atomic loads and stores, ensuring that buffer pointer updates and degree increments are properly sequenced for safe concurrent access. [[1]](diffhunk://#diff-00f81dc78c5aadbf2d169832569c394901cb80e4d4c80bf3483986ed6293b9a7L409-R415) [[2]](diffhunk://#diff-00f81dc78c5aadbf2d169832569c394901cb80e4d4c80bf3483986ed6293b9a7L436-R447) [[3]](diffhunk://#diff-00f81dc78c5aadbf2d169832569c394901cb80e4d4c80bf3483986ed6293b9a7L455-R465) [[4]](diffhunk://#diff-00f81dc78c5aadbf2d169832569c394901cb80e4d4c80bf3483986ed6293b9a7L604-R621)

**Buffer Management Adjustments:**
* Modified logic for buffer resizing, copying, and pointer updates to ensure that atomic degree increments/releases are used as synchronization anchors, so readers always see a consistent view of the adjacency buffers. [[1]](diffhunk://#diff-f94c884c9ed46d6ce76cf207babcb87077e3c7db1946112d16f95c74908f9f13L122-R126) [[2]](diffhunk://#diff-f94c884c9ed46d6ce76cf207babcb87077e3c7db1946112d16f95c74908f9f13L138-R144) [[3]](diffhunk://#diff-35b4bd50487625c9ddee735b90b1066317fc3a3871ac6cd8a23c88bd8365c092L492-R518) [[4]](diffhunk://#diff-35b4bd50487625c9ddee735b90b1066317fc3a3871ac6cd8a23c88bd8365c092L510-R533)

**Test and Include Updates:**
* Added necessary includes for `<atomic>`, `<thread>`, and `<vector>` in test files to support atomic operations and potential multithreaded tests.

Overall, these changes make the mutable CSR implementation safe for concurrent modifications and queries, which is crucial for high-performance, multi-threaded graph processing.