### PR TITLE
refactor: remove unused LFIndexer::build_empty_LFIndexer (#384)

### DIFF
--- a/include/neug/utils/id_indexer.h
+++ b/include/neug/utils/id_indexer.h
@@ -35,7 +35,6 @@ limitations under the License.
 #include "neug/storages/container/container_utils.h"
 #include "neug/storages/container/i_container.h"
 #include "neug/utils/bitset.h"
-#include "neug/utils/file_utils.h"
 #include "neug/utils/likely.h"
 #include "neug/utils/pb_utils.h"
 #include "neug/utils/property/column.h"
@@ -269,19 +268,6 @@ class LFIndexer {
           type.ToString());
     }
     }
-  }
-
-  void build_empty_LFIndexer(const std::string& filename,
-                             const std::string& snapshot_dir,
-                             const std::string& work_dir) {
-    keys_->open(filename + ".keys", "", work_dir);
-    auto full_path = work_dir + "/" + filename + ".indices";
-    file_utils::create_file(full_path, sizeof(FileHeader));
-
-    num_elements_.store(0);
-    indices_size_ = 0;
-    dump_meta(work_dir + "/" + filename + ".meta");
-    keys_->close();
   }
 
   void reserve(size_t size) { rehash(std::max(size, num_elements_.load())); }

--- a/tests/unittest/test_indexer.cc
+++ b/tests/unittest/test_indexer.cc
@@ -194,19 +194,7 @@ TEST_F(LFIndexerTest, DumpsAndOpensAcrossBackends) {
   hugepage_indexer.close();
 }
 
-TEST_F(LFIndexerTest, SupportsBuildEmptySwapAndVarcharKeys) {
-  const std::string empty_name = "empty_index";
-  const std::string empty_dir = test_dir_ + "/empty_dir";
-  std::filesystem::create_directories(empty_dir);
-  CreateEmptyIndicesFile(empty_dir + "/" + empty_name);
-
-  LFIndexer<uint32_t> empty_indexer;
-  empty_indexer.init(DataTypeId::kInt64);
-  empty_indexer.build_empty_LFIndexer(empty_name, "", empty_dir);
-  EXPECT_TRUE(std::filesystem::exists(empty_dir + "/" + empty_name + ".meta"));
-  EXPECT_TRUE(
-      std::filesystem::exists(empty_dir + "/" + empty_name + ".indices"));
-
+TEST_F(LFIndexerTest, SupportsSwapAndVarcharKeys) {
   const std::string lhs_base = test_dir_ + "/lhs_varchar";
   const std::string rhs_base = test_dir_ + "/rhs_varchar";
   CreateEmptyIndicesFile(lhs_base);


### PR DESCRIPTION
Fix #384 