### PR TITLE
build: replace clang-format-8 static binary with PyPI clang-format==10.0.1

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -106,9 +106,8 @@ jobs:
 
     - name: Cpp Format and Lint Check
       run: |
-        # install clang-format
-        sudo curl -L https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-22538c65/clang-format-8_linux-amd64 --output /usr/local/bin/clang-format
-        sudo chmod +x /usr/local/bin/clang-format
+        # Install pinned clang-format from PyPI (cross-platform: Linux, macOS, Windows)
+        python3 -m pip install 'clang-format==10.0.1'
 
         # validate format
         function prepend() { while read line; do echo "${1}${line}"; done; }
@@ -129,9 +128,8 @@ jobs:
             echo "|"
             echo "| to fix this error."
             echo "|"
-            echo "| Ensure you are working with clang-format-8, which can be obtained from"
-            echo "| sudo curl -L https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-22538c65/clang-format-8_linux-amd64 --output /usr/local/bin/clang-format"
-            echo "| sudo chmod +x /usr/local/bin/clang-format"
+            echo "| Ensure you are working with clang-format 10.0.1, install with:"
+            echo "|     python3 -m pip install 'clang-format==10.0.1'"
             echo "|"
             echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
             exit 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -952,7 +952,7 @@ list(FILTER FILES_NEED_FORMAT EXCLUDE REGEX ".*\.clang-format$")
 
 add_custom_target(neug_clformat
     COMMAND clang-format --style=file -i ${FILES_NEED_FORMAT}
-    COMMENT "Running clang-format, using clang-format-8 from https://github.com/muttleyxd/clang-tools-static-binaries/releases"
+    COMMENT "Running clang-format (pin: clang-format==10.0.1; install via 'python3 -m pip install clang-format==10.0.1')"
     VERBATIM)
 
 file(GLOB_RECURSE FILES_NEED_FORMAT

--- a/include/neug/compiler/common/copy_constructors.h
+++ b/include/neug/compiler/common/copy_constructors.h
@@ -100,7 +100,8 @@ static std::vector<T> copyVector(const std::vector<T>& objects) {
 }
 
 template <typename T>
-static std::vector<std::shared_ptr<T>> copyVector(const std::vector<std::shared_ptr<T>>& objects) {
+static std::vector<std::shared_ptr<T>> copyVector(
+    const std::vector<std::shared_ptr<T>>& objects) {
   std::vector<std::shared_ptr<T>> result;
   result.reserve(objects.size());
   for (auto& object : objects) {
@@ -111,7 +112,8 @@ static std::vector<std::shared_ptr<T>> copyVector(const std::vector<std::shared_
 }
 
 template <typename T>
-static std::vector<std::unique_ptr<T>> copyVector(const std::vector<std::unique_ptr<T>>& objects) {
+static std::vector<std::unique_ptr<T>> copyVector(
+    const std::vector<std::unique_ptr<T>>& objects) {
   std::vector<std::unique_ptr<T>> result;
   result.reserve(objects.size());
   for (auto& object : objects) {
@@ -122,7 +124,8 @@ static std::vector<std::unique_ptr<T>> copyVector(const std::vector<std::unique_
 }
 
 template <typename K, typename V>
-static std::unordered_map<K, V> copyUnorderedMap(const std::unordered_map<K, V>& objects) {
+static std::unordered_map<K, V> copyUnorderedMap(
+    const std::unordered_map<K, V>& objects) {
   std::unordered_map<K, V> result;
   for (auto& [k, v] : objects) {
     result.insert({k, v.copy()});

--- a/include/neug/compiler/common/mask.h
+++ b/include/neug/compiler/common/mask.h
@@ -30,7 +30,8 @@ namespace common {
 // Note that this class is NOT thread-safe.
 class SemiMask {
  public:
-  explicit SemiMask(offset_t maxOffset) : maxOffset{maxOffset}, enabled{false} {}
+  explicit SemiMask(offset_t maxOffset)
+      : maxOffset{maxOffset}, enabled{false} {}
 
   virtual ~SemiMask() = default;
 
@@ -75,7 +76,9 @@ class NodeOffsetMaskMap {
     return result;
   }
 
-  bool containsTableID(table_id_t tableID) const { return maskMap.contains(tableID); }
+  bool containsTableID(table_id_t tableID) const {
+    return maskMap.contains(tableID);
+  }
   SemiMask* getOffsetMask(table_id_t tableID) const {
     NEUG_ASSERT(containsTableID(tableID));
     return maskMap.at(tableID).get();

--- a/include/neug/execution/common/operators/retrieve/path_expand.h
+++ b/include/neug/execution/common/operators/retrieve/path_expand.h
@@ -29,31 +29,39 @@ class PathExpand {
  public:
   // PathExpand(expandOpt == Vertex && alias == -1 && resultOpt == END_V) +
   // GetV(opt == END)
-  static neug::result<Context> edge_expand_v(const StorageReadInterface& graph, Context&& ctx,
+  static neug::result<Context> edge_expand_v(const StorageReadInterface& graph,
+                                             Context&& ctx,
                                              const PathExpandParams& params);
-  static neug::result<Context> edge_expand_p(const StorageReadInterface& graph, Context&& ctx,
+  static neug::result<Context> edge_expand_p(const StorageReadInterface& graph,
+                                             Context&& ctx,
                                              const PathExpandParams& params);
 
   static neug::result<Context> all_shortest_paths_with_given_source_and_dest(
-      const StorageReadInterface& graph, Context&& ctx, const ShortestPathParams& params,
-      const std::pair<label_t, vid_t>& dst);
+      const StorageReadInterface& graph, Context&& ctx,
+      const ShortestPathParams& params, const std::pair<label_t, vid_t>& dst);
   // single dst
   static neug::result<Context> single_source_single_dest_shortest_path(
-      const StorageReadInterface& graph, Context&& ctx, const ShortestPathParams& params,
-      std::pair<label_t, vid_t>& dest);
+      const StorageReadInterface& graph, Context&& ctx,
+      const ShortestPathParams& params, std::pair<label_t, vid_t>& dest);
 
   template <typename PRED_T>
-  static neug::result<Context> single_source_shortest_path_with_order_by_length_limit(
-      const StorageReadInterface& graph, Context&& ctx, const ShortestPathParams& params,
-      const PRED_T& pred, int limit_upper) {
+  static neug::result<Context>
+  single_source_shortest_path_with_order_by_length_limit(
+      const StorageReadInterface& graph, Context&& ctx,
+      const ShortestPathParams& params, const PRED_T& pred, int limit_upper) {
     std::vector<size_t> shuffle_offset;
-    auto input_vertex_col = std::dynamic_pointer_cast<IVertexColumn>(ctx.get(params.start_tag));
-    if (params.labels.size() == 1 && params.labels[0].src_label == params.labels[0].dst_label &&
-        params.dir == Direction::kBoth && input_vertex_col->get_labels_set().size() == 1) {
-      auto tup = single_source_shortest_path_with_order_by_length_limit_impl<PRED_T>(
-          graph, *input_vertex_col, params.labels[0].edge_label, params.dir, params.hop_lower,
-          params.hop_upper, pred, limit_upper);
-      ctx.set_with_reshuffle(params.v_alias, std::get<0>(tup), std::get<2>(tup));
+    auto input_vertex_col =
+        std::dynamic_pointer_cast<IVertexColumn>(ctx.get(params.start_tag));
+    if (params.labels.size() == 1 &&
+        params.labels[0].src_label == params.labels[0].dst_label &&
+        params.dir == Direction::kBoth &&
+        input_vertex_col->get_labels_set().size() == 1) {
+      auto tup =
+          single_source_shortest_path_with_order_by_length_limit_impl<PRED_T>(
+              graph, *input_vertex_col, params.labels[0].edge_label, params.dir,
+              params.hop_lower, params.hop_upper, pred, limit_upper);
+      ctx.set_with_reshuffle(params.v_alias, std::get<0>(tup),
+                             std::get<2>(tup));
       ctx.set(params.alias, std::get<1>(tup));
       return ctx;
     }
@@ -63,47 +71,54 @@ class PathExpand {
   }
 
   template <typename PRED_T>
-  static neug::result<Context> single_source_shortest_path(const StorageReadInterface& graph,
-                                                           Context&& ctx,
-                                                           const ShortestPathParams& params,
-                                                           const PRED_T& pred) {
+  static neug::result<Context> single_source_shortest_path(
+      const StorageReadInterface& graph, Context&& ctx,
+      const ShortestPathParams& params, const PRED_T& pred) {
     std::vector<size_t> shuffle_offset;
-    auto input_vertex_col = std::dynamic_pointer_cast<IVertexColumn>(ctx.get(params.start_tag));
-    if (params.labels.size() == 1 && params.labels[0].src_label == params.labels[0].dst_label &&
-        params.dir == Direction::kBoth && input_vertex_col->get_labels_set().size() == 1) {
-      auto tup = single_source_shortest_path_impl<PRED_T>(graph, *input_vertex_col,
-                                                          params.labels[0].edge_label, params.dir,
-                                                          params.hop_lower, params.hop_upper, pred);
-      ctx.set_with_reshuffle(params.v_alias, std::get<0>(tup), std::get<2>(tup));
+    auto input_vertex_col =
+        std::dynamic_pointer_cast<IVertexColumn>(ctx.get(params.start_tag));
+    if (params.labels.size() == 1 &&
+        params.labels[0].src_label == params.labels[0].dst_label &&
+        params.dir == Direction::kBoth &&
+        input_vertex_col->get_labels_set().size() == 1) {
+      auto tup = single_source_shortest_path_impl<PRED_T>(
+          graph, *input_vertex_col, params.labels[0].edge_label, params.dir,
+          params.hop_lower, params.hop_upper, pred);
+      ctx.set_with_reshuffle(params.v_alias, std::get<0>(tup),
+                             std::get<2>(tup));
       ctx.set(params.alias, std::get<1>(tup));
       return ctx;
     }
     auto tup = default_single_source_shortest_path_impl<PRED_T>(
-        graph, *input_vertex_col, params.labels, params.dir, params.hop_lower, params.hop_upper,
-        pred);
+        graph, *input_vertex_col, params.labels, params.dir, params.hop_lower,
+        params.hop_upper, pred);
     ctx.set_with_reshuffle(params.v_alias, std::get<0>(tup), std::get<2>(tup));
     ctx.set(params.alias, std::get<1>(tup));
     return ctx;
   }
 
-  static neug::result<Context> single_source_shortest_path_with_special_vertex_predicate(
-      const StorageReadInterface& graph, Context&& ctx, const ShortestPathParams& params,
-      const SpecialPredicateConfig& config, const ParamsMap& query_params);
+  static neug::result<Context>
+  single_source_shortest_path_with_special_vertex_predicate(
+      const StorageReadInterface& graph, Context&& ctx,
+      const ShortestPathParams& params, const SpecialPredicateConfig& config,
+      const ParamsMap& query_params);
 
   template <typename PRED_T>
-  static neug::result<Context> edge_expand_p_with_pred(const StorageReadInterface& graph,
-                                                       Context&& ctx,
-                                                       const PathExpandParams& params,
-                                                       const PRED_T& pred) {
+  static neug::result<Context> edge_expand_p_with_pred(
+      const StorageReadInterface& graph, Context&& ctx,
+      const PathExpandParams& params, const PRED_T& pred) {
     if (params.opt != PathOpt::kArbitrary) {
       LOG(ERROR) << "only support arbitrary path expand with predicate";
-      RETURN_UNSUPPORTED_ERROR("only support arbitrary path expand with predicate");
+      RETURN_UNSUPPORTED_ERROR(
+          "only support arbitrary path expand with predicate");
     }
     std::vector<size_t> shuffle_offset;
-    auto& input_vertex_list = *std::dynamic_pointer_cast<IVertexColumn>(ctx.get(params.start_tag));
+    auto& input_vertex_list =
+        *std::dynamic_pointer_cast<IVertexColumn>(ctx.get(params.start_tag));
     auto label_sets = input_vertex_list.get_labels_set();
     auto labels = params.labels;
-    std::vector<std::vector<LabelTriplet>> out_labels_map(graph.schema().vertex_label_frontier()),
+    std::vector<std::vector<LabelTriplet>> out_labels_map(
+        graph.schema().vertex_label_frontier()),
         in_labels_map(graph.schema().vertex_label_frontier());
     for (const auto& triplet : labels) {
       out_labels_map[triplet.src_label].emplace_back(triplet);
@@ -116,10 +131,11 @@ class PathExpand {
     PathColumnBuilder builder;
 
     if (dir == Direction::kOut) {
-      foreach_vertex(input_vertex_list, [&](size_t index, label_t label, vid_t v) {
-        auto p = Path(label, v);
-        input.emplace_back(std::move(p), index);
-      });
+      foreach_vertex(input_vertex_list,
+                     [&](size_t index, label_t label, vid_t v) {
+                       auto p = Path(label, v);
+                       input.emplace_back(std::move(p), index);
+                     });
       int depth = 0;
       while (depth < params.hop_upper) {
         output.clear();
@@ -127,13 +143,16 @@ class PathExpand {
           for (auto& [path, index] : input) {
             auto end = path.end_node();
             for (const auto& label_triplet : out_labels_map[end.label_]) {
-              auto oview = graph.GetGenericOutgoingGraphView(end.label_, label_triplet.dst_label,
-                                                             label_triplet.edge_label);
+              auto oview = graph.GetGenericOutgoingGraphView(
+                  end.label_, label_triplet.dst_label,
+                  label_triplet.edge_label);
               auto oes = oview.get_edges(end.vid_);
               for (auto it = oes.begin(); it != oes.end(); ++it) {
-                if (pred(label_triplet, end.vid_, it.get_vertex(), it.get_data_ptr())) {
-                  Path new_path = path.expand(label_triplet.edge_label, label_triplet.dst_label,
-                                              it.get_vertex(), Direction::kOut, it.get_data_ptr());
+                if (pred(label_triplet, end.vid_, it.get_vertex(),
+                         it.get_data_ptr())) {
+                  Path new_path = path.expand(
+                      label_triplet.edge_label, label_triplet.dst_label,
+                      it.get_vertex(), Direction::kOut, it.get_data_ptr());
                   output.emplace_back(std::move(new_path), index);
                 }
               }
@@ -159,10 +178,11 @@ class PathExpand {
 
       return ctx;
     } else if (dir == Direction::kIn) {
-      foreach_vertex(input_vertex_list, [&](size_t index, label_t label, vid_t v) {
-        auto p = Path(label, v);
-        input.emplace_back(std::move(p), index);
-      });
+      foreach_vertex(input_vertex_list,
+                     [&](size_t index, label_t label, vid_t v) {
+                       auto p = Path(label, v);
+                       input.emplace_back(std::move(p), index);
+                     });
       int depth = 0;
       while (depth < params.hop_upper) {
         output.clear();
@@ -171,13 +191,16 @@ class PathExpand {
           for (const auto& [path, index] : input) {
             auto end = path.end_node();
             for (const auto& label_triplet : in_labels_map[end.label_]) {
-              auto iview = graph.GetGenericIncomingGraphView(end.label_, label_triplet.src_label,
-                                                             label_triplet.edge_label);
+              auto iview = graph.GetGenericIncomingGraphView(
+                  end.label_, label_triplet.src_label,
+                  label_triplet.edge_label);
               auto ies = iview.get_edges(end.vid_);
               for (auto it = ies.begin(); it != ies.end(); ++it) {
-                if (pred(label_triplet, it.get_vertex(), end.vid_, it.get_data_ptr())) {
-                  Path new_path = path.expand(label_triplet.edge_label, label_triplet.src_label,
-                                              it.get_vertex(), Direction::kIn, it.get_data_ptr());
+                if (pred(label_triplet, it.get_vertex(), end.vid_,
+                         it.get_data_ptr())) {
+                  Path new_path = path.expand(
+                      label_triplet.edge_label, label_triplet.src_label,
+                      it.get_vertex(), Direction::kIn, it.get_data_ptr());
                   output.emplace_back(std::move(new_path), index);
                 }
               }
@@ -204,10 +227,11 @@ class PathExpand {
       return ctx;
 
     } else if (dir == Direction::kBoth) {
-      foreach_vertex(input_vertex_list, [&](size_t index, label_t label, vid_t v) {
-        auto p = Path(label, v);
-        input.emplace_back(std::move(p), index);
-      });
+      foreach_vertex(input_vertex_list,
+                     [&](size_t index, label_t label, vid_t v) {
+                       auto p = Path(label, v);
+                       input.emplace_back(std::move(p), index);
+                     });
       int depth = 0;
       while (depth < params.hop_upper) {
         output.clear();
@@ -215,26 +239,32 @@ class PathExpand {
           for (auto& [path, index] : input) {
             auto end = path.end_node();
             for (const auto& label_triplet : out_labels_map[end.label_]) {
-              auto oview = graph.GetGenericOutgoingGraphView(end.label_, label_triplet.dst_label,
-                                                             label_triplet.edge_label);
+              auto oview = graph.GetGenericOutgoingGraphView(
+                  end.label_, label_triplet.dst_label,
+                  label_triplet.edge_label);
               auto oes = oview.get_edges(end.vid_);
               for (auto it = oes.begin(); it != oes.end(); ++it) {
-                if (pred(label_triplet, end.vid_, it.get_vertex(), it.get_data_ptr())) {
-                  Path new_path = path.expand(label_triplet.edge_label, label_triplet.dst_label,
-                                              it.get_vertex(), Direction::kOut, it.get_data_ptr());
+                if (pred(label_triplet, end.vid_, it.get_vertex(),
+                         it.get_data_ptr())) {
+                  Path new_path = path.expand(
+                      label_triplet.edge_label, label_triplet.dst_label,
+                      it.get_vertex(), Direction::kOut, it.get_data_ptr());
                   output.emplace_back(std::move(new_path), index);
                 }
               }
             }
 
             for (const auto& label_triplet : in_labels_map[end.label_]) {
-              auto iview = graph.GetGenericIncomingGraphView(end.label_, label_triplet.src_label,
-                                                             label_triplet.edge_label);
+              auto iview = graph.GetGenericIncomingGraphView(
+                  end.label_, label_triplet.src_label,
+                  label_triplet.edge_label);
               auto ies = iview.get_edges(end.vid_);
               for (auto it = ies.begin(); it != ies.end(); ++it) {
-                if (pred(label_triplet, it.get_vertex(), end.vid_, it.get_data_ptr())) {
-                  Path new_path = path.expand(label_triplet.edge_label, label_triplet.src_label,
-                                              it.get_vertex(), Direction::kIn, it.get_data_ptr());
+                if (pred(label_triplet, it.get_vertex(), end.vid_,
+                         it.get_data_ptr())) {
+                  Path new_path = path.expand(
+                      label_triplet.edge_label, label_triplet.src_label,
+                      it.get_vertex(), Direction::kIn, it.get_data_ptr());
                   output.emplace_back(std::move(new_path), index);
                 }
               }
@@ -264,15 +294,15 @@ class PathExpand {
   }
 
   template <typename FUNC_T>
-  static neug::result<Context> any_weighted_shortest_path(const StorageReadInterface& graph,
-                                                          Context&& ctx,
-                                                          const PathExpandParams& params,
-                                                          const FUNC_T& weight_func) {
+  static neug::result<Context> any_weighted_shortest_path(
+      const StorageReadInterface& graph, Context&& ctx,
+      const PathExpandParams& params, const FUNC_T& weight_func) {
     auto col = ctx.get(params.start_tag);
     auto& input_vertex_list = *std::dynamic_pointer_cast<IVertexColumn>(col);
     PathColumnBuilder path_builder;
     std::vector<size_t> shuffle_offset;
-    foreach_vertex(input_vertex_list, [&](size_t index, label_t label, vid_t v) {
+    foreach_vertex(input_vertex_list, [&](size_t index, label_t label,
+                                          vid_t v) {
       std::unordered_map<VertexRecord, double> dist;
       std::unordered_set<VertexRecord> visited;
       VertexRecord start_vr(label, v);
@@ -300,21 +330,27 @@ class PathExpand {
         shuffle_offset.push_back(index);
         pq.pop();
         for (LabelTriplet label_triplet : params.labels) {
-          if (label_triplet.src_label != label && label_triplet.dst_label != label) {
+          if (label_triplet.src_label != label &&
+              label_triplet.dst_label != label) {
             continue;
           }
 
           if (label_triplet.src_label == label &&
-              (params.dir == Direction::kOut || params.dir == Direction::kBoth)) {
+              (params.dir == Direction::kOut ||
+               params.dir == Direction::kBoth)) {
             auto oe_view = graph.GetGenericOutgoingGraphView(
-                label_triplet.src_label, label_triplet.dst_label, label_triplet.edge_label);
+                label_triplet.src_label, label_triplet.dst_label,
+                label_triplet.edge_label);
             auto oes = oe_view.get_edges(cur);
             for (auto it = oes.begin(); it != oes.end(); ++it) {
               vid_t nbr = it.get_vertex();
               VertexRecord nbr_vr(label_triplet.dst_label, nbr);
-              double weight = weight_func(label_triplet, cur, nbr, it.get_data_ptr());
-              if (dist.count(nbr_vr) == 0 || dist[nbr_vr] > path.get_weight() + weight) {
-                auto new_path = path.expand(label_triplet.edge_label, label_triplet.dst_label, nbr,
+              double weight =
+                  weight_func(label_triplet, cur, nbr, it.get_data_ptr());
+              if (dist.count(nbr_vr) == 0 ||
+                  dist[nbr_vr] > path.get_weight() + weight) {
+                auto new_path = path.expand(label_triplet.edge_label,
+                                            label_triplet.dst_label, nbr,
                                             Direction::kOut, it.get_data_ptr());
                 new_path.set_weight(path.get_weight() + weight);
                 dist[nbr_vr] = new_path.get_weight() + weight;
@@ -324,16 +360,21 @@ class PathExpand {
             }
           }
           if (label_triplet.dst_label == label &&
-              (params.dir == Direction::kIn || params.dir == Direction::kBoth)) {
+              (params.dir == Direction::kIn ||
+               params.dir == Direction::kBoth)) {
             auto ie_view = graph.GetGenericIncomingGraphView(
-                label_triplet.dst_label, label_triplet.src_label, label_triplet.edge_label);
+                label_triplet.dst_label, label_triplet.src_label,
+                label_triplet.edge_label);
             auto ies = ie_view.get_edges(cur);
             for (auto it = ies.begin(); it != ies.end(); ++it) {
               vid_t nbr = it.get_vertex();
               VertexRecord nbr_vr(label_triplet.src_label, nbr);
-              double weight = weight_func(label_triplet, cur, nbr, it.get_data_ptr());
-              if (dist.count(nbr_vr) == 0 || dist[nbr_vr] > path.get_weight() + weight) {
-                auto new_path = path.expand(label_triplet.edge_label, label_triplet.src_label, nbr,
+              double weight =
+                  weight_func(label_triplet, cur, nbr, it.get_data_ptr());
+              if (dist.count(nbr_vr) == 0 ||
+                  dist[nbr_vr] > path.get_weight() + weight) {
+                auto new_path = path.expand(label_triplet.edge_label,
+                                            label_triplet.src_label, nbr,
                                             Direction::kOut, it.get_data_ptr());
                 new_path.set_weight(path.get_weight() + weight);
                 dist[nbr_vr] = new_path.get_weight() + weight;

--- a/include/neug/utils/string_utils.h
+++ b/include/neug/utils/string_utils.h
@@ -64,7 +64,8 @@ struct to_string_impl<std::unordered_map<K, V>> {
     // map{key:value, ...}
     ss << "map{";
     for (auto& [k, v] : vec) {
-      ss << to_string_impl<K>::to_string(k) << ":" << to_string_impl<V>::to_string(v) << ",";
+      ss << to_string_impl<K>::to_string(k) << ":"
+         << to_string_impl<V>::to_string(v) << ",";
     }
     ss << "}";
     return ss.str();
@@ -84,7 +85,8 @@ struct to_string_impl<std::array<T, N>> {
 
 template <typename T, size_t M, size_t N>
 struct to_string_impl<std::array<std::array<T, N>, M>> {
-  static inline std::string to_string(const std::array<std::array<T, N>, M>& empty) {
+  static inline std::string to_string(
+      const std::array<std::array<T, N>, M>& empty) {
     std::stringstream ss;
     ss << "[";
     for (auto i : empty) {
@@ -97,12 +99,16 @@ struct to_string_impl<std::array<std::array<T, N>, M>> {
 
 template <>
 struct to_string_impl<Date> {
-  static inline std::string to_string(const Date& empty) { return empty.to_string(); }
+  static inline std::string to_string(const Date& empty) {
+    return empty.to_string();
+  }
 };
 
 template <>
 struct to_string_impl<std::string_view> {
-  static inline std::string to_string(const std::string_view& empty) { return std::string(empty); }
+  static inline std::string to_string(const std::string_view& empty) {
+    return std::string(empty);
+  }
 };
 
 template <>
@@ -119,37 +125,51 @@ struct to_string_impl<uint8_t> {
 
 template <>
 struct to_string_impl<int64_t> {
-  static inline std::string to_string(const int64_t& empty) { return std::to_string(empty); }
+  static inline std::string to_string(const int64_t& empty) {
+    return std::to_string(empty);
+  }
 };
 
 template <>
 struct to_string_impl<bool> {
-  static inline std::string to_string(const bool& empty) { return std::to_string(empty); }
+  static inline std::string to_string(const bool& empty) {
+    return std::to_string(empty);
+  }
 };
 
 template <>
 struct to_string_impl<uint64_t> {
-  static inline std::string to_string(const uint64_t& empty) { return std::to_string(empty); }
+  static inline std::string to_string(const uint64_t& empty) {
+    return std::to_string(empty);
+  }
 };
 
 template <>
 struct to_string_impl<int32_t> {
-  static inline std::string to_string(const int32_t& empty) { return std::to_string(empty); }
+  static inline std::string to_string(const int32_t& empty) {
+    return std::to_string(empty);
+  }
 };
 
 template <>
 struct to_string_impl<uint32_t> {
-  static inline std::string to_string(const uint32_t& empty) { return std::to_string(empty); }
+  static inline std::string to_string(const uint32_t& empty) {
+    return std::to_string(empty);
+  }
 };
 
 template <>
 struct to_string_impl<double> {
-  static inline std::string to_string(const double& empty) { return std::to_string(empty); }
+  static inline std::string to_string(const double& empty) {
+    return std::to_string(empty);
+  }
 };
 
 template <>
 struct to_string_impl<std::string> {
-  static inline std::string to_string(const std::string& empty) { return empty; }
+  static inline std::string to_string(const std::string& empty) {
+    return empty;
+  }
 };
 
 template <typename... Args>
@@ -160,8 +180,8 @@ struct to_string_impl<std::tuple<Args...>> {
     std::apply(
         [&result](const auto&... v) {
           ((result +=
-            (to_string_impl<std::remove_const_t<std::remove_reference_t<decltype(v)>>>::to_string(
-                v)) +
+            (to_string_impl<std::remove_const_t<
+                 std::remove_reference_t<decltype(v)>>>::to_string(v)) +
             ","),
            ...);
         },

--- a/scripts/pre_commit_check.sh
+++ b/scripts/pre_commit_check.sh
@@ -182,7 +182,7 @@ check_prerequisites() {
     
     if ! check_command "clang-format"; then
         print_warning "clang-format not found. C++ format check will be skipped."
-        print_info "Install with: sudo curl -L https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-22538c65/clang-format-8_linux-amd64 --output /usr/local/bin/clang-format && sudo chmod +x /usr/local/bin/clang-format"
+        print_info "Install with: $PIP_CMD install 'clang-format==10.0.1'"
     fi
     
     if [ ${#missing_tools[@]} -ne 0 ]; then

--- a/tools/python_bind/requirements_dev.txt
+++ b/tools/python_bind/requirements_dev.txt
@@ -4,6 +4,7 @@ importlib_resources
 black>=23.3.0, <=25.9.0
 flake8>=6.0.0
 isort==5.10.1
+clang-format==10.0.1
 neo4j>=4.4.19
 pytest-benchmark[histogram]==5.1.0
 pytest-html==4.1.1


### PR DESCRIPTION
Fixes #419.

## Summary

- Replaces the Linux-only `clang-format-8` static-binary install in CI/local scripts with `python3 -m pip install 'clang-format==10.0.1'`, which ships prebuilt binaries for Linux (x86_64/aarch64), macOS (Intel/Apple Silicon), and Windows. macOS contributors can now run `make format-check` against the same pinned version as CI.
- Pin chosen as v10.0.1 — closest to the prior v8 — so the mechanical reformat is small (4 headers, ~170 lines of column-wrap diff). A future bump to a more current major can be a separate PR.
- Updates install hints in `.github/workflows/format-check.yml`, `scripts/pre_commit_check.sh`, and the `neug_clformat` `CMakeLists.txt` comment, and adds `clang-format==10.0.1` to `tools/python_bind/requirements_dev.txt` so `make requirements` brings it in for local dev.