### PR TITLE
docs: mark Parquet as supported via PARQUET extension in load_data

### DIFF
--- a/doc/source/data_io/load_data.md
+++ b/doc/source/data_io/load_data.md
@@ -57,7 +57,17 @@ See the [JSON Extension](../extensions/load_json) page for format-specific optio
 
 ### Parquet
 
-Parquet support is planned for v0.2.
+Parquet is supported via the PARQUET extension (available since v0.1.1). After a one-time install and load, you can use `LOAD FROM` to read `.parquet` files directly:
+
+```cypher
+INSTALL PARQUET;
+LOAD PARQUET;
+
+LOAD FROM "person.parquet"
+RETURN *;
+```
+
+See the [Parquet Extension](../extensions/load_parquet) page for format-specific options (`buffered_stream`, `pre_buffer`, `enable_io_coalescing`, `parquet_batch_rows`) and examples, including how to export query results to Parquet via `COPY TO`.
 
 ## Relational Operations
 


### PR DESCRIPTION
## Summary

- The LOAD FROM reference (`doc/source/data_io/load_data.md`) still said *"Parquet support is planned for v0.2"*, but the PARQUET extension has actually been available since v0.1.1 (see `doc/source/extensions/index.md`) and provides both `LOAD FROM` and `COPY TO` support.
- Replace the placeholder with a minimal `INSTALL` / `LOAD` / `LOAD FROM` example, mirroring the structure of the JSON section right above it.
- Link out to the [Parquet Extension](../extensions/load_parquet) page for the full options list (`buffered_stream`, `pre_buffer`, `enable_io_coalescing`, `parquet_batch_rows`) and `COPY TO` examples, instead of duplicating them here.

No code changes; docs-only.

## Test plan

- [ ] Build the docs locally and confirm the Parquet section renders correctly and the `../extensions/load_parquet` link resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)