### PR TITLE
refactor: consolidate Schema vertex/edge label check API

### DIFF
--- a/include/neug/execution/common/operators/retrieve/edge_expand_impl.h
+++ b/include/neug/execution/common/operators/retrieve/edge_expand_impl.h
@@ -73,7 +73,7 @@ get_label_dirs(label_t input_label, const Schema& schema,
                const std::vector<LabelTriplet>& labels, Direction dir) {
   std::vector<std::tuple<label_t, label_t, Direction>> label_dirs;
   for (auto& triplet : labels) {
-    if (!schema.exist(triplet.src_label, triplet.dst_label,
+    if (!schema.is_edge_triplet_valid(triplet.src_label, triplet.dst_label,
                       triplet.edge_label)) {
       continue;
     }
@@ -103,7 +103,7 @@ get_label_dirs_list(const std::set<label_t>& input_labels, const Schema& schema,
   std::vector<std::vector<std::tuple<label_t, label_t, Direction>>> label_dirs(
       label_num);
   for (auto& triplet : labels) {
-    if (!schema.exist(triplet.src_label, triplet.dst_label,
+    if (!schema.is_edge_triplet_valid(triplet.src_label, triplet.dst_label,
                       triplet.edge_label)) {
       continue;
     }
@@ -229,7 +229,7 @@ expand_vertex_impl(const StorageReadInterface& graph,
   std::set<label_t> nbr_labels;
   bool single_view_per_label = true;
   for (label_t v_label = 0; v_label < label_num; ++v_label) {
-    if (!graph.schema().vertex_label_valid(v_label)) {
+    if (!graph.schema().is_vertex_label_valid(v_label)) {
       continue;
     }
     for (auto& t : label_dirs[v_label]) {
@@ -636,7 +636,7 @@ expand_vertex_impl(const StorageReadInterface& graph,
       get_label_dirs_list(input_labels, graph.schema(), labels, dir);
   std::set<label_t> nbr_labels;
   for (label_t v_label = 0; v_label < label_num; ++v_label) {
-    if (!graph.schema().vertex_label_valid(v_label)) {
+    if (!graph.schema().is_vertex_label_valid(v_label)) {
       continue;
     }
     for (auto& t : label_dirs[v_label]) {
@@ -1017,7 +1017,7 @@ expand_edge_impl(const StorageReadInterface& graph, const MLVertexColumn& input,
   std::vector<std::vector<GenericView>> views(label_num);
   std::vector<LabelTriplet> all_triplets;
   for (label_t v_label = 0; v_label < label_num; ++v_label) {
-    if (!graph.schema().vertex_label_valid(v_label)) {
+    if (!graph.schema().is_vertex_label_valid(v_label)) {
       continue;
     }
     for (auto& t : label_dirs[v_label]) {

--- a/include/neug/execution/common/operators/retrieve/edge_expand_impl.h
+++ b/include/neug/execution/common/operators/retrieve/edge_expand_impl.h
@@ -74,7 +74,7 @@ get_label_dirs(label_t input_label, const Schema& schema,
   std::vector<std::tuple<label_t, label_t, Direction>> label_dirs;
   for (auto& triplet : labels) {
     if (!schema.is_edge_triplet_valid(triplet.src_label, triplet.dst_label,
-                      triplet.edge_label)) {
+                                      triplet.edge_label)) {
       continue;
     }
     if (triplet.src_label == input_label &&
@@ -104,7 +104,7 @@ get_label_dirs_list(const std::set<label_t>& input_labels, const Schema& schema,
       label_num);
   for (auto& triplet : labels) {
     if (!schema.is_edge_triplet_valid(triplet.src_label, triplet.dst_label,
-                      triplet.edge_label)) {
+                                      triplet.edge_label)) {
       continue;
     }
     if ((input_labels.find(triplet.src_label) != input_labels.end()) &&

--- a/include/neug/execution/common/operators/retrieve/path_expand_impl.h
+++ b/include/neug/execution/common/operators/retrieve/path_expand_impl.h
@@ -427,8 +427,8 @@ default_single_source_shortest_path_impl(
   const auto& input_labels_set = input.get_labels_set();
   std::set<label_t> dest_labels;
   for (auto& triplet : labels) {
-    if (!graph.schema().is_edge_triplet_valid(triplet.src_label, triplet.dst_label,
-                              triplet.edge_label)) {
+    if (!graph.schema().is_edge_triplet_valid(
+            triplet.src_label, triplet.dst_label, triplet.edge_label)) {
       continue;
     }
     if (dir == Direction::kOut || dir == Direction::kBoth) {

--- a/include/neug/execution/common/operators/retrieve/path_expand_impl.h
+++ b/include/neug/execution/common/operators/retrieve/path_expand_impl.h
@@ -427,7 +427,7 @@ default_single_source_shortest_path_impl(
   const auto& input_labels_set = input.get_labels_set();
   std::set<label_t> dest_labels;
   for (auto& triplet : labels) {
-    if (!graph.schema().exist(triplet.src_label, triplet.dst_label,
+    if (!graph.schema().is_edge_triplet_valid(triplet.src_label, triplet.dst_label,
                               triplet.edge_label)) {
       continue;
     }

--- a/include/neug/execution/expression/special_predicates.h
+++ b/include/neug/execution/expression/special_predicates.h
@@ -140,7 +140,7 @@ class MLVertexPropertyGetter {
                          const std::string& property_name) {
     const auto& graph = dynamic_cast<const StorageReadInterface&>(gi);
     for (label_t i = 0; i < graph.schema().vertex_label_frontier(); ++i) {
-      if (!graph.schema().vertex_label_valid(i)) {
+      if (!graph.schema().is_vertex_label_valid(i)) {
         continue;
       }
       columns_.emplace_back(

--- a/include/neug/storages/graph/property_graph.h
+++ b/include/neug/storages/graph/property_graph.h
@@ -591,11 +591,6 @@ class PropertyGraph {
                             const std::string& dst_type_name,
                             const std::string& edge_type_name);
 
-  // Check whether the edge triplet exists, maybe marked as deleted
-  Status edge_triplet_exist(const std::string& src_type_name,
-                            const std::string& dst_type_name,
-                            const std::string& edge_type_name);
-
   Status vertex_label_check(const std::string& vertex_type_name);
 
   void compact_schema();

--- a/include/neug/storages/graph/schema.h
+++ b/include/neug/storages/graph/schema.h
@@ -339,14 +339,14 @@ struct EdgeSchema {
  * const neug::Schema& schema = graph.schema();
  *
  * // Get vertex type information
- * if (schema.contains_vertex_label("Person")) {
+ * if (schema.is_vertex_label_valid("Person")) {
  *     label_t person_id = schema.get_vertex_label_id("Person");
  *     auto props = schema.get_vertex_properties(person_id);
  *     auto names = schema.get_vertex_property_names(person_id);
  * }
  *
  * // Check edge type existence
- * if (schema.exist("Person", "Person", "KNOWS")) {
+ * if (schema.is_edge_triplet_valid("Person", "Person", "KNOWS")) {
  *     auto edge_props = schema.get_edge_properties("Person", "Person",
  * "KNOWS");
  * }
@@ -514,31 +514,31 @@ class Schema {
                             const std::vector<std::string>& properties_names,
                             const std::vector<std::string>& properties_renames);
 
-  bool IsVertexLabelSoftDeleted(const std::string& label) const;
+  bool is_vertex_label_soft_deleted(const std::string& label) const;
 
-  bool IsVertexLabelSoftDeleted(label_t v_label) const;
+  bool is_vertex_label_soft_deleted(label_t v_label) const;
 
-  bool IsEdgeLabelSoftDeleted(label_t src_label, label_t dst_label,
-                              label_t edge_label) const;
+  bool is_edge_label_soft_deleted(label_t src_label, label_t dst_label,
+                                  label_t edge_label) const;
 
-  bool IsEdgeLabelSoftDeleted(const std::string& src_label,
-                              const std::string& dst_label,
-                              const std::string& edge_label) const;
+  bool is_edge_label_soft_deleted(const std::string& src_label,
+                                  const std::string& dst_label,
+                                  const std::string& edge_label) const;
 
-  bool IsVertexPropertySoftDeleted(const std::string& label,
-                                   const std::string& property) const;
+  bool is_vertex_property_soft_deleted(const std::string& label,
+                                       const std::string& property) const;
 
-  bool IsVertexPropertySoftDeleted(label_t label,
-                                   const std::string& property) const;
+  bool is_vertex_property_soft_deleted(label_t label,
+                                       const std::string& property) const;
 
-  bool IsEdgePropertySoftDeleted(const std::string& src_label,
-                                 const std::string& dst_label,
-                                 const std::string& edge_label,
-                                 const std::string& property) const;
+  bool is_edge_property_soft_deleted(const std::string& src_label,
+                                     const std::string& dst_label,
+                                     const std::string& edge_label,
+                                     const std::string& property) const;
 
-  bool IsEdgePropertySoftDeleted(label_t src_label, label_t dst_label,
-                                 label_t edge_label,
-                                 const std::string& property) const;
+  bool is_edge_property_soft_deleted(label_t src_label, label_t dst_label,
+                                     label_t edge_label,
+                                     const std::string& property) const;
 
   void DeleteVertexProperties(const std::string& label,
                               const std::vector<std::string>& properties_names,
@@ -587,9 +587,9 @@ class Schema {
    */
   label_t edge_label_frontier() const;
 
-  bool contains_vertex_label(const std::string& label) const;
+  bool is_vertex_label_valid(const std::string& label) const;
 
-  bool vertex_label_valid(label_t label_id) const;
+  bool is_vertex_label_valid(label_t label_id) const;
 
   label_t get_vertex_label_id(const std::string& label) const;
 
@@ -620,11 +620,12 @@ class Schema {
 
   size_t get_max_vnum(const std::string& label) const;
 
-  bool exist(const std::string& src_label, const std::string& dst_label,
-             const std::string& edge_label) const;
+  bool is_edge_triplet_valid(const std::string& src_label,
+                             const std::string& dst_label,
+                             const std::string& edge_label) const;
 
-  bool exist(label_type src_label, label_type dst_label,
-             label_type edge_label) const;
+  bool is_edge_triplet_valid(label_type src_label, label_type dst_label,
+                             label_type edge_label) const;
 
   const std::vector<execution::Value>& get_edge_default_property_values(
       label_t src_label_id, label_t dst_label_id, label_t edge_label_id) const;
@@ -677,12 +678,12 @@ class Schema {
                          label_t edge_label, const std::string& prop) const;
 
   // Even when triplet is soft deleted, it return true
-  bool has_edge_label(const std::string& src_label,
+  bool has_edge_triplet(const std::string& src_label,
                       const std::string& dst_label,
                       const std::string& edge_label) const;
 
   // Even when triplet is soft deleted, it return true
-  bool has_edge_label(label_t src_label, label_t dst_label,
+  bool has_edge_triplet(label_t src_label, label_t dst_label,
                       label_t edge_label) const;
 
   EdgeStrategy get_outgoing_edge_strategy(const std::string& src_label,
@@ -725,11 +726,9 @@ class Schema {
                                                   label_t dst_label,
                                                   label_t label) const;
 
-  bool contains_edge_label(const std::string& label) const;
+  bool is_edge_label_valid(const std::string& label) const;
 
-  bool edge_label_valid(label_t label_id) const;
-
-  bool edge_triplet_valid(label_t src, label_t dst, label_t edge) const;
+  bool is_edge_label_valid(label_t label_id) const;
 
   label_t get_edge_label_id(const std::string& label) const;
 

--- a/include/neug/storages/graph/schema.h
+++ b/include/neug/storages/graph/schema.h
@@ -679,12 +679,12 @@ class Schema {
 
   // Even when triplet is soft deleted, it return true
   bool has_edge_triplet(const std::string& src_label,
-                      const std::string& dst_label,
-                      const std::string& edge_label) const;
+                        const std::string& dst_label,
+                        const std::string& edge_label) const;
 
   // Even when triplet is soft deleted, it return true
   bool has_edge_triplet(label_t src_label, label_t dst_label,
-                      label_t edge_label) const;
+                        label_t edge_label) const;
 
   EdgeStrategy get_outgoing_edge_strategy(const std::string& src_label,
                                           const std::string& dst_label,

--- a/src/execution/common/columns/arrow_context_column.cc
+++ b/src/execution/common/columns/arrow_context_column.cc
@@ -18,7 +18,6 @@
 #include <arrow/array/array_binary.h>
 #include <arrow/array/builder_binary.h>
 #include <arrow/array/builder_primitive.h>
-#include "neug/utils/exception/exception.h"
 #include <arrow/array/builder_time.h>
 #include <arrow/type.h>
 #include <glog/logging.h>

--- a/src/execution/common/columns/columns_utils.cc
+++ b/src/execution/common/columns/columns_utils.cc
@@ -18,9 +18,9 @@
 #include "neug/execution/common/columns/list_columns.h"
 #include "neug/execution/common/columns/path_columns.h"
 #include "neug/execution/common/columns/struct_columns.h"
-#include "neug/utils/exception/exception.h"
 #include "neug/execution/common/columns/value_columns.h"
 #include "neug/execution/common/columns/vertex_columns.h"
+#include "neug/utils/exception/exception.h"
 
 namespace neug {
 namespace execution {

--- a/src/execution/common/columns/list_columns.cc
+++ b/src/execution/common/columns/list_columns.cc
@@ -90,8 +90,9 @@ ListColumn::unfold() const {
     return {builder.finish(), offsets};
   }
   default:
-    THROW_NOT_IMPLEMENTED_EXCEPTION("not implemented for " + this->column_info() + " " +
-                                    std::to_string(static_cast<int>(elem_type_.id())));
+    THROW_NOT_IMPLEMENTED_EXCEPTION(
+        "not implemented for " + this->column_info() + " " +
+        std::to_string(static_cast<int>(elem_type_.id())));
     return {nullptr, std::vector<size_t>()};
   }
 }

--- a/src/execution/common/operators/retrieve/edge_expand.cc
+++ b/src/execution/common/operators/retrieve/edge_expand.cc
@@ -355,8 +355,8 @@ neug::result<Context> EdgeExpand::expand_vertex_ep_cmp(
     label_t input_label = casted_input_vertex_list->label();
     std::vector<std::tuple<label_t, label_t, Direction>> label_dirs;
     for (auto& triplet : params.labels) {
-      if (!graph.schema().is_edge_triplet_valid(triplet.src_label, triplet.dst_label,
-                                triplet.edge_label)) {
+      if (!graph.schema().is_edge_triplet_valid(
+              triplet.src_label, triplet.dst_label, triplet.edge_label)) {
         continue;
       }
       if (triplet.src_label == input_label &&

--- a/src/execution/common/operators/retrieve/edge_expand.cc
+++ b/src/execution/common/operators/retrieve/edge_expand.cc
@@ -355,7 +355,7 @@ neug::result<Context> EdgeExpand::expand_vertex_ep_cmp(
     label_t input_label = casted_input_vertex_list->label();
     std::vector<std::tuple<label_t, label_t, Direction>> label_dirs;
     for (auto& triplet : params.labels) {
-      if (!graph.schema().exist(triplet.src_label, triplet.dst_label,
+      if (!graph.schema().is_edge_triplet_valid(triplet.src_label, triplet.dst_label,
                                 triplet.edge_label)) {
         continue;
       }

--- a/src/execution/common/operators/retrieve/join.cc
+++ b/src/execution/common/operators/retrieve/join.cc
@@ -18,10 +18,10 @@
 #include "neug/common/types.h"
 #include "neug/execution/common/columns/vertex_columns.h"
 #include "neug/execution/common/context.h"
-#include "neug/utils/exception/exception.h"
 #include "neug/execution/utils/params.h"
 #include "neug/storages/graph/graph_interface.h"
 #include "neug/utils/encoder.h"
+#include "neug/utils/exception/exception.h"
 #include "neug/utils/property/types.h"
 #include "neug/utils/result.h"
 #include "parallel_hashmap/phmap.h"
@@ -646,8 +646,9 @@ neug::result<Context> Join::join(Context&& ctx, Context&& ctx2,
   } else if (params.join_type == JoinKind::kTimesJoin) {
     return default_times_join(std::move(ctx), std::move(ctx2), params);
   }
-  THROW_NOT_SUPPORTED_EXCEPTION("Unsupported join type" +
-                                std::to_string(static_cast<int>(params.join_type)));
+  THROW_NOT_SUPPORTED_EXCEPTION(
+      "Unsupported join type" +
+      std::to_string(static_cast<int>(params.join_type)));
   return ctx;
 }
 

--- a/src/execution/execute/ops/batch/batch_insert_edge.cc
+++ b/src/execution/execute/ops/batch/batch_insert_edge.cc
@@ -17,8 +17,8 @@
 #include "neug/execution/common/context.h"
 #include "neug/execution/execute/ops/batch/batch_update_utils.h"
 #include "neug/storages/graph/graph_interface.h"
-#include "neug/utils/result.h"
 #include "neug/utils/exception/exception.h"
+#include "neug/utils/result.h"
 
 #include <glog/logging.h>
 #include <string>
@@ -160,7 +160,8 @@ neug::result<OpBuildResultT> BatchInsertEdgeOprBuilder::Build(
   const auto& opr = plan.plan(op_idx).opr().load_edge();
 
   if (!opr.has_edge_type()) {
-    THROW_INTERNAL_EXCEPTION("BatchInsertEdgeOprBuilder::Build: edge type is not set");
+    THROW_INTERNAL_EXCEPTION(
+        "BatchInsertEdgeOprBuilder::Build: edge type is not set");
   }
 
   std::vector<std::pair<int32_t, std::string>> prop_mappings,

--- a/src/execution/execute/ops/batch/batch_insert_edge.cc
+++ b/src/execution/execute/ops/batch/batch_insert_edge.cc
@@ -43,7 +43,7 @@ bool resolve_vertex_label_id(const Schema& schema, const common::NameOrId& ni,
     return true;
   }
   case common::NameOrId::kName: {
-    if (!schema.contains_vertex_label(ni.name())) {
+    if (!schema.is_vertex_label_valid(ni.name())) {
       LOG(ERROR) << "Unknown vertex type: " << ni.DebugString();
       return false;
     }
@@ -67,7 +67,7 @@ bool resolve_edge_triplet(const Schema& schema,
     break;
   case common::NameOrId::kName: {
     const auto& name = edge_type.type_name().name();
-    if (!schema.contains_edge_label(name)) {
+    if (!schema.is_edge_label_valid(name)) {
       LOG(ERROR) << "Unknown edge type: "
                  << edge_type.type_name().DebugString();
       return false;

--- a/src/execution/execute/ops/batch/batch_insert_vertex.cc
+++ b/src/execution/execute/ops/batch/batch_insert_vertex.cc
@@ -17,8 +17,8 @@
 #include "neug/execution/common/context.h"
 #include "neug/execution/execute/ops/batch/batch_update_utils.h"
 #include "neug/storages/graph/graph_interface.h"
-#include "neug/utils/result.h"
 #include "neug/utils/exception/exception.h"
+#include "neug/utils/result.h"
 
 #include <glog/logging.h>
 #include <string>
@@ -73,8 +73,9 @@ neug::result<Context> BatchInsertVertexOpr::Eval(
     break;
   }
   default:
-    THROW_INVALID_ARGUMENT_EXCEPTION("BatchInsertVertexOpr: invalid vertex_type: " +
-                                     vertex_type_.DebugString());
+    THROW_INVALID_ARGUMENT_EXCEPTION(
+        "BatchInsertVertexOpr: invalid vertex_type: " +
+        vertex_type_.DebugString());
   }
   auto suppliers = create_record_batch_supplier(ctx, prop_mappings_);
   for (auto supplier : suppliers) {

--- a/src/execution/execute/ops/batch/batch_insert_vertex.cc
+++ b/src/execution/execute/ops/batch/batch_insert_vertex.cc
@@ -64,7 +64,7 @@ neug::result<Context> BatchInsertVertexOpr::Eval(
     break;
   case common::NameOrId::kName: {
     const auto& name = vertex_type_.name();
-    if (!graph.schema().contains_vertex_label(name)) {
+    if (!graph.schema().is_vertex_label_valid(name)) {
       LOG(ERROR) << "Unknown vertex type: " << vertex_type_.DebugString();
       RETURN_STATUS_ERROR(StatusCode::ERR_INVALID_ARGUMENT,
                           "Unknown vertex type: " + name);

--- a/src/execution/execute/ops/batch/batch_update_utils.cc
+++ b/src/execution/execute/ops/batch/batch_update_utils.cc
@@ -24,12 +24,12 @@
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 
-#include "neug/utils/exception/exception.h"
 #include <stddef.h>
 #include <cstdint>
 #include <ostream>
 #include <stdexcept>
 #include <tuple>
+#include "neug/utils/exception/exception.h"
 
 #include "neug/execution/common/columns/arrow_context_column.h"
 #include "neug/execution/common/columns/i_context_column.h"
@@ -614,7 +614,8 @@ void parse_property_mappings(
       auto prop_name = mapping.property().key().name();
       if (mapping.data().operators_size() != 1 ||
           !mapping.data().operators(0).has_var()) {
-        THROW_INVALID_ARGUMENT_EXCEPTION("Invalid property mapping: " + prop_name);
+        THROW_INVALID_ARGUMENT_EXCEPTION("Invalid property mapping: " +
+                                         prop_name);
       }
       auto tag_id = mapping.data().operators(0).var().tag().id();
       prop_mappings.emplace_back(tag_id, prop_name);

--- a/src/execution/execute/ops/insert/create_vertex.cc
+++ b/src/execution/execute/ops/insert/create_vertex.cc
@@ -99,10 +99,12 @@ neug::result<OpBuildResultT> CreateVertexOprBuilder::Build(
     std::vector<std::pair<std::string, std::unique_ptr<ExprBase>>> props;
     for (const auto& prop : entry.property_mappings()) {
       if (!prop.has_property()) {
-        THROW_INTERNAL_EXCEPTION("PropertyMapping has no property: " + prop.DebugString());
+        THROW_INTERNAL_EXCEPTION("PropertyMapping has no property: " +
+                                 prop.DebugString());
       }
       if (!prop.has_data()) {
-        THROW_INTERNAL_EXCEPTION("PropertyMapping has no data: " + prop.DebugString());
+        THROW_INTERNAL_EXCEPTION("PropertyMapping has no data: " +
+                                 prop.DebugString());
       }
       auto expr = parse_expression(prop.data(), ctx_meta, VarType::kRecord);
       props.emplace_back(prop.property().key().name(), std::move(expr));

--- a/src/execution/execute/ops/retrieve/group_by.cc
+++ b/src/execution/execute/ops/retrieve/group_by.cc
@@ -18,9 +18,9 @@
 #include "neug/execution/common/context.h"
 #include "neug/execution/common/operators/retrieve/group_by.h"
 #include "neug/execution/common/operators/retrieve/project.h"
-#include "neug/utils/exception/exception.h"
 #include "neug/execution/execute/ops/retrieve/group_by_utils.h"
 #include "neug/storages/graph/graph_interface.h"
+#include "neug/utils/exception/exception.h"
 #include "neug/utils/property/types.h"
 
 namespace neug {

--- a/src/execution/execute/ops/retrieve/group_by_utils.cc
+++ b/src/execution/execute/ops/retrieve/group_by_utils.cc
@@ -597,7 +597,8 @@ std::unique_ptr<ReducerBase> create_typed_reducer(EXPR&& expr, AggrKind kind) {
     if constexpr (std::is_arithmetic<typename EXPR::V>::value) {
       return std::make_unique<SumReducer<EXPR, IS_OPTIONAL>>(std::move(expr));
     } else {
-      THROW_NOT_SUPPORTED_EXCEPTION("unsupport" + std::to_string(static_cast<int>(kind)));
+      THROW_NOT_SUPPORTED_EXCEPTION("unsupport" +
+                                    std::to_string(static_cast<int>(kind)));
       return nullptr;
     }
   }
@@ -641,12 +642,14 @@ std::unique_ptr<ReducerBase> create_typed_reducer(EXPR&& expr, AggrKind kind) {
     if constexpr (std::is_arithmetic<typename EXPR::V>::value) {
       return std::make_unique<AvgReducer<EXPR, IS_OPTIONAL>>(std::move(expr));
     } else {
-      THROW_NOT_SUPPORTED_EXCEPTION("unsupport" + std::to_string(static_cast<int>(kind)));
+      THROW_NOT_SUPPORTED_EXCEPTION("unsupport" +
+                                    std::to_string(static_cast<int>(kind)));
       return nullptr;
     }
   }
   default:
-    THROW_NOT_SUPPORTED_EXCEPTION("unsupport" + std::to_string(static_cast<int>(kind)));
+    THROW_NOT_SUPPORTED_EXCEPTION("unsupport" +
+                                  std::to_string(static_cast<int>(kind)));
     return nullptr;
   }
 }
@@ -679,11 +682,10 @@ static std::unique_ptr<ReducerBase> create_general_reducer(
           std::move(var_wrap), var->elem_type());
     }
   } else {
-    THROW_NOT_SUPPORTED_EXCEPTION("not support var reduce " +
-                                  std::to_string(static_cast<int>(kind)) +
-                                  var->elem_type().ToString() + " " +
-                                  std::to_string(var->is_optional()) + " " +
-                                  var->column_info());
+    THROW_NOT_SUPPORTED_EXCEPTION(
+        "not support var reduce " + std::to_string(static_cast<int>(kind)) +
+        var->elem_type().ToString() + " " + std::to_string(var->is_optional()) +
+        " " + var->column_info());
   }
   return nullptr;  // This line is unreachable but avoids compiler warning.
 }

--- a/src/execution/execute/ops/retrieve/order_by_utils.cc
+++ b/src/execution/execute/ops/retrieve/order_by_utils.cc
@@ -30,7 +30,7 @@ bool vertex_property_topN_impl(bool asc, size_t limit,
       property_columns;
   label_t label_num = graph.schema().vertex_label_frontier();
   for (label_t i = 0; i < label_num; ++i) {
-    if (!graph.schema().vertex_label_valid(i)) {
+    if (!graph.schema().is_vertex_label_valid(i)) {
       continue;
     }
     property_columns.emplace_back(

--- a/src/execution/expression/accessors/edge_accessor.cc
+++ b/src/execution/expression/accessors/edge_accessor.cc
@@ -27,16 +27,16 @@ class BindedEdgePropertyAccessor : public EdgeExprBase {
     label_t edge_label_num = graph.schema().edge_label_frontier();
     label_t vertex_label_num = graph.schema().vertex_label_frontier();
     for (label_t src_label = 0; src_label < vertex_label_num; ++src_label) {
-      if (!graph.schema().vertex_label_valid(src_label)) {
+      if (!graph.schema().is_vertex_label_valid(src_label)) {
         continue;
       }
       for (label_t dst_label = 0; dst_label < vertex_label_num; ++dst_label) {
-        if (!graph.schema().vertex_label_valid(dst_label)) {
+        if (!graph.schema().is_vertex_label_valid(dst_label)) {
           continue;
         }
         for (label_t edge_label = 0; edge_label < edge_label_num;
              ++edge_label) {
-          if (!graph.schema().exist(src_label, dst_label, edge_label)) {
+          if (!graph.schema().is_edge_triplet_valid(src_label, dst_label, edge_label)) {
             continue;
           }
           const std::vector<std::string>& names =

--- a/src/execution/expression/accessors/edge_accessor.cc
+++ b/src/execution/expression/accessors/edge_accessor.cc
@@ -36,7 +36,8 @@ class BindedEdgePropertyAccessor : public EdgeExprBase {
         }
         for (label_t edge_label = 0; edge_label < edge_label_num;
              ++edge_label) {
-          if (!graph.schema().is_edge_triplet_valid(src_label, dst_label, edge_label)) {
+          if (!graph.schema().is_edge_triplet_valid(src_label, dst_label,
+                                                    edge_label)) {
             continue;
           }
           const std::vector<std::string>& names =
@@ -147,8 +148,9 @@ std::unique_ptr<BindedExprBase> EdgeAccessor::bind(
     return std::make_unique<BindedEdgeIdentityAccessor>();
   }
   default:
-    THROW_NOT_SUPPORTED_EXCEPTION("Unknown GraphAccessorType: " +
-                                  std::to_string(static_cast<int>(access_type_)));
+    THROW_NOT_SUPPORTED_EXCEPTION(
+        "Unknown GraphAccessorType: " +
+        std::to_string(static_cast<int>(access_type_)));
     break;
   }
   return nullptr;

--- a/src/execution/expression/accessors/record_accessor.cc
+++ b/src/execution/expression/accessors/record_accessor.cc
@@ -14,8 +14,8 @@
  */
 
 #include "neug/execution/expression/accessors/record_accessor.h"
-#include "neug/utils/exception/exception.h"
 #include "neug/execution/common/columns/i_context_column.h"
+#include "neug/utils/exception/exception.h"
 
 namespace neug {
 namespace execution {
@@ -140,8 +140,9 @@ std::unique_ptr<BindedExprBase> RecordVertexAccessor::bind(
   case GraphAccessType::kGid:
     return std::make_unique<BindedRecordVertexGIdExpr>(tag_);
   default:
-    THROW_NOT_SUPPORTED_EXCEPTION("Unknown RecordVertexAccessor GraphAccessType: " +
-                                  std::to_string(static_cast<int>(access_type_)));
+    THROW_NOT_SUPPORTED_EXCEPTION(
+        "Unknown RecordVertexAccessor GraphAccessType: " +
+        std::to_string(static_cast<int>(access_type_)));
     break;
   }
   return nullptr;
@@ -166,7 +167,8 @@ class BindedEdgeRecordPropertyExpr : public RecordExprBase {
         }
         for (label_t edge_label = 0; edge_label < edge_label_num;
              ++edge_label) {
-          if (!graph.schema().is_edge_triplet_valid(src_label, dst_label, edge_label)) {
+          if (!graph.schema().is_edge_triplet_valid(src_label, dst_label,
+                                                    edge_label)) {
             continue;
           }
           const std::vector<std::string>& names =
@@ -263,8 +265,9 @@ std::unique_ptr<BindedExprBase> RecordEdgeAccessor::bind(
   case GraphAccessType::kGid:
     return std::make_unique<BindedEdgeRecordGIdExpr>(tag_);
   default:
-    THROW_NOT_SUPPORTED_EXCEPTION("Unknown RecordEdgeAccessor GraphAccessType: " +
-                                  std::to_string(static_cast<int>(access_type_)));
+    THROW_NOT_SUPPORTED_EXCEPTION(
+        "Unknown RecordEdgeAccessor GraphAccessType: " +
+        std::to_string(static_cast<int>(access_type_)));
     break;
   }
   return nullptr;
@@ -315,7 +318,8 @@ std::unique_ptr<BindedExprBase> RecordPathAccessor::bind(
   } else if (property_ == "cost") {
     return std::make_unique<BindedPathWeightExpr>(tag_);
   }
-  THROW_NOT_SUPPORTED_EXCEPTION("Unknown RecordPathAccessor property: " + property_);
+  THROW_NOT_SUPPORTED_EXCEPTION("Unknown RecordPathAccessor property: " +
+                                property_);
   return nullptr;
 }
 

--- a/src/execution/expression/accessors/record_accessor.cc
+++ b/src/execution/expression/accessors/record_accessor.cc
@@ -52,7 +52,7 @@ class BindedRecordVertexPropertyExpr : public RecordExprBase {
     property_columns_.reserve(storage.schema().vertex_label_frontier());
     for (label_t label = 0; label < storage.schema().vertex_label_frontier();
          ++label) {
-      if (!storage.schema().vertex_label_valid(label)) {
+      if (!storage.schema().is_vertex_label_valid(label)) {
         continue;
       }
       property_columns_.emplace_back(
@@ -157,16 +157,16 @@ class BindedEdgeRecordPropertyExpr : public RecordExprBase {
     label_t edge_label_num = graph.schema().edge_label_frontier();
     label_t vertex_label_num = graph.schema().vertex_label_frontier();
     for (label_t src_label = 0; src_label < vertex_label_num; ++src_label) {
-      if (!graph.schema().vertex_label_valid(src_label)) {
+      if (!graph.schema().is_vertex_label_valid(src_label)) {
         continue;
       }
       for (label_t dst_label = 0; dst_label < vertex_label_num; ++dst_label) {
-        if (!graph.schema().vertex_label_valid(dst_label)) {
+        if (!graph.schema().is_vertex_label_valid(dst_label)) {
           continue;
         }
         for (label_t edge_label = 0; edge_label < edge_label_num;
              ++edge_label) {
-          if (!graph.schema().exist(src_label, dst_label, edge_label)) {
+          if (!graph.schema().is_edge_triplet_valid(src_label, dst_label, edge_label)) {
             continue;
           }
           const std::vector<std::string>& names =

--- a/src/execution/expression/accessors/vertex_accessor.cc
+++ b/src/execution/expression/accessors/vertex_accessor.cc
@@ -117,8 +117,9 @@ std::unique_ptr<BindedExprBase> VertexAccessor::bind(
     return std::make_unique<BindedVertexIdentityAccessor>();
   }
   default:
-    THROW_NOT_SUPPORTED_EXCEPTION("Unknown GraphAccessType: " +
-                                  std::to_string(static_cast<int>(access_type_)));
+    THROW_NOT_SUPPORTED_EXCEPTION(
+        "Unknown GraphAccessType: " +
+        std::to_string(static_cast<int>(access_type_)));
     break;
   }
   return nullptr;

--- a/src/execution/expression/accessors/vertex_accessor.cc
+++ b/src/execution/expression/accessors/vertex_accessor.cc
@@ -27,7 +27,7 @@ class BindedVertexPropertyAccessor : public VertexExprBase {
       : type_(type) {
     int32_t label_num = graph.schema().vertex_label_frontier();
     for (label_t label = 0; label < label_num; ++label) {
-      if (!graph.schema().vertex_label_valid(label)) {
+      if (!graph.schema().is_vertex_label_valid(label)) {
         continue;
       }
       property_columns_.emplace_back(

--- a/src/execution/expression/expr.cc
+++ b/src/execution/expression/expr.cc
@@ -18,7 +18,6 @@
 
 #include "neug/compiler/function/neug_scalar_function.h"
 #include "neug/compiler/function/scalar_function.h"
-#include "neug/utils/exception/exception.h"
 #include "neug/compiler/main/metadata_registry.h"
 #include "neug/execution/expression/accessors/const_accessor.h"
 #include "neug/execution/expression/exprs/arith_expr.h"
@@ -29,6 +28,7 @@
 #include "neug/execution/expression/exprs/struct_expr.h"
 #include "neug/execution/expression/exprs/udfs.h"
 #include "neug/execution/expression/exprs/variable.h"
+#include "neug/utils/exception/exception.h"
 
 #include "neug/generated/proto/plan/expr.pb.h"
 
@@ -204,7 +204,8 @@ static std::unique_ptr<ExprBase> build_expr(
       int tag = opr.path_func().has_tag() ? opr.path_func().tag().id() : -1;
       if (opr.node_type().data_type().item_case() !=
           ::common::DataType::kArray) {
-        THROW_INVALID_ARGUMENT_EXCEPTION("path function node_type is not array type");
+        THROW_INVALID_ARGUMENT_EXCEPTION(
+            "path function node_type is not array type");
         return nullptr;
       }
       auto type = parse_from_data_type(
@@ -216,7 +217,8 @@ static std::unique_ptr<ExprBase> build_expr(
                  ::common::PathFunction_FuncOpt::PathFunction_FuncOpt_EDGE) {
         return std::make_unique<PathPropsExpr>(tag, name, type, false);
       } else {
-        THROW_NOT_SUPPORTED_EXCEPTION("unsupport path function opt" + opr.DebugString());
+        THROW_NOT_SUPPORTED_EXCEPTION("unsupport path function opt" +
+                                      opr.DebugString());
       }
 
       break;

--- a/src/execution/expression/exprs/extract_expr.cc
+++ b/src/execution/expression/exprs/extract_expr.cc
@@ -15,8 +15,8 @@
 
 #include "neug/execution/expression/exprs/extract_expr.h"
 
-#include "neug/utils/exception/exception.h"
 #include "neug/generated/proto/plan/expr.pb.h"
+#include "neug/utils/exception/exception.h"
 
 namespace neug {
 namespace execution {
@@ -95,8 +95,8 @@ class BindedExtractExpr : public VertexExprBase,
         return Value(DataType::INT64);
       }
     } else {
-      THROW_NOT_SUPPORTED_EXCEPTION("not support: " +
-                                    std::to_string(static_cast<int>(val.type().id())));
+      THROW_NOT_SUPPORTED_EXCEPTION(
+          "not support: " + std::to_string(static_cast<int>(val.type().id())));
       return Value(DataType::INT64);
     }
   }

--- a/src/execution/expression/exprs/logical_expr.cc
+++ b/src/execution/expression/exprs/logical_expr.cc
@@ -114,9 +114,8 @@ class BindedBinaryLogicalExpr : public VertexExprBase,
       return Value::BOOLEAN(std::regex_match(lhs_str, std::regex(rhs_str)));
     }
     default:
-      THROW_NOT_SUPPORTED_EXCEPTION(
-          "Unsupported binary logical operation: " +
-          std::to_string(static_cast<int>(logical_)));
+      THROW_NOT_SUPPORTED_EXCEPTION("Unsupported binary logical operation: " +
+                                    std::to_string(static_cast<int>(logical_)));
       return Value(type_);
     }
   }

--- a/src/execution/expression/exprs/variable.cc
+++ b/src/execution/expression/exprs/variable.cc
@@ -318,7 +318,8 @@ std::unique_ptr<ExprBase> parse_variable(const common::Variable& var,
                                          const ContextMeta& ctx_meta,
                                          VarType var_type) {
   if (!var.has_node_type()) {
-    THROW_INTERNAL_EXCEPTION("variable missing node_type: " + var.DebugString());
+    THROW_INTERNAL_EXCEPTION("variable missing node_type: " +
+                             var.DebugString());
   }
   DataType type = parse_from_ir_data_type(var.node_type());
   int tag = var.has_tag() ? var.tag().id() : -1;

--- a/src/execution/utils/pb_parse_utils.cc
+++ b/src/execution/utils/pb_parse_utils.cc
@@ -61,7 +61,8 @@ Direction parse_direction(const physical::EdgeExpand_Direction& dir) {
   } else if (dir == physical::EdgeExpand_Direction_BOTH) {
     return Direction::kBoth;
   }
-  THROW_NOT_SUPPORTED_EXCEPTION("not support..." + std::to_string(static_cast<int>(dir)));
+  THROW_NOT_SUPPORTED_EXCEPTION("not support..." +
+                                std::to_string(static_cast<int>(dir)));
   return Direction::kOut;
 }
 
@@ -163,7 +164,8 @@ AggrKind parse_aggregate(physical::GroupBy_AggFunc::Aggregate v) {
   } else if (v == physical::GroupBy_AggFunc::AVG) {
     return AggrKind::kAvg;
   } else {
-    THROW_NOT_SUPPORTED_EXCEPTION("unsupport" + std::to_string(static_cast<int>(v)));
+    THROW_NOT_SUPPORTED_EXCEPTION("unsupport" +
+                                  std::to_string(static_cast<int>(v)));
     return AggrKind::kSum;
   }
 }

--- a/src/storages/graph/property_graph.cc
+++ b/src/storages/graph/property_graph.cc
@@ -57,7 +57,7 @@ void PropertyGraph::Clear() {
 }
 
 Status PropertyGraph::EnsureCapacity(label_t v_label, size_t capacity) {
-  if (schema_.vertex_label_valid(v_label)) {
+  if (schema_.is_vertex_label_valid(v_label)) {
     auto old_cap = vertex_tables_[v_label].Capacity();
     if (capacity <= old_cap) {
       return neug::Status::OK();
@@ -65,7 +65,7 @@ Status PropertyGraph::EnsureCapacity(label_t v_label, size_t capacity) {
     auto v_new_cap = vertex_tables_[v_label].EnsureCapacity(capacity);
     for (label_t dst_label = 0; dst_label < vertex_label_total_count_;
          ++dst_label) {
-      if (!schema_.vertex_label_valid(dst_label)) {
+      if (!schema_.is_vertex_label_valid(dst_label)) {
         continue;
       }
       for (label_t e_label = 0; e_label < edge_label_total_count_; ++e_label) {
@@ -92,7 +92,7 @@ Status PropertyGraph::EnsureCapacity(label_t v_label, size_t capacity) {
 
 Status PropertyGraph::EnsureCapacity(label_t src_label, label_t dst_label,
                                      label_t edge_label, size_t capacity) {
-  if (!schema_.exist(src_label, dst_label, edge_label)) {
+  if (!schema_.is_edge_triplet_valid(src_label, dst_label, edge_label)) {
     return Status(StatusCode::ERR_INVALID_ARGUMENT,
                   "Edge label does not exist for the given source and "
                   "destination vertex labels.");
@@ -114,7 +114,7 @@ Status PropertyGraph::EnsureCapacity(label_t src_label, label_t dst_label,
 Status PropertyGraph::EnsureCapacity(label_t src_label, label_t dst_label,
                                      label_t edge_label, size_t src_v_cap,
                                      size_t dst_v_cap, size_t capacity) {
-  if (!schema_.exist(src_label, dst_label, edge_label)) {
+  if (!schema_.is_edge_triplet_valid(src_label, dst_label, edge_label)) {
     return Status(StatusCode::ERR_INVALID_ARGUMENT,
                   "Edge label does not exist for the given source and "
                   "destination vertex labels.");
@@ -151,7 +151,7 @@ Status PropertyGraph::BatchAddEdges(
 }
 
 Status PropertyGraph::CreateVertexType(const CreateVertexTypeParam& config) {
-  if (schema_.contains_vertex_label(config.GetVertexLabel())) {
+  if (schema_.is_vertex_label_valid(config.GetVertexLabel())) {
     return Status(StatusCode::ERR_SCHEMA_MISMATCH,
                   "Vertex label already exists.");
   }
@@ -257,21 +257,21 @@ Status PropertyGraph::CreateEdgeType(const CreateEdgeTypeParam& config) {
   LOG(INFO) << "CreateEdgeType: src_vertex_type: " << src_vertex_type
             << ", dst_vertex_type: " << dst_vertex_type
             << ", edge_type_name: " << edge_type_name;
-  if (!schema_.contains_vertex_label(src_vertex_type)) {
+  if (!schema_.is_vertex_label_valid(src_vertex_type)) {
     LOG(ERROR) << "Source_vertex [" << src_vertex_type
                << "] does not exist in the graph.";
     return Status(
         StatusCode::ERR_INVALID_ARGUMENT,
         "Source_vertex [" + src_vertex_type + "] does not exist in the graph.");
   }
-  if (!schema_.contains_vertex_label(dst_vertex_type)) {
+  if (!schema_.is_vertex_label_valid(dst_vertex_type)) {
     LOG(ERROR) << "Destination_vertex [" << dst_vertex_type
                << "] does not exist in the graph.";
     return Status(StatusCode::ERR_INVALID_ARGUMENT,
                   "Destination_vertex [" + dst_vertex_type +
                       "] does not exist in the graph.");
   }
-  if (schema_.has_edge_label(src_vertex_type, dst_vertex_type,
+  if (schema_.has_edge_triplet(src_vertex_type, dst_vertex_type,
                              edge_type_name)) {
     LOG(ERROR) << "Edge [" << edge_type_name << "] from [" << src_vertex_type
                << "] to [" << dst_vertex_type << "] already exists";
@@ -587,21 +587,21 @@ Status PropertyGraph::DeleteVertexType(label_t v_label_id) {
   vertex_tables_[v_label_id].Drop();
 
   for (label_t i = 0; i < vertex_label_total_count_; i++) {
-    if (!schema_.vertex_label_valid(i)) {
+    if (!schema_.is_vertex_label_valid(i)) {
       continue;
     }
     for (label_t j = 0; j < edge_label_total_count_; j++) {
-      if (!schema_.edge_label_valid(j)) {
+      if (!schema_.is_edge_label_valid(j)) {
         continue;
       }
-      if (schema_.exist(v_label_id, i, j)) {
+      if (schema_.is_edge_triplet_valid(v_label_id, i, j)) {
         schema_.DeleteEdgeLabel(v_label_id, i, j);
         size_t index = schema_.generate_edge_label(v_label_id, i, j);
         if (edge_tables_.count(index) > 0) {
           edge_tables_.erase(index);
         }
       }
-      if (schema_.exist(i, v_label_id, j)) {
+      if (schema_.is_edge_triplet_valid(i, v_label_id, j)) {
         schema_.DeleteEdgeLabel(i, v_label_id, j);
         size_t index = schema_.generate_edge_label(i, v_label_id, j);
         if (edge_tables_.count(index) > 0) {
@@ -640,15 +640,15 @@ Status PropertyGraph::BatchDeleteVertices(label_t v_label_id,
   std::set<vid_t> vids_set(vids.begin(), vids.end());
 
   for (label_t i = 0; i < vertex_label_total_count_; i++) {
-    if (!schema_.vertex_label_valid(i)) {
+    if (!schema_.is_vertex_label_valid(i)) {
       continue;
     }
     for (label_t j = 0; j < edge_label_total_count_; j++) {
-      if (schema_.has_edge_label(i, v_label_id, j)) {
+      if (schema_.has_edge_triplet(i, v_label_id, j)) {
         size_t index = schema_.generate_edge_label(i, v_label_id, j);
         edge_tables_.at(index).BatchDeleteVertices({}, vids_set);
       }
-      if (schema_.has_edge_label(v_label_id, i, j)) {
+      if (schema_.has_edge_triplet(v_label_id, i, j)) {
         size_t index = schema_.generate_edge_label(v_label_id, i, j);
         edge_tables_.at(index).BatchDeleteVertices(vids_set, {});
       }
@@ -670,16 +670,16 @@ Status PropertyGraph::DeleteVertex(label_t label, const Property& oid,
 
 Status PropertyGraph::DeleteVertex(label_t label, vid_t lid, timestamp_t ts) {
   for (label_t i = 0; i < vertex_label_total_count_; i++) {
-    if (!schema_.vertex_label_valid(i)) {
+    if (!schema_.is_vertex_label_valid(i)) {
       continue;
     }
     for (label_t j = 0; j < edge_label_total_count_; j++) {
-      if (schema_.has_edge_label(i, label, j)) {
+      if (schema_.has_edge_triplet(i, label, j)) {
         size_t index = schema_.generate_edge_label(i, label, j);
         assert(edge_tables_.count(index) > 0);
         edge_tables_.at(index).DeleteVertex(true, lid, ts);
       }
-      if (schema_.has_edge_label(label, i, j)) {
+      if (schema_.has_edge_triplet(label, i, j)) {
         size_t index = schema_.generate_edge_label(label, i, j);
         assert(edge_tables_.count(index) > 0);
         edge_tables_.at(index).DeleteVertex(false, lid, ts);
@@ -749,7 +749,7 @@ void PropertyGraph::Open(const std::string& work_dir,
   vertex_label_total_count_ = schema_.vertex_label_frontier();
   edge_label_total_count_ = schema_.edge_label_frontier();
   for (size_t i = 0; i < vertex_label_total_count_; i++) {
-    if (!schema_.vertex_label_valid(i)) {
+    if (!schema_.is_vertex_label_valid(i)) {
       THROW_INTERNAL_EXCEPTION("Invalid vertex label id: " + std::to_string(i));
     }
     vertex_tables_.emplace_back(schema_.get_vertex_schema(i));
@@ -765,7 +765,7 @@ void PropertyGraph::Open(const std::string& work_dir,
 
   std::vector<size_t> vertex_capacities(vertex_label_total_count_, 0);
   for (size_t i = 0; i < vertex_label_total_count_; ++i) {
-    if (!schema_.vertex_label_valid(i)) {
+    if (!schema_.is_vertex_label_valid(i)) {
       continue;
     }
     std::string v_label_name = schema_.get_vertex_label_name(i);
@@ -783,26 +783,26 @@ void PropertyGraph::Open(const std::string& work_dir,
 
   for (size_t src_label_i = 0; src_label_i != vertex_label_total_count_;
        ++src_label_i) {
-    if (!schema_.vertex_label_valid(src_label_i)) {
+    if (!schema_.is_vertex_label_valid(src_label_i)) {
       continue;
     }
     std::string src_label =
         schema_.get_vertex_label_name(static_cast<label_t>(src_label_i));
     for (size_t dst_label_i = 0; dst_label_i != vertex_label_total_count_;
          ++dst_label_i) {
-      if (!schema_.vertex_label_valid(dst_label_i)) {
+      if (!schema_.is_vertex_label_valid(dst_label_i)) {
         continue;
       }
       std::string dst_label =
           schema_.get_vertex_label_name(static_cast<label_t>(dst_label_i));
       for (size_t e_label_i = 0; e_label_i != edge_label_total_count_;
            ++e_label_i) {
-        if (!schema_.edge_label_valid(e_label_i)) {
+        if (!schema_.is_edge_label_valid(e_label_i)) {
           continue;
         }
         std::string edge_label =
             schema_.get_edge_label_name(static_cast<label_t>(e_label_i));
-        if (!schema_.exist(src_label, dst_label, edge_label)) {
+        if (!schema_.is_edge_triplet_valid(src_label, dst_label, edge_label)) {
           continue;
         }
         size_t index =
@@ -832,7 +832,7 @@ void PropertyGraph::compact_schema() {
 
   for (size_t old_v_label = 0; old_v_label != vertex_label_total_count_;
        ++old_v_label) {
-    if (schema_.vertex_label_valid(old_v_label)) {
+    if (schema_.is_vertex_label_valid(old_v_label)) {
       auto src_name = schema_.get_vertex_label_name(old_v_label);
       size_t cur_new_label_id =
           new_schema.get_vertex_label_id_internal(src_name);
@@ -848,20 +848,20 @@ void PropertyGraph::compact_schema() {
   assert(new_vertex_tables.size() == new_schema.vertex_label_frontier());
   for (size_t old_src_label = 0; old_src_label != vertex_label_total_count_;
        ++old_src_label) {
-    if (!schema_.vertex_label_valid(old_src_label)) {
+    if (!schema_.is_vertex_label_valid(old_src_label)) {
       continue;
     }
     auto src_name = schema_.get_vertex_label_name(old_src_label);
     for (size_t old_dst_label = 0; old_dst_label != vertex_label_total_count_;
          ++old_dst_label) {
-      if (!schema_.vertex_label_valid(old_dst_label)) {
+      if (!schema_.is_vertex_label_valid(old_dst_label)) {
         continue;
       }
       auto dst_name = schema_.get_vertex_label_name(old_dst_label);
       for (size_t old_e_label = 0; old_e_label != edge_label_total_count_;
            ++old_e_label) {
-        if (!schema_.edge_label_valid(old_e_label) ||
-            !schema_.exist(old_src_label, old_dst_label, old_e_label)) {
+        if (!schema_.is_edge_label_valid(old_e_label) ||
+            !schema_.is_edge_triplet_valid(old_src_label, old_dst_label, old_e_label)) {
           continue;
         }
         auto e_name = schema_.get_edge_label_name(old_e_label);
@@ -906,20 +906,20 @@ void PropertyGraph::Compact(bool compact_csr, float reserve_ratio,
   compact_schema();
   for (size_t src_label_i = 0; src_label_i != vertex_label_total_count_;
        ++src_label_i) {
-    if (schema_.vertex_label_valid(src_label_i)) {
+    if (schema_.is_vertex_label_valid(src_label_i)) {
       vertex_tables_[src_label_i].Compact(ts);
     } else {
       continue;
     }
     for (size_t dst_label_i = 0; dst_label_i != vertex_label_total_count_;
          ++dst_label_i) {
-      if (!schema_.vertex_label_valid(dst_label_i)) {
+      if (!schema_.is_vertex_label_valid(dst_label_i)) {
         continue;
       }
       for (size_t e_label_i = 0; e_label_i != edge_label_total_count_;
            ++e_label_i) {
-        if (schema_.edge_label_valid(e_label_i) &&
-            schema_.exist(src_label_i, dst_label_i, e_label_i)) {
+        if (schema_.is_edge_label_valid(e_label_i) &&
+            schema_.is_edge_triplet_valid(src_label_i, dst_label_i, e_label_i)) {
           size_t index =
               schema_.generate_edge_label(src_label_i, dst_label_i, e_label_i);
           const auto& sort_key_for_nbr =
@@ -967,18 +967,18 @@ void PropertyGraph::Dump(bool reopen) {
 
   for (size_t src_label_i = 0; src_label_i != vertex_label_total_count_;
        ++src_label_i) {
-    if (!schema_.vertex_label_valid(src_label_i)) {
+    if (!schema_.is_vertex_label_valid(src_label_i)) {
       continue;
     }
     for (size_t dst_label_i = 0; dst_label_i != vertex_label_total_count_;
          ++dst_label_i) {
-      if (!schema_.vertex_label_valid(dst_label_i)) {
+      if (!schema_.is_vertex_label_valid(dst_label_i)) {
         continue;
       }
       for (size_t e_label_i = 0; e_label_i != edge_label_total_count_;
            ++e_label_i) {
-        if (!schema_.edge_label_valid(e_label_i) ||
-            !schema_.exist(src_label_i, dst_label_i, e_label_i)) {
+        if (!schema_.is_edge_label_valid(e_label_i) ||
+            !schema_.is_edge_triplet_valid(src_label_i, dst_label_i, e_label_i)) {
           continue;
         }
         size_t index =
@@ -1102,7 +1102,7 @@ Status PropertyGraph::UpdateVertexProperty(label_t v_label, vid_t vid,
                                            const Property& value,
                                            timestamp_t ts) {
   assert(prop_id >= 0);
-  assert(schema_.vertex_label_valid(v_label));
+  assert(schema_.is_vertex_label_valid(v_label));
   if (!vertex_tables_[v_label].UpdateProperty(vid, prop_id, value, ts)) {
     return Status(StatusCode::ERR_INVALID_ARGUMENT,
                   "Fail to update vertex property.");
@@ -1117,7 +1117,7 @@ Status PropertyGraph::UpdateEdgeProperty(label_t src_v_label, vid_t src_vid,
                                          const Property& value,
                                          timestamp_t ts) {
   assert(prop_id >= 0);
-  assert(schema_.edge_label_valid(e_label));
+  assert(schema_.is_edge_label_valid(e_label));
   size_t index = schema_.generate_edge_label(src_v_label, dst_v_label, e_label);
   if (edge_tables_.count(index) == 0) {
     LOG(ERROR) << "Edge table does not exist for edge label: " << e_label;
@@ -1164,7 +1164,7 @@ std::string PropertyGraph::get_statistics_json() const {
   }
   for (label_t edge_label = 0; edge_label < edge_label_total_count_;
        ++edge_label) {
-    if (!schema_.edge_label_valid(edge_label)) {
+    if (!schema_.is_edge_label_valid(edge_label)) {
       continue;
     }
     auto edge_label_name = schema_.get_edge_label_name(edge_label);
@@ -1178,16 +1178,16 @@ std::string PropertyGraph::get_statistics_json() const {
     rapidjson::Value vertex_type_pair_statistics(rapidjson::kArrayType);
     for (label_t src_label = 0; src_label < vertex_label_total_count_;
          ++src_label) {
-      if (!schema_.vertex_label_valid(src_label)) {
+      if (!schema_.is_vertex_label_valid(src_label)) {
         continue;
       }
       auto src_label_name = schema_.get_vertex_label_name(src_label);
       for (label_t dst_label = 0; dst_label < vertex_label_total_count_;
            ++dst_label) {
-        if (!schema_.vertex_label_valid(dst_label)) {
+        if (!schema_.is_vertex_label_valid(dst_label)) {
           continue;
         }
-        if (!schema_.exist(src_label, dst_label, edge_label)) {
+        if (!schema_.is_edge_triplet_valid(src_label, dst_label, edge_label)) {
           continue;
         }
         auto dst_label_name = schema_.get_vertex_label_name(dst_label);
@@ -1234,22 +1234,7 @@ std::string PropertyGraph::get_statistics_json() const {
 Status PropertyGraph::edge_triplet_check(const std::string& src_type_name,
                                          const std::string& dst_type_name,
                                          const std::string& edge_type_name) {
-  if (!schema_.exist(src_type_name, dst_type_name, edge_type_name)) {
-    LOG(ERROR) << "Edge [" << edge_type_name << "] from [" << src_type_name
-               << "] to [" << dst_type_name << "] does not exist";
-    return Status(StatusCode::ERR_INVALID_ARGUMENT,
-                  "Edge [" + edge_type_name + "] from [" + src_type_name +
-                      "] to [" + dst_type_name + "] does not exist");
-  }
-  return neug::Status::OK();
-}
-
-Status PropertyGraph::edge_triplet_exist(const std::string& src_type_name,
-                                         const std::string& dst_type_name,
-                                         const std::string& edge_type_name) {
-  auto ret =
-      schema_.has_edge_label(src_type_name, dst_type_name, edge_type_name);
-  if (!ret) {
+  if (!schema_.is_edge_triplet_valid(src_type_name, dst_type_name, edge_type_name)) {
     LOG(ERROR) << "Edge [" << edge_type_name << "] from [" << src_type_name
                << "] to [" << dst_type_name << "] does not exist";
     return Status(StatusCode::ERR_INVALID_ARGUMENT,
@@ -1260,7 +1245,7 @@ Status PropertyGraph::edge_triplet_exist(const std::string& src_type_name,
 }
 
 Status PropertyGraph::vertex_label_check(const std::string& vertex_type_name) {
-  if (!schema_.contains_vertex_label(vertex_type_name)) {
+  if (!schema_.is_vertex_label_valid(vertex_type_name)) {
     LOG(ERROR) << "Vertex label[" << vertex_type_name << "] does not exists.";
     return Status(StatusCode::ERR_INVALID_ARGUMENT,
                   "Vertex label[" + vertex_type_name + "] does not exists.");

--- a/src/storages/graph/property_graph.cc
+++ b/src/storages/graph/property_graph.cc
@@ -272,7 +272,7 @@ Status PropertyGraph::CreateEdgeType(const CreateEdgeTypeParam& config) {
                       "] does not exist in the graph.");
   }
   if (schema_.has_edge_triplet(src_vertex_type, dst_vertex_type,
-                             edge_type_name)) {
+                               edge_type_name)) {
     LOG(ERROR) << "Edge [" << edge_type_name << "] from [" << src_vertex_type
                << "] to [" << dst_vertex_type << "] already exists";
     return Status(StatusCode::ERR_SCHEMA_MISMATCH,
@@ -861,7 +861,8 @@ void PropertyGraph::compact_schema() {
       for (size_t old_e_label = 0; old_e_label != edge_label_total_count_;
            ++old_e_label) {
         if (!schema_.is_edge_label_valid(old_e_label) ||
-            !schema_.is_edge_triplet_valid(old_src_label, old_dst_label, old_e_label)) {
+            !schema_.is_edge_triplet_valid(old_src_label, old_dst_label,
+                                           old_e_label)) {
           continue;
         }
         auto e_name = schema_.get_edge_label_name(old_e_label);
@@ -919,7 +920,8 @@ void PropertyGraph::Compact(bool compact_csr, float reserve_ratio,
       for (size_t e_label_i = 0; e_label_i != edge_label_total_count_;
            ++e_label_i) {
         if (schema_.is_edge_label_valid(e_label_i) &&
-            schema_.is_edge_triplet_valid(src_label_i, dst_label_i, e_label_i)) {
+            schema_.is_edge_triplet_valid(src_label_i, dst_label_i,
+                                          e_label_i)) {
           size_t index =
               schema_.generate_edge_label(src_label_i, dst_label_i, e_label_i);
           const auto& sort_key_for_nbr =
@@ -978,7 +980,8 @@ void PropertyGraph::Dump(bool reopen) {
       for (size_t e_label_i = 0; e_label_i != edge_label_total_count_;
            ++e_label_i) {
         if (!schema_.is_edge_label_valid(e_label_i) ||
-            !schema_.is_edge_triplet_valid(src_label_i, dst_label_i, e_label_i)) {
+            !schema_.is_edge_triplet_valid(src_label_i, dst_label_i,
+                                           e_label_i)) {
           continue;
         }
         size_t index =
@@ -1234,7 +1237,8 @@ std::string PropertyGraph::get_statistics_json() const {
 Status PropertyGraph::edge_triplet_check(const std::string& src_type_name,
                                          const std::string& dst_type_name,
                                          const std::string& edge_type_name) {
-  if (!schema_.is_edge_triplet_valid(src_type_name, dst_type_name, edge_type_name)) {
+  if (!schema_.is_edge_triplet_valid(src_type_name, dst_type_name,
+                                     edge_type_name)) {
     LOG(ERROR) << "Edge [" << edge_type_name << "] from [" << src_type_name
                << "] to [" << dst_type_name << "] does not exist";
     return Status(StatusCode::ERR_INVALID_ARGUMENT,

--- a/src/storages/graph/schema.cc
+++ b/src/storages/graph/schema.cc
@@ -938,10 +938,10 @@ bool Schema::Equals(const Schema& other) const {
         std::string src_label_name = get_vertex_label_name(src_label);
         std::string dst_label_name = get_vertex_label_name(dst_label);
         std::string edge_label_name = get_edge_label_name(edge_label);
-        auto lhs_exists =
-            is_edge_triplet_valid(src_label_name, dst_label_name, edge_label_name);
-        auto rhs_exists =
-            other.is_edge_triplet_valid(src_label_name, dst_label_name, edge_label_name);
+        auto lhs_exists = is_edge_triplet_valid(src_label_name, dst_label_name,
+                                                edge_label_name);
+        auto rhs_exists = other.is_edge_triplet_valid(
+            src_label_name, dst_label_name, edge_label_name);
         if (lhs_exists != rhs_exists) {
           return false;
         }
@@ -1317,7 +1317,7 @@ static Status parse_edge_schema(YAML::Node node, Schema& schema) {
     }
     // check whether edge triplet exists in current schema
     if (schema.has_edge_triplet(src_label_name, dst_label_name,
-                              edge_label_name)) {
+                                edge_label_name)) {
       LOG(ERROR) << "Edge [" << edge_label_name << "] from [" << src_label_name
                  << "] to [" << dst_label_name << "] already exists";
       return Status(StatusCode::ERR_INVALID_SCHEMA,
@@ -1692,8 +1692,8 @@ bool Schema::edge_has_property(label_t src_label, label_t dst_label,
 }
 
 bool Schema::has_edge_triplet(const std::string& src_label,
-                            const std::string& dst_label,
-                            const std::string& label) const {
+                              const std::string& dst_label,
+                              const std::string& label) const {
   label_t edge_label_id;
   if (!is_vertex_label_valid(src_label) || !is_vertex_label_valid(dst_label)) {
     LOG(ERROR) << "src_label or dst_label not found:" << src_label << ", "
@@ -1709,7 +1709,7 @@ bool Schema::has_edge_triplet(const std::string& src_label,
 }
 
 bool Schema::has_edge_triplet(label_t src_label, label_t dst_label,
-                            label_t edge_label) const {
+                              label_t edge_label) const {
   uint32_t e_label_id = generate_edge_label(src_label, dst_label, edge_label);
   return e_schemas_.find(e_label_id) != e_schemas_.end();
 }

--- a/src/storages/graph/schema.cc
+++ b/src/storages/graph/schema.cc
@@ -458,21 +458,21 @@ label_t Schema::edge_label_frontier() const {
   return static_cast<label_t>(elabel_indexer_.size());
 }
 
-bool Schema::contains_vertex_label(const std::string& label) const {
+bool Schema::is_vertex_label_valid(const std::string& label) const {
   label_t ret;
   return vlabel_indexer_.get_index(label, ret) && !vlabel_tomb_.get(ret);
 }
 
-bool Schema::contains_edge_label(const std::string& label) const {
+bool Schema::is_edge_label_valid(const std::string& label) const {
   label_t ret;
   return elabel_indexer_.get_index(label, ret) && !elabel_tomb_.get(ret);
 }
 
-bool Schema::vertex_label_valid(label_t label_id) const {
+bool Schema::is_vertex_label_valid(label_t label_id) const {
   return label_id < vlabel_indexer_.size() && !vlabel_tomb_.get(label_id);
 }
 
-bool Schema::edge_label_valid(label_t label_id) const {
+bool Schema::is_edge_label_valid(label_t label_id) const {
   return label_id < elabel_indexer_.size() && !elabel_tomb_.get(label_id);
 }
 
@@ -588,23 +588,24 @@ size_t Schema::get_max_vnum(const std::string& label) const {
   return v_schemas_[index]->max_num;
 }
 
-bool Schema::exist(const std::string& src_label, const std::string& dst_label,
-                   const std::string& edge_label) const {
-  if (!contains_vertex_label(src_label) || !contains_vertex_label(dst_label) ||
-      !contains_edge_label(edge_label)) {
+bool Schema::is_edge_triplet_valid(const std::string& src_label,
+                                   const std::string& dst_label,
+                                   const std::string& edge_label) const {
+  if (!is_vertex_label_valid(src_label) || !is_vertex_label_valid(dst_label) ||
+      !is_edge_label_valid(edge_label)) {
     return false;
   }
   label_t src = get_vertex_label_id(src_label);
   label_t dst = get_vertex_label_id(dst_label);
   label_t edge = get_edge_label_id(edge_label);
-  return exist(src, dst, edge);
+  return is_edge_triplet_valid(src, dst, edge);
 }
 
-bool Schema::exist(label_t src_label, label_t dst_label,
-                   label_t edge_label) const {
-  return edge_triplet_valid(src_label, dst_label, edge_label) &&
-         e_schemas_.count(
-             generate_edge_label(src_label, dst_label, edge_label)) > 0;
+bool Schema::is_edge_triplet_valid(label_t src_label, label_t dst_label,
+                                   label_t edge_label) const {
+  uint32_t index = generate_edge_label(src_label, dst_label, edge_label);
+  return (elabel_triplet_tomb_.size() > index) &&
+         !elabel_triplet_tomb_.get(index) && e_schemas_.count(index) > 0;
 }
 
 std::vector<DataType> Schema::get_edge_properties(
@@ -775,12 +776,6 @@ std::optional<std::string> Schema::get_sort_key_for_nbr(label_t src_label,
   return e_schemas_.at(index)->sort_key_for_nbr;
 }
 
-bool Schema::edge_triplet_valid(label_t src, label_t dst, label_t edge) const {
-  uint32_t index = generate_edge_label(src, dst, edge);
-  return (elabel_triplet_tomb_.size() > index) &&
-         !elabel_triplet_tomb_.get(index);
-}
-
 const std::string& Schema::get_vertex_label_name(label_t index) const {
   std::string ret;
   if (vlabel_tomb_.get(index)) {
@@ -910,10 +905,10 @@ bool Schema::Equals(const Schema& other) const {
     return false;
   }
   for (label_t i = 0; i < vertex_label_frontier(); ++i) {
-    if (vertex_label_valid(i) ^ other.vertex_label_valid(i)) {
+    if (is_vertex_label_valid(i) ^ other.is_vertex_label_valid(i)) {
       return false;
     }
-    if (!vertex_label_valid(i)) {
+    if (!is_vertex_label_valid(i)) {
       continue;
     }
     std::string label_name = get_vertex_label_name(i);
@@ -930,12 +925,12 @@ bool Schema::Equals(const Schema& other) const {
   }
   for (label_t src_label = 0; src_label < vertex_label_frontier();
        ++src_label) {
-    if (!vertex_label_valid(src_label)) {
+    if (!is_vertex_label_valid(src_label)) {
       continue;
     }
     for (label_t dst_label = 0; dst_label < vertex_label_frontier();
          ++dst_label) {
-      if (!vertex_label_valid(dst_label)) {
+      if (!is_vertex_label_valid(dst_label)) {
         continue;
       }
       for (label_t edge_label = 0; edge_label < edge_label_frontier();
@@ -944,9 +939,9 @@ bool Schema::Equals(const Schema& other) const {
         std::string dst_label_name = get_vertex_label_name(dst_label);
         std::string edge_label_name = get_edge_label_name(edge_label);
         auto lhs_exists =
-            exist(src_label_name, dst_label_name, edge_label_name);
+            is_edge_triplet_valid(src_label_name, dst_label_name, edge_label_name);
         auto rhs_exists =
-            other.exist(src_label_name, dst_label_name, edge_label_name);
+            other.is_edge_triplet_valid(src_label_name, dst_label_name, edge_label_name);
         if (lhs_exists != rhs_exists) {
           return false;
         }
@@ -1139,7 +1134,7 @@ static Status parse_vertex_schema(YAML::Node node, Schema& schema) {
                   "vertex type_name is not set");
   }
   // Cannot add two vertex label with same name
-  if (schema.contains_vertex_label(label_name)) {
+  if (schema.is_vertex_label_valid(label_name)) {
     LOG(ERROR) << "Vertex label " << label_name << " already exists";
     return Status(StatusCode::ERR_INVALID_SCHEMA,
                   "Vertex label " + label_name + " already exists");
@@ -1321,7 +1316,7 @@ static Status parse_edge_schema(YAML::Node node, Schema& schema) {
                         edge_label_name + "] in vertex_type_pair_relations");
     }
     // check whether edge triplet exists in current schema
-    if (schema.has_edge_label(src_label_name, dst_label_name,
+    if (schema.has_edge_triplet(src_label_name, dst_label_name,
                               edge_label_name)) {
       LOG(ERROR) << "Edge [" << edge_label_name << "] from [" << src_label_name
                  << "] to [" << dst_label_name << "] already exists";
@@ -1595,7 +1590,7 @@ bool dump_edges_schema(const Schema& schema, YAML::Node& node) {
 
     for (auto src_v : v_labels) {
       for (auto dst_v : v_labels) {
-        if (schema.exist(src_v, dst_v, e_label)) {
+        if (schema.is_edge_triplet_valid(src_v, dst_v, e_label)) {
           if (!properties_set) {
             auto properties = schema.get_edge_properties(src_v, dst_v, e_label);
             auto property_names =
@@ -1658,7 +1653,7 @@ bool Schema::vertex_has_property(const std::string& label,
 
 bool Schema::vertex_has_property(label_t v_label,
                                  const std::string& prop) const {
-  assert(vertex_label_valid(v_label));
+  assert(is_vertex_label_valid(v_label));
   return v_schemas_.at(v_label)->has_property(prop);
 }
 
@@ -1696,11 +1691,11 @@ bool Schema::edge_has_property(label_t src_label, label_t dst_label,
   return e_schemas_.at(label_id)->has_property(prop);
 }
 
-bool Schema::has_edge_label(const std::string& src_label,
+bool Schema::has_edge_triplet(const std::string& src_label,
                             const std::string& dst_label,
                             const std::string& label) const {
   label_t edge_label_id;
-  if (!contains_vertex_label(src_label) || !contains_vertex_label(dst_label)) {
+  if (!is_vertex_label_valid(src_label) || !is_vertex_label_valid(dst_label)) {
     LOG(ERROR) << "src_label or dst_label not found:" << src_label << ", "
                << dst_label;
     return false;
@@ -1710,10 +1705,10 @@ bool Schema::has_edge_label(const std::string& src_label,
   if (!elabel_indexer_.get_index(label, edge_label_id)) {
     return false;
   }
-  return has_edge_label(src_label_id, dst_label_id, edge_label_id);
+  return has_edge_triplet(src_label_id, dst_label_id, edge_label_id);
 }
 
-bool Schema::has_edge_label(label_t src_label, label_t dst_label,
+bool Schema::has_edge_triplet(label_t src_label, label_t dst_label,
                             label_t edge_label) const {
   uint32_t e_label_id = generate_edge_label(src_label, dst_label, edge_label);
   return e_schemas_.find(e_label_id) != e_schemas_.end();
@@ -1773,59 +1768,60 @@ void Schema::AddVertexProperties(
                                          properties_default_values);
 }
 
-bool Schema::IsVertexLabelSoftDeleted(const std::string& label) const {
+bool Schema::is_vertex_label_soft_deleted(const std::string& label) const {
   auto v_label_id = get_vertex_label_id_internal(label);
   return vlabel_tomb_.get(v_label_id) && !v_schemas_[v_label_id]->empty();
 }
 
-bool Schema::IsVertexLabelSoftDeleted(label_t v_label) const {
+bool Schema::is_vertex_label_soft_deleted(label_t v_label) const {
   return vlabel_tomb_.get(v_label) && !v_schemas_[v_label]->empty();
 }
 
-bool Schema::IsEdgeLabelSoftDeleted(const std::string& src_label,
-                                    const std::string& dst_label,
-                                    const std::string& edge_label) const {
+bool Schema::is_edge_label_soft_deleted(const std::string& src_label,
+                                        const std::string& dst_label,
+                                        const std::string& edge_label) const {
   label_t src = get_vertex_label_id_internal(src_label);
   label_t dst = get_vertex_label_id_internal(dst_label);
   label_t edge = get_edge_label_id_internal(edge_label);
-  return IsEdgeLabelSoftDeleted(src, dst, edge);
+  return is_edge_label_soft_deleted(src, dst, edge);
 }
 
-bool Schema::IsEdgeLabelSoftDeleted(label_t src_label, label_t dst_label,
-                                    label_t edge_label) const {
-  assert(vertex_label_valid(src_label) || IsVertexLabelSoftDeleted(src_label));
-  assert(vertex_label_valid(dst_label) || IsVertexLabelSoftDeleted(dst_label));
-  assert(edge_label_valid(edge_label));
+bool Schema::is_edge_label_soft_deleted(label_t src_label, label_t dst_label,
+                                        label_t edge_label) const {
+  assert(is_vertex_label_valid(src_label) ||
+         is_vertex_label_soft_deleted(src_label));
+  assert(is_vertex_label_valid(dst_label) ||
+         is_vertex_label_soft_deleted(dst_label));
+  assert(is_edge_label_valid(edge_label));
   uint32_t index = generate_edge_label(src_label, dst_label, edge_label);
   return elabel_triplet_tomb_.get(index) && e_schemas_.count(index) > 0;
 }
 
-bool Schema::IsVertexPropertySoftDeleted(
+bool Schema::is_vertex_property_soft_deleted(
     const std::string& label, const std::string& property_name) const {
   auto v_label_id = get_vertex_label_id(label);
   assert(v_label_id < v_schemas_.size());
   return v_schemas_[v_label_id]->is_property_soft_deleted(property_name);
 }
 
-bool Schema::IsVertexPropertySoftDeleted(
+bool Schema::is_vertex_property_soft_deleted(
     label_t v_label, const std::string& property_name) const {
   assert(v_label < v_schemas_.size());
   return v_schemas_[v_label]->is_property_soft_deleted(property_name);
 }
 
-bool Schema::IsEdgePropertySoftDeleted(const std::string& src_label,
-                                       const std::string& dst_label,
-                                       const std::string& edge_label,
-                                       const std::string& property_name) const {
+bool Schema::is_edge_property_soft_deleted(
+    const std::string& src_label, const std::string& dst_label,
+    const std::string& edge_label, const std::string& property_name) const {
   label_t src = get_vertex_label_id(src_label);
   label_t dst = get_vertex_label_id(dst_label);
   label_t edge = get_edge_label_id(edge_label);
-  return IsEdgePropertySoftDeleted(src, dst, edge, property_name);
+  return is_edge_property_soft_deleted(src, dst, edge, property_name);
 }
 
-bool Schema::IsEdgePropertySoftDeleted(label_t src_label, label_t dst_label,
-                                       label_t edge_label,
-                                       const std::string& property_name) const {
+bool Schema::is_edge_property_soft_deleted(
+    label_t src_label, label_t dst_label, label_t edge_label,
+    const std::string& property_name) const {
   uint32_t index = generate_edge_label(src_label, dst_label, edge_label);
   assert(e_schemas_.count(index) > 0);
   return e_schemas_.at(index)->is_property_soft_deleted(property_name);
@@ -1881,7 +1877,7 @@ void Schema::DeleteEdgeLabel(const std::string& label, bool is_soft) {
       if (vlabel_tomb_.get(dst_v_label)) {
         continue;
       }
-      if (exist(src_v_label, dst_v_label, e_label_id)) {
+      if (is_edge_triplet_valid(src_v_label, dst_v_label, e_label_id)) {
         uint32_t index =
             generate_edge_label(src_v_label, dst_v_label, e_label_id);
         if (!is_soft) {
@@ -1991,12 +1987,12 @@ void Schema::RevertDeleteEdgeProperties(
 std::string Schema::get_edge_strategy(label_t src_label, label_t dst_label,
                                       label_t edge_label) const {
   uint32_t index = generate_edge_label(src_label, dst_label, edge_label);
-  if (!edge_triplet_valid(src_label, dst_label, edge_label)) {
+  if (!is_edge_triplet_valid(src_label, dst_label, edge_label)) {
     THROW_RUNTIME_ERROR(
         "Edge label triplet not found: " + std::to_string(src_label) + "-" +
         std::to_string(edge_label) + "->" + std::to_string(dst_label));
   }
-  assert(edge_triplet_valid(src_label, dst_label, edge_label));
+  assert(is_edge_triplet_valid(src_label, dst_label, edge_label));
   assert(e_schemas_.count(index) > 0);
   auto oe_strategy = e_schemas_.at(index)->oe_strategy;
   auto ie_strategy = e_schemas_.at(index)->ie_strategy;
@@ -2050,14 +2046,14 @@ void Schema::RevertDeleteEdgeLabel(const std::string& src_label,
 }
 
 void Schema::ensure_vertex_label_valid(label_t v_label_id) const {
-  if (!vertex_label_valid(v_label_id)) {
+  if (!is_vertex_label_valid(v_label_id)) {
     THROW_RUNTIME_ERROR("Vertex label id " + std::to_string(v_label_id) +
                         " is not valid");
   }
 }
 
 void Schema::ensure_edge_label_valid(label_t e_label_id) const {
-  if (!edge_label_valid(e_label_id)) {
+  if (!is_edge_label_valid(e_label_id)) {
     THROW_RUNTIME_ERROR("Edge label id " + std::to_string(e_label_id) +
                         " is not valid");
   }
@@ -2065,7 +2061,7 @@ void Schema::ensure_edge_label_valid(label_t e_label_id) const {
 
 void Schema::ensure_edge_triplet_valid(label_t src_label, label_t dst_label,
                                        label_t edge_label) const {
-  if (!edge_triplet_valid(src_label, dst_label, edge_label)) {
+  if (!is_edge_triplet_valid(src_label, dst_label, edge_label)) {
     THROW_RUNTIME_ERROR(
         "Edge label triplet not found: " + std::to_string(src_label) + "-" +
         std::to_string(edge_label) + "->" + std::to_string(dst_label));
@@ -2090,7 +2086,7 @@ label_t Schema::get_edge_label_id_internal(const std::string& label) const {
 
 bool Schema::vertex_has_property_internal(label_t label,
                                           const std::string& prop) const {
-  assert(vertex_label_valid(label));
+  assert(is_vertex_label_valid(label));
   return v_schemas_.at(label)->has_property_internal(prop);
 }
 
@@ -2139,7 +2135,7 @@ Schema Schema::Compact() const {
     std::tie(src_v, dst_v, e_label) = parse_edge_label(pair.first);
     if (vlabel_tomb_.get(src_v) || vlabel_tomb_.get(dst_v) ||
         elabel_tomb_.get(e_label) ||
-        !edge_triplet_valid(src_v, dst_v, e_label)) {
+        !is_edge_triplet_valid(src_v, dst_v, e_label)) {
       continue;
     }
     auto src_label_name = vlabel_indexer_.get_key(src_v);

--- a/src/storages/loader/loading_config.cc
+++ b/src/storages/loader/loading_config.cc
@@ -219,7 +219,7 @@ static Status parse_vertex_files(
                   "Vertex label name is not set");
   }
   // Check label exists in schema
-  if (!schema.contains_vertex_label(label_name)) {
+  if (!schema.is_vertex_label_valid(label_name)) {
     LOG(ERROR) << "Vertex label [" << label_name << "] does not exist in "
                << "the schema";
     return Status(StatusCode::ERR_INVALID_ARGUMENT, "Vertex label [" +
@@ -371,7 +371,7 @@ static Status parse_edge_files(
 
   {
     // check whether src_label, dst_label and edge_label exist in schema
-    if (!schema.contains_vertex_label(src_label)) {
+    if (!schema.is_vertex_label_valid(src_label)) {
       LOG(ERROR) << "Vertex label [" << src_label << "] does not exist in "
                  << "the schema";
       return Status(StatusCode::ERR_INVALID_ARGUMENT, "Vertex label [" +
@@ -379,7 +379,7 @@ static Status parse_edge_files(
                                                           "] does not exist in "
                                                           "the schema");
     }
-    if (!schema.contains_vertex_label(dst_label)) {
+    if (!schema.is_vertex_label_valid(dst_label)) {
       LOG(ERROR) << "Vertex label [" << dst_label << "] does not exist in "
                  << "the schema";
       return Status(StatusCode::ERR_INVALID_ARGUMENT, "Vertex label [" +
@@ -387,7 +387,7 @@ static Status parse_edge_files(
                                                           "] does not exist in "
                                                           "the schema");
     }
-    if (!schema.has_edge_label(src_label, dst_label, edge_label)) {
+    if (!schema.has_edge_triplet(src_label, dst_label, edge_label)) {
       LOG(ERROR) << "Edge label [" << edge_label << "] does not exist in "
                  << "the schema";
       return Status(StatusCode::ERR_INVALID_ARGUMENT, "Edge label [" +

--- a/src/transaction/undo_log.cc
+++ b/src/transaction/undo_log.cc
@@ -31,7 +31,8 @@ void InsertVertexUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
 };
 
 void InsertEdgeUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
-  assert(graph.schema().is_edge_triplet_valid(src_label, dst_label, edge_label));
+  assert(
+      graph.schema().is_edge_triplet_valid(src_label, dst_label, edge_label));
   graph.DeleteEdge(src_label, src_lid, dst_label, dst_lid, edge_label,
                    oe_offset, ie_offset, ts);
 };
@@ -42,7 +43,8 @@ void UpdateVertexPropUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
 };
 
 void UpdateEdgePropUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
-  assert(graph.schema().is_edge_triplet_valid(src_label, dst_label, edge_label));
+  assert(
+      graph.schema().is_edge_triplet_valid(src_label, dst_label, edge_label));
   graph.UpdateEdgeProperty(src_label, src_lid, dst_label, dst_lid, edge_label,
                            oe_offset, ie_offset, col_id, value, ts);
 };
@@ -61,7 +63,8 @@ void RemoveVertexUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
 };
 
 void RemoveEdgeUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
-  assert(graph.schema().is_edge_triplet_valid(src_label, dst_label, edge_label));
+  assert(
+      graph.schema().is_edge_triplet_valid(src_label, dst_label, edge_label));
   graph.get_edge_table(src_label, dst_label, edge_label)
       .RevertDeleteEdge(src_lid, dst_lid, oe_offset, ie_offset, ts);
 };
@@ -195,7 +198,7 @@ void DeleteEdgeTypeUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
                         edge_label + " since it exists.");
   }
   if (!graph.schema().is_edge_label_soft_deleted(src_label, dst_label,
-                                             edge_label)) {
+                                                 edge_label)) {
     THROW_RUNTIME_ERROR("Cannot undo DeleteEdgeType for edge label " +
                         edge_label + " since it is not soft deleted.");
   }

--- a/src/transaction/undo_log.cc
+++ b/src/transaction/undo_log.cc
@@ -26,29 +26,29 @@ void CreateEdgeTypeUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
 };
 
 void InsertVertexUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
-  assert(graph.schema().vertex_label_valid(v_label));
+  assert(graph.schema().is_vertex_label_valid(v_label));
   graph.DeleteVertex(v_label, vid, ts);
 };
 
 void InsertEdgeUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
-  assert(graph.schema().exist(src_label, dst_label, edge_label));
+  assert(graph.schema().is_edge_triplet_valid(src_label, dst_label, edge_label));
   graph.DeleteEdge(src_label, src_lid, dst_label, dst_lid, edge_label,
                    oe_offset, ie_offset, ts);
 };
 
 void UpdateVertexPropUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
-  assert(graph.schema().vertex_label_valid(v_label));
+  assert(graph.schema().is_vertex_label_valid(v_label));
   graph.UpdateVertexProperty(v_label, vid, col_id, value, ts);
 };
 
 void UpdateEdgePropUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
-  assert(graph.schema().exist(src_label, dst_label, edge_label));
+  assert(graph.schema().is_edge_triplet_valid(src_label, dst_label, edge_label));
   graph.UpdateEdgeProperty(src_label, src_lid, dst_label, dst_lid, edge_label,
                            oe_offset, ie_offset, col_id, value, ts);
 };
 
 void RemoveVertexUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
-  assert(graph.schema().vertex_label_valid(v_label));
+  assert(graph.schema().is_vertex_label_valid(v_label));
   graph.get_vertex_table(v_label).RevertDeleteVertex(lid, ts);
   for (const auto& [edge_triplet_id, edge_vec] : related_edges) {
     auto [src_label, dst_label, edge_label] =
@@ -61,13 +61,13 @@ void RemoveVertexUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
 };
 
 void RemoveEdgeUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
-  assert(graph.schema().exist(src_label, dst_label, edge_label));
+  assert(graph.schema().is_edge_triplet_valid(src_label, dst_label, edge_label));
   graph.get_edge_table(src_label, dst_label, edge_label)
       .RevertDeleteEdge(src_lid, dst_lid, oe_offset, ie_offset, ts);
 };
 
 void AddVertexPropUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
-  if (!graph.schema().vertex_label_valid(label)) {
+  if (!graph.schema().is_vertex_label_valid(label)) {
     THROW_INTERNAL_EXCEPTION("Vertex label  not found in schema: " +
                              std::to_string(label));
   }
@@ -83,7 +83,7 @@ void AddVertexPropUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
 };
 
 void AddEdgePropUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
-  if (!graph.schema().exist(src_label, dst_label, edge_label)) {
+  if (!graph.schema().is_edge_triplet_valid(src_label, dst_label, edge_label)) {
     THROW_INTERNAL_EXCEPTION(
         "Edge label not found in schema: " + std::to_string(src_label) + "->" +
         std::to_string(dst_label) + ":" + std::to_string(edge_label));
@@ -106,7 +106,7 @@ void AddEdgePropUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
 };
 
 void RenameVertexPropUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
-  if (!graph.schema().vertex_label_valid(label)) {
+  if (!graph.schema().is_vertex_label_valid(label)) {
     THROW_INTERNAL_EXCEPTION("Vertex label  not found in schema: " +
                              std::to_string(label));
   }
@@ -127,7 +127,7 @@ void RenameVertexPropUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
 };
 
 void RenameEdgePropUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
-  if (!graph.schema().exist(src_label, dst_label, edge_label)) {
+  if (!graph.schema().is_edge_triplet_valid(src_label, dst_label, edge_label)) {
     THROW_INTERNAL_EXCEPTION(
         "Edge label not found in schema: " + std::to_string(src_label) + "->" +
         std::to_string(dst_label) + ":" + std::to_string(edge_label));
@@ -154,7 +154,7 @@ void RenameEdgePropUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
 };
 
 void DeleteVertexPropUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
-  if (!graph.schema().vertex_label_valid(label)) {
+  if (!graph.schema().is_vertex_label_valid(label)) {
     THROW_INTERNAL_EXCEPTION("Vertex label  not found in schema: " +
                              std::to_string(label));
   }
@@ -163,7 +163,7 @@ void DeleteVertexPropUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
 };
 
 void DeleteEdgePropUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
-  if (!graph.schema().exist(src_label, dst_label, edge_label)) {
+  if (!graph.schema().is_edge_triplet_valid(src_label, dst_label, edge_label)) {
     THROW_INTERNAL_EXCEPTION(
         "Edge label not found in schema: " + std::to_string(src_label) + "->" +
         std::to_string(dst_label) + ":" + std::to_string(edge_label));
@@ -176,11 +176,11 @@ void DeleteEdgePropUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
 };
 
 void DeleteVertexTypeUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
-  if (graph.schema().contains_vertex_label(v_label)) {
+  if (graph.schema().is_vertex_label_valid(v_label)) {
     THROW_RUNTIME_ERROR("Cannot undo DeleteVertexType for vertex label " +
                         v_label + " since it does  exist.");
   }
-  if (!graph.schema().IsVertexLabelSoftDeleted(v_label)) {
+  if (!graph.schema().is_vertex_label_soft_deleted(v_label)) {
     THROW_RUNTIME_ERROR("Cannot undo DeleteVertexType for vertex label " +
                         v_label + " since it is not soft deleted.");
   }
@@ -190,11 +190,11 @@ void DeleteVertexTypeUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
 };
 
 void DeleteEdgeTypeUndo::Undo(PropertyGraph& graph, timestamp_t ts) const {
-  if (graph.schema().exist(src_label, dst_label, edge_label)) {
+  if (graph.schema().is_edge_triplet_valid(src_label, dst_label, edge_label)) {
     THROW_RUNTIME_ERROR("Cannot undo DeleteEdgeType for edge label " +
                         edge_label + " since it exists.");
   }
-  if (!graph.schema().IsEdgeLabelSoftDeleted(src_label, dst_label,
+  if (!graph.schema().is_edge_label_soft_deleted(src_label, dst_label,
                                              edge_label)) {
     THROW_RUNTIME_ERROR("Cannot undo DeleteEdgeType for edge label " +
                         edge_label + " since it is not soft deleted.");

--- a/src/transaction/update_transaction.cc
+++ b/src/transaction/update_transaction.cc
@@ -49,7 +49,7 @@ namespace neug {
 static Status resolveVertexLabel(const Schema& schema,
                                  const std::string& vertex_type_name,
                                  label_t& label_id) {
-  if (!schema.contains_vertex_label(vertex_type_name)) {
+  if (!schema.is_vertex_label_valid(vertex_type_name)) {
     LOG(ERROR) << "Vertex type " << vertex_type_name << " does not exist.";
     return Status(StatusCode::ERR_SCHEMA_MISMATCH,
                   "Vertex type " + vertex_type_name + " does not exist.");
@@ -64,7 +64,7 @@ static Status resolveEdgeTriplet(const Schema& schema,
                                  const std::string& edge_type,
                                  label_t& src_label_id, label_t& dst_label_id,
                                  label_t& edge_label_id) {
-  if (!schema.exist(src_type, dst_type, edge_type)) {
+  if (!schema.is_edge_triplet_valid(src_type, dst_type, edge_type)) {
     LOG(ERROR) << "Edge type " << edge_type << " does not exist between "
                << src_type << " and " << dst_type << ".";
     return Status(StatusCode::ERR_SCHEMA_MISMATCH,
@@ -129,14 +129,14 @@ fetch_edges_related_to_vertex(UpdateTransaction& txn, label_t v_label,
   auto& schema = txn.schema();
   for (auto other_label_id = 0; other_label_id < v_label_num;
        ++other_label_id) {
-    if (!schema.vertex_label_valid(other_label_id)) {
+    if (!schema.is_vertex_label_valid(other_label_id)) {
       continue;
     }
     for (auto e_label_id = 0; e_label_id < e_label_num; ++e_label_id) {
-      if (!schema.edge_label_valid(e_label_id)) {
+      if (!schema.is_edge_label_valid(e_label_id)) {
         continue;
       }
-      if (schema.exist(v_label, other_label_id, e_label_id)) {
+      if (schema.is_edge_triplet_valid(v_label, other_label_id, e_label_id)) {
         auto props =
             schema.get_edge_properties(v_label, other_label_id, e_label_id);
         auto edge_triplet_id =
@@ -151,7 +151,7 @@ fetch_edges_related_to_vertex(UpdateTransaction& txn, label_t v_label,
                                                     lid, true, ts);
       }
       if (other_label_id != v_label &&
-          schema.exist(other_label_id, v_label, e_label_id)) {
+          schema.is_edge_triplet_valid(other_label_id, v_label, e_label_id)) {
         auto props =
             schema.get_edge_properties(other_label_id, v_label, e_label_id);
         auto edge_triplet_id =
@@ -233,7 +233,7 @@ void UpdateTransaction::revert_changes() {
 Status UpdateTransaction::CreateVertexType(
     const CreateVertexTypeParam& config) {
   auto name = config.GetVertexLabel();
-  if (graph_.schema().contains_vertex_label(name)) {
+  if (graph_.schema().is_vertex_label_valid(name)) {
     LOG(ERROR) << "Vertex type " << name << " already exists.";
     return Status(StatusCode::ERR_SCHEMA_MISMATCH,
                   "Vertex type " + name + " already exists.");
@@ -259,7 +259,7 @@ Status UpdateTransaction::CreateEdgeType(const CreateEdgeTypeParam& config) {
   const auto& src_type = config.GetSrcLabel();
   const auto& dst_type = config.GetDstLabel();
   const auto& edge_type = config.GetEdgeLabel();
-  if (graph_.schema().exist(src_type, dst_type, edge_type)) {
+  if (graph_.schema().is_edge_triplet_valid(src_type, dst_type, edge_type)) {
     LOG(ERROR) << "Edge type " << edge_type << " already exists between "
                << src_type << " and " << dst_type << ".";
     return Status(StatusCode::ERR_SCHEMA_MISMATCH,
@@ -511,15 +511,17 @@ Status UpdateTransaction::DeleteVertexType(
   auto vertex_label_num = graph_.schema().vertex_label_frontier();
   auto edge_label_num = graph_.schema().edge_label_frontier();
   for (label_t dst_label = 0; dst_label < vertex_label_num; ++dst_label) {
-    if (!graph_.schema().vertex_label_valid(dst_label)) {
+    if (!graph_.schema().is_vertex_label_valid(dst_label)) {
       continue;
     }
     for (label_t edge_label = 0; edge_label < edge_label_num; ++edge_label) {
-      if (graph_.schema().exist(v_label, dst_label, edge_label)) {
+      if (graph_.schema().is_edge_triplet_valid(v_label, dst_label,
+                                                edge_label)) {
         deleted_edge_labels_.emplace(
             std::make_tuple(v_label, dst_label, edge_label));
       }
-      if (graph_.schema().exist(dst_label, v_label, edge_label)) {
+      if (graph_.schema().is_edge_triplet_valid(dst_label, v_label,
+                                                edge_label)) {
         deleted_edge_labels_.emplace(
             std::make_tuple(dst_label, v_label, edge_label));
       }
@@ -1100,7 +1102,7 @@ void UpdateTransaction::applyEdgeTypeDeletions() {
 void UpdateTransaction::applyVertexPropDeletion() {
   for (label_t v_label = 0; v_label < deleted_vertex_properties_.size();
        ++v_label) {
-    if (!graph_.schema().vertex_label_valid(v_label)) {
+    if (!graph_.schema().is_vertex_label_valid(v_label)) {
       continue;
     }
     auto v_label_name = graph_.schema().get_vertex_label_name(v_label);
@@ -1126,7 +1128,8 @@ void UpdateTransaction::applyEdgePropDeletion() {
     label_t src_label, dst_label, edge_label;
     std::tie(src_label, dst_label, edge_label) =
         graph_.schema().parse_edge_label(index);
-    if (!graph_.schema().edge_triplet_valid(src_label, dst_label, edge_label)) {
+    if (!graph_.schema().is_edge_triplet_valid(src_label, dst_label,
+                                               edge_label)) {
       continue;
     }
 

--- a/src/transaction/update_transaction.cc
+++ b/src/transaction/update_transaction.cc
@@ -495,7 +495,7 @@ Status UpdateTransaction::DeleteVertexType(
   label_t v_label;
   RETURN_IF_NOT_OK(
       resolveVertexLabel(graph_.schema(), vertex_type_name, v_label));
-  if (graph_.schema().IsVertexLabelSoftDeleted(v_label)) {
+  if (graph_.schema().is_vertex_label_soft_deleted(v_label)) {
     LOG(ERROR) << "Vertex type " << vertex_type_name
                << " is already deleted (soft delete).";
     return Status(StatusCode::ERR_SCHEMA_MISMATCH,
@@ -538,8 +538,8 @@ Status UpdateTransaction::DeleteEdgeType(const std::string& src_type,
   RETURN_IF_NOT_OK(resolveEdgeTriplet(graph_.schema(), src_type, dst_type,
                                       edge_type, src_label_id, dst_label_id,
                                       edge_label_id));
-  if (graph_.schema().IsEdgeLabelSoftDeleted(src_label_id, dst_label_id,
-                                             edge_label_id)) {
+  if (graph_.schema().is_edge_label_soft_deleted(src_label_id, dst_label_id,
+                                                 edge_label_id)) {
     LOG(ERROR) << "Edge type " << edge_type << " between " << src_type
                << " and " << dst_type << " is already deleted (soft delete).";
     return Status(StatusCode::ERR_SCHEMA_MISMATCH,

--- a/src/transaction/wal/local_wal_writer.cc
+++ b/src/transaction/wal/local_wal_writer.cc
@@ -51,10 +51,12 @@ void LocalWalWriter::open() {
     break;
   }
   if (fd_ == -1) {
-    THROW_IO_EXCEPTION("Failed to open wal file " + std::string(strerror(errno)));
+    THROW_IO_EXCEPTION("Failed to open wal file " +
+                       std::string(strerror(errno)));
   }
   if (ftruncate(fd_, TRUNC_SIZE) != 0) {
-    THROW_IO_EXCEPTION("Failed to truncate wal file " + std::string(strerror(errno)));
+    THROW_IO_EXCEPTION("Failed to truncate wal file " +
+                       std::string(strerror(errno)));
   }
   file_size_ = TRUNC_SIZE;
   file_used_ = 0;
@@ -79,7 +81,8 @@ bool LocalWalWriter::append(const char* data, size_t length) {
   if (expected_size > file_size_) {
     size_t new_file_size = (expected_size / TRUNC_SIZE + 1) * TRUNC_SIZE;
     if (ftruncate(fd_, new_file_size) != 0) {
-      THROW_IO_EXCEPTION("Failed to truncate wal file " + std::string(strerror(errno)));
+      THROW_IO_EXCEPTION("Failed to truncate wal file " +
+                         std::string(strerror(errno)));
     }
     file_size_ = new_file_size;
   }
@@ -87,22 +90,26 @@ bool LocalWalWriter::append(const char* data, size_t length) {
   file_used_ += length;
 
   if (static_cast<size_t>(write(fd_, data, length)) != length) {
-    THROW_IO_EXCEPTION("Failed to write wal file " + std::string(strerror(errno)));
+    THROW_IO_EXCEPTION("Failed to write wal file " +
+                       std::string(strerror(errno)));
   }
 
 #if 1
 #ifdef F_FULLFSYNC
   if (fcntl(fd_, F_FULLFSYNC) != 0) {
 #ifdef __APPLE__
-    THROW_IO_EXCEPTION("Failed to fcntl sync wal file " + std::string(strerror(errno)));
+    THROW_IO_EXCEPTION("Failed to fcntl sync wal file " +
+                       std::string(strerror(errno)));
 #else
-    THROW_IO_EXCEPTION("Failed to fcntl sync wal file " + std::string(strerrno(errno)));
+    THROW_IO_EXCEPTION("Failed to fcntl sync wal file " +
+                       std::string(strerrno(errno)));
 #endif
   }
 #else
   // if (fsync(fd_) != 0) {
   if (fdatasync(fd_) != 0) {
-    THROW_IO_EXCEPTION("Failed to fsync wal file " + std::string(strerror(errno)));
+    THROW_IO_EXCEPTION("Failed to fsync wal file " +
+                       std::string(strerror(errno)));
   }
 #endif
 #endif

--- a/src/utils/pb_utils.cc
+++ b/src/utils/pb_utils.cc
@@ -15,7 +15,6 @@
 
 #include "neug/utils/pb_utils.h"
 
-#include "neug/utils/exception/exception.h"
 #include <glog/logging.h>
 #include <google/protobuf/stubs/port.h>
 #include <google/protobuf/util/json_util.h>
@@ -25,6 +24,7 @@
 #include <rapidjson/rapidjson.h>
 #include <rapidjson/stringbuffer.h>
 #include <stddef.h>
+#include "neug/utils/exception/exception.h"
 
 #include <cstdint>
 #include <limits>

--- a/tests/transaction/test_insert_transaction.cc
+++ b/tests/transaction/test_insert_transaction.cc
@@ -98,7 +98,7 @@ TEST_F(InsertTransactionTest, InsertTransactionBasic) {
     auto sess = svc->AcquireSession();
     auto txn = sess->GetInsertTransaction();
     EXPECT_EQ(txn.timestamp(), 1);
-    EXPECT_TRUE(txn.schema().contains_vertex_label("person"));
+    EXPECT_TRUE(txn.schema().is_vertex_label_valid("person"));
   }
 }
 

--- a/tests/transaction/test_update_transaction.cc
+++ b/tests/transaction/test_update_transaction.cc
@@ -1238,7 +1238,7 @@ TEST_F(UpdateTransactionTest, CreteEdgeTypeAndAbort) {
     EXPECT_THROW(gi.schema().get_vertex_label_id("company"),
                  neug::exception::Exception);
     EXPECT_FALSE(
-        gi.schema().has_edge_label("person", "company", "employed_by"));
+        gi.schema().has_edge_triplet("person", "company", "employed_by"));
     EXPECT_THROW(
         gi.GetGenericOutgoingGraphView(person_label, cmp_label, employ_label),
         neug::exception::Exception);
@@ -1295,7 +1295,7 @@ TEST_F(UpdateTransactionTest, DeleteEdgeTypeAbort) {
     auto person_label = txn.schema().get_vertex_label_id("person");
     auto software_label = txn.schema().get_vertex_label_id("software");
     EXPECT_TRUE(txn.DeleteEdgeType("person", "software", "created"));
-    EXPECT_FALSE(txn.schema().edge_triplet_valid(person_label, software_label,
+    EXPECT_FALSE(txn.schema().is_edge_triplet_valid(person_label, software_label,
                                                  created_label));
     txn.Abort();
   }
@@ -1306,8 +1306,8 @@ TEST_F(UpdateTransactionTest, DeleteEdgeTypeAbort) {
     auto created_label = gi.schema().get_edge_label_id("created");
     auto person_label = gi.schema().get_vertex_label_id("person");
     auto software_label = gi.schema().get_vertex_label_id("software");
-    EXPECT_TRUE(gi.schema().exist("person", "software", "created"));
-    EXPECT_TRUE(gi.schema().edge_triplet_valid(person_label, software_label,
+    EXPECT_TRUE(gi.schema().is_edge_triplet_valid("person", "software", "created"));
+    EXPECT_TRUE(gi.schema().is_edge_triplet_valid(person_label, software_label,
                                                created_label));
   }
   db.Close();
@@ -1730,10 +1730,10 @@ TEST_F(UpdateTransactionTest, TestReplayWal) {
       }
     }
     EXPECT_TRUE(found);
-    EXPECT_FALSE(gi.schema().contains_vertex_label("software"));
-    EXPECT_TRUE(gi.schema().contains_vertex_label("company"));
-    EXPECT_FALSE(gi.schema().contains_edge_label("created"));
-    EXPECT_TRUE(gi.schema().contains_edge_label("employed_by"));
+    EXPECT_FALSE(gi.schema().is_vertex_label_valid("software"));
+    EXPECT_TRUE(gi.schema().is_vertex_label_valid("company"));
+    EXPECT_FALSE(gi.schema().is_edge_label_valid("created"));
+    EXPECT_TRUE(gi.schema().is_edge_label_valid("employed_by"));
     txn.Commit();
     db.Close();
   }

--- a/tests/transaction/test_update_transaction.cc
+++ b/tests/transaction/test_update_transaction.cc
@@ -1295,8 +1295,8 @@ TEST_F(UpdateTransactionTest, DeleteEdgeTypeAbort) {
     auto person_label = txn.schema().get_vertex_label_id("person");
     auto software_label = txn.schema().get_vertex_label_id("software");
     EXPECT_TRUE(txn.DeleteEdgeType("person", "software", "created"));
-    EXPECT_FALSE(txn.schema().is_edge_triplet_valid(person_label, software_label,
-                                                 created_label));
+    EXPECT_FALSE(txn.schema().is_edge_triplet_valid(
+        person_label, software_label, created_label));
     txn.Abort();
   }
   {
@@ -1306,9 +1306,10 @@ TEST_F(UpdateTransactionTest, DeleteEdgeTypeAbort) {
     auto created_label = gi.schema().get_edge_label_id("created");
     auto person_label = gi.schema().get_vertex_label_id("person");
     auto software_label = gi.schema().get_vertex_label_id("software");
-    EXPECT_TRUE(gi.schema().is_edge_triplet_valid("person", "software", "created"));
+    EXPECT_TRUE(
+        gi.schema().is_edge_triplet_valid("person", "software", "created"));
     EXPECT_TRUE(gi.schema().is_edge_triplet_valid(person_label, software_label,
-                                               created_label));
+                                                  created_label));
   }
   db.Close();
 }

--- a/tests/unittest/logical_delete_test.cc
+++ b/tests/unittest/logical_delete_test.cc
@@ -205,7 +205,8 @@ TEST_F(PropertyGraphLogicalDeleteTest, DeleteEdgeTypePhysical_RemovesEdgeType) {
   ASSERT_TRUE(status.ok());
 
   // Verify edge type is removed
-  EXPECT_FALSE(graph_.schema().has_edge_triplet("Person", "Company", "WorksAt"));
+  EXPECT_FALSE(
+      graph_.schema().has_edge_triplet("Person", "Company", "WorksAt"));
 }
 
 // Test DeleteVertexProperties

--- a/tests/unittest/logical_delete_test.cc
+++ b/tests/unittest/logical_delete_test.cc
@@ -110,7 +110,7 @@ TEST_F(PropertyGraphLogicalDeleteTest, DeleteVertexType_RemovesTypeAndData) {
   ASSERT_TRUE(status.ok());
 
   // Verify vertex type exists
-  EXPECT_TRUE(graph_.schema().contains_vertex_label("Person"));
+  EXPECT_TRUE(graph_.schema().is_vertex_label_valid("Person"));
   label_t v_label = graph_.schema().get_vertex_label_id("Person");
   EXPECT_EQ(graph_.schema().get_vertex_label_name(v_label), "Person");
 
@@ -119,7 +119,7 @@ TEST_F(PropertyGraphLogicalDeleteTest, DeleteVertexType_RemovesTypeAndData) {
   ASSERT_TRUE(status.ok());
 
   // Verify type is physically deleted (not visible in schema)
-  EXPECT_FALSE(graph_.schema().contains_vertex_label("Person"));
+  EXPECT_FALSE(graph_.schema().is_vertex_label_valid("Person"));
 }
 
 // Test corner case: Create -> Delete Physical -> Create again
@@ -139,17 +139,17 @@ TEST_F(PropertyGraphLogicalDeleteTest, CreateDeletePhysicalRecreate_Succeeds) {
   // Physical delete
   status = graph_.DeleteVertexType("Person");
   ASSERT_TRUE(status.ok());
-  EXPECT_FALSE(graph_.schema().contains_vertex_label("Person"));
+  EXPECT_FALSE(graph_.schema().is_vertex_label_valid("Person"));
 
   // Recreate should succeed
   status = graph_.CreateVertexType(
       BuildCreateVertexTypeParam("Person", properties, pk_names));
   ASSERT_TRUE(status.ok());
   label_t second_label = graph_.schema().get_vertex_label_id("Person");
-  EXPECT_TRUE(graph_.schema().vertex_label_valid(second_label));
+  EXPECT_TRUE(graph_.schema().is_vertex_label_valid(second_label));
 
   // May get same or different label ID depending on implementation
-  EXPECT_TRUE(graph_.schema().contains_vertex_label("Person"));
+  EXPECT_TRUE(graph_.schema().is_vertex_label_valid("Person"));
 }
 
 TEST_F(PropertyGraphLogicalDeleteTest,
@@ -198,14 +198,14 @@ TEST_F(PropertyGraphLogicalDeleteTest, DeleteEdgeTypePhysical_RemovesEdgeType) {
   ASSERT_TRUE(status.ok());
 
   // Verify edge exists
-  EXPECT_TRUE(graph_.schema().has_edge_label("Person", "Company", "WorksAt"));
+  EXPECT_TRUE(graph_.schema().has_edge_triplet("Person", "Company", "WorksAt"));
 
   // Delete physically
   status = graph_.DeleteEdgeType("Person", "Company", "WorksAt");
   ASSERT_TRUE(status.ok());
 
   // Verify edge type is removed
-  EXPECT_FALSE(graph_.schema().has_edge_label("Person", "Company", "WorksAt"));
+  EXPECT_FALSE(graph_.schema().has_edge_triplet("Person", "Company", "WorksAt"));
 }
 
 // Test DeleteVertexProperties

--- a/tests/unittest/schema_test.cc
+++ b/tests/unittest/schema_test.cc
@@ -60,7 +60,7 @@ TEST(SchemaTest, AddVertexLabel_AddRenameDeleteVertexProperties_Physical) {
                         /*max_vnum*/ 1024, /*desc*/ "person vertex");
 
   // Check basics
-  EXPECT_TRUE(schema.contains_vertex_label("Person"));
+  EXPECT_TRUE(schema.is_vertex_label_valid("Person"));
   auto vid = schema.get_vertex_label_id("Person");
   EXPECT_EQ(schema.get_vertex_label_name(vid), "Person");
   EXPECT_EQ(schema.get_vertex_description("Person"), "person vertex");
@@ -128,7 +128,7 @@ TEST(SchemaTest, AddEdgeLabel_AddRenameDeleteEdgeProperties_Physical) {
                       /*desc*/ "employment");
 
   // Check basics
-  EXPECT_TRUE(schema.exist("Person", "Company", "WorksAt"));
+  EXPECT_TRUE(schema.is_edge_triplet_valid("Person", "Company", "WorksAt"));
   auto props = schema.get_edge_properties("Person", "Company", "WorksAt");
   ASSERT_EQ(props.size(), 1);
   EXPECT_EQ(props[0], DataTypeId::kInt32);
@@ -196,15 +196,15 @@ TEST(SchemaTest, DeleteVertexLabel_LogicalThenReAddActsAsRevert) {
   auto n = VNames({"name"});
   auto pk = VPk(DataTypeId::kInt64, "id", 0);
   schema.AddVertexLabel("City", t, {n.begin(), n.end()}, pk, 100, "");
-  ASSERT_TRUE(schema.contains_vertex_label("City"));
+  ASSERT_TRUE(schema.is_vertex_label_valid("City"));
 
   schema.DeleteVertexLabel("City", true);
-  EXPECT_FALSE(schema.contains_vertex_label("City"));
+  EXPECT_FALSE(schema.is_vertex_label_valid("City"));
 
   schema.AddVertexLabel("City", {DataTypeId::kVarchar}, {"name"},
                         VPk(DataTypeId::kVarchar, "name", 0),
                         /*max_vnum*/ 100, "");
-  EXPECT_TRUE(schema.contains_vertex_label("City"));
+  EXPECT_TRUE(schema.is_vertex_label_valid("City"));
   EXPECT_EQ(schema.get_vertex_property_names("City")[0], "name");
 }
 
@@ -214,15 +214,15 @@ TEST(SchemaTest, DeleteVertexLabel_PhysicalThenReAdd) {
   auto n = VNames({"name"});
   auto pk = VPk(DataTypeId::kInt64, "id", 0);
   schema.AddVertexLabel("Project", t, {n.begin(), n.end()}, pk, 100, "");
-  ASSERT_TRUE(schema.contains_vertex_label("Project"));
+  ASSERT_TRUE(schema.is_vertex_label_valid("Project"));
 
   schema.DeleteVertexLabel("Project");
-  EXPECT_FALSE(schema.contains_vertex_label("Project"));
+  EXPECT_FALSE(schema.is_vertex_label_valid("Project"));
 
   schema.AddVertexLabel("Project", {DataTypeId::kVarchar}, {"name"},
                         VPk(DataTypeId::kVarchar, "name", 0),
                         /*max_vnum*/ 100, "");
-  EXPECT_TRUE(schema.contains_vertex_label("Project"));
+  EXPECT_TRUE(schema.is_vertex_label_valid("Project"));
 }
 
 TEST(SchemaTest, DeleteEdgeLabel_LogicalAndPhysicalAndReAdd) {
@@ -239,30 +239,30 @@ TEST(SchemaTest, DeleteEdgeLabel_LogicalAndPhysicalAndReAdd) {
                       EdgeStrategy::kMultiple, EdgeStrategy::kMultiple, true,
                       true, std::nullopt, "");
 
-  ASSERT_TRUE(schema.exist("A", "B", "Link"));
+  ASSERT_TRUE(schema.is_edge_triplet_valid("A", "B", "Link"));
   auto src = schema.get_vertex_label_id("A");
   auto dst = schema.get_vertex_label_id("B");
   auto el = schema.get_edge_label_id("Link");
 
   schema.DeleteEdgeLabel(src, dst, el, true);
-  EXPECT_FALSE(schema.exist(src, dst, el));
-  EXPECT_FALSE(schema.exist(src, dst, el));
+  EXPECT_FALSE(schema.is_edge_triplet_valid(src, dst, el));
+  EXPECT_FALSE(schema.is_edge_triplet_valid(src, dst, el));
 
   schema.AddEdgeLabel("A", "B", "Link", {DataTypeId::kInt32}, {"w"},
                       EdgeStrategy::kMultiple, EdgeStrategy::kMultiple, true,
                       true, std::nullopt, "");
-  EXPECT_TRUE(schema.edge_triplet_valid(src, dst, el));
+  EXPECT_TRUE(schema.is_edge_triplet_valid(src, dst, el));
 
   schema.DeleteEdgeLabel(src, dst, el);
-  EXPECT_FALSE(schema.exist(src, dst, el));
+  EXPECT_FALSE(schema.is_edge_triplet_valid(src, dst, el));
 
   schema.AddEdgeLabel("A", "B", "Link", {DataTypeId::kInt32}, {"w"},
                       EdgeStrategy::kMultiple, EdgeStrategy::kMultiple, true,
                       true, std::nullopt, "");
-  EXPECT_TRUE(schema.exist(src, dst, el));
+  EXPECT_TRUE(schema.is_edge_triplet_valid(src, dst, el));
 
   schema.DeleteEdgeLabel("Link");
-  EXPECT_FALSE(schema.contains_edge_label("Link"));
+  EXPECT_FALSE(schema.is_edge_label_valid("Link"));
 }
 
 TEST(SchemaTest, LogicalDeleteVertexProperties_HidesProperty) {
@@ -322,14 +322,14 @@ TEST(SchemaTest, RevertDeleteVertexLabel_ClearsTombstone) {
   auto n = VNames({"name"});
   auto pk = VPk(DataTypeId::kInt64, "id", 0);
   schema.AddVertexLabel("City", t, {n.begin(), n.end()}, pk, 100, "");
-  ASSERT_TRUE(schema.contains_vertex_label("City"));
+  ASSERT_TRUE(schema.is_vertex_label_valid("City"));
 
   schema.DeleteVertexLabel("City", true);
-  EXPECT_FALSE(schema.contains_vertex_label("City"));
+  EXPECT_FALSE(schema.is_vertex_label_valid("City"));
 
   // When implemented, this should restore visibility
   schema.RevertDeleteVertexLabel("City");
-  EXPECT_TRUE(schema.contains_vertex_label("City"));
+  EXPECT_TRUE(schema.is_vertex_label_valid("City"));
 }
 
 TEST(SchemaTest, RevertDeleteEdgeLabel_ByName_ClearsTombstone) {
@@ -343,14 +343,14 @@ TEST(SchemaTest, RevertDeleteEdgeLabel_ByName_ClearsTombstone) {
   schema.AddEdgeLabel("A", "B", "Link", {DataTypeId::kInt32}, {"w"},
                       EdgeStrategy::kMultiple, EdgeStrategy::kMultiple, true,
                       true, std::nullopt, "");
-  ASSERT_TRUE(schema.contains_edge_label("Link"));
+  ASSERT_TRUE(schema.is_edge_label_valid("Link"));
   auto e_label = schema.get_edge_label_id("Link");
 
   schema.DeleteEdgeLabel("Link", true);
-  EXPECT_FALSE(schema.contains_edge_label("Link"));
+  EXPECT_FALSE(schema.is_edge_label_valid("Link"));
 
   schema.RevertDeleteEdgeLabel(e_label);
-  EXPECT_TRUE(schema.contains_edge_label("Link"));
+  EXPECT_TRUE(schema.is_edge_label_valid("Link"));
 }
 
 TEST(SchemaTest, RevertDeleteEdgeLabel_ByTriplet_ClearsTombstone) {
@@ -367,13 +367,13 @@ TEST(SchemaTest, RevertDeleteEdgeLabel_ByTriplet_ClearsTombstone) {
   auto src = schema.get_vertex_label_id("A");
   auto dst = schema.get_vertex_label_id("B");
   auto el = schema.get_edge_label_id("Link");
-  ASSERT_TRUE(schema.edge_triplet_valid(src, dst, el));
+  ASSERT_TRUE(schema.is_edge_triplet_valid(src, dst, el));
 
   schema.DeleteEdgeLabel(src, dst, el, true);
-  EXPECT_FALSE(schema.edge_triplet_valid(src, dst, el));
+  EXPECT_FALSE(schema.is_edge_triplet_valid(src, dst, el));
 
   schema.RevertDeleteEdgeLabel("A", "B", "Link");
-  EXPECT_TRUE(schema.edge_triplet_valid(src, dst, el));
+  EXPECT_TRUE(schema.is_edge_triplet_valid(src, dst, el));
 }
 
 TEST(SchemaDumpTest, SchemaDumpWithMultipleEdgeTriplet) {
@@ -562,95 +562,95 @@ TEST_F(SchemaDeleteTest, EdgeSchemaPropertySoftDelete) {
   EXPECT_EQ(e_prop_names.size(), 1);
 }
 
-// Test Schema::IsVertexLabelSoftDeleted
+// Test Schema::is_vertex_label_soft_deleted
 TEST_F(SchemaDeleteTest, VertexLabelLogicalDelete) {
   // Initially, vertex label should not be deleted
-  EXPECT_FALSE(schema_->IsVertexLabelSoftDeleted("person"));
-  EXPECT_FALSE(schema_->IsVertexLabelSoftDeleted("company"));
+  EXPECT_FALSE(schema_->is_vertex_label_soft_deleted("person"));
+  EXPECT_FALSE(schema_->is_vertex_label_soft_deleted("company"));
 
   auto person_label = schema_->get_vertex_label_id("person");
-  EXPECT_FALSE(schema_->IsVertexLabelSoftDeleted(person_label));
+  EXPECT_FALSE(schema_->is_vertex_label_soft_deleted(person_label));
 
   // Logically delete "person" vertex label
   schema_->DeleteVertexLabel("person", true);
 
   // Check that "person" is now logically deleted
-  EXPECT_TRUE(schema_->IsVertexLabelSoftDeleted("person"));
-  EXPECT_TRUE(schema_->IsVertexLabelSoftDeleted(person_label));
-  EXPECT_FALSE(schema_->IsVertexLabelSoftDeleted("company"));
+  EXPECT_TRUE(schema_->is_vertex_label_soft_deleted("person"));
+  EXPECT_TRUE(schema_->is_vertex_label_soft_deleted(person_label));
+  EXPECT_FALSE(schema_->is_vertex_label_soft_deleted("company"));
 
   // Revert the deletion
   schema_->RevertDeleteVertexLabel("person");
 
   // Check that "person" is no longer logically deleted
-  EXPECT_FALSE(schema_->IsVertexLabelSoftDeleted("person"));
-  EXPECT_FALSE(schema_->IsVertexLabelSoftDeleted(person_label));
+  EXPECT_FALSE(schema_->is_vertex_label_soft_deleted("person"));
+  EXPECT_FALSE(schema_->is_vertex_label_soft_deleted(person_label));
 }
 
-// Test Schema::IsEdgeLabelSoftDeleted
+// Test Schema::is_edge_label_soft_deleted
 TEST_F(SchemaDeleteTest, EdgeLabelLogicalDelete) {
   auto person_label = schema_->get_vertex_label_id("person");
   auto knows_label = schema_->get_edge_label_id("knows");
 
   // Initially, edge labels should not be deleted
-  EXPECT_FALSE(schema_->IsEdgeLabelSoftDeleted("person", "person", "knows"));
+  EXPECT_FALSE(schema_->is_edge_label_soft_deleted("person", "person", "knows"));
   EXPECT_FALSE(
-      schema_->IsEdgeLabelSoftDeleted(person_label, person_label, knows_label));
+      schema_->is_edge_label_soft_deleted(person_label, person_label, knows_label));
 
   // Logically delete "knows" edge label
   schema_->DeleteEdgeLabel("person", "person", "knows", true);
 
   // Check that "knows" is now logically deleted
-  EXPECT_TRUE(schema_->IsEdgeLabelSoftDeleted("person", "person", "knows"));
+  EXPECT_TRUE(schema_->is_edge_label_soft_deleted("person", "person", "knows"));
   EXPECT_TRUE(
-      schema_->IsEdgeLabelSoftDeleted(person_label, person_label, knows_label));
-  EXPECT_FALSE(schema_->IsEdgeLabelSoftDeleted("person", "company", "worksAt"));
+      schema_->is_edge_label_soft_deleted(person_label, person_label, knows_label));
+  EXPECT_FALSE(schema_->is_edge_label_soft_deleted("person", "company", "worksAt"));
 
   // Revert the deletion
   schema_->RevertDeleteEdgeLabel("person", "person", "knows");
 
   // Check that "knows" is no longer logically deleted
-  EXPECT_FALSE(schema_->IsEdgeLabelSoftDeleted("person", "person", "knows"));
+  EXPECT_FALSE(schema_->is_edge_label_soft_deleted("person", "person", "knows"));
   EXPECT_FALSE(
-      schema_->IsEdgeLabelSoftDeleted(person_label, person_label, knows_label));
+      schema_->is_edge_label_soft_deleted(person_label, person_label, knows_label));
 }
 
-// Test Schema::IsVertexPropertySoftDeleted
+// Test Schema::is_vertex_property_soft_deleted
 TEST_F(SchemaDeleteTest, VertexPropertyLogicalDelete) {
   auto person_label = schema_->get_vertex_label_id("person");
 
   // Initially, no properties should be logically deleted
-  EXPECT_FALSE(schema_->IsVertexPropertySoftDeleted("person", "name"));
-  EXPECT_FALSE(schema_->IsVertexPropertySoftDeleted("person", "age"));
-  EXPECT_FALSE(schema_->IsVertexPropertySoftDeleted(person_label, "score"));
+  EXPECT_FALSE(schema_->is_vertex_property_soft_deleted("person", "name"));
+  EXPECT_FALSE(schema_->is_vertex_property_soft_deleted("person", "age"));
+  EXPECT_FALSE(schema_->is_vertex_property_soft_deleted(person_label, "score"));
 
   // Logically delete "age" property
   std::vector<std::string> props_to_delete = {"age"};
   schema_->DeleteVertexProperties("person", props_to_delete, true);
 
   // Check that "age" is now logically deleted
-  EXPECT_TRUE(schema_->IsVertexPropertySoftDeleted("person", "age"));
-  EXPECT_TRUE(schema_->IsVertexPropertySoftDeleted(person_label, "age"));
-  EXPECT_FALSE(schema_->IsVertexPropertySoftDeleted("person", "name"));
-  EXPECT_FALSE(schema_->IsVertexPropertySoftDeleted("person", "score"));
+  EXPECT_TRUE(schema_->is_vertex_property_soft_deleted("person", "age"));
+  EXPECT_TRUE(schema_->is_vertex_property_soft_deleted(person_label, "age"));
+  EXPECT_FALSE(schema_->is_vertex_property_soft_deleted("person", "name"));
+  EXPECT_FALSE(schema_->is_vertex_property_soft_deleted("person", "score"));
 
   // Revert the deletion
   schema_->RevertDeleteVertexProperties("person", props_to_delete);
 
   // Check that "age" is no longer logically deleted
-  EXPECT_FALSE(schema_->IsVertexPropertySoftDeleted("person", "age"));
-  EXPECT_FALSE(schema_->IsVertexPropertySoftDeleted(person_label, "age"));
+  EXPECT_FALSE(schema_->is_vertex_property_soft_deleted("person", "age"));
+  EXPECT_FALSE(schema_->is_vertex_property_soft_deleted(person_label, "age"));
 }
 
-// Test Schema::IsEdgePropertySoftDeleted
+// Test Schema::is_edge_property_soft_deleted
 TEST_F(SchemaDeleteTest, EdgePropertyLogicalDelete) {
   auto person_label = schema_->get_vertex_label_id("person");
   auto knows_label = schema_->get_edge_label_id("knows");
 
   // Initially, no properties should be logically deleted
   EXPECT_FALSE(
-      schema_->IsEdgePropertySoftDeleted("person", "person", "knows", "since"));
-  EXPECT_FALSE(schema_->IsEdgePropertySoftDeleted(person_label, person_label,
+      schema_->is_edge_property_soft_deleted("person", "person", "knows", "since"));
+  EXPECT_FALSE(schema_->is_edge_property_soft_deleted(person_label, person_label,
                                                   knows_label, "since"));
 
   // Soft delete "since" property
@@ -660,8 +660,8 @@ TEST_F(SchemaDeleteTest, EdgePropertyLogicalDelete) {
 
   // Check that "since" is now logically deleted
   EXPECT_TRUE(
-      schema_->IsEdgePropertySoftDeleted("person", "person", "knows", "since"));
-  EXPECT_TRUE(schema_->IsEdgePropertySoftDeleted(person_label, person_label,
+      schema_->is_edge_property_soft_deleted("person", "person", "knows", "since"));
+  EXPECT_TRUE(schema_->is_edge_property_soft_deleted(person_label, person_label,
                                                  knows_label, "since"));
 
   // Revert the deletion
@@ -670,8 +670,8 @@ TEST_F(SchemaDeleteTest, EdgePropertyLogicalDelete) {
 
   // Check that "since" is no longer soft deleted
   EXPECT_FALSE(
-      schema_->IsEdgePropertySoftDeleted("person", "person", "knows", "since"));
-  EXPECT_FALSE(schema_->IsEdgePropertySoftDeleted(person_label, person_label,
+      schema_->is_edge_property_soft_deleted("person", "person", "knows", "since"));
+  EXPECT_FALSE(schema_->is_edge_property_soft_deleted(person_label, person_label,
                                                   knows_label, "since"));
 }
 
@@ -682,25 +682,25 @@ TEST_F(SchemaDeleteTest, MultipleVertexPropertiesDeletionAndRevert) {
   schema_->DeleteVertexProperties("person", props_to_delete, true);
 
   // Verify all are deleted
-  EXPECT_TRUE(schema_->IsVertexPropertySoftDeleted("person", "name"));
-  EXPECT_TRUE(schema_->IsVertexPropertySoftDeleted("person", "score"));
-  EXPECT_FALSE(schema_->IsVertexPropertySoftDeleted("person", "age"));
+  EXPECT_TRUE(schema_->is_vertex_property_soft_deleted("person", "name"));
+  EXPECT_TRUE(schema_->is_vertex_property_soft_deleted("person", "score"));
+  EXPECT_FALSE(schema_->is_vertex_property_soft_deleted("person", "age"));
 
   // Revert one property
   std::vector<std::string> props_to_revert = {"name"};
   schema_->RevertDeleteVertexProperties("person", props_to_revert);
 
   // Verify only "name" is reverted
-  EXPECT_FALSE(schema_->IsVertexPropertySoftDeleted("person", "name"));
-  EXPECT_TRUE(schema_->IsVertexPropertySoftDeleted("person", "score"));
+  EXPECT_FALSE(schema_->is_vertex_property_soft_deleted("person", "name"));
+  EXPECT_TRUE(schema_->is_vertex_property_soft_deleted("person", "score"));
 
   // Revert the other property
   std::vector<std::string> props_to_revert2 = {"score"};
   schema_->RevertDeleteVertexProperties("person", props_to_revert2);
 
   // Verify both are reverted
-  EXPECT_FALSE(schema_->IsVertexPropertySoftDeleted("person", "name"));
-  EXPECT_FALSE(schema_->IsVertexPropertySoftDeleted("person", "score"));
+  EXPECT_FALSE(schema_->is_vertex_property_soft_deleted("person", "name"));
+  EXPECT_FALSE(schema_->is_vertex_property_soft_deleted("person", "score"));
 }
 
 // Test edge property operations with label_t overloads
@@ -715,8 +715,8 @@ TEST_F(SchemaDeleteTest, EdgePropertyOperationsWithLabelId) {
 
   // Verify using both string and label_t overloads
   EXPECT_TRUE(
-      schema_->IsEdgePropertySoftDeleted("person", "person", "knows", "since"));
-  EXPECT_TRUE(schema_->IsEdgePropertySoftDeleted(person_label, person_label,
+      schema_->is_edge_property_soft_deleted("person", "person", "knows", "since"));
+  EXPECT_TRUE(schema_->is_edge_property_soft_deleted(person_label, person_label,
                                                  knows_label, "since"));
 
   // Revert using label_t overload
@@ -725,8 +725,8 @@ TEST_F(SchemaDeleteTest, EdgePropertyOperationsWithLabelId) {
 
   // Verify property is reverted
   EXPECT_FALSE(
-      schema_->IsEdgePropertySoftDeleted("person", "person", "knows", "since"));
-  EXPECT_FALSE(schema_->IsEdgePropertySoftDeleted(person_label, person_label,
+      schema_->is_edge_property_soft_deleted("person", "person", "knows", "since"));
+  EXPECT_FALSE(schema_->is_edge_property_soft_deleted(person_label, person_label,
                                                   knows_label, "since"));
 }
 

--- a/tests/unittest/schema_test.cc
+++ b/tests/unittest/schema_test.cc
@@ -593,26 +593,29 @@ TEST_F(SchemaDeleteTest, EdgeLabelLogicalDelete) {
   auto knows_label = schema_->get_edge_label_id("knows");
 
   // Initially, edge labels should not be deleted
-  EXPECT_FALSE(schema_->is_edge_label_soft_deleted("person", "person", "knows"));
   EXPECT_FALSE(
-      schema_->is_edge_label_soft_deleted(person_label, person_label, knows_label));
+      schema_->is_edge_label_soft_deleted("person", "person", "knows"));
+  EXPECT_FALSE(schema_->is_edge_label_soft_deleted(person_label, person_label,
+                                                   knows_label));
 
   // Logically delete "knows" edge label
   schema_->DeleteEdgeLabel("person", "person", "knows", true);
 
   // Check that "knows" is now logically deleted
   EXPECT_TRUE(schema_->is_edge_label_soft_deleted("person", "person", "knows"));
-  EXPECT_TRUE(
-      schema_->is_edge_label_soft_deleted(person_label, person_label, knows_label));
-  EXPECT_FALSE(schema_->is_edge_label_soft_deleted("person", "company", "worksAt"));
+  EXPECT_TRUE(schema_->is_edge_label_soft_deleted(person_label, person_label,
+                                                  knows_label));
+  EXPECT_FALSE(
+      schema_->is_edge_label_soft_deleted("person", "company", "worksAt"));
 
   // Revert the deletion
   schema_->RevertDeleteEdgeLabel("person", "person", "knows");
 
   // Check that "knows" is no longer logically deleted
-  EXPECT_FALSE(schema_->is_edge_label_soft_deleted("person", "person", "knows"));
   EXPECT_FALSE(
-      schema_->is_edge_label_soft_deleted(person_label, person_label, knows_label));
+      schema_->is_edge_label_soft_deleted("person", "person", "knows"));
+  EXPECT_FALSE(schema_->is_edge_label_soft_deleted(person_label, person_label,
+                                                   knows_label));
 }
 
 // Test Schema::is_vertex_property_soft_deleted
@@ -648,10 +651,10 @@ TEST_F(SchemaDeleteTest, EdgePropertyLogicalDelete) {
   auto knows_label = schema_->get_edge_label_id("knows");
 
   // Initially, no properties should be logically deleted
-  EXPECT_FALSE(
-      schema_->is_edge_property_soft_deleted("person", "person", "knows", "since"));
-  EXPECT_FALSE(schema_->is_edge_property_soft_deleted(person_label, person_label,
-                                                  knows_label, "since"));
+  EXPECT_FALSE(schema_->is_edge_property_soft_deleted("person", "person",
+                                                      "knows", "since"));
+  EXPECT_FALSE(schema_->is_edge_property_soft_deleted(
+      person_label, person_label, knows_label, "since"));
 
   // Soft delete "since" property
   std::vector<std::string> props_to_delete = {"since"};
@@ -659,20 +662,20 @@ TEST_F(SchemaDeleteTest, EdgePropertyLogicalDelete) {
                                 true);
 
   // Check that "since" is now logically deleted
-  EXPECT_TRUE(
-      schema_->is_edge_property_soft_deleted("person", "person", "knows", "since"));
+  EXPECT_TRUE(schema_->is_edge_property_soft_deleted("person", "person",
+                                                     "knows", "since"));
   EXPECT_TRUE(schema_->is_edge_property_soft_deleted(person_label, person_label,
-                                                 knows_label, "since"));
+                                                     knows_label, "since"));
 
   // Revert the deletion
   schema_->RevertDeleteEdgeProperties("person", "person", "knows",
                                       props_to_delete);
 
   // Check that "since" is no longer soft deleted
-  EXPECT_FALSE(
-      schema_->is_edge_property_soft_deleted("person", "person", "knows", "since"));
-  EXPECT_FALSE(schema_->is_edge_property_soft_deleted(person_label, person_label,
-                                                  knows_label, "since"));
+  EXPECT_FALSE(schema_->is_edge_property_soft_deleted("person", "person",
+                                                      "knows", "since"));
+  EXPECT_FALSE(schema_->is_edge_property_soft_deleted(
+      person_label, person_label, knows_label, "since"));
 }
 
 // Test multiple vertex properties deletion and revert
@@ -714,20 +717,20 @@ TEST_F(SchemaDeleteTest, EdgePropertyOperationsWithLabelId) {
                                 true);
 
   // Verify using both string and label_t overloads
-  EXPECT_TRUE(
-      schema_->is_edge_property_soft_deleted("person", "person", "knows", "since"));
+  EXPECT_TRUE(schema_->is_edge_property_soft_deleted("person", "person",
+                                                     "knows", "since"));
   EXPECT_TRUE(schema_->is_edge_property_soft_deleted(person_label, person_label,
-                                                 knows_label, "since"));
+                                                     knows_label, "since"));
 
   // Revert using label_t overload
   schema_->RevertDeleteEdgeProperties(person_label, person_label, knows_label,
                                       props_to_delete);
 
   // Verify property is reverted
-  EXPECT_FALSE(
-      schema_->is_edge_property_soft_deleted("person", "person", "knows", "since"));
-  EXPECT_FALSE(schema_->is_edge_property_soft_deleted(person_label, person_label,
-                                                  knows_label, "since"));
+  EXPECT_FALSE(schema_->is_edge_property_soft_deleted("person", "person",
+                                                      "knows", "since"));
+  EXPECT_FALSE(schema_->is_edge_property_soft_deleted(
+      person_label, person_label, knows_label, "since"));
 }
 
 // Test has_property behavior with soft-deleted properties


### PR DESCRIPTION
Fixes #392

## Summary

- Unify the naming convention of Schema's label existence/validity checks under a single snake_case `is_*` family
- Merge the weak `Schema::edge_triplet_valid` (tomb-bit-only) into the strong `is_edge_triplet_valid` (which also requires `e_schemas_` presence); this fixes the prior divergence between the two `PropertyGraph::edge_triplet_check` overloads as a side effect
- Remove dead `PropertyGraph::edge_triplet_exist` (no callers anywhere)

See #392 for the full rename table and the rationale.

The `is_*_soft_deleted` family is renamed (snake_case) but **kept** in this PR — `UpdateTransaction` still calls it on `main`. Removing the family is a separate cleanup tied to the COW Update Transaction work.
