### PR TITLE
refactor: validate label / edge-triplet IDs at PropertyGraph API boundary

### DIFF
--- a/include/neug/storages/graph/property_graph.h
+++ b/include/neug/storages/graph/property_graph.h
@@ -329,10 +329,12 @@ class PropertyGraph {
       const std::vector<std::pair<vid_t, int32_t>>& ie_edges);
 
   inline VertexTable& get_vertex_table(label_t vertex_label) {
+    schema_.ensure_vertex_label_valid(vertex_label);
     return vertex_tables_[vertex_label];
   }
 
   inline const VertexTable& get_vertex_table(label_t vertex_label) const {
+    schema_.ensure_vertex_label_valid(vertex_label);
     return vertex_tables_[vertex_label];
   }
 
@@ -556,16 +558,25 @@ class PropertyGraph {
   void loadSchema(const std::string& filename);
   inline std::shared_ptr<RefColumnBase> GetVertexPropertyColumn(
       uint8_t label, int32_t col_id) const {
+    schema_.ensure_vertex_label_valid(label);
+    auto props = schema_.get_vertex_properties(label);
+    if (col_id < 0 || static_cast<size_t>(col_id) >= props.size()) {
+      THROW_INVALID_ARGUMENT_EXCEPTION(
+          "Vertex property column id out of range: " + std::to_string(col_id) +
+          " (label has " + std::to_string(props.size()) + " properties)");
+    }
     return vertex_tables_[label].GetPropertyColumn(col_id);
   }
 
   inline std::shared_ptr<RefColumnBase> GetVertexPropertyColumn(
       uint8_t label, const std::string& prop) const {
+    schema_.ensure_vertex_label_valid(label);
     return vertex_tables_[label].GetPropertyColumn(prop);
   }
 
   inline VertexSet GetVertexSet(label_t label,
                                 timestamp_t ts = MAX_TIMESTAMP) const {
+    schema_.ensure_vertex_label_valid(label);
     return vertex_tables_[label].GetVertexSet(ts);
   }
 
@@ -587,11 +598,14 @@ class PropertyGraph {
                                       const std::vector<std::string>& props,
                                       std::vector<std::string>& valid_props);
 
+  Status vertex_label_check(const std::string& vertex_type_name) const;
+  Status vertex_label_check(label_t label) const;
+
   Status edge_triplet_check(const std::string& src_type_name,
                             const std::string& dst_type_name,
-                            const std::string& edge_type_name);
-
-  Status vertex_label_check(const std::string& vertex_type_name);
+                            const std::string& edge_type_name) const;
+  Status edge_triplet_check(label_t src_label, label_t dst_label,
+                            label_t edge_label) const;
 
   void compact_schema();
 

--- a/src/storages/graph/property_graph.cc
+++ b/src/storages/graph/property_graph.cc
@@ -131,7 +131,7 @@ Status PropertyGraph::EnsureCapacity(label_t src_label, label_t dst_label,
 
 Status PropertyGraph::BatchAddVertices(
     label_t v_label, std::shared_ptr<IRecordBatchSupplier> supplier) {
-  assert(v_label < vertex_tables_.size());
+  RETURN_IF_NOT_OK(vertex_label_check(v_label));
   vertex_tables_[v_label].insert_vertices(supplier);
   return neug::Status::OK();
 }
@@ -139,9 +139,7 @@ Status PropertyGraph::BatchAddVertices(
 Status PropertyGraph::BatchAddEdges(
     label_t src_v_label, label_t dst_v_label, label_t e_label,
     std::shared_ptr<IRecordBatchSupplier> supplier) {
-  schema_.ensure_vertex_label_valid(src_v_label);
-  schema_.ensure_vertex_label_valid(dst_v_label);
-  schema_.ensure_edge_triplet_valid(src_v_label, dst_v_label, e_label);
+  RETURN_IF_NOT_OK(edge_triplet_check(src_v_label, dst_v_label, e_label));
   size_t index = schema_.generate_edge_label(src_v_label, dst_v_label, e_label);
   assert(edge_tables_.count(index) > 0);
   edge_tables_.at(index).BatchAddEdges(
@@ -632,6 +630,7 @@ Status PropertyGraph::DeleteEdgeType(label_t src_v_label, label_t dst_v_label,
 
 Status PropertyGraph::BatchDeleteVertices(label_t v_label_id,
                                           const std::vector<vid_t>& vids) {
+  RETURN_IF_NOT_OK(vertex_label_check(v_label_id));
   vertex_tables_[v_label_id].BatchDeleteVertices(vids);
 
   std::set<vid_t> vids_set(vids.begin(), vids.end());
@@ -657,6 +656,7 @@ Status PropertyGraph::BatchDeleteVertices(label_t v_label_id,
 
 Status PropertyGraph::DeleteVertex(label_t label, const Property& oid,
                                    timestamp_t ts) {
+  RETURN_IF_NOT_OK(vertex_label_check(label));
   vid_t lid;
   if (!vertex_tables_.at(label).get_index(oid, lid, ts)) {
     return Status(StatusCode::ERR_INVALID_ARGUMENT,
@@ -666,6 +666,7 @@ Status PropertyGraph::DeleteVertex(label_t label, const Property& oid,
 }
 
 Status PropertyGraph::DeleteVertex(label_t label, vid_t lid, timestamp_t ts) {
+  RETURN_IF_NOT_OK(vertex_label_check(label));
   for (label_t i = 0; i < vertex_label_total_count_; i++) {
     if (!schema_.is_vertex_label_valid(i)) {
       continue;
@@ -691,6 +692,7 @@ Status PropertyGraph::DeleteEdge(label_t src_label, vid_t src_lid,
                                  label_t dst_label, vid_t dst_lid,
                                  label_t edge_label, int32_t oe_offset,
                                  int32_t ie_offset, timestamp_t ts) {
+  RETURN_IF_NOT_OK(edge_triplet_check(src_label, dst_label, edge_label));
   size_t index = schema_.generate_edge_label(src_label, dst_label, edge_label);
   if (edge_tables_.count(index) == 0) {
     return Status(StatusCode::ERR_INVALID_ARGUMENT,
@@ -703,6 +705,7 @@ Status PropertyGraph::DeleteEdge(label_t src_label, vid_t src_lid,
 Status PropertyGraph::BatchDeleteEdges(
     label_t src_v_label, label_t dst_v_label, label_t edge_label,
     const std::vector<std::tuple<vid_t, vid_t>>& edges_vec) {
+  RETURN_IF_NOT_OK(edge_triplet_check(src_v_label, dst_v_label, edge_label));
   size_t index =
       schema_.generate_edge_label(src_v_label, dst_v_label, edge_label);
   std::vector<vid_t> src_vids, dst_vids;
@@ -718,6 +721,7 @@ Status PropertyGraph::BatchDeleteEdges(
     label_t src_v_label, label_t dst_v_label, label_t edge_label,
     const std::vector<std::pair<vid_t, int32_t>>& oe_edges,
     const std::vector<std::pair<vid_t, int32_t>>& ie_edges) {
+  RETURN_IF_NOT_OK(edge_triplet_check(src_v_label, dst_v_label, edge_label));
   size_t index =
       schema_.generate_edge_label(src_v_label, dst_v_label, edge_label);
   edge_tables_.at(index).BatchDeleteEdges(oe_edges, ie_edges);
@@ -1035,15 +1039,18 @@ const Schema& PropertyGraph::schema() const { return schema_; }
 Schema& PropertyGraph::mutable_schema() { return schema_; }
 
 vid_t PropertyGraph::LidNum(label_t vertex_label) const {
+  schema_.ensure_vertex_label_valid(vertex_label);
   return vertex_tables_[vertex_label].LidNum();
 }
 
 vid_t PropertyGraph::VertexNum(label_t vertex_label, timestamp_t ts) const {
+  schema_.ensure_vertex_label_valid(vertex_label);
   return vertex_tables_[vertex_label].VertexNum(ts);
 }
 
 bool PropertyGraph::IsValidLid(label_t vertex_label, vid_t lid,
                                timestamp_t ts) const {
+  schema_.ensure_vertex_label_valid(vertex_label);
   return vertex_tables_[vertex_label].IsValidLid(lid, ts);
 }
 
@@ -1059,16 +1066,19 @@ size_t PropertyGraph::EdgeNum(label_t src_label, label_t edge_label,
 
 bool PropertyGraph::get_lid(label_t label, const Property& oid, vid_t& lid,
                             timestamp_t ts) const {
+  schema_.ensure_vertex_label_valid(label);
   return vertex_tables_[label].get_index(oid, lid, ts);
 }
 
 Property PropertyGraph::GetOid(label_t label, vid_t lid, timestamp_t ts) const {
+  schema_.ensure_vertex_label_valid(label);
   return vertex_tables_[label].GetOid(lid, ts);
 }
 
 Status PropertyGraph::AddVertex(label_t label, const Property& id,
                                 const std::vector<Property>& props, vid_t& ret,
                                 timestamp_t ts, bool insert_safe) {
+  RETURN_IF_NOT_OK(vertex_label_check(label));
   if (!vertex_tables_[label].AddVertex(id, props, ret, ts, insert_safe)) {
     return Status(StatusCode::ERR_INVALID_ARGUMENT, "Fail to add vertex.");
   }
@@ -1105,7 +1115,7 @@ Status PropertyGraph::UpdateVertexProperty(label_t v_label, vid_t vid,
                                            const Property& value,
                                            timestamp_t ts) {
   assert(prop_id >= 0);
-  assert(schema_.is_vertex_label_valid(v_label));
+  RETURN_IF_NOT_OK(vertex_label_check(v_label));
   if (!vertex_tables_[v_label].UpdateProperty(vid, prop_id, value, ts)) {
     return Status(StatusCode::ERR_INVALID_ARGUMENT,
                   "Fail to update vertex property.");
@@ -1120,7 +1130,7 @@ Status PropertyGraph::UpdateEdgeProperty(label_t src_v_label, vid_t src_vid,
                                          const Property& value,
                                          timestamp_t ts) {
   assert(prop_id >= 0);
-  assert(schema_.is_edge_label_valid(e_label));
+  RETURN_IF_NOT_OK(edge_triplet_check(src_v_label, dst_v_label, e_label));
   size_t index = schema_.generate_edge_label(src_v_label, dst_v_label, e_label);
   if (edge_tables_.count(index) == 0) {
     LOG(ERROR) << "Edge table does not exist for edge label: " << e_label;
@@ -1234,27 +1244,52 @@ std::string PropertyGraph::get_statistics_json() const {
   return buffer.GetString();
 }
 
-Status PropertyGraph::edge_triplet_check(const std::string& src_type_name,
-                                         const std::string& dst_type_name,
-                                         const std::string& edge_type_name) {
-  if (!schema_.is_edge_triplet_valid(src_type_name, dst_type_name,
-                                     edge_type_name)) {
-    LOG(ERROR) << "Edge [" << edge_type_name << "] from [" << src_type_name
-               << "] to [" << dst_type_name << "] does not exist";
+Status PropertyGraph::vertex_label_check(
+    const std::string& vertex_type_name) const {
+  if (!schema_.is_vertex_label_valid(vertex_type_name)) {
     return Status(StatusCode::ERR_INVALID_ARGUMENT,
-                  "Edge [" + edge_type_name + "] from [" + src_type_name +
-                      "] to [" + dst_type_name + "] does not exist");
+                  "Vertex label '" + vertex_type_name + "' is not valid");
   }
-  return neug::Status::OK();
+  return Status::OK();
 }
 
-Status PropertyGraph::vertex_label_check(const std::string& vertex_type_name) {
-  if (!schema_.is_vertex_label_valid(vertex_type_name)) {
-    LOG(ERROR) << "Vertex label[" << vertex_type_name << "] does not exists.";
+Status PropertyGraph::vertex_label_check(label_t label) const {
+  if (!schema_.is_vertex_label_valid(label)) {
     return Status(StatusCode::ERR_INVALID_ARGUMENT,
-                  "Vertex label[" + vertex_type_name + "] does not exists.");
+                  "Vertex label id " + std::to_string(label) + " is not valid");
   }
-  return neug::Status::OK();
+  return Status::OK();
+}
+
+Status PropertyGraph::edge_triplet_check(
+    const std::string& src_type_name, const std::string& dst_type_name,
+    const std::string& edge_type_name) const {
+  RETURN_IF_NOT_OK(vertex_label_check(src_type_name));
+  RETURN_IF_NOT_OK(vertex_label_check(dst_type_name));
+  if (!schema_.is_edge_label_valid(edge_type_name)) {
+    return Status(StatusCode::ERR_INVALID_ARGUMENT,
+                  "Edge label '" + edge_type_name + "' is not valid");
+  }
+  if (!schema_.is_edge_triplet_valid(src_type_name, dst_type_name,
+                                     edge_type_name)) {
+    return Status(StatusCode::ERR_INVALID_ARGUMENT,
+                  "Edge triplet <" + src_type_name + ", " + dst_type_name +
+                      ", " + edge_type_name + "> is not valid");
+  }
+  return Status::OK();
+}
+
+Status PropertyGraph::edge_triplet_check(label_t src_label, label_t dst_label,
+                                         label_t edge_label) const {
+  RETURN_IF_NOT_OK(vertex_label_check(src_label));
+  RETURN_IF_NOT_OK(vertex_label_check(dst_label));
+  if (!schema_.is_edge_triplet_valid(src_label, dst_label, edge_label)) {
+    return Status(StatusCode::ERR_INVALID_ARGUMENT,
+                  "Edge triplet <" + std::to_string(src_label) + ", " +
+                      std::to_string(dst_label) + ", " +
+                      std::to_string(edge_label) + "> is not valid");
+  }
+  return Status::OK();
 }
 
 }  // namespace neug

--- a/tests/storage/test_graph_view.cc
+++ b/tests/storage/test_graph_view.cc
@@ -197,8 +197,10 @@ TEST_F(GraphViewTest, GetVertexPropertyColumnByIdSkipsPk) {
   ASSERT_NE(col0, nullptr);
 
   // Negative / out-of-range ids return null rather than throw.
-  EXPECT_EQ(view.GetVertexPropertyColumn(person_label, -1), nullptr);
-  EXPECT_EQ(view.GetVertexPropertyColumn(person_label, 100), nullptr);
+  EXPECT_THROW(view.GetVertexPropertyColumn(person_label, -1),
+               exception::InvalidArgumentException);
+  EXPECT_THROW(view.GetVertexPropertyColumn(person_label, 100),
+               exception::InvalidArgumentException);
 }
 
 TEST_F(GraphViewTest, EdgeBasicTraversal) {


### PR DESCRIPTION
## What do these changes do?

Harden `PropertyGraph`'s label-id and edge-triplet validation so that bad caller-supplied IDs no longer become undefined behavior in Release builds, and unify the existing private check helpers so the string and `label_t` overloads behave consistently.

- Add `label_t` overloads of the private helpers and make all four overloads `const`. Both `edge_triplet_check` overloads now delegate per-vertex validation to `vertex_label_check`, so they share logic and produce equally granular errors:
  ```cpp
  Status vertex_label_check(const std::string&) const;
  Status vertex_label_check(label_t) const;
  Status edge_triplet_check(const std::string&, const std::string&,
                            const std::string&) const;
  Status edge_triplet_check(label_t, label_t, label_t) const;
  ```
- **Mutating APIs** (`BatchAddVertices`, `BatchDeleteVertices`, `DeleteVertex` ×2, `DeleteEdge`, `BatchDeleteEdges` ×2, `AddVertex`, `UpdateVertexProperty`, `UpdateEdgeProperty`) now `RETURN_IF_NOT_OK(vertex_label_check(...) / edge_triplet_check(...))` instead of `assert(...)` or relying on the callee to catch the bad ID.
- **Non-Status accessors** (`get_vertex_table` ×2, `GetVertexPropertyColumn` ×2, `GetVertexSet`, `LidNum`, `VertexNum`, `IsValidLid`, `get_lid`, `GetOid`) now call `schema_.ensure_vertex_label_valid(...)` (throws `InvalidArgumentException`) — the only viable signal channel for non-`Status` returns.
- `GetVertexPropertyColumn(label, col_id)` additionally bounds-checks `col_id` against the label's property count.
- Unify error wording across overloads: `"Vertex label '<name>' is not valid"` / `"Vertex label id <N> is not valid"`; same `"Edge triplet <...> is not valid"` shape. Drop the `LOG(ERROR)` calls from the existing string-based helpers (caller decides).

No behavior change for valid inputs. Verified no tests assert on the old error wording.

## Background

These changes were originally bundled inside the `zl/update-txn-cow` branch (PR #370 split work) but have no semantic dependency on the workspace/checkpoint or COW refactor. Splitting them out keeps those downstream PRs focused and lets this hardening land independently against `main`.

## Related issue number

Fixes #421
