### PR TITLE
fix: optimize Arrow memory usage in infer_schema and create_scanner stages

### DIFF
--- a/extension/parquet/include/parquet_read_function.h
+++ b/extension/parquet/include/parquet_read_function.h
@@ -19,7 +19,6 @@
 #include <arrow/filesystem/filesystem.h>
 #include <arrow/filesystem/localfs.h>
 #include <memory>
-#include "parquet_options.h"
 #include "neug/compiler/function/function.h"
 #include "neug/compiler/function/read_function.h"
 #include "neug/compiler/main/metadata_registry.h"
@@ -28,6 +27,7 @@
 #include "neug/utils/reader/reader.h"
 #include "neug/utils/reader/schema.h"
 #include "neug/utils/reader/sniffer.h"
+#include "parquet_options.h"
 
 namespace neug {
 namespace function {
@@ -58,15 +58,15 @@ struct ParquetReadFunction {
                            resolved.end());
     }
     state->schema.file.paths = std::move(resolvedPaths);
-    
+
     // Create Parquet-specific options builder
     auto optionsBuilder =
         std::make_unique<reader::ArrowParquetOptionsBuilder>(state);
-    
+
     // Create Arrow reader with Parquet options
     auto reader = std::make_unique<reader::ArrowReader>(
         state, std::move(optionsBuilder), fs->toArrowFileSystem());
-    
+
     // Execute read operation.
     // ArrowReader::read() throws exceptions (via THROW_IO_EXCEPTION /
     // THROW_INVALID_ARGUMENT_EXCEPTION) on all Arrow error paths, so
@@ -81,12 +81,14 @@ struct ParquetReadFunction {
       const reader::FileSchema& schema) {
     auto state = std::make_shared<reader::ReadSharedState>();
     auto& externalSchema = state->schema;
-    
+
     // Create table entry schema with empty column names and types,
     // which need to be inferred from Parquet metadata
     externalSchema.entry = std::make_shared<reader::TableEntrySchema>();
     externalSchema.file = schema;
-    
+    externalSchema.file.options["BATCH_SIZE"] =
+        std::to_string(reader::kSniffBlockSize);
+
     // Resolve file paths
     const auto& vfs = neug::main::MetadataRegistry::getVFS();
     const auto& fs = vfs->Provide(state->schema.file);
@@ -97,19 +99,19 @@ struct ParquetReadFunction {
                            resolved.end());
     }
     state->schema.file.paths = std::move(resolvedPaths);
-    
+
     // Create Parquet-specific options builder
     auto optionsBuilder =
         std::make_unique<reader::ArrowParquetOptionsBuilder>(state);
-    
+
     // Create Arrow reader with Parquet options
     auto reader = std::make_shared<reader::ArrowReader>(
         state, std::move(optionsBuilder), fs->toArrowFileSystem());
-    
+
     // Create sniffer to infer schema from Parquet metadata
     auto sniffer = std::make_shared<reader::ArrowSniffer>(reader);
     auto sniffResult = sniffer->sniff();
-    
+
     if (!sniffResult) {
       LOG(ERROR) << "Failed to sniff Parquet schema: "
                  << sniffResult.error().ToString();

--- a/include/neug/compiler/function/import/csv_read_function.h
+++ b/include/neug/compiler/function/import/csv_read_function.h
@@ -144,6 +144,8 @@ struct CSVReadFunction {
     externalSchema.entry = std::make_shared<reader::TableEntrySchema>();
     externalSchema.file = schema;
     validateAndConvertSniffOptions(externalSchema.file);
+    externalSchema.file.options["BATCH_SIZE"] =
+        std::to_string(reader::kSniffBlockSize);
     const auto& vfs = neug::main::MetadataRegistry::getVFS();
     const auto& fs = vfs->Provide(state->schema.file);
     auto resolvedPaths = std::vector<std::string>();
@@ -172,7 +174,12 @@ struct CSVReadFunction {
     if (hasHeader) {
       options.insert({"SKIP_ROWS", "1"});
       options.insert({"AUTOGENERATE_COLUMN_NAMES", "TRUE"});
-      sniffResult = sniffer->sniff();
+      auto optionsBuilder2 =
+          std::make_unique<reader::ArrowCsvOptionsBuilder>(state);
+      auto reader2 = std::make_shared<reader::ArrowReader>(
+          state, std::move(optionsBuilder2), fs->toArrowFileSystem());
+      auto sniffer2 = std::make_shared<reader::ArrowSniffer>(reader2);
+      sniffResult = sniffer2->sniff();
       if (sniffResult) {
         return sniffResult.value();
       }

--- a/include/neug/compiler/function/import/json_read_function.h
+++ b/include/neug/compiler/function/import/json_read_function.h
@@ -79,6 +79,8 @@ struct JsonReadFunction {
     // to be inferred.
     externalSchema.entry = std::make_shared<reader::TableEntrySchema>();
     externalSchema.file = schema;
+    externalSchema.file.options["BATCH_SIZE"] =
+        std::to_string(reader::kSniffBlockSize);
     const auto& vfs = neug::main::MetadataRegistry::getVFS();
     const auto& fs = vfs->Provide(state->schema.file);
     auto resolvedPaths = std::vector<std::string>();
@@ -150,6 +152,8 @@ struct JsonLReadFunction {
     // to be inferred.
     externalSchema.entry = std::make_shared<reader::TableEntrySchema>();
     externalSchema.file = schema;
+    externalSchema.file.options["BATCH_SIZE"] =
+        std::to_string(reader::kSniffBlockSize);
     // todo: get file system from vfs manager
     const auto& vfs = neug::main::MetadataRegistry::getVFS();
     const auto& fs = vfs->Provide(state->schema.file);

--- a/include/neug/utils/reader/options.h
+++ b/include/neug/utils/reader/options.h
@@ -28,6 +28,12 @@
 namespace neug {
 namespace reader {
 
+// Small block size used during schema sniffing to avoid excessive memory
+// allocation. Only 1 batch is read for type inference, so a large batch_size
+// is unnecessary and can leak memory proportional to block_size in Arrow's
+// memory pool.
+static constexpr int64_t kSniffBlockSize = 1 << 20;  // 1 MB
+
 struct ReadSharedState;
 struct EntrySchema;
 
@@ -227,7 +233,7 @@ class ArrowOptionsBuilder : public OptionsBuilder<ArrowOptions> {
    * @param state The shared read state containing schema and configuration
    */
   explicit ArrowOptionsBuilder(std::shared_ptr<ReadSharedState> state)
-      : OptionsBuilder<ArrowOptions>(state){};
+      : OptionsBuilder<ArrowOptions>(state) {};
 
   virtual ~ArrowOptionsBuilder() override = default;
 
@@ -286,7 +292,7 @@ class ArrowCsvOptionsBuilder : public ArrowOptionsBuilder {
    * @param state The shared read state containing CSV schema and configuration
    */
   explicit ArrowCsvOptionsBuilder(std::shared_ptr<ReadSharedState> state)
-      : ArrowOptionsBuilder(state){};
+      : ArrowOptionsBuilder(state) {};
 
   virtual ArrowOptions build() const override;
 

--- a/include/neug/utils/reader/options.h
+++ b/include/neug/utils/reader/options.h
@@ -233,7 +233,7 @@ class ArrowOptionsBuilder : public OptionsBuilder<ArrowOptions> {
    * @param state The shared read state containing schema and configuration
    */
   explicit ArrowOptionsBuilder(std::shared_ptr<ReadSharedState> state)
-      : OptionsBuilder<ArrowOptions>(state) {};
+      : OptionsBuilder<ArrowOptions>(state){};
 
   virtual ~ArrowOptionsBuilder() override = default;
 
@@ -292,7 +292,7 @@ class ArrowCsvOptionsBuilder : public ArrowOptionsBuilder {
    * @param state The shared read state containing CSV schema and configuration
    */
   explicit ArrowCsvOptionsBuilder(std::shared_ptr<ReadSharedState> state)
-      : ArrowOptionsBuilder(state) {};
+      : ArrowOptionsBuilder(state){};
 
   virtual ArrowOptions build() const override;
 

--- a/src/utils/reader/options.cc
+++ b/src/utils/reader/options.cc
@@ -126,6 +126,16 @@ ArrowOptions ArrowCsvOptionsBuilder::build() const {
 
   auto scanOptions = std::make_shared<arrow::dataset::ScanOptions>();
 
+  // Set dataset_schema from entry schema when available, so that
+  // factory->Finish(schema) is used instead of factory->Finish() which
+  // triggers Inspect(). Inspect() reads block_size bytes from the file just
+  // to re-infer a schema we already know, causing massive memory allocation
+  // when block_size is large (e.g., 256MB block_size → 3.6GB allocation).
+  if (state->schema.entry && !state->schema.entry->columnNames.empty() &&
+      !state->schema.entry->columnTypes.empty()) {
+    scanOptions->dataset_schema = createSchema(*state->schema.entry);
+  }
+
   // Build format-specific fragment scan options
   auto fragment_scan_options = buildFragmentOptions();
   scanOptions->fragment_scan_options = fragment_scan_options;


### PR DESCRIPTION
## Summary

- Extract `kSniffBlockSize` (1MB) as a shared constant in `neug::reader` namespace
- Apply small `BATCH_SIZE` in CSV, JSON, JSONL, and Parquet sniff functions to avoid excessive Arrow memory pool allocation during schema inference
- Set `dataset_schema` in `ScanOptions` to skip redundant `Inspect()` call in `create_scanner`, preventing large block_size-proportional allocations

Fixes #220

## Test plan

- [x] C++ `utils_test` passes (includes sniffer tests)
- [x] Manual verification with large CSV files to confirm reduced peak memory, see report in #220 

🤖 Generated with [Claude Code](https://claude.com/claude-code)