### PR TITLE
fix: DROP TABLE no longer leaks across checkpoint boundary (#293, #398)

### DIFF
--- a/include/neug/storages/file_names.h
+++ b/include/neug/storages/file_names.h
@@ -187,22 +187,4 @@ inline std::string statistics_file_prefix(const std::string& src_label,
   return "statistics_" + src_label + "_" + edge_label + "_" + dst_label;
 }
 
-// True iff fname is exactly p, or fname starts with p followed by '.' or '_'.
-// Plain starts_with is unsafe for label-keyed cleanup: a prefix of "User"
-// would also match "UserAccount.col_0" and wipe a different label's data.
-inline bool filename_matches_label_prefix(const std::string& fname,
-                                          const std::string& p) {
-  if (p.empty() || fname.size() < p.size()) {
-    return false;
-  }
-  if (fname.compare(0, p.size(), p) != 0) {
-    return false;
-  }
-  if (fname.size() == p.size()) {
-    return true;
-  }
-  char next = fname[p.size()];
-  return next == '.' || next == '_';
-}
-
 }  // namespace neug

--- a/include/neug/storages/file_names.h
+++ b/include/neug/storages/file_names.h
@@ -187,4 +187,22 @@ inline std::string statistics_file_prefix(const std::string& src_label,
   return "statistics_" + src_label + "_" + edge_label + "_" + dst_label;
 }
 
+// True iff fname is exactly p, or fname starts with p followed by '.' or '_'.
+// Plain starts_with is unsafe for label-keyed cleanup: a prefix of "User"
+// would also match "UserAccount.col_0" and wipe a different label's data.
+inline bool filename_matches_label_prefix(const std::string& fname,
+                                          const std::string& p) {
+  if (p.empty() || fname.size() < p.size()) {
+    return false;
+  }
+  if (fname.compare(0, p.size(), p) != 0) {
+    return false;
+  }
+  if (fname.size() == p.size()) {
+    return true;
+  }
+  char next = fname[p.size()];
+  return next == '.' || next == '_';
+}
+
 }  // namespace neug

--- a/include/neug/storages/graph/edge_table.h
+++ b/include/neug/storages/graph/edge_table.h
@@ -54,13 +54,9 @@ class EdgeTable {
   void Open(const std::string& work_dir, MemoryLevel memory_level);
 
   // Bring up a freshly-created edge table with no checkpoint to read.
-  // Also clears any stale tmp_dir files left behind by a prior DROP of the
-  // same (src, dst, edge) triple within this process.
   void Initialize(const std::string& work_dir, MemoryLevel memory_level);
 
   void Close();
-
-  void Drop();
 
   void Dump(const std::string& checkpoint_dir_path);
 
@@ -142,9 +138,6 @@ class EdgeTable {
   size_t Capacity() const;
 
  private:
-  // Shared implementation for Open and Initialize. An empty
-  // checkpoint_dir_path skips loading any pre-existing snapshot, producing
-  // fresh empty backing storage.
   void openImpl(const std::string& work_dir, MemoryLevel memory_level,
                 const std::string& checkpoint_dir_path);
 

--- a/include/neug/storages/graph/edge_table.h
+++ b/include/neug/storages/graph/edge_table.h
@@ -50,7 +50,17 @@ class EdgeTable {
 
   void SetEdgeSchema(std::shared_ptr<const EdgeSchema> meta);
 
+  // Restore an existing edge table from its checkpoint snapshot.
   void Open(const std::string& work_dir, MemoryLevel memory_level);
+
+  // Bring up a freshly-created edge table with no checkpoint to read.
+  // Also clears any stale tmp_dir files left behind by a prior DROP of the
+  // same (src, dst, edge) triple within this process.
+  void Initialize(const std::string& work_dir, MemoryLevel memory_level);
+
+  void Close();
+
+  void Drop();
 
   void Dump(const std::string& checkpoint_dir_path);
 
@@ -132,6 +142,12 @@ class EdgeTable {
   size_t Capacity() const;
 
  private:
+  // Shared implementation for Open and Initialize. An empty
+  // checkpoint_dir_path skips loading any pre-existing snapshot, producing
+  // fresh empty backing storage.
+  void openImpl(const std::string& work_dir, MemoryLevel memory_level,
+                const std::string& checkpoint_dir_path);
+
   void dropAndCreateNewBundledCSR(std::shared_ptr<ColumnBase> prev_data_col);
   void dropAndCreateNewUnbundledCSR(bool delete_property);
   std::string get_next_csr_path_suffix();

--- a/include/neug/storages/graph/vertex_table.h
+++ b/include/neug/storages/graph/vertex_table.h
@@ -123,8 +123,6 @@ class VertexTable {
   void Open(const std::string& work_dir, MemoryLevel memory_level);
 
   // Bring up a freshly-created vertex table with no checkpoint to read.
-  // Also clears any stale tmp_dir files left behind by a prior DROP of the
-  // same label within this process.
   void Initialize(const std::string& work_dir, MemoryLevel memory_level);
 
   void Dump(const std::string& target_dir);
@@ -134,8 +132,6 @@ class VertexTable {
   void SetVertexSchema(std::shared_ptr<const VertexSchema> vertex_schema);
 
   size_t EnsureCapacity(size_t capacity);
-
-  bool is_dropped() const { return table_ == nullptr; }
 
   bool get_index(const Property& oid, vid_t& lid,
                  timestamp_t ts = MAX_TIMESTAMP) const;
@@ -204,8 +200,6 @@ class VertexTable {
 
   void DeleteProperties(const std::vector<std::string>& properties);
 
-  void Drop();
-
   void RenameProperties(const std::vector<std::string>& old_names,
                         const std::vector<std::string>& new_names);
 
@@ -220,9 +214,6 @@ class VertexTable {
   const VertexTimestamp& get_vertex_timestamp() const { return *v_ts_; }
 
  private:
-  // Shared implementation for Open and Initialize. An empty
-  // checkpoint_dir_path skips loading any pre-existing snapshot, producing
-  // fresh empty backing storage.
   void openImpl(const std::string& work_dir, MemoryLevel memory_level,
                 const std::string& checkpoint_dir_path);
 

--- a/include/neug/storages/graph/vertex_table.h
+++ b/include/neug/storages/graph/vertex_table.h
@@ -79,6 +79,13 @@ class VertexSet {
 class PropertyGraph;
 class VertexTable {
  public:
+  VertexTable()
+      : table_(nullptr),
+        vertex_schema_(nullptr),
+        v_ts_(),
+        memory_level_(MemoryLevel::kInMemory),
+        work_dir_("") {}
+
   VertexTable(std::shared_ptr<const VertexSchema> vertex_schema)
       : indexer_(std::make_shared<IndexerType>()),
         table_(std::make_unique<Table>()),
@@ -112,7 +119,13 @@ class VertexTable {
     std::swap(work_dir_, other.work_dir_);
   }
 
+  // Restore an existing vertex table from its checkpoint snapshot.
   void Open(const std::string& work_dir, MemoryLevel memory_level);
+
+  // Bring up a freshly-created vertex table with no checkpoint to read.
+  // Also clears any stale tmp_dir files left behind by a prior DROP of the
+  // same label within this process.
+  void Initialize(const std::string& work_dir, MemoryLevel memory_level);
 
   void Dump(const std::string& target_dir);
 
@@ -207,6 +220,12 @@ class VertexTable {
   const VertexTimestamp& get_vertex_timestamp() const { return *v_ts_; }
 
  private:
+  // Shared implementation for Open and Initialize. An empty
+  // checkpoint_dir_path skips loading any pre-existing snapshot, producing
+  // fresh empty backing storage.
+  void openImpl(const std::string& work_dir, MemoryLevel memory_level,
+                const std::string& checkpoint_dir_path);
+
   vid_t insert_vertex_pk(const Property& id, timestamp_t ts, bool insert_safe);
   template <typename PK_T>
   std::vector<vid_t> insert_primary_keys(

--- a/include/neug/utils/id_indexer.h
+++ b/include/neug/utils/id_indexer.h
@@ -472,11 +472,6 @@ class LFIndexer {
     indices_size_ = 0;
   }
 
-  void drop() {
-    close();
-    // TODO(zhanglei): delete files in work_dir
-  }
-
   void dump_meta(const std::string& filename) const {
     InArchive arc;
     arc << get_type() << num_elements_.load() << num_slots_minus_one_

--- a/include/neug/utils/property/table.h
+++ b/include/neug/utils/property/table.h
@@ -102,8 +102,6 @@ class Table {
 
   void close();
 
-  void drop();
-
   void set_name(const std::string& name);
 
   void set_work_dir(const std::string& work_dir);

--- a/src/storages/csr/mutable_csr.cc
+++ b/src/storages/csr/mutable_csr.cc
@@ -558,8 +558,12 @@ void SingleMutableCsr<EDATA_T>::open(const std::string& name,
                                      const std::string& snapshot_dir,
                                      const std::string& work_dir) {
   close();
-  load_meta(snapshot_dir + "/" + name);
-  nbr_list_ = OpenContainer(snapshot_dir + "/" + name + ".snbr",
+  std::string snap_prefix =
+      (!snapshot_dir.empty() && std::filesystem::exists(snapshot_dir))
+          ? snapshot_dir + "/" + name
+          : "";
+  load_meta(snap_prefix);
+  nbr_list_ = OpenContainer(snap_prefix.empty() ? "" : snap_prefix + ".snbr",
                             tmp_dir(work_dir) + "/" + name + ".snbr",
                             MemoryLevel::kSyncToFile);
 }

--- a/src/storages/graph/edge_table.cc
+++ b/src/storages/graph/edge_table.cc
@@ -59,8 +59,7 @@ void cleanup_edge_label_tmp_files(const std::string& work_dir,
       edata_prefix(src_label_name, dst_label_name, edge_label_name),
       statistics_file_prefix(src_label_name, dst_label_name, edge_label_name),
   };
-  for (const auto& entry :
-       std::filesystem::directory_iterator(tmp_dir_path)) {
+  for (const auto& entry : std::filesystem::directory_iterator(tmp_dir_path)) {
     if (!entry.is_regular_file()) {
       continue;
     }
@@ -631,12 +630,14 @@ void EdgeTable::openImpl(const std::string& work_dir, MemoryLevel memory_level,
                                  ? ""
                                  : checkpoint_dir_path + "/" + oe_prefix_path);
   } else if (memory_level == MemoryLevel::kHugePagePreferred) {
-    in_csr_->open_with_hugepages(
-        checkpoint_dir_path.empty() ? ""
-                                    : checkpoint_dir_path + "/" + ie_prefix_path);
-    out_csr_->open_with_hugepages(
-        checkpoint_dir_path.empty() ? ""
-                                    : checkpoint_dir_path + "/" + oe_prefix_path);
+    in_csr_->open_with_hugepages(checkpoint_dir_path.empty()
+                                     ? ""
+                                     : checkpoint_dir_path + "/" +
+                                           ie_prefix_path);
+    out_csr_->open_with_hugepages(checkpoint_dir_path.empty()
+                                      ? ""
+                                      : checkpoint_dir_path + "/" +
+                                            oe_prefix_path);
   } else {
     THROW_INVALID_ARGUMENT_EXCEPTION(
         "unsupported memory level: " +

--- a/src/storages/graph/edge_table.cc
+++ b/src/storages/graph/edge_table.cc
@@ -38,6 +38,49 @@
 
 namespace neug {
 
+namespace {
+
+// Remove any tmp_dir files belonging to a previously dropped edge label of
+// the given (src, edge, dst) triple. tmp filenames key on label strings
+// (not numeric label_t), and Schema reuses the same numeric ids when a same-
+// triple edge is re-created, so without this sweep an in-process DROP+CREATE
+// would re-mmap the prior edge label's leftover data.
+void cleanup_edge_label_tmp_files(const std::string& work_dir,
+                                  const std::string& src_label_name,
+                                  const std::string& dst_label_name,
+                                  const std::string& edge_label_name) {
+  std::string tmp_dir_path = tmp_dir(work_dir);
+  if (!std::filesystem::exists(tmp_dir_path)) {
+    return;
+  }
+  const std::string prefixes[] = {
+      ie_prefix(src_label_name, dst_label_name, edge_label_name),
+      oe_prefix(src_label_name, dst_label_name, edge_label_name),
+      edata_prefix(src_label_name, dst_label_name, edge_label_name),
+      statistics_file_prefix(src_label_name, dst_label_name, edge_label_name),
+  };
+  for (const auto& entry :
+       std::filesystem::directory_iterator(tmp_dir_path)) {
+    if (!entry.is_regular_file()) {
+      continue;
+    }
+    const std::string fname = entry.path().filename().string();
+    for (const auto& p : prefixes) {
+      if (!p.empty() && fname.rfind(p, 0) == 0) {
+        std::error_code ec;
+        std::filesystem::remove(entry.path(), ec);
+        if (ec) {
+          LOG(WARNING) << "Failed to remove stale tmp file " << entry.path()
+                       << ": " << ec.message();
+        }
+        break;
+      }
+    }
+  }
+}
+
+}  // namespace
+
 std::tuple<std::vector<vid_t>, std::vector<vid_t>, std::vector<bool>>
 filterInvalidEdges(const std::vector<vid_t>& src_lid,
                    const std::vector<vid_t>& dst_lid) {
@@ -551,9 +594,26 @@ void load_statistic_file(const std::string& work_dir,
 }
 
 void EdgeTable::Open(const std::string& work_dir, MemoryLevel memory_level) {
+  openImpl(work_dir, memory_level, checkpoint_dir(work_dir));
+}
+
+// Initialize releases nothing on the filesystem itself: it only sweeps stale
+// tmp files left behind by a prior in-process DROP of the same edge triple and
+// then opens fresh containers. Persistent checkpoint state is never touched
+// here — only the next CHECKPOINT (PropertyGraph::Dump) advances it.
+void EdgeTable::Initialize(const std::string& work_dir,
+                           MemoryLevel memory_level) {
+  if (meta_) {
+    cleanup_edge_label_tmp_files(work_dir, meta_->src_label_name,
+                                 meta_->dst_label_name, meta_->edge_label_name);
+  }
+  openImpl(work_dir, memory_level, "");
+}
+
+void EdgeTable::openImpl(const std::string& work_dir, MemoryLevel memory_level,
+                         const std::string& checkpoint_dir_path) {
   work_dir_ = work_dir;
   memory_level_ = memory_level;
-  auto ckp_dir_path = checkpoint_dir(work_dir);
   auto ie_prefix_path = ie_prefix(meta_->src_label_name, meta_->dst_label_name,
                                   meta_->edge_label_name);
   auto oe_prefix_path = oe_prefix(meta_->src_label_name, meta_->dst_label_name,
@@ -561,14 +621,22 @@ void EdgeTable::Open(const std::string& work_dir, MemoryLevel memory_level) {
   auto edata_prefix_path = edata_prefix(
       meta_->src_label_name, meta_->dst_label_name, meta_->edge_label_name);
   if (memory_level == MemoryLevel::kSyncToFile) {
-    in_csr_->open(ie_prefix_path, ckp_dir_path, work_dir);
-    out_csr_->open(oe_prefix_path, ckp_dir_path, work_dir);
+    in_csr_->open(ie_prefix_path, checkpoint_dir_path, work_dir);
+    out_csr_->open(oe_prefix_path, checkpoint_dir_path, work_dir);
   } else if (memory_level == MemoryLevel::kInMemory) {
-    in_csr_->open_in_memory(ckp_dir_path + "/" + ie_prefix_path);
-    out_csr_->open_in_memory(ckp_dir_path + "/" + oe_prefix_path);
+    in_csr_->open_in_memory(checkpoint_dir_path.empty()
+                                ? ""
+                                : checkpoint_dir_path + "/" + ie_prefix_path);
+    out_csr_->open_in_memory(checkpoint_dir_path.empty()
+                                 ? ""
+                                 : checkpoint_dir_path + "/" + oe_prefix_path);
   } else if (memory_level == MemoryLevel::kHugePagePreferred) {
-    in_csr_->open_with_hugepages(ckp_dir_path + "/" + ie_prefix_path);
-    out_csr_->open_with_hugepages(ckp_dir_path + "/" + oe_prefix_path);
+    in_csr_->open_with_hugepages(
+        checkpoint_dir_path.empty() ? ""
+                                    : checkpoint_dir_path + "/" + ie_prefix_path);
+    out_csr_->open_with_hugepages(
+        checkpoint_dir_path.empty() ? ""
+                                    : checkpoint_dir_path + "/" + oe_prefix_path);
   } else {
     THROW_INVALID_ARGUMENT_EXCEPTION(
         "unsupported memory level: " +
@@ -592,14 +660,48 @@ void EdgeTable::Open(const std::string& work_dir, MemoryLevel memory_level) {
     }
     assert(table_->col_num() > 0);
     size_t table_cap = table_->get_column_by_id(0)->size();
-    load_statistic_file(work_dir, meta_->src_label_name, meta_->dst_label_name,
-                        meta_->edge_label_name, capacity_, table_idx_);
-    if (table_cap != capacity_.load()) {
-      THROW_INVALID_ARGUMENT_EXCEPTION(
-          "capacity in statistic file not match actual table capacity, maybe "
-          "the graph is not dumped properly");
+    if (!checkpoint_dir_path.empty()) {
+      load_statistic_file(work_dir, meta_->src_label_name,
+                          meta_->dst_label_name, meta_->edge_label_name,
+                          capacity_, table_idx_);
+      if (table_cap != capacity_.load()) {
+        THROW_INVALID_ARGUMENT_EXCEPTION(
+            "capacity in statistic file not match actual table capacity, maybe "
+            "the graph is not dumped properly");
+      }
     }
   }
+}
+
+void EdgeTable::Close() {
+  if (out_csr_) {
+    out_csr_->close();
+  }
+  if (in_csr_) {
+    in_csr_->close();
+  }
+  if (table_) {
+    table_->close();
+  }
+}
+
+// Drop releases the table's in-memory state only. It does NOT touch the
+// filesystem.
+//
+// Physical tmp_dir cleanup happens at three explicit gates:
+//   - process startup: PropertyGraph::Open wipes tmp_dir
+//   - next CREATE for the same triple: Initialize sweeps stale tmp files
+//   - next CHECKPOINT: PropertyGraph::Dump rewrites checkpoint_dir from scratch
+//
+// checkpoint_dir is never modified outside of CHECKPOINT — this is what gives
+// DROP its implicit crash-rollback semantics (a crash between DROP and the
+// next CHECKPOINT re-reads the prior checkpoint, effectively undoing the
+// DROP). Do not make this function delete files; doing so requires writing
+// DROP to the WAL first or that rollback invariant will break.
+void EdgeTable::Drop() {
+  out_csr_.reset();
+  in_csr_.reset();
+  table_.reset();
 }
 
 void EdgeTable::Dump(const std::string& checkpoint_dir_path) {

--- a/src/storages/graph/edge_table.cc
+++ b/src/storages/graph/edge_table.cc
@@ -554,10 +554,6 @@ void EdgeTable::Open(const std::string& work_dir, MemoryLevel memory_level) {
   openImpl(work_dir, memory_level, checkpoint_dir(work_dir));
 }
 
-// Initialize releases nothing on the filesystem itself: it only sweeps stale
-// tmp files left behind by a prior in-process DROP of the same edge triple and
-// then opens fresh containers. Persistent checkpoint state is never touched
-// here — only the next CHECKPOINT (PropertyGraph::Dump) advances it.
 void EdgeTable::Initialize(const std::string& work_dir,
                            MemoryLevel memory_level) {
   openImpl(work_dir, memory_level, "");
@@ -639,8 +635,6 @@ void EdgeTable::Close() {
     table_->close();
   }
 }
-
-void EdgeTable::Drop() { Close(); }
 
 void EdgeTable::Dump(const std::string& checkpoint_dir_path) {
   in_csr_->dump(ie_prefix(meta_->src_label_name, meta_->dst_label_name,
@@ -1105,7 +1099,7 @@ void EdgeTable::dropAndCreateNewBundledCSR(
                                    new_in_csr.get());
   }
 
-  table_->drop();
+  table_->close();
   table_ = std::make_unique<Table>();
   table_idx_.store(0);
   capacity_.store(0);

--- a/src/storages/graph/edge_table.cc
+++ b/src/storages/graph/edge_table.cc
@@ -38,48 +38,6 @@
 
 namespace neug {
 
-namespace {
-
-// Remove any tmp_dir files belonging to a previously dropped edge label of
-// the given (src, edge, dst) triple. tmp filenames key on label strings
-// (not numeric label_t), and Schema reuses the same numeric ids when a same-
-// triple edge is re-created, so without this sweep an in-process DROP+CREATE
-// would re-mmap the prior edge label's leftover data.
-void cleanup_edge_label_tmp_files(const std::string& work_dir,
-                                  const std::string& src_label_name,
-                                  const std::string& dst_label_name,
-                                  const std::string& edge_label_name) {
-  std::string tmp_dir_path = tmp_dir(work_dir);
-  if (!std::filesystem::exists(tmp_dir_path)) {
-    return;
-  }
-  const std::string prefixes[] = {
-      ie_prefix(src_label_name, dst_label_name, edge_label_name),
-      oe_prefix(src_label_name, dst_label_name, edge_label_name),
-      edata_prefix(src_label_name, dst_label_name, edge_label_name),
-      statistics_file_prefix(src_label_name, dst_label_name, edge_label_name),
-  };
-  for (const auto& entry : std::filesystem::directory_iterator(tmp_dir_path)) {
-    if (!entry.is_regular_file()) {
-      continue;
-    }
-    const std::string fname = entry.path().filename().string();
-    for (const auto& p : prefixes) {
-      if (filename_matches_label_prefix(fname, p)) {
-        std::error_code ec;
-        std::filesystem::remove(entry.path(), ec);
-        if (ec) {
-          LOG(WARNING) << "Failed to remove stale tmp file " << entry.path()
-                       << ": " << ec.message();
-        }
-        break;
-      }
-    }
-  }
-}
-
-}  // namespace
-
 std::tuple<std::vector<vid_t>, std::vector<vid_t>, std::vector<bool>>
 filterInvalidEdges(const std::vector<vid_t>& src_lid,
                    const std::vector<vid_t>& dst_lid) {
@@ -602,10 +560,6 @@ void EdgeTable::Open(const std::string& work_dir, MemoryLevel memory_level) {
 // here — only the next CHECKPOINT (PropertyGraph::Dump) advances it.
 void EdgeTable::Initialize(const std::string& work_dir,
                            MemoryLevel memory_level) {
-  if (meta_) {
-    cleanup_edge_label_tmp_files(work_dir, meta_->src_label_name,
-                                 meta_->dst_label_name, meta_->edge_label_name);
-  }
   openImpl(work_dir, memory_level, "");
 }
 
@@ -666,7 +620,7 @@ void EdgeTable::openImpl(const std::string& work_dir, MemoryLevel memory_level,
                           meta_->dst_label_name, meta_->edge_label_name,
                           capacity_, table_idx_);
       if (table_cap != capacity_.load()) {
-        THROW_INVALID_ARGUMENT_EXCEPTION(
+        THROW_INTERNAL_EXCEPTION(
             "capacity in statistic file not match actual table capacity, maybe "
             "the graph is not dumped properly");
       }
@@ -686,24 +640,7 @@ void EdgeTable::Close() {
   }
 }
 
-// Drop releases the table's in-memory state only. It does NOT touch the
-// filesystem.
-//
-// Physical tmp_dir cleanup happens at three explicit gates:
-//   - process startup: PropertyGraph::Open wipes tmp_dir
-//   - next CREATE for the same triple: Initialize sweeps stale tmp files
-//   - next CHECKPOINT: PropertyGraph::Dump rewrites checkpoint_dir from scratch
-//
-// checkpoint_dir is never modified outside of CHECKPOINT — this is what gives
-// DROP its implicit crash-rollback semantics (a crash between DROP and the
-// next CHECKPOINT re-reads the prior checkpoint, effectively undoing the
-// DROP). Do not make this function delete files; doing so requires writing
-// DROP to the WAL first or that rollback invariant will break.
-void EdgeTable::Drop() {
-  out_csr_.reset();
-  in_csr_.reset();
-  table_.reset();
-}
+void EdgeTable::Drop() { Close(); }
 
 void EdgeTable::Dump(const std::string& checkpoint_dir_path) {
   in_csr_->dump(ie_prefix(meta_->src_label_name, meta_->dst_label_name,

--- a/src/storages/graph/edge_table.cc
+++ b/src/storages/graph/edge_table.cc
@@ -66,7 +66,7 @@ void cleanup_edge_label_tmp_files(const std::string& work_dir,
     }
     const std::string fname = entry.path().filename().string();
     for (const auto& p : prefixes) {
-      if (!p.empty() && fname.rfind(p, 0) == 0) {
+      if (filename_matches_label_prefix(fname, p)) {
         std::error_code ec;
         std::filesystem::remove(entry.path(), ec);
         if (ec) {

--- a/src/storages/graph/property_graph.cc
+++ b/src/storages/graph/property_graph.cc
@@ -233,7 +233,7 @@ Status PropertyGraph::CreateVertexType(const CreateVertexTypeParam& config) {
   }
 
   auto& vtable = vertex_tables_[vertex_label_id];
-  vtable.Open(work_dir_, memory_level_);
+  vtable.Initialize(work_dir_, memory_level_);
   vtable.EnsureCapacity(4096);
   vertex_label_total_count_ = schema_.vertex_label_frontier();
   assert(vertex_tables_.size() == vertex_label_total_count_);
@@ -316,7 +316,7 @@ Status PropertyGraph::CreateEdgeType(const CreateEdgeTypeParam& config) {
       vertex_tables_[src_label_i].get_indexer().capacity(), (size_t) 4096);
   auto dst_v_capacity = std::max(
       vertex_tables_[dst_label_i].get_indexer().capacity(), (size_t) 4096);
-  edge_tables_.at(index).Open(work_dir_, memory_level_);
+  edge_tables_.at(index).Initialize(work_dir_, memory_level_);
   edge_tables_.at(index).EnsureCapacity(src_v_capacity, dst_v_capacity, 4096);
 
   return neug::Status::OK();
@@ -597,15 +597,19 @@ Status PropertyGraph::DeleteVertexType(label_t v_label_id) {
       if (schema_.is_edge_triplet_valid(v_label_id, i, j)) {
         schema_.DeleteEdgeLabel(v_label_id, i, j);
         size_t index = schema_.generate_edge_label(v_label_id, i, j);
-        if (edge_tables_.count(index) > 0) {
-          edge_tables_.erase(index);
+        auto it = edge_tables_.find(index);
+        if (it != edge_tables_.end()) {
+          it->second.Drop();
+          edge_tables_.erase(it);
         }
       }
       if (schema_.is_edge_triplet_valid(i, v_label_id, j)) {
         schema_.DeleteEdgeLabel(i, v_label_id, j);
         size_t index = schema_.generate_edge_label(i, v_label_id, j);
-        if (edge_tables_.count(index) > 0) {
-          edge_tables_.erase(index);
+        auto it = edge_tables_.find(index);
+        if (it != edge_tables_.end()) {
+          it->second.Drop();
+          edge_tables_.erase(it);
         }
       }
     }
@@ -627,8 +631,10 @@ Status PropertyGraph::DeleteEdgeType(label_t src_v_label, label_t dst_v_label,
   size_t index =
       schema_.generate_edge_label(src_v_label, dst_v_label, edge_label);
   schema_.DeleteEdgeLabel(src_v_label, dst_v_label, edge_label, false);
-  if (edge_tables_.count(index) > 0) {
-    edge_tables_.erase(index);
+  auto it = edge_tables_.find(index);
+  if (it != edge_tables_.end()) {
+    it->second.Drop();
+    edge_tables_.erase(it);
   }
   return neug::Status::OK();
 }
@@ -749,8 +755,11 @@ void PropertyGraph::Open(const std::string& work_dir,
   vertex_label_total_count_ = schema_.vertex_label_frontier();
   edge_label_total_count_ = schema_.edge_label_frontier();
   for (size_t i = 0; i < vertex_label_total_count_; i++) {
-    if (!schema_.is_vertex_label_valid(i)) {
-      THROW_INTERNAL_EXCEPTION("Invalid vertex label id: " + std::to_string(i));
+    if (!schema_.vertex_label_valid(i)) {
+      // Tombstoned vertex label: keep the slot to preserve label_t -> index
+      // mapping, but leave the VertexTable in a dropped state.
+      vertex_tables_.emplace_back();
+      continue;
     }
     vertex_tables_.emplace_back(schema_.get_vertex_schema(i));
   }

--- a/src/storages/graph/property_graph.cc
+++ b/src/storages/graph/property_graph.cc
@@ -217,17 +217,8 @@ Status PropertyGraph::CreateVertexType(const CreateVertexTypeParam& config) {
                          default_property_values);
   label_t vertex_label_id = schema_.get_vertex_label_id(vertex_type_name);
   if (vertex_label_id < vertex_tables_.size()) {
-    auto& vtable = vertex_tables_[vertex_label_id];
-    if (vtable.is_dropped()) {
-      // Reuse a dropped vertex table
-      auto new_v_table =
-          VertexTable(schema_.get_vertex_schema(vertex_label_id));
-
-      vtable.Swap(new_v_table);
-    } else {
-      return Status(StatusCode::ERR_INVALID_ARGUMENT,
-                    "Vertex label id conflict.");
-    }
+    auto new_v_table = VertexTable(schema_.get_vertex_schema(vertex_label_id));
+    vertex_tables_[vertex_label_id].Swap(new_v_table);
   } else {
     vertex_tables_.emplace_back(schema_.get_vertex_schema(vertex_label_id));
   }
@@ -584,7 +575,7 @@ Status PropertyGraph::DeleteVertexType(const std::string& vertex_type_name) {
 
 Status PropertyGraph::DeleteVertexType(label_t v_label_id) {
   schema_.DeleteVertexLabel(v_label_id, false);
-  vertex_tables_[v_label_id].Drop();
+  vertex_tables_[v_label_id].Close();
 
   for (label_t i = 0; i < vertex_label_total_count_; i++) {
     if (!schema_.is_vertex_label_valid(i)) {
@@ -599,7 +590,7 @@ Status PropertyGraph::DeleteVertexType(label_t v_label_id) {
         size_t index = schema_.generate_edge_label(v_label_id, i, j);
         auto it = edge_tables_.find(index);
         if (it != edge_tables_.end()) {
-          it->second.Drop();
+          it->second.Close();
           edge_tables_.erase(it);
         }
       }
@@ -608,7 +599,7 @@ Status PropertyGraph::DeleteVertexType(label_t v_label_id) {
         size_t index = schema_.generate_edge_label(i, v_label_id, j);
         auto it = edge_tables_.find(index);
         if (it != edge_tables_.end()) {
-          it->second.Drop();
+          it->second.Close();
           edge_tables_.erase(it);
         }
       }
@@ -633,7 +624,7 @@ Status PropertyGraph::DeleteEdgeType(label_t src_v_label, label_t dst_v_label,
   schema_.DeleteEdgeLabel(src_v_label, dst_v_label, edge_label, false);
   auto it = edge_tables_.find(index);
   if (it != edge_tables_.end()) {
-    it->second.Drop();
+    it->second.Close();
     edge_tables_.erase(it);
   }
   return neug::Status::OK();
@@ -967,7 +958,7 @@ void PropertyGraph::Dump(bool reopen) {
   std::vector<size_t> vertex_num(vertex_label_total_count_, 0);
   std::vector<size_t> vertex_capacity(vertex_label_total_count_, 0);
   for (size_t i = 0; i < vertex_label_total_count_; ++i) {
-    if (!vertex_tables_[i].is_dropped()) {
+    if (schema_.is_vertex_label_valid(i)) {
       vertex_num[i] = vertex_tables_[i].LidNum();
       EnsureCapacity(
           i, vertex_num[i] < 4096 ? 4096 : vertex_num[i] + vertex_num[i] / 4);

--- a/src/storages/graph/property_graph.cc
+++ b/src/storages/graph/property_graph.cc
@@ -755,7 +755,7 @@ void PropertyGraph::Open(const std::string& work_dir,
   vertex_label_total_count_ = schema_.vertex_label_frontier();
   edge_label_total_count_ = schema_.edge_label_frontier();
   for (size_t i = 0; i < vertex_label_total_count_; i++) {
-    if (!schema_.vertex_label_valid(i)) {
+    if (!schema_.is_vertex_label_valid(i)) {
       // Tombstoned vertex label: keep the slot to preserve label_t -> index
       // mapping, but leave the VertexTable in a dropped state.
       vertex_tables_.emplace_back();

--- a/src/storages/graph/vertex_table.cc
+++ b/src/storages/graph/vertex_table.cc
@@ -14,20 +14,80 @@
  */
 
 #include "neug/storages/graph/vertex_table.h"
+#include <filesystem>
 #include "neug/utils/file_utils.h"
 #include "neug/utils/likely.h"
 
 namespace neug {
 
+namespace {
+
+// Remove any tmp_dir files belonging to a previously dropped vertex label of
+// the given name. tmp filenames key on the label string (not the numeric
+// label_t), and Schema reuses the same numeric id when a same-name label is
+// re-created, so without this sweep an in-process DROP+CREATE would re-mmap
+// the prior label's leftover data.
+void cleanup_vertex_label_tmp_files(const std::string& work_dir,
+                                    const std::string& label_name) {
+  std::string tmp_dir_path = tmp_dir(work_dir);
+  if (!std::filesystem::exists(tmp_dir_path)) {
+    return;
+  }
+  const std::string prefixes[] = {
+      vertex_table_prefix(label_name),
+      vertex_map_prefix(label_name),
+      IndexerType::prefix() + "_" + vertex_map_prefix(label_name),
+      vertex_tracker_file(label_name),
+  };
+  for (const auto& entry :
+       std::filesystem::directory_iterator(tmp_dir_path)) {
+    if (!entry.is_regular_file()) {
+      continue;
+    }
+    const std::string fname = entry.path().filename().string();
+    for (const auto& p : prefixes) {
+      if (!p.empty() && fname.rfind(p, 0) == 0) {
+        std::error_code ec;
+        std::filesystem::remove(entry.path(), ec);
+        if (ec) {
+          LOG(WARNING) << "Failed to remove stale tmp file " << entry.path()
+                       << ": " << ec.message();
+        }
+        break;
+      }
+    }
+  }
+}
+
+}  // namespace
+
 void VertexTable::Open(const std::string& work_dir, MemoryLevel memory_level) {
+  openImpl(work_dir, memory_level, checkpoint_dir(work_dir));
+}
+
+// Initialize releases nothing on the filesystem itself: it only sweeps stale
+// tmp files left behind by a prior in-process DROP of the same label and then
+// opens fresh containers. Persistent checkpoint state is never touched here —
+// only the next CHECKPOINT (PropertyGraph::Dump) advances it.
+void VertexTable::Initialize(const std::string& work_dir,
+                             MemoryLevel memory_level) {
+  if (vertex_schema_) {
+    cleanup_vertex_label_tmp_files(work_dir, vertex_schema_->label_name);
+  }
+  openImpl(work_dir, memory_level, "");
+}
+
+void VertexTable::openImpl(const std::string& work_dir,
+                           MemoryLevel memory_level,
+                           const std::string& checkpoint_dir_path) {
   memory_level_ = memory_level;
   work_dir_ = work_dir;
-  std::string tmp_dir_path = tmp_dir(work_dir_);
-  std::string checkpoint_dir_path = checkpoint_dir(work_dir_);
 
   const auto& label_name = vertex_schema_->label_name;
   std::string vertex_tracker_filename =
-      checkpoint_dir_path + "/" + vertex_tracker_file(label_name);
+      checkpoint_dir_path.empty()
+          ? ""
+          : checkpoint_dir_path + "/" + vertex_tracker_file(label_name);
   auto indexer_filename =
       IndexerType::prefix() + "_" + vertex_map_prefix(label_name);
   if (memory_level_ == MemoryLevel::kSyncToFile) {
@@ -37,13 +97,17 @@ void VertexTable::Open(const std::string& work_dir, MemoryLevel memory_level) {
                  vertex_schema_->property_types);
 
   } else if (memory_level_ == MemoryLevel::kInMemory) {
-    indexer_->open_in_memory(checkpoint_dir_path + "/" + indexer_filename);
+    indexer_->open_in_memory(checkpoint_dir_path.empty()
+                                 ? ""
+                                 : checkpoint_dir_path + "/" + indexer_filename);
     table_->open_in_memory(vertex_table_prefix(label_name), work_dir_,
                            vertex_schema_->property_names,
                            vertex_schema_->property_types);
 
   } else if (memory_level_ == MemoryLevel::kHugePagePreferred) {
-    indexer_->open_with_hugepages(checkpoint_dir_path + "/" + indexer_filename);
+    indexer_->open_with_hugepages(
+        checkpoint_dir_path.empty() ? ""
+                                    : checkpoint_dir_path + "/" + indexer_filename);
     table_->open_with_hugepages(vertex_table_prefix(label_name), work_dir_,
                                 vertex_schema_->property_names,
                                 vertex_schema_->property_types);
@@ -241,6 +305,19 @@ void VertexTable::AddProperties(const std::vector<std::string>& properties,
                       memory_level_);
 }
 
+// Drop releases the table's in-memory state only. It does NOT touch the
+// filesystem.
+//
+// Physical tmp_dir cleanup happens at three explicit gates:
+//   - process startup: PropertyGraph::Open wipes tmp_dir
+//   - next CREATE for the same label: Initialize sweeps stale tmp files
+//   - next CHECKPOINT: PropertyGraph::Dump rewrites checkpoint_dir from scratch
+//
+// checkpoint_dir is never modified outside of CHECKPOINT — this is what gives
+// DROP its implicit crash-rollback semantics (a crash between DROP and the
+// next CHECKPOINT re-reads the prior checkpoint, effectively undoing the
+// DROP). Do not make this function delete files; doing so requires writing
+// DROP to the WAL first or that rollback invariant will break.
 void VertexTable::Drop() {
   indexer_->drop();
   table_->drop();
@@ -248,8 +325,6 @@ void VertexTable::Drop() {
   indexer_.reset();
   table_.reset();
   v_ts_.reset();
-  // TODO(zhanglei): reset the indexer.
-  // indexer_ = IndexerType();
 }
 
 void VertexTable::RenameProperties(const std::vector<std::string>& old_names,

--- a/src/storages/graph/vertex_table.cc
+++ b/src/storages/graph/vertex_table.cc
@@ -39,14 +39,13 @@ void cleanup_vertex_label_tmp_files(const std::string& work_dir,
       IndexerType::prefix() + "_" + vertex_map_prefix(label_name),
       vertex_tracker_file(label_name),
   };
-  for (const auto& entry :
-       std::filesystem::directory_iterator(tmp_dir_path)) {
+  for (const auto& entry : std::filesystem::directory_iterator(tmp_dir_path)) {
     if (!entry.is_regular_file()) {
       continue;
     }
     const std::string fname = entry.path().filename().string();
     for (const auto& p : prefixes) {
-      if (!p.empty() && fname.rfind(p, 0) == 0) {
+      if (filename_matches_label_prefix(fname, p)) {
         std::error_code ec;
         std::filesystem::remove(entry.path(), ec);
         if (ec) {
@@ -99,15 +98,17 @@ void VertexTable::openImpl(const std::string& work_dir,
   } else if (memory_level_ == MemoryLevel::kInMemory) {
     indexer_->open_in_memory(checkpoint_dir_path.empty()
                                  ? ""
-                                 : checkpoint_dir_path + "/" + indexer_filename);
+                                 : checkpoint_dir_path + "/" +
+                                       indexer_filename);
     table_->open_in_memory(vertex_table_prefix(label_name), work_dir_,
                            vertex_schema_->property_names,
                            vertex_schema_->property_types);
 
   } else if (memory_level_ == MemoryLevel::kHugePagePreferred) {
-    indexer_->open_with_hugepages(
-        checkpoint_dir_path.empty() ? ""
-                                    : checkpoint_dir_path + "/" + indexer_filename);
+    indexer_->open_with_hugepages(checkpoint_dir_path.empty()
+                                      ? ""
+                                      : checkpoint_dir_path + "/" +
+                                            indexer_filename);
     table_->open_with_hugepages(vertex_table_prefix(label_name), work_dir_,
                                 vertex_schema_->property_names,
                                 vertex_schema_->property_types);
@@ -305,19 +306,6 @@ void VertexTable::AddProperties(const std::vector<std::string>& properties,
                       memory_level_);
 }
 
-// Drop releases the table's in-memory state only. It does NOT touch the
-// filesystem.
-//
-// Physical tmp_dir cleanup happens at three explicit gates:
-//   - process startup: PropertyGraph::Open wipes tmp_dir
-//   - next CREATE for the same label: Initialize sweeps stale tmp files
-//   - next CHECKPOINT: PropertyGraph::Dump rewrites checkpoint_dir from scratch
-//
-// checkpoint_dir is never modified outside of CHECKPOINT — this is what gives
-// DROP its implicit crash-rollback semantics (a crash between DROP and the
-// next CHECKPOINT re-reads the prior checkpoint, effectively undoing the
-// DROP). Do not make this function delete files; doing so requires writing
-// DROP to the WAL first or that rollback invariant will break.
 void VertexTable::Drop() {
   indexer_->drop();
   table_->drop();

--- a/src/storages/graph/vertex_table.cc
+++ b/src/storages/graph/vertex_table.cc
@@ -14,51 +14,10 @@
  */
 
 #include "neug/storages/graph/vertex_table.h"
-#include <filesystem>
 #include "neug/utils/file_utils.h"
 #include "neug/utils/likely.h"
 
 namespace neug {
-
-namespace {
-
-// Remove any tmp_dir files belonging to a previously dropped vertex label of
-// the given name. tmp filenames key on the label string (not the numeric
-// label_t), and Schema reuses the same numeric id when a same-name label is
-// re-created, so without this sweep an in-process DROP+CREATE would re-mmap
-// the prior label's leftover data.
-void cleanup_vertex_label_tmp_files(const std::string& work_dir,
-                                    const std::string& label_name) {
-  std::string tmp_dir_path = tmp_dir(work_dir);
-  if (!std::filesystem::exists(tmp_dir_path)) {
-    return;
-  }
-  const std::string prefixes[] = {
-      vertex_table_prefix(label_name),
-      vertex_map_prefix(label_name),
-      IndexerType::prefix() + "_" + vertex_map_prefix(label_name),
-      vertex_tracker_file(label_name),
-  };
-  for (const auto& entry : std::filesystem::directory_iterator(tmp_dir_path)) {
-    if (!entry.is_regular_file()) {
-      continue;
-    }
-    const std::string fname = entry.path().filename().string();
-    for (const auto& p : prefixes) {
-      if (filename_matches_label_prefix(fname, p)) {
-        std::error_code ec;
-        std::filesystem::remove(entry.path(), ec);
-        if (ec) {
-          LOG(WARNING) << "Failed to remove stale tmp file " << entry.path()
-                       << ": " << ec.message();
-        }
-        break;
-      }
-    }
-  }
-}
-
-}  // namespace
 
 void VertexTable::Open(const std::string& work_dir, MemoryLevel memory_level) {
   openImpl(work_dir, memory_level, checkpoint_dir(work_dir));
@@ -70,9 +29,6 @@ void VertexTable::Open(const std::string& work_dir, MemoryLevel memory_level) {
 // only the next CHECKPOINT (PropertyGraph::Dump) advances it.
 void VertexTable::Initialize(const std::string& work_dir,
                              MemoryLevel memory_level) {
-  if (vertex_schema_) {
-    cleanup_vertex_label_tmp_files(work_dir, vertex_schema_->label_name);
-  }
   openImpl(work_dir, memory_level, "");
 }
 

--- a/src/storages/graph/vertex_table.cc
+++ b/src/storages/graph/vertex_table.cc
@@ -23,10 +23,6 @@ void VertexTable::Open(const std::string& work_dir, MemoryLevel memory_level) {
   openImpl(work_dir, memory_level, checkpoint_dir(work_dir));
 }
 
-// Initialize releases nothing on the filesystem itself: it only sweeps stale
-// tmp files left behind by a prior in-process DROP of the same label and then
-// opens fresh containers. Persistent checkpoint state is never touched here —
-// only the next CHECKPOINT (PropertyGraph::Dump) advances it.
 void VertexTable::Initialize(const std::string& work_dir,
                              MemoryLevel memory_level) {
   openImpl(work_dir, memory_level, "");
@@ -260,15 +256,6 @@ void VertexTable::AddProperties(const std::vector<std::string>& properties,
                                 const std::vector<Property>& default_values) {
   table_->add_columns(properties, types, default_values, indexer_->capacity(),
                       memory_level_);
-}
-
-void VertexTable::Drop() {
-  indexer_->drop();
-  table_->drop();
-  v_ts_->Clear();
-  indexer_.reset();
-  table_.reset();
-  v_ts_.reset();
 }
 
 void VertexTable::RenameProperties(const std::vector<std::string>& old_names,

--- a/src/utils/property/table.cc
+++ b/src/utils/property/table.cc
@@ -312,11 +312,6 @@ void Table::ingest(uint32_t index, OutArchive& arc) {
 
 void Table::close() { columns_.clear(); }
 
-void Table::drop() {
-  close();
-  // TODO(zhanglei): delete files in work_dir
-}
-
 void Table::set_name(const std::string& name) { name_ = name; }
 
 void Table::set_work_dir(const std::string& work_dir) { work_dir_ = work_dir; }

--- a/tests/storage/test_checkpoint.cc
+++ b/tests/storage/test_checkpoint.cc
@@ -19,8 +19,10 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <vector>
 #include "column_assertions.h"
+#include "neug/config.h"
 #include "neug/main/connection.h"
 #include "neug/main/neug_db.h"
 #include "neug/server/neug_db_service.h"
@@ -30,6 +32,22 @@
 
 namespace {
 
+// ---------------------------------------------------------------------------
+// Memory level traits for typed tests.
+// ---------------------------------------------------------------------------
+template <neug::MemoryLevel kLevel>
+struct MemoryLevelTag {
+  static constexpr neug::MemoryLevel value = kLevel;
+};
+
+using InMemoryLevel = MemoryLevelTag<neug::MemoryLevel::kInMemory>;
+using SyncToFileLevel = MemoryLevelTag<neug::MemoryLevel::kSyncToFile>;
+
+using AllMemoryLevels = ::testing::Types<InMemoryLevel, SyncToFileLevel>;
+
+// ---------------------------------------------------------------------------
+// Test data constants
+// ---------------------------------------------------------------------------
 constexpr std::array<int64_t, 4> kPersonIds = {1, 2, 4, 6};
 const std::vector<int64_t> kPersonIdValues(kPersonIds.begin(),
                                            kPersonIds.end());
@@ -39,6 +57,9 @@ constexpr std::array<int64_t, 4> kPersonAges = {29, 27, 32, 35};
 const std::vector<int64_t> kPersonAgeValues(kPersonAges.begin(),
                                             kPersonAges.end());
 
+// ---------------------------------------------------------------------------
+// Assertion helpers
+// ---------------------------------------------------------------------------
 void AssertPersonVertexBasic(const neug::QueryResponse& table) {
   ASSERT_EQ(table.row_count(), 4);
   ASSERT_EQ(table.arrays_size(), 3);
@@ -130,438 +151,608 @@ void AssertCreatedEdgesSnapshotResult(
   neug::test::AssertInt64Column(table, 1, since);
   neug::test::AssertInt64Column(table, 2, software_ids);
 }
+
 }  // namespace
 
 namespace neug {
-
 namespace test {
 
-class CheckpointTest : public ::testing::Test {
+// ===========================================================================
+// Base fixture — shared DB lifecycle helpers for all checkpoint suites.
+// Parameterized by MemoryLevelTag<kLevel> via CRTP so typed tests inherit it.
+// ===========================================================================
+template <typename MemoryLevelT>
+class CheckpointTestBase : public ::testing::Test {
  protected:
-  static constexpr const char* DB_DIR = "/tmp/checkpoint_test";
+  static constexpr neug::MemoryLevel kMemoryLevel = MemoryLevelT::value;
 
-  void SetUp() override {
-    if (std::filesystem::exists(DB_DIR)) {
-      std::filesystem::remove_all(DB_DIR);
-    }
-    std::filesystem::create_directories(DB_DIR);
+  // -- Config / open helpers (single source of truth) ----------------------
 
-    std::unique_ptr<neug::NeugDB> db_ = std::make_unique<neug::NeugDB>();
+  static neug::NeugDBConfig MakeConfig(const std::string& data_dir) {
     neug::NeugDBConfig config;
-    config.data_dir = DB_DIR;
+    config.data_dir = data_dir;
+    config.memory_level = kMemoryLevel;
     config.checkpoint_on_close = true;
     config.compact_on_close = true;
     config.compact_csr = true;
-    config.enable_auto_compaction = false;  // TODO(zhanglei): very slow
-    db_->Open(config);
-    auto conn = db_->Connect();
+    config.enable_auto_compaction = false;
+    return config;
+  }
 
+  static void OpenDB(neug::NeugDB& db, const std::string& data_dir) {
+    db.Open(MakeConfig(data_dir));
+  }
+
+  // -- Directory lifecycle -------------------------------------------------
+
+  static void CleanDir(const std::string& dir) {
+    if (std::filesystem::exists(dir)) {
+      std::filesystem::remove_all(dir);
+    }
+  }
+
+  static void EnsureCleanDir(const std::string& dir) {
+    CleanDir(dir);
+    std::filesystem::create_directories(dir);
+  }
+
+  // -- Unique per-test directory generation --------------------------------
+
+  static std::string MakeUniqueDir(const std::string& prefix) {
+    const auto* test_info =
+        ::testing::UnitTest::GetInstance()->current_test_info();
+    std::string dir = (std::filesystem::temp_directory_path() /
+                       (prefix + "_" + test_info->test_suite_name() + "_" +
+                        test_info->name()))
+                          .string();
+    EnsureCleanDir(dir);
+    return dir;
+  }
+
+  // -- Query helpers (avoid repetitive boilerplate) ------------------------
+
+  static void ExpectQuery(neug::Connection& conn, const std::string& cypher) {
+    auto res = conn.Query(cypher);
+    EXPECT_TRUE(res) << res.error().ToString();
+  }
+
+  static neug::QueryResponse RunQuery(neug::Connection& conn,
+                                      const std::string& cypher) {
+    auto res = conn.Query(cypher);
+    EXPECT_TRUE(res) << res.error().ToString();
+    return res.value().response();
+  }
+
+  // -- Common assertion combos used across many tests ----------------------
+
+  static void AssertBasicPersonAndKnows(neug::Connection& conn,
+                                        const std::vector<double>& weights) {
+    AssertPersonVertexBasic(RunQuery(conn, "MATCH (v:person) RETURN v.*;"));
+    AssertKnowsWeight(
+        RunQuery(conn, "MATCH (v:person)-[e:knows]->(:person) RETURN e.*;"),
+        weights);
+  }
+};
+
+// ===========================================================================
+// CheckpointTest — modern-graph based checkpoint scenarios
+// ===========================================================================
+template <typename T>
+class CheckpointTest : public CheckpointTestBase<T> {
+ protected:
+  std::string db_dir_;
+
+  void SetUp() override {
+    db_dir_ = this->MakeUniqueDir("checkpoint_test");
+    neug::NeugDB db;
+    this->OpenDB(db, db_dir_);
+    auto conn = db.Connect();
     load_modern_graph(conn);
     LOG(INFO) << "[CheckPointTest]: Finished loading modern graph";
     conn->Close();
-    db_->Close();
-    db_.reset();
+    db.Close();
   }
 
-  void TearDown() override {}
+  void TearDown() override { this->CleanDir(db_dir_); }
 };
 
-TEST_F(CheckpointTest, test_basic) {
-  std::unique_ptr<neug::NeugDB> db_ = std::make_unique<neug::NeugDB>();
-  db_->Open(DB_DIR);
-  auto conn = db_->Connect();
+TYPED_TEST_SUITE(CheckpointTest, AllMemoryLevels);
 
-  db_->Close();
-  db_->Open(DB_DIR);
-
-  conn = db_->Connect();
-  {
-    auto res = conn->Query("MATCH (v:person) RETURN v.*;");
-    EXPECT_TRUE(res) << res.error().ToString();
-    const auto& table = res.value().response();
-    AssertPersonVertexBasic(table);
-  }
-  {
-    auto res = conn->Query("MATCH (v:person)-[e:knows]->(:person) RETURN e.*;");
-    EXPECT_TRUE(res) << res.error().ToString();
-    const auto& table = res.value().response();
-    AssertKnowsWeight(table, {0.5, 1.0});
-  }
+TYPED_TEST(CheckpointTest, basic) {
+  neug::NeugDB db;
+  this->OpenDB(db, this->db_dir_);
+  db.Close();
+  this->OpenDB(db, this->db_dir_);
+  auto conn = db.Connect();
+  this->AssertBasicPersonAndKnows(*conn, {0.5, 1.0});
 }
 
-TEST_F(CheckpointTest, test_after_add_vertex_property) {
+TYPED_TEST(CheckpointTest, after_add_vertex_property) {
   neug::NeugDB db;
-  db.Open(DB_DIR);
+  this->OpenDB(db, this->db_dir_);
+  auto conn = db.Connect();
+  this->ExpectQuery(*conn, "ALTER TABLE person ADD created STRING;");
+
+  db.Close();
+  this->OpenDB(db, this->db_dir_);
+  conn = db.Connect();
+
+  AssertPersonVertexWithCreated(
+      this->RunQuery(*conn, "MATCH (v:person) RETURN v.*;"), {"", "", "", ""});
+  AssertKnowsWeight(
+      this->RunQuery(*conn,
+                     "MATCH (v:person)-[e:knows]->(:person) RETURN e.*;"),
+      {0.5, 1.0});
+}
+
+TYPED_TEST(CheckpointTest, after_delete_vertex_property) {
+  neug::NeugDB db;
+  this->OpenDB(db, this->db_dir_);
+  auto conn = db.Connect();
+  this->ExpectQuery(*conn, "ALTER TABLE person DROP age;");
+
+  db.Close();
+  this->OpenDB(db, this->db_dir_);
+  conn = db.Connect();
+
+  AssertPersonVertexWithoutAge(
+      this->RunQuery(*conn, "MATCH (v:person) RETURN v.*;"));
+  AssertKnowsWeight(
+      this->RunQuery(*conn,
+                     "MATCH (v:person)-[e:knows]->(:person) RETURN e.*;"),
+      {0.5, 1.0});
+}
+
+TYPED_TEST(CheckpointTest, after_delete_vertex) {
+  neug::NeugDB db;
+  this->OpenDB(db, this->db_dir_);
+  auto conn = db.Connect();
+  this->ExpectQuery(*conn, "MATCH (v:person) WHERE v.id = 1 DELETE v;");
+
+  db.Close();
+  this->OpenDB(db, this->db_dir_);
+  conn = db.Connect();
+
+  AssertPersonVertexAfterDelete(
+      this->RunQuery(*conn, "MATCH (v:person) RETURN v.*;"));
+  AssertKnowsWeight(
+      this->RunQuery(*conn,
+                     "MATCH (v:person)-[e:knows]->(:person) RETURN e.*;"),
+      {});
+}
+
+TYPED_TEST(CheckpointTest, after_add_edge_property1) {
+  neug::NeugDB db;
+  this->OpenDB(db, this->db_dir_);
+  auto conn = db.Connect();
+  this->ExpectQuery(*conn, "ALTER TABLE knows ADD registration DATE;");
+
+  AssertKnowsWeightAndRegistration(
+      this->RunQuery(*conn,
+                     "MATCH (v:person)-[e:knows]->(:person) RETURN e.*;"),
+      {0.5, 1.0}, {0, 0});
+
+  db.Close();
+  this->OpenDB(db, this->db_dir_);
+  conn = db.Connect();
+
+  AssertPersonVertexBasic(
+      this->RunQuery(*conn, "MATCH (v:person) RETURN v.*;"));
+  AssertKnowsWeightAndRegistration(
+      this->RunQuery(*conn,
+                     "MATCH (v:person)-[e:knows]->(:person) RETURN e.*;"),
+      {0.5, 1.0}, {0, 0});
+}
+
+TYPED_TEST(CheckpointTest, after_add_edge_property2) {
+  neug::NeugDB db;
+  this->OpenDB(db, this->db_dir_);
   auto conn = db.Connect();
 
-  {
-    auto res = conn->Query("ALTER TABLE person ADD created STRING;");
-    EXPECT_TRUE(res) << res.error().ToString();
-  }
+  AssertPersonVertexBasic(
+      this->RunQuery(*conn, "MATCH (v:person) RETURN v.*;"));
+  this->ExpectQuery(*conn, "ALTER TABLE knows ADD description STRING;");
 
   db.Close();
-  db.Open(DB_DIR);
-
+  this->OpenDB(db, this->db_dir_);
   conn = db.Connect();
-  {
-    auto res = conn->Query("MATCH (v:person) RETURN v.*;");
-    EXPECT_TRUE(res) << res.error().ToString();
-    const auto& table = res.value().response();
-    AssertPersonVertexWithCreated(table, {"", "", "", ""});
-  }
-  {
-    auto res = conn->Query("MATCH (v:person)-[e:knows]->(:person) RETURN e.*;");
-    EXPECT_TRUE(res) << res.error().ToString();
-    const auto& table = res.value().response();
-    AssertKnowsWeight(table, {0.5, 1.0});
-  }
+
+  AssertKnowsWeightAndDescription(
+      this->RunQuery(*conn,
+                     "MATCH (v:person)-[e:knows]->(:person) RETURN e.*;"),
+      {0.5, 1.0}, {"", ""});
+
+  this->ExpectQuery(*conn, "ALTER TABLE knows ADD date DATE;");
+
+  db.Close();
+  this->OpenDB(db, this->db_dir_);
+  conn = db.Connect();
+
+  AssertPersonVertexBasic(
+      this->RunQuery(*conn, "MATCH (v:person) RETURN v.*;"));
+  AssertKnowsFullSchema(
+      this->RunQuery(*conn,
+                     "MATCH (v:person)-[e:knows]->(:person) RETURN e.*;"),
+      {0.5, 1.0}, {"", ""}, {0, 0});
 }
 
-TEST_F(CheckpointTest, test_after_delete_vertex_property) {
+TYPED_TEST(CheckpointTest, after_delete_edge_property) {
   neug::NeugDB db;
-  db.Open(DB_DIR);
-  auto conn = db.Connect();
-
-  {
-    auto res = conn->Query("ALTER TABLE person DROP age;");
-    EXPECT_TRUE(res) << res.error().ToString();
-  }
-
-  db.Close();
-  db.Open(DB_DIR);
-  conn = db.Connect();
-
-  {
-    auto res = conn->Query("MATCH (v:person) RETURN v.*;");
-    EXPECT_TRUE(res) << res.error().ToString();
-    const auto& table = res.value().response();
-    AssertPersonVertexWithoutAge(table);
-  }
-  {
-    auto res = conn->Query("MATCH (v:person)-[e:knows]->(:person) RETURN e.*;");
-    EXPECT_TRUE(res) << res.error().ToString();
-    const auto& table = res.value().response();
-    AssertKnowsWeight(table, {0.5, 1.0});
-  }
-}
-
-TEST_F(CheckpointTest, test_after_delete_vertex) {
-  neug::NeugDB db;
-  db.Open(DB_DIR);
-  auto conn = db.Connect();
-
-  {
-    auto res = conn->Query("MATCH (v:person) WHERE v.id = 1 DELETE v;");
-    EXPECT_TRUE(res) << res.error().ToString();
-  }
-
-  db.Close();
-  db.Open(DB_DIR);
-  conn = db.Connect();
-
-  {
-    auto res = conn->Query("MATCH (v:person) RETURN v.*;");
-    EXPECT_TRUE(res) << res.error().ToString();
-    const auto& table = res.value().response();
-    AssertPersonVertexAfterDelete(table);
-  }
-
-  {
-    auto res = conn->Query("MATCH (v:person)-[e:knows]->(:person) RETURN e.*;");
-    EXPECT_TRUE(res) << res.error().ToString();
-    const auto& table = res.value().response();
-    AssertKnowsWeight(table, {});
-  }
-}
-
-TEST_F(CheckpointTest, test_after_add_edge_property1) {
-  neug::NeugDB db;
-  db.Open(DB_DIR);
-  auto conn = db.Connect();
-
-  {
-    auto res = conn->Query("ALTER TABLE knows ADD registration DATE;");
-    EXPECT_TRUE(res) << res.error().ToString();
-  }
-
-  {
-    auto res = conn->Query("MATCH (v:person)-[e:knows]->(:person) RETURN e.*;");
-    EXPECT_TRUE(res) << res.error().ToString();
-    const auto& table = res.value().response();
-    AssertKnowsWeightAndRegistration(table, {0.5, 1.0}, {0, 0});
-  }
-
-  db.Close();
-  db.Open(DB_DIR);
-
-  conn = db.Connect();
-
-  {
-    auto res = conn->Query("MATCH (v:person) RETURN v.*;");
-    EXPECT_TRUE(res) << res.error().ToString();
-    const auto& table = res.value().response();
-    AssertPersonVertexBasic(table);
-  }
-
-  {
-    auto res = conn->Query("MATCH (v:person)-[e:knows]->(:person) RETURN e.*;");
-    EXPECT_TRUE(res) << res.error().ToString();
-    const auto& table = res.value().response();
-    AssertKnowsWeightAndRegistration(table, {0.5, 1.0}, {0, 0});
-  }
-}
-
-// Add a test test_after_add_edge_property2 which add property to an edge
-// table which already have 2 properties
-TEST_F(CheckpointTest, test_after_add_edge_property2) {
-  neug::NeugDB db;
-  db.Open(DB_DIR);
-  auto conn = db.Connect();
-
-  {
-    auto res = conn->Query("MATCH (v:person) RETURN v.*;");
-    EXPECT_TRUE(res) << res.error().ToString();
-    const auto& table = res.value().response();
-    AssertPersonVertexBasic(table);
-  }
-  {
-    auto res = conn->Query("ALTER TABLE knows ADD description STRING;");
-    EXPECT_TRUE(res) << res.error().ToString();
-  }
-
-  db.Close();
-  db.Open(DB_DIR);
-
-  conn = db.Connect();
-  {
-    auto res = conn->Query("MATCH (v:person)-[e:knows]->(:person) RETURN e.*;");
-    EXPECT_TRUE(res) << res.error().ToString();
-    const auto& table = res.value().response();
-    AssertKnowsWeightAndDescription(table, {0.5, 1.0}, {"", ""});
-  }
-
-  {
-    // Add another edge to check if the new property is added correctly
-    auto res = conn->Query("ALTER TABLE knows ADD date DATE;");
-    EXPECT_TRUE(res) << res.error().ToString();
-  }
-
-  db.Close();
-  db.Open(DB_DIR);
-
-  conn = db.Connect();
-
-  {
-    auto res = conn->Query("MATCH (v:person) RETURN v.*;");
-    EXPECT_TRUE(res) << res.error().ToString();
-    const auto& table = res.value().response();
-    AssertPersonVertexBasic(table);
-  }
-
-  {
-    auto res = conn->Query("MATCH (v:person)-[e:knows]->(:person) RETURN e.*;");
-    EXPECT_TRUE(res) << res.error().ToString();
-    const auto& table = res.value().response();
-    AssertKnowsFullSchema(table, {0.5, 1.0}, {"", ""}, {0, 0});
-  }
-}
-
-TEST_F(CheckpointTest, test_after_delete_edge_property) {
-  neug::NeugDB db;
-  db.Open(DB_DIR);
-
+  this->OpenDB(db, this->db_dir_);
   {
     auto conn = db.Connect();
-    auto res = conn->Query("ALTER TABLE knows DROP weight");
-    EXPECT_TRUE(res) << res.error().ToString();
+    this->ExpectQuery(*conn, "ALTER TABLE knows DROP weight");
   }
 
   db.Close();
-  db.Open(DB_DIR);
+  this->OpenDB(db, this->db_dir_);
   auto conn = db.Connect();
 
-  {
-    auto res = conn->Query("MATCH (v:person) RETURN v.*;");
-    EXPECT_TRUE(res) << res.error().ToString();
-    const auto& table = res.value().response();
-    AssertPersonVertexBasic(table);
-  }
-
-  {
-    auto res = conn->Query("MATCH (v:person)-[e:knows]->(:person) RETURN e;");
-    EXPECT_TRUE(res) << res.error().ToString();
-    const auto& table = res.value().response();
-    AssertMapColumn(table, 2);
-  }
+  AssertPersonVertexBasic(
+      this->RunQuery(*conn, "MATCH (v:person) RETURN v.*;"));
+  AssertMapColumn(
+      this->RunQuery(*conn, "MATCH (v:person)-[e:knows]->(:person) RETURN e;"),
+      2);
 }
 
-TEST_F(CheckpointTest, test_after_delete_edge) {
+TYPED_TEST(CheckpointTest, after_delete_edge) {
   neug::NeugDB db;
-  db.Open(DB_DIR);
-
+  this->OpenDB(db, this->db_dir_);
   {
     auto conn = db.Connect();
-    auto res = conn->Query(
+    this->ExpectQuery(
+        *conn,
         "MATCH (v:person)-[e:knows]->(:person) WHERE v.id = 1 DELETE e;");
-    EXPECT_TRUE(res) << res.error().ToString();
   }
 
   db.Close();
-  db.Open(DB_DIR);
+  this->OpenDB(db, this->db_dir_);
   auto conn = db.Connect();
 
-  {
-    auto res = conn->Query("MATCH (v:person) RETURN v.*;");
-    EXPECT_TRUE(res) << res.error().ToString();
-    const auto& table = res.value().response();
-    AssertPersonVertexBasic(table);
-  }
-  {
-    auto res = conn->Query("MATCH (:person)-[e:knows]->(v:person) RETURN e.*;");
-    EXPECT_TRUE(res) << res.error().ToString();
-    const auto& table = res.value().response();
-    AssertKnowsWeight(table, {});
-  }
+  AssertPersonVertexBasic(
+      this->RunQuery(*conn, "MATCH (v:person) RETURN v.*;"));
+  AssertKnowsWeight(
+      this->RunQuery(*conn,
+                     "MATCH (:person)-[e:knows]->(v:person) RETURN e.*;"),
+      {});
 }
 
-TEST_F(CheckpointTest, test_compact) {
-  std::string db_path = "/tmp/test_compact_db";
-  if (std::filesystem::exists(db_path)) {
-    std::filesystem::remove_all(db_path);
-  }
-  std::filesystem::create_directories(db_path);
+TYPED_TEST(CheckpointTest, compact) {
+  std::string db_path = this->MakeUniqueDir("compact");
+
   {
     neug::NeugDB db;
-    db.Open(db_path);
+    this->OpenDB(db, db_path);
     auto conn = db.Connect();
     load_modern_graph(conn);
     conn->Close();
     auto svc = std::make_shared<neug::NeugDBService>(db);
-
     auto sess = svc->AcquireSession();
-    auto compact_txn = sess->GetCompactTransaction();
-    compact_txn.Commit();
-
+    sess->GetCompactTransaction().Commit();
     db.Close();
   }
 
   neug::NeugDB db2;
-  db2.Open(db_path);
+  this->OpenDB(db2, db_path);
   auto svc = std::make_shared<neug::NeugDBService>(db2);
   auto conn2 = db2.Connect();
-  {
-    auto res = conn2->Query("MATCH (v:person) RETURN COUNT(v);");
-    EXPECT_TRUE(res) << res.error().ToString();
-    AssertSingleInt64Result(res.value().response(), 4);
-  }
 
-  {
-    // Delete half vertices
-    auto res = conn2->Query("MATCH (v:person) WHERE v.id <= 2 DELETE v;");
-    EXPECT_TRUE(res) << res.error().ToString();
-  }
+  AssertSingleInt64Result(
+      this->RunQuery(*conn2, "MATCH (v:person) RETURN COUNT(v);"), 4);
+  this->ExpectQuery(*conn2, "MATCH (v:person) WHERE v.id <= 2 DELETE v;");
 
-  auto sess2 = svc->AcquireSession();
-  auto compact_txn2 = sess2->GetCompactTransaction();
-  compact_txn2.Commit();
+  svc->AcquireSession()->GetCompactTransaction().Commit();
 
-  {
-    auto res = conn2->Query("MATCH (v:person) RETURN COUNT(v);");
-    EXPECT_TRUE(res) << res.error().ToString();
-    AssertSingleInt64Result(res.value().response(), 2);
-  }
+  AssertSingleInt64Result(
+      this->RunQuery(*conn2, "MATCH (v:person) RETURN COUNT(v);"), 2);
+  AssertSingleInt64Result(
+      this->RunQuery(*conn2,
+                     "MATCH (v:person)-[e:knows]->(:person) RETURN count(e);"),
+      0);
 
-  {
-    auto res =
-        conn2->Query("MATCH (v:person)-[e:knows]->(:person) RETURN count(e);");
-    EXPECT_TRUE(res) << res.error().ToString();
-    AssertSingleInt64Result(res.value().response(), 0);
-  }
   conn2->Close();
   db2.Close();
+  this->CleanDir(db_path);
 }
 
-TEST_F(CheckpointTest, test_recover_from_checkpoint) {
+TYPED_TEST(CheckpointTest, recover_from_checkpoint) {
   neug::NeugDB db;
-  db.Open(DB_DIR);
+  this->OpenDB(db, this->db_dir_);
   auto conn = db.Connect();
 
-  {
-    auto res = conn->Query("MATCH (v:person) RETURN COUNT(v);");
-    EXPECT_TRUE(res) << res.error().ToString();
-    AssertSingleInt64Result(res.value().response(), 4);
-  }
-  {
-    auto res = conn->Query("MATCH (v)-[e]->(a) RETURN COUNT(e);");
-    EXPECT_TRUE(res) << res.error().ToString();
-    AssertSingleInt64Result(res.value().response(), 6);
-  }
+  AssertSingleInt64Result(
+      this->RunQuery(*conn, "MATCH (v:person) RETURN COUNT(v);"), 4);
+  AssertSingleInt64Result(
+      this->RunQuery(*conn, "MATCH (v)-[e]->(a) RETURN COUNT(e);"), 6);
+  AssertCreatedEdgesSnapshotResult(
+      this->RunQuery(*conn,
+                     "MATCH (v:person)-[e:created]->(f:software) return v.id, "
+                     "e.since, f.id;"),
+      {1, 4, 4, 6}, {2020, 2022, 2021, 2023}, {3, 3, 5, 3});
 
-  {
-    auto res = conn->Query(
-        "MATCH (v:person)-[e:created]->(f:software) return v.id, e.since, "
-        "f.id;");
-    EXPECT_TRUE(res) << res.error().ToString();
-    AssertCreatedEdgesSnapshotResult(res.value().response(), {1, 4, 4, 6},
-                                     {2020, 2022, 2021, 2023}, {3, 3, 5, 3});
-  }
-
-  EXPECT_TRUE(conn->Query("MATCH (v:person) WHERE v.id = 1 DELETE v;"));
-  EXPECT_TRUE(
-      conn->Query("MATCH (v:person)-[e:created]->(f:software) WHERE "
-                  "v.id > 4 DELETE e;"));
-  auto res = conn->Query(
-      "MATCH (v:person)-[e:created]->(f:software) return v.id, e.since, "
-      "f.id;");
-  EXPECT_TRUE(res) << res.error().ToString();
+  this->ExpectQuery(*conn, "MATCH (v:person) WHERE v.id = 1 DELETE v;");
+  this->ExpectQuery(
+      *conn,
+      "MATCH (v:person)-[e:created]->(f:software) WHERE v.id > 4 DELETE e;");
   conn->Close();
   db.Close();
 
-  // Reopen the db, should recover from checkpoint
   neug::NeugDB db2;
-  db2.Open(DB_DIR);
+  this->OpenDB(db2, this->db_dir_);
   auto conn2 = db2.Connect();
+  AssertSingleInt64Result(
+      this->RunQuery(*conn2, "MATCH (v:person) RETURN COUNT(v);"), 3);
+  AssertSingleInt64Result(
+      this->RunQuery(*conn2, "MATCH (v)-[e]->(a) RETURN COUNT(e);"), 2);
+}
+
+TYPED_TEST(CheckpointTest, checkpoint_with_string_edge_prop) {
+  std::string db_path = this->MakeUniqueDir("string_edge_prop");
   {
-    auto res = conn2->Query("MATCH (v:person) RETURN COUNT(v);");
-    EXPECT_TRUE(res) << res.error().ToString();
-    AssertSingleInt64Result(res.value().response(), 3);
+    neug::NeugDB db;
+    this->OpenDB(db, db_path);
+    auto conn = db.Connect();
+    this->ExpectQuery(*conn,
+                      "CREATE NODE TABLE A (id STRING, PRIMARY KEY(id));");
+    this->ExpectQuery(*conn,
+                      "CREATE NODE TABLE B (id STRING, PRIMARY KEY(id));");
+    this->ExpectQuery(*conn, "CREATE REL TABLE R (FROM A TO B, prop STRING);");
+    this->ExpectQuery(*conn, "CREATE (a:A {id: 'a1'})");
+    this->ExpectQuery(*conn, "CREATE (b:B {id: 'b1'})");
+    this->ExpectQuery(*conn, "CHECKPOINT;");
+    this->ExpectQuery(
+        *conn,
+        "MATCH (a:A {id: 'a1'}), (b:B {id: 'b1'}) CREATE (a)-[:R {prop: "
+        "'hello'}]->(b)");
+    conn->Close();
+    db.Close();
   }
+  this->CleanDir(db_path);
+}
+
+// ===========================================================================
+// DropTableCheckpointTest — DROP TABLE checkpoint correctness
+// ===========================================================================
+template <typename T>
+class DropTableCheckpointTest : public CheckpointTestBase<T> {
+ protected:
+  std::string db_dir_;
+
+  void SetUp() override { db_dir_ = this->MakeUniqueDir("drop_table_ckpt"); }
+  void TearDown() override { this->CleanDir(db_dir_); }
+
+  void CreateAndCheckpointPerson() {
+    neug::NeugDB db;
+    this->OpenDB(db, db_dir_);
+    auto conn = db.Connect();
+    this->ExpectQuery(*conn,
+                      "CREATE NODE TABLE IF NOT EXISTS Person"
+                      "(id STRING, PRIMARY KEY(id));");
+    this->ExpectQuery(*conn, "CREATE (p:Person {id: 'alice'});");
+    this->ExpectQuery(*conn, "CHECKPOINT;");
+    auto table = this->RunQuery(*conn, "MATCH (p:Person) RETURN p.id;");
+    ASSERT_EQ(table.row_count(), 1);
+    conn->Close();
+    db.Close();
+  }
+
+  // Creates Person + Software vertex tables and a Created edge table,
+  // inserts sample data, and checkpoints.
+  void CreateGraphWithEdgesAndCheckpoint() {
+    neug::NeugDB db;
+    this->OpenDB(db, db_dir_);
+    auto conn = db.Connect();
+    this->ExpectQuery(*conn,
+                      "CREATE NODE TABLE IF NOT EXISTS Person"
+                      "(id STRING, PRIMARY KEY(id));");
+    this->ExpectQuery(*conn,
+                      "CREATE NODE TABLE IF NOT EXISTS Software"
+                      "(id STRING, PRIMARY KEY(id));");
+    this->ExpectQuery(*conn,
+                      "CREATE REL TABLE IF NOT EXISTS Created"
+                      "(FROM Person TO Software, weight DOUBLE);");
+    this->ExpectQuery(*conn, "CREATE (p:Person {id: 'alice'});");
+    this->ExpectQuery(*conn, "CREATE (s:Software {id: 'neug'});");
+    this->ExpectQuery(
+        *conn,
+        "MATCH (p:Person {id: 'alice'}), (s:Software {id: 'neug'}) "
+        "CREATE (p)-[:Created {weight: 1.0}]->(s);");
+    this->ExpectQuery(*conn, "CHECKPOINT;");
+
+    AssertSingleInt64Result(
+        this->RunQuery(
+            *conn,
+            "MATCH (p:Person)-[e:Created]->(s:Software) RETURN count(e);"),
+        1);
+    conn->Close();
+    db.Close();
+  }
+
+  void ReopenAndVerifyPersonEmpty() {
+    neug::NeugDB db;
+    this->OpenDB(db, db_dir_);
+    auto conn = db.Connect();
+    this->ExpectQuery(*conn,
+                      "CREATE NODE TABLE IF NOT EXISTS Person"
+                      "(id STRING, PRIMARY KEY(id));");
+    auto table = this->RunQuery(*conn, "MATCH (p:Person) RETURN p.id;");
+    EXPECT_EQ(table.row_count(), 0);
+    conn->Close();
+    db.Close();
+  }
+};
+
+TYPED_TEST_SUITE(DropTableCheckpointTest, AllMemoryLevels);
+
+TYPED_TEST(DropTableCheckpointTest, drop_and_recreate_clears_stale_data) {
+  this->CreateAndCheckpointPerson();
+
+  neug::NeugDB db;
+  this->OpenDB(db, this->db_dir_);
+  auto conn = db.Connect();
+
+  this->ExpectQuery(*conn, "DROP TABLE IF EXISTS Person;");
+  this->ExpectQuery(
+      *conn,
+      "CREATE NODE TABLE IF NOT EXISTS Person(id STRING, PRIMARY KEY(id));");
+
+  auto table = this->RunQuery(*conn, "MATCH (p:Person) RETURN p.id;");
+  EXPECT_EQ(table.row_count(), 0)
+      << "Stale data visible after DROP TABLE + re-CREATE";
+
+  this->ExpectQuery(*conn, "CREATE (p:Person {id: 'bob'});");
+  auto table2 = this->RunQuery(*conn, "MATCH (p:Person) RETURN p.id;");
+  EXPECT_EQ(table2.row_count(), 1)
+      << "Expected only 'bob', but stale data may be present";
+  neug::test::AssertStringColumn(table2, 0, {"bob"});
+
+  conn->Close();
+  db.Close();
+}
+
+TYPED_TEST(DropTableCheckpointTest, checkpoint_after_drop_succeeds) {
+  this->CreateAndCheckpointPerson();
+
   {
-    auto res = conn2->Query("MATCH (v)-[e]->(a) RETURN COUNT(e);");
-    EXPECT_TRUE(res) << res.error().ToString();
-    AssertSingleInt64Result(res.value().response(), 2);
+    neug::NeugDB db;
+    this->OpenDB(db, this->db_dir_);
+    auto conn = db.Connect();
+    this->ExpectQuery(*conn, "DROP TABLE IF EXISTS Person;");
+    this->ExpectQuery(*conn, "CHECKPOINT;");
+    conn->Close();
+    db.Close();
+  }
+
+  this->ReopenAndVerifyPersonEmpty();
+}
+
+TYPED_TEST(DropTableCheckpointTest,
+           drop_checkpoint_reopen_recreate_has_no_stale_data) {
+  this->CreateAndCheckpointPerson();
+
+  {
+    neug::NeugDB db;
+    this->OpenDB(db, this->db_dir_);
+    auto conn = db.Connect();
+    this->ExpectQuery(*conn, "DROP TABLE IF EXISTS Person;");
+    this->ExpectQuery(*conn, "CHECKPOINT;");
+    conn->Close();
+    db.Close();
+  }
+
+  this->ReopenAndVerifyPersonEmpty();
+}
+
+TYPED_TEST(DropTableCheckpointTest, drop_edge_table_and_checkpoint) {
+  this->CreateGraphWithEdgesAndCheckpoint();
+
+  {
+    neug::NeugDB db;
+    this->OpenDB(db, this->db_dir_);
+    auto conn = db.Connect();
+
+    // Drop the edge table while keeping vertex tables intact
+    this->ExpectQuery(*conn, "DROP TABLE IF EXISTS Created;");
+    this->ExpectQuery(*conn, "CHECKPOINT;");
+
+    conn->Close();
+    db.Close();
+  }
+
+  // Reopen: vertex tables should survive, edge table should be gone
+  {
+    neug::NeugDB db;
+    this->OpenDB(db, this->db_dir_);
+    auto conn = db.Connect();
+
+    // Vertices are still present
+    auto person_table = this->RunQuery(*conn, "MATCH (p:Person) RETURN p.id;");
+    EXPECT_EQ(person_table.row_count(), 1);
+
+    auto software_table =
+        this->RunQuery(*conn, "MATCH (s:Software) RETURN s.id;");
+    EXPECT_EQ(software_table.row_count(), 1);
+
+    // Re-create the edge table — it should be empty
+    this->ExpectQuery(*conn,
+                      "CREATE REL TABLE IF NOT EXISTS Created"
+                      "(FROM Person TO Software, weight DOUBLE);");
+    AssertSingleInt64Result(
+        this->RunQuery(
+            *conn,
+            "MATCH (p:Person)-[e:Created]->(s:Software) RETURN count(e);"),
+        0);
+
+    conn->Close();
+    db.Close();
   }
 }
 
-TEST(CheckpointTestStringProp, test_checkpoint_with_string_edge_prop) {
-  std::string db_path = "/tmp/test_checkpoint_string_edge_prop_db";
-  if (std::filesystem::exists(db_path)) {
-    std::filesystem::remove_all(db_path);
-  }
-  std::filesystem::create_directories(db_path);
+TYPED_TEST(DropTableCheckpointTest,
+           drop_edge_table_and_recreate_clears_stale_data) {
+  this->CreateGraphWithEdgesAndCheckpoint();
+
+  neug::NeugDB db;
+  this->OpenDB(db, this->db_dir_);
+  auto conn = db.Connect();
+
+  // Drop + re-create in the same session
+  this->ExpectQuery(*conn, "DROP TABLE IF EXISTS Created;");
+  this->ExpectQuery(*conn,
+                    "CREATE REL TABLE IF NOT EXISTS Created"
+                    "(FROM Person TO Software, weight DOUBLE);");
+
+  // Old edge data must not be visible
+  AssertSingleInt64Result(
+      this->RunQuery(
+          *conn, "MATCH (p:Person)-[e:Created]->(s:Software) RETURN count(e);"),
+      0);
+
+  // Insert fresh edge — only this one should appear
+  this->ExpectQuery(*conn,
+                    "MATCH (p:Person {id: 'alice'}), (s:Software {id: 'neug'}) "
+                    "CREATE (p)-[:Created {weight: 2.0}]->(s);");
+  AssertSingleInt64Result(
+      this->RunQuery(
+          *conn, "MATCH (p:Person)-[e:Created]->(s:Software) RETURN count(e);"),
+      1);
+
+  conn->Close();
+  db.Close();
+}
+
+TYPED_TEST(DropTableCheckpointTest,
+           drop_edge_table_checkpoint_reopen_recreate_has_no_stale_data) {
+  this->CreateGraphWithEdgesAndCheckpoint();
+
+  // Drop edge table + checkpoint
   {
     neug::NeugDB db;
-    db.Open(db_path);
+    this->OpenDB(db, this->db_dir_);
     auto conn = db.Connect();
-    EXPECT_TRUE(
-        conn->Query("CREATE NODE TABLE A (id STRING, PRIMARY KEY(id));"));
-    EXPECT_TRUE(
-        conn->Query("CREATE NODE TABLE B (id STRING, PRIMARY KEY(id));"));
-    EXPECT_TRUE(conn->Query("CREATE REL TABLE R (FROM A TO B, prop STRING);"));
-    EXPECT_TRUE(conn->Query("CREATE (a:A {id: 'a1'})"));
-    EXPECT_TRUE(conn->Query("CREATE (b:B {id: 'b1'})"));
-    EXPECT_TRUE(conn->Query("CHECKPOINT;"));
+    this->ExpectQuery(*conn, "DROP TABLE IF EXISTS Created;");
+    this->ExpectQuery(*conn, "CHECKPOINT;");
+    conn->Close();
+    db.Close();
+  }
 
-    auto ret = conn->Query(
-        "MATCH (a:A {id: 'a1'}), (b:B {id: 'b1'}) CREATE (a)-[:R {prop: "
-        "'hello'}]->(b)");
-    EXPECT_TRUE(ret) << ret.error().ToString();
-
+  // Reopen, re-create edge table, verify empty
+  {
+    neug::NeugDB db;
+    this->OpenDB(db, this->db_dir_);
+    auto conn = db.Connect();
+    this->ExpectQuery(*conn,
+                      "CREATE REL TABLE IF NOT EXISTS Created"
+                      "(FROM Person TO Software, weight DOUBLE);");
+    AssertSingleInt64Result(
+        this->RunQuery(
+            *conn,
+            "MATCH (p:Person)-[e:Created]->(s:Software) RETURN count(e);"),
+        0);
     conn->Close();
     db.Close();
   }
 }
 
 }  // namespace test
-
 }  // namespace neug

--- a/tests/storage/test_checkpoint.cc
+++ b/tests/storage/test_checkpoint.cc
@@ -754,5 +754,36 @@ TYPED_TEST(DropTableCheckpointTest,
   }
 }
 
+// Regression: tmp-file cleanup on DROP must key on the full label name, not a
+// bare prefix. Dropping "User" must not wipe files for "UserAccount".
+TYPED_TEST(DropTableCheckpointTest,
+           drop_label_does_not_sweep_sibling_with_shared_prefix) {
+  neug::NeugDB db;
+  this->OpenDB(db, this->db_dir_);
+  auto conn = db.Connect();
+
+  this->ExpectQuery(*conn,
+                    "CREATE NODE TABLE IF NOT EXISTS User"
+                    "(id STRING, PRIMARY KEY(id));");
+  this->ExpectQuery(*conn,
+                    "CREATE NODE TABLE IF NOT EXISTS UserAccount"
+                    "(id STRING, PRIMARY KEY(id));");
+  this->ExpectQuery(*conn, "CREATE (u:User {id: 'u1'});");
+  this->ExpectQuery(*conn, "CREATE (a:UserAccount {id: 'a1'});");
+  this->ExpectQuery(*conn, "CHECKPOINT;");
+
+  // Drop only the shorter-named label. UserAccount data must survive.
+  this->ExpectQuery(*conn, "DROP TABLE IF EXISTS User;");
+
+  auto account_table =
+      this->RunQuery(*conn, "MATCH (a:UserAccount) RETURN a.id;");
+  EXPECT_EQ(account_table.row_count(), 1)
+      << "DROP TABLE User wiped sibling label UserAccount (prefix collision)";
+  neug::test::AssertStringColumn(account_table, 0, {"a1"});
+
+  conn->Close();
+  db.Close();
+}
+
 }  // namespace test
 }  // namespace neug

--- a/tests/storage/test_edge_table.cc
+++ b/tests/storage/test_edge_table.cc
@@ -95,7 +95,7 @@ class EdgeTableTest : public ::testing::Test {
   void build_indexer(neug::LFIndexer<neug::vid_t>& indexer, neug::vid_t num,
                      const std::string& name, const std::string& snapshot_dir,
                      const std::string& work_dir) {
-    indexer.drop();
+    indexer.close();
     indexer.init(DataTypeId::kInt64);
     indexer.open(name, snapshot_dir, work_dir);
     indexer.reserve(num);

--- a/tests/storage/test_vertex_table.cc
+++ b/tests/storage/test_vertex_table.cc
@@ -152,7 +152,7 @@ TEST_F(VertexTableTest, VertexTableBasicOps) {
   EXPECT_FALSE(table.get_index(oid1, tmp_vid, 0));
   EXPECT_TRUE(table.get_index(oid1, tmp_vid, 1));
 
-  table.Drop();
+  table.Close();
 }
 
 TEST_F(VertexTableTest, VertexTableDumpAndReload) {

--- a/tests/unittest/test_indexer.cc
+++ b/tests/unittest/test_indexer.cc
@@ -179,7 +179,7 @@ TEST_F(LFIndexerTest, DumpsAndOpensAcrossBackends) {
       std::filesystem::exists(tmp_dir(work_dir_) + "/" + name + ".keys"));
   EXPECT_TRUE(
       std::filesystem::exists(tmp_dir(work_dir_) + "/" + name + ".indices"));
-  copied_to_workdir.drop();
+  copied_to_workdir.close();
 
   LFIndexer<uint32_t> in_memory;
   in_memory.init(DataTypeId::kInt64);
@@ -242,7 +242,7 @@ TEST_F(LFIndexerTest, SupportsBuildEmptySwapAndVarcharKeys) {
   ExpectStringValues(lhs, rhs_values);
   ExpectStringValues(rhs, lhs_values);
 
-  rhs.drop();
+  rhs.close();
   lhs.close();
 }
 
@@ -593,7 +593,7 @@ TEST_F(LFIndexerTest, VarcharShortDumpReopenReserveThenInsertLong_SyncToFile) {
   std::vector<std::string> all = short_values;
   all.insert(all.end(), long_values.begin(), long_values.end());
   ExpectStringValues(indexer, all);
-  indexer.drop();
+  indexer.close();
 }
 
 // Test: String overflow handling when inserting strings exceeding max length.

--- a/tests/utils/test_table.cc
+++ b/tests/utils/test_table.cc
@@ -288,8 +288,8 @@ TEST(TableTest, TestTableBasic) {
   }
 
   disk_table.dump("disk_table", std::string(TEST_DIR) + "/checkpoint");
-  disk_table.drop();
-  mem_table.drop();
+  disk_table.close();
+  mem_table.close();
 
   disk_table.open("disk_table", std::string(TEST_DIR), col_name,
                   property_types);
@@ -301,7 +301,7 @@ TEST(TableTest, TestTableBasic) {
   disk_table.delete_column("renamed_bool_column");
   EXPECT_EQ(disk_table.col_num(), 10);
   disk_table.set_work_dir(std::string(TEST_DIR));
-  disk_table.drop();
+  disk_table.close();
 
   mem_table.open_in_memory("disk_table", std::string(TEST_DIR), col_name,
                            property_types);

--- a/tools/python_bind/tests/test_db_query.py
+++ b/tools/python_bind/tests/test_db_query.py
@@ -3061,6 +3061,30 @@ def test_not_starts_with(tmp_path):
     assert records == []
     conn.close()
     db.close()
+def test_drop_and_recreate_node_table_no_stale_data(tmp_path):
+    """After DROP + re-CREATE of a node table, old rows must not reappear."""
+    db_dir = tmp_path / "drop_recreate_stale"
+    db = Database(db_path=str(db_dir), mode="w")
+    conn = db.connect()
+
+    conn.execute("CREATE NODE TABLE IF NOT EXISTS Person(id STRING PRIMARY KEY);")
+    conn.execute("CREATE (p:Person {id: 'alice'});")
+    conn.execute("CHECKPOINT")
+    assert list(conn.execute("MATCH (p:Person) RETURN p.id;")) == [["alice"]]
+
+    # Drop and re-create with the same schema
+    conn.execute("DROP TABLE IF EXISTS Person;")
+    conn.execute("CREATE NODE TABLE IF NOT EXISTS Person(id STRING PRIMARY KEY);")
+
+    # Old data must be gone
+    assert list(conn.execute("MATCH (p:Person) RETURN p.id;")) == []
+
+    # Only newly inserted data should be visible
+    conn.execute("CREATE (p:Person {id: 'bob'});")
+    assert list(conn.execute("MATCH (p:Person) RETURN p.id;")) == [["bob"]]
+
+    conn.close()
+    db.close()
 
 
 def test_not_list_contains(tmp_path):
@@ -3105,3 +3129,28 @@ def test_unsupported_operator_error_message():
     query = "CREATE MACRO f(x) AS x + 1"
     with pytest.raises(Exception, match="Unsupported operator type: CREATE_MACRO"):
         conn.execute(query)
+def test_delete_all_rows_then_reinsert_visible(tmp_path):
+    """After deleting all rows, newly inserted rows must be visible."""
+    db_dir = tmp_path / "delete_reinsert"
+    db = Database(db_path=str(db_dir), mode="w")
+    conn = db.connect()
+
+    conn.execute("CREATE NODE TABLE IF NOT EXISTS Person(id STRING PRIMARY KEY);")
+    conn.execute("CREATE (p:Person {id: 'alice'});")
+    conn.execute("CREATE (p:Person {id: 'bob'});")
+    conn.execute("CHECKPOINT")
+    assert sorted(list(conn.execute("MATCH (p:Person) RETURN p.id;"))) == [
+        ["alice"],
+        ["bob"],
+    ]
+
+    # Delete all rows
+    conn.execute("MATCH (a:Person) DELETE a;")
+    assert list(conn.execute("MATCH (p:Person) RETURN p.id;")) == []
+
+    # Re-insert — new data must be visible
+    conn.execute("CREATE (p:Person {id: 'charlie'});")
+    assert list(conn.execute("MATCH (p:Person) RETURN p.id;")) == [["charlie"]]
+
+    conn.close()
+    db.close()

--- a/tools/python_bind/tests/test_db_query.py
+++ b/tools/python_bind/tests/test_db_query.py
@@ -3061,6 +3061,8 @@ def test_not_starts_with(tmp_path):
     assert records == []
     conn.close()
     db.close()
+
+
 def test_drop_and_recreate_node_table_no_stale_data(tmp_path):
     """After DROP + re-CREATE of a node table, old rows must not reappear."""
     db_dir = tmp_path / "drop_recreate_stale"
@@ -3129,6 +3131,8 @@ def test_unsupported_operator_error_message():
     query = "CREATE MACRO f(x) AS x + 1"
     with pytest.raises(Exception, match="Unsupported operator type: CREATE_MACRO"):
         conn.execute(query)
+
+
 def test_delete_all_rows_then_reinsert_visible(tmp_path):
     """After deleting all rows, newly inserted rows must be visible."""
     db_dir = tmp_path / "delete_reinsert"


### PR DESCRIPTION
## Summary

Fixes #293 and implements the refactor tracked in #398. Replaces the earlier PR #306 approach with a tighter Drop/checkpoint contract that keeps file-system mutation out of the container layer.

- **Drop()** at every layer releases in-memory state only; `checkpoint_dir` is touched exclusively by `Dump()`. This preserves the implicit crash-rollback semantics for DROP-before-CHECKPOINT.
- **`Open()` split into `Open()` (restore from checkpoint) and `Initialize()` (fresh table).** Replaces the leaky `bool load_from_checkpoint = true` parameter.
- **`Initialize()` sweeps `tmp_dir` for files keyed on the same label name/triple** before opening fresh containers. This is what unsticks the same-session DROP+CREATE stale-data path — schema reuses the numeric `label_t` for a same-name CREATE, but tmp filenames key on the string name.
- **`DeleteVertexType` and `DeleteEdgeType` call `Drop()` before erasing**, making the two paths symmetric.
- **`IDataContainer::Drop()` is intentionally NOT added.** In `kInMemory` / `kHugePagePreferred` modes a container's `path_` points at the checkpoint file, so a generic Drop-deletes-path contract would silently corrupt checkpoint state. See #398 for the full rationale.
