### PR TITLE
fix: centralize neug path setup in conftest to prefer local package

### DIFF
--- a/tools/python_bind/tests/conftest.py
+++ b/tools/python_bind/tests/conftest.py
@@ -16,6 +16,11 @@
 # limitations under the License.
 #
 
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
 import pytest
 
 from neug.session import Session

--- a/tools/python_bind/tests/test_alter_property.py
+++ b/tools/python_bind/tests/test_alter_property.py
@@ -22,8 +22,6 @@ import sys
 import time
 import unittest
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
-
 from neug.database import Database
 
 logger = logging.getLogger(__name__)

--- a/tools/python_bind/tests/test_batch_loading.py
+++ b/tools/python_bind/tests/test_batch_loading.py
@@ -23,8 +23,6 @@ import sys
 import time
 import unittest
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
-
 from neug.database import Database
 
 logger = logging.getLogger(__name__)

--- a/tools/python_bind/tests/test_call_string_literal.py
+++ b/tools/python_bind/tests/test_call_string_literal.py
@@ -55,8 +55,6 @@ import sys
 
 import pytest
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
-
 from neug.database import Database
 
 logger = logging.getLogger(__name__)

--- a/tools/python_bind/tests/test_data_io_docs.py
+++ b/tools/python_bind/tests/test_data_io_docs.py
@@ -35,8 +35,6 @@ import sys
 
 import pytest
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
-
 from neug.database import Database
 
 

--- a/tools/python_bind/tests/test_db_cases.py
+++ b/tools/python_bind/tests/test_db_cases.py
@@ -22,7 +22,6 @@ import sys
 
 import pytest
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
 from neug.database import Database
 from neug.proto.error_pb2 import ERR_TYPE_CONVERSION
 from neug.proto.error_pb2 import ERR_TYPE_OVERFLOW

--- a/tools/python_bind/tests/test_db_concurrent.py
+++ b/tools/python_bind/tests/test_db_concurrent.py
@@ -24,7 +24,6 @@ import time
 
 import pytest
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
 import threading
 
 from neug.database import Database

--- a/tools/python_bind/tests/test_db_concurrent.py
+++ b/tools/python_bind/tests/test_db_concurrent.py
@@ -20,11 +20,10 @@ import os
 import random
 import shutil
 import sys
+import threading
 import time
 
 import pytest
-
-import threading
 
 from neug.database import Database
 from neug.session import Session

--- a/tools/python_bind/tests/test_db_connection.py
+++ b/tools/python_bind/tests/test_db_connection.py
@@ -23,7 +23,6 @@ import time
 
 import pytest
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
 from neug.database import Database
 from neug.proto.error_pb2 import ERR_CONFIG_INVALID
 from neug.proto.error_pb2 import ERR_CONNECTION_CLOSED

--- a/tools/python_bind/tests/test_db_import_export.py
+++ b/tools/python_bind/tests/test_db_import_export.py
@@ -24,7 +24,6 @@ from pathlib import Path
 
 import pytest
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
 from neug.database import Database
 from neug.proto.error_pb2 import ERR_BAD_ENCODING
 from neug.proto.error_pb2 import ERR_COMPILATION

--- a/tools/python_bind/tests/test_db_init.py
+++ b/tools/python_bind/tests/test_db_init.py
@@ -23,7 +23,6 @@ import sys
 
 import pytest
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
 from neug.database import Database
 from neug.proto.error_pb2 import ERR_CONFIG_INVALID
 from neug.proto.error_pb2 import ERR_CORRUPTION_DETECTED

--- a/tools/python_bind/tests/test_db_list.py
+++ b/tools/python_bind/tests/test_db_list.py
@@ -22,7 +22,6 @@ import sys
 
 import pytest
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
 from neug.database import Database
 
 

--- a/tools/python_bind/tests/test_db_query.py
+++ b/tools/python_bind/tests/test_db_query.py
@@ -24,8 +24,6 @@ from unittest import result
 
 import pytest
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
-
 from ctypes import sizeof
 
 from conftest import ensure_result_cnt_eq

--- a/tools/python_bind/tests/test_db_query.py
+++ b/tools/python_bind/tests/test_db_query.py
@@ -20,12 +20,10 @@ import logging
 import os
 import shutil
 import sys
+from ctypes import sizeof
 from unittest import result
 
 import pytest
-
-from ctypes import sizeof
-
 from conftest import ensure_result_cnt_eq
 from conftest import ensure_result_cnt_gt_zero
 from conftest import submit_cypher_query

--- a/tools/python_bind/tests/test_db_transaction.py
+++ b/tools/python_bind/tests/test_db_transaction.py
@@ -23,7 +23,6 @@ import time
 
 import pytest
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
 from neug.database import Database
 from neug.proto.error_pb2 import ERR_COMPILATION
 from neug.proto.error_pb2 import ERR_DATABASE_LOCKED

--- a/tools/python_bind/tests/test_ddl.py
+++ b/tools/python_bind/tests/test_ddl.py
@@ -25,8 +25,6 @@ import unittest
 
 import pytest
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
-
 from neug.database import Database
 
 logger = logging.getLogger(__name__)

--- a/tools/python_bind/tests/test_export.py
+++ b/tools/python_bind/tests/test_export.py
@@ -24,8 +24,6 @@ import sys
 
 import pytest
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
-
 from neug.database import Database
 
 EXTENSION_TESTS_ENABLED = os.environ.get("NEUG_RUN_EXTENSION_TESTS", "").lower() in (

--- a/tools/python_bind/tests/test_java_driver.py
+++ b/tools/python_bind/tests/test_java_driver.py
@@ -7,8 +7,6 @@ import subprocess
 import sys
 import time
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
-
 from neug.database import Database
 
 

--- a/tools/python_bind/tests/test_load.py
+++ b/tools/python_bind/tests/test_load.py
@@ -22,8 +22,6 @@ import sys
 
 import pytest
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
-
 from neug import Database
 
 EXTENSION_TESTS_ENABLED = os.environ.get("NEUG_RUN_EXTENSION_TESTS", "").lower() in (

--- a/tools/python_bind/tests/test_lsqb.py
+++ b/tools/python_bind/tests/test_lsqb.py
@@ -26,8 +26,6 @@ from conftest import ensure_result_cnt_eq
 from conftest import ensure_result_cnt_gt_zero
 from conftest import submit_cypher_query
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
-
 from neug.database import Database
 
 logger = logging.getLogger(__name__)

--- a/tools/python_bind/tests/test_merge.py
+++ b/tools/python_bind/tests/test_merge.py
@@ -29,8 +29,6 @@ import sys
 
 import pytest
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
-
 from neug.database import Database
 
 logger = logging.getLogger(__name__)

--- a/tools/python_bind/tests/test_ngcli_basics.py
+++ b/tools/python_bind/tests/test_ngcli_basics.py
@@ -23,8 +23,6 @@ import sys
 import pytest
 from prompt_toolkit.document import Document
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
-
 from neug import neug_cli
 from neug.database import Database
 

--- a/tools/python_bind/tests/test_ngcli_commands.py
+++ b/tools/python_bind/tests/test_ngcli_commands.py
@@ -27,7 +27,6 @@ import pytest
 import requests
 from click.testing import CliRunner
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
 from neug import neug_cli
 from neug import web_ui
 from neug.database import Database

--- a/tools/python_bind/tests/test_query.py
+++ b/tools/python_bind/tests/test_query.py
@@ -22,8 +22,6 @@ import sys
 import time
 import unittest
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
-
 from neug.database import Database
 
 logger = logging.getLogger(__name__)

--- a/tools/python_bind/tests/test_sniffer.py
+++ b/tools/python_bind/tests/test_sniffer.py
@@ -25,8 +25,6 @@ from datetime import datetime
 
 import pytest
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
-
 from neug import Database
 
 EXTENSION_TESTS_ENABLED = os.environ.get("NEUG_RUN_EXTENSION_TESTS", "").lower() in (

--- a/tools/python_bind/tests/test_tinysnb_tutorial.py
+++ b/tools/python_bind/tests/test_tinysnb_tutorial.py
@@ -29,8 +29,6 @@ import sys
 
 import pytest
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
-
 import neug
 from neug.database import Database
 

--- a/tools/python_bind/tests/test_to_arrow.py
+++ b/tools/python_bind/tests/test_to_arrow.py
@@ -33,8 +33,6 @@ import sys
 
 import pytest
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
-
 pa = pytest.importorskip("pyarrow")
 
 from neug.database import Database

--- a/tools/python_bind/tests/test_tp_service.py
+++ b/tools/python_bind/tests/test_tp_service.py
@@ -25,8 +25,6 @@ import time
 
 import pytest
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
-
 from conftest import wait_for_server_ready
 
 from neug.database import Database

--- a/tools/python_bind/tests/test_tp_service.py
+++ b/tools/python_bind/tests/test_tp_service.py
@@ -24,7 +24,6 @@ import sys
 import time
 
 import pytest
-
 from conftest import wait_for_server_ready
 
 from neug.database import Database

--- a/tools/python_bind/tests/transaction/elle_tester.py
+++ b/tools/python_bind/tests/transaction/elle_tester.py
@@ -23,8 +23,6 @@ import sys
 import time
 from pathlib import Path
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../../"))
-
 import threading
 from datetime import datetime
 

--- a/tools/python_bind/tests/transaction/elle_tester.py
+++ b/tools/python_bind/tests/transaction/elle_tester.py
@@ -20,11 +20,10 @@ import os
 import random
 import shutil
 import sys
-import time
-from pathlib import Path
-
 import threading
+import time
 from datetime import datetime
+from pathlib import Path
 
 import networkx as nx
 


### PR DESCRIPTION
## Related Issues
fix #429

## What does this PR do?
统一在 conftest.py 中配置 neug 包路径，确保优先使用本地 neug/ 而非 site-packages 中安装的版本。

## What changes in this PR?
- 在 tests/conftest.py 中添加 `sys.path.insert(0, ...)` 将 tools/python_bind/ 置于 sys.path 最前面
- 解决了 conftest.py 先于测试文件加载，导致 append 无效的问题
- 删除所有测试文件中冗余的 `sys.path.append` 调用（共 25 处）
- 解决了 append 优先级低于 site-packages，本地包被 pip 版本遮蔽的问题

## Why the old code was ineffective
- `sys.path.append` in test files runs AFTER conftest.py is loaded, so it cannot help conftest.py's imports
- `append` places the local path AFTER site-packages, so pip-installed neug takes priority
- `conftest.py` is pytest's auto-loaded file that runs before any test module in the same directory