### PR TITLE
fix: Optimize `copy_file` for sparse file

### DIFF
--- a/src/utils/file_utils.cc
+++ b/src/utils/file_utils.cc
@@ -196,147 +196,95 @@ static bool is_block_zero(const char* buf, size_t n) {
   return true;
 }
 
-static void write_all(int fd, const char* buf, size_t n,
-                      const std::string& dst_path) {
-  size_t written = 0;
-  while (written < n) {
-    ssize_t x = ::write(fd, buf + written, n - written);
-    if (x < 0) {
-      throw std::runtime_error("Failed to write to destination file: " +
-                               dst_path);
+// pwrite exact n bytes at off; throws on short write / error.
+static void pwrite_all(int fd, const char* buf, size_t n, off_t off,
+                       const std::string& path) {
+  while (n > 0) {
+    ssize_t w = ::pwrite(fd, buf, n, off);
+    if (w <= 0) {
+      throw std::runtime_error("pwrite failed on " + path + ": " +
+                               std::strerror(errno));
     }
-    written += static_cast<size_t>(x);
+    buf += w;
+    off += w;
+    n -= static_cast<size_t>(w);
   }
 }
 
-/**
- * @brief Sparse-aware copy using SEEK_DATA / SEEK_HOLE.
- *
- * Walks the source's data extents and copies only those, leaving holes
- * unallocated in the destination. Returns false if the filesystem does
- * not support SEEK_HOLE (caller should fall back).
- */
-static bool sparse_copy_seek_hole(int src_fd, int dst_fd, off_t file_size,
-                                  const std::string& src_path,
-                                  const std::string& dst_path) {
+// Walk source's data extents via SEEK_DATA/SEEK_HOLE; pwrite each extent
+// at the same offset in dst (dst has already been ftruncate'd to the
+// final size, so holes are pre-allocated). Returns false iff the FS
+// doesn't implement SEEK_HOLE — caller should fall back.
+static bool sparse_copy_seek_hole(int src_fd, int dst_fd, off_t size,
+                                  const std::string& src,
+                                  const std::string& dst) {
 #ifdef SEEK_HOLE
-  // Empty file: nothing to seek over. Just anchor dst size and return.
-  if (file_size == 0) {
-    if (::ftruncate(dst_fd, 0) < 0) {
-      throw std::runtime_error("Failed to ftruncate destination: " + dst_path);
-    }
-    return true;
-  }
-  // Probe support: on filesystems without SEEK_HOLE, lseek fails with EINVAL.
-  // ENXIO at offset 0 means "no data/hole past offset"; valid response on
-  // some platforms (e.g. macOS) for files that are entirely past EOF.
-  if (::lseek(src_fd, 0, SEEK_HOLE) == -1) {
-    if (errno == EINVAL || errno == ENOTSUP) {
-      return false;
-    }
-    if (errno == ENXIO) {
-      if (::ftruncate(dst_fd, file_size) < 0) {
-        throw std::runtime_error("Failed to ftruncate destination: " +
-                                 dst_path);
-      }
-      return true;
-    }
-    throw std::runtime_error("lseek(SEEK_HOLE) failed on " + src_path + ": " +
-                             std::strerror(errno));
-  }
-
-  std::unique_ptr<char[]> buffer(new char[COPY_BUFFER_SIZE]);
+  auto buf = std::make_unique<char[]>(COPY_BUFFER_SIZE);
   off_t off = 0;
-  while (off < file_size) {
-    off_t data_start = ::lseek(src_fd, off, SEEK_DATA);
-    if (data_start == -1) {
-      if (errno == ENXIO) {
-        break;  // no more data; remainder is hole.
-      }
-      throw std::runtime_error("lseek(SEEK_DATA) failed on " + src_path + ": " +
+  while (off < size) {
+    off_t data = ::lseek(src_fd, off, SEEK_DATA);
+    if (data == -1) {
+      if (errno == ENXIO) break;  // remainder is hole
+      if (errno == EINVAL || errno == ENOTSUP) return false;
+      throw std::runtime_error("SEEK_DATA failed on " + src + ": " +
                                std::strerror(errno));
     }
-    off_t hole_start = ::lseek(src_fd, data_start, SEEK_HOLE);
-    if (hole_start == -1) {
-      hole_start = file_size;
-    }
+    off_t hole = ::lseek(src_fd, data, SEEK_HOLE);
+    if (hole == -1) hole = size;
 
-    if (::lseek(src_fd, data_start, SEEK_SET) == -1 ||
-        ::lseek(dst_fd, data_start, SEEK_SET) == -1) {
-      throw std::runtime_error("lseek failed during sparse copy of " +
-                               src_path + ": " + std::strerror(errno));
-    }
-
-    size_t remaining = static_cast<size_t>(hole_start - data_start);
-    while (remaining > 0) {
-      size_t to_read = std::min(remaining, COPY_BUFFER_SIZE);
-      ssize_t r = ::read(src_fd, buffer.get(), to_read);
+    for (off_t cur = data; cur < hole;) {
+      size_t to_read =
+          std::min(static_cast<size_t>(hole - cur), COPY_BUFFER_SIZE);
+      ssize_t r = ::pread(src_fd, buf.get(), to_read, cur);
       if (r <= 0) {
-        throw std::runtime_error("Failed to read from source file: " +
-                                 src_path);
+        throw std::runtime_error("pread failed on " + src + ": " +
+                                 std::strerror(errno));
       }
-      write_all(dst_fd, buffer.get(), static_cast<size_t>(r), dst_path);
-      remaining -= static_cast<size_t>(r);
+      pwrite_all(dst_fd, buf.get(), static_cast<size_t>(r), cur, dst);
+      cur += r;
     }
-    off = hole_start;
-  }
-
-  if (::ftruncate(dst_fd, file_size) < 0) {
-    throw std::runtime_error("Failed to ftruncate destination: " + dst_path);
+    off = hole;
   }
   return true;
 #else
   (void) src_fd;
   (void) dst_fd;
-  (void) file_size;
-  (void) src_path;
-  (void) dst_path;
+  (void) size;
+  (void) src;
+  (void) dst;
   return false;
 #endif
 }
 
-/**
- * @brief Sparse-aware fallback: read everything, but skip all-zero blocks
- *        with lseek so the destination ends up sparse too.
- *
- * Used when SEEK_HOLE is unavailable. Still reads the whole source (pages
- * back from cache fast for sparse holes), but avoids writing zero bytes.
- */
-static void sparse_copy_zero_detect(int src_fd, int dst_fd, off_t file_size,
-                                    const std::string& src_path,
-                                    const std::string& dst_path) {
-  if (::lseek(src_fd, 0, SEEK_SET) == -1 ||
-      ::lseek(dst_fd, 0, SEEK_SET) == -1) {
-    throw std::runtime_error("lseek to start failed during copy of " +
-                             src_path);
-  }
-
-  std::unique_ptr<char[]> buffer(new char[COPY_BUFFER_SIZE]);
-  ssize_t r;
-  while ((r = ::read(src_fd, buffer.get(), COPY_BUFFER_SIZE)) > 0) {
-    if (is_block_zero(buffer.get(), static_cast<size_t>(r))) {
-      if (::lseek(dst_fd, r, SEEK_CUR) == -1) {
-        throw std::runtime_error("lseek over hole failed on " + dst_path);
-      }
-    } else {
-      write_all(dst_fd, buffer.get(), static_cast<size_t>(r), dst_path);
+// Fallback for FS without SEEK_HOLE: read every block linearly and pwrite
+// only the non-zero ones; zero blocks stay as the dst's pre-allocated hole.
+static void sparse_copy_zero_detect(int src_fd, int dst_fd, off_t size,
+                                    const std::string& src,
+                                    const std::string& dst) {
+  auto buf = std::make_unique<char[]>(COPY_BUFFER_SIZE);
+  for (off_t off = 0; off < size;) {
+    size_t to_read =
+        std::min(static_cast<size_t>(size - off), COPY_BUFFER_SIZE);
+    ssize_t r = ::pread(src_fd, buf.get(), to_read, off);
+    if (r <= 0) {
+      throw std::runtime_error("pread failed on " + src + ": " +
+                               std::strerror(errno));
     }
-  }
-  if (r < 0) {
-    throw std::runtime_error("Failed to read from source file: " + src_path);
-  }
-
-  if (::ftruncate(dst_fd, file_size) < 0) {
-    throw std::runtime_error("Failed to ftruncate destination: " + dst_path);
+    if (!is_block_zero(buf.get(), static_cast<size_t>(r))) {
+      pwrite_all(dst_fd, buf.get(), static_cast<size_t>(r), off, dst);
+    }
+    off += r;
   }
 }
 
 /**
  * @brief Fallback file copy that preserves sparseness.
  *
- * Tries SEEK_DATA/SEEK_HOLE first to copy only allocated extents; if the
- * filesystem doesn't support it, falls back to a read loop that skips
- * all-zero blocks via lseek. Final size is anchored with ftruncate.
+ * Anchors dst at the final size with ftruncate, then pwrites only the
+ * source's allocated extents into the corresponding offsets — holes in
+ * the source stay as holes in the destination. Tries SEEK_DATA/SEEK_HOLE
+ * first; on filesystems that don't implement them, falls back to reading
+ * every block and pwriting only the non-zero ones.
  *
  * Non-static so tests can call it directly (clonefile/FICLONE fast paths
  * normally shadow this helper on supported filesystems).
@@ -347,7 +295,6 @@ void fallback_copy(const std::string& src_path, const std::string& dst_path,
   if (src_fd < 0) {
     throw std::runtime_error("Failed to open source file: " + src_path);
   }
-
   int dst_fd =
       ::open(dst_path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, src_stat.st_mode);
   if (dst_fd < 0) {
@@ -360,6 +307,11 @@ void fallback_copy(const std::string& src_path, const std::string& dst_path,
 #endif
 
   try {
+    // Anchor dst size up front. Empty / all-hole / trailing-hole cases all
+    // fall out naturally: the inner loops simply don't run for hole regions.
+    if (::ftruncate(dst_fd, src_stat.st_size) < 0) {
+      throw std::runtime_error("ftruncate failed on " + dst_path);
+    }
     if (!sparse_copy_seek_hole(src_fd, dst_fd, src_stat.st_size, src_path,
                                dst_path)) {
       sparse_copy_zero_detect(src_fd, dst_fd, src_stat.st_size, src_path,
@@ -374,7 +326,6 @@ void fallback_copy(const std::string& src_path, const std::string& dst_path,
 
   ::close(src_fd);
   ::close(dst_fd);
-
   copy_metadata(src_stat, dst_path);
 }
 

--- a/src/utils/file_utils.cc
+++ b/src/utils/file_utils.cc
@@ -26,10 +26,15 @@
 #include <linux/fs.h>
 #include <sys/syscall.h>
 #endif
+#ifdef __APPLE__
+#include <sys/clonefile.h>
+#endif
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <algorithm>
+#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <stdexcept>
@@ -63,14 +68,31 @@ static void copy_metadata(const struct stat& src_stat,
 }
 
 /**
- * @brief Try to use FICLONE ioctl for reflink copy.
+ * @brief Try to create an O(1) COW clone of the file.
  *
- * Supported filesystems: Btrfs, XFS (with reflink=1), OCFS2
- * This is the most efficient method - creates instant COW clone.
+ * Platform-specific instant-clone primitives:
+ *   - Linux: ioctl(FICLONE) on Btrfs, XFS (reflink=1), OCFS2
+ *   - macOS: clonefile(2) on APFS (preserves sparseness exactly)
+ *
+ * On success the destination shares its underlying storage with the
+ * source via copy-on-write, with no data copied.
  */
 static bool try_reflink(const std::string& src_path,
                         const std::string& dst_path,
                         const struct stat& src_stat) {
+#if defined(__APPLE__)
+  // clonefile() requires dst to not exist. The overwrite policy was
+  // already enforced by the caller; remove any leftover dst here.
+  ::unlink(dst_path.c_str());
+  if (::clonefile(src_path.c_str(), dst_path.c_str(), 0) == 0) {
+    // clonefile preserves mode/timestamps/ACLs by default; no need to
+    // re-apply metadata.
+    return true;
+  }
+  // Not on APFS or unsupported — leave no partial file behind.
+  ::unlink(dst_path.c_str());
+  return false;
+#elif defined(FICLONE)
   int src_fd = ::open(src_path.c_str(), O_RDONLY);
   if (src_fd < 0) {
     return false;
@@ -83,13 +105,7 @@ static bool try_reflink(const std::string& src_path,
     return false;
   }
 
-// FICLONE: Clone entire file using COW
-#ifdef FICLONE
   int ret = ::ioctl(dst_fd, FICLONE, src_fd);
-#else
-  int ret = -1;  // FICLONE not supported
-#endif
-
   ::close(src_fd);
   ::close(dst_fd);
 
@@ -98,9 +114,14 @@ static bool try_reflink(const std::string& src_path,
     return true;
   }
 
-  // Failed - remove partially created file
   ::unlink(dst_path.c_str());
   return false;
+#else
+  (void) src_path;
+  (void) dst_path;
+  (void) src_stat;
+  return false;
+#endif
 }
 
 /**
@@ -161,15 +182,167 @@ static bool try_copy_file_range(const std::string& src_path,
 #endif
 }
 
+constexpr size_t COPY_BUFFER_SIZE = 64 * 1024;
+
+static bool is_block_zero(const char* buf, size_t n) {
+  const uint64_t* q = reinterpret_cast<const uint64_t*>(buf);
+  size_t qcount = n / sizeof(uint64_t);
+  for (size_t i = 0; i < qcount; ++i) {
+    if (q[i] != 0) return false;
+  }
+  for (size_t i = qcount * sizeof(uint64_t); i < n; ++i) {
+    if (buf[i] != 0) return false;
+  }
+  return true;
+}
+
+static void write_all(int fd, const char* buf, size_t n,
+                      const std::string& dst_path) {
+  size_t written = 0;
+  while (written < n) {
+    ssize_t x = ::write(fd, buf + written, n - written);
+    if (x < 0) {
+      throw std::runtime_error("Failed to write to destination file: " +
+                               dst_path);
+    }
+    written += static_cast<size_t>(x);
+  }
+}
+
 /**
- * @brief Traditional file copy using read/write with buffer.
+ * @brief Sparse-aware copy using SEEK_DATA / SEEK_HOLE.
  *
- * Fallback method that works on all filesystems.
- * Uses 64KB buffer for reasonable performance.
+ * Walks the source's data extents and copies only those, leaving holes
+ * unallocated in the destination. Returns false if the filesystem does
+ * not support SEEK_HOLE (caller should fall back).
  */
-static void fallback_copy(const std::string& src_path,
-                          const std::string& dst_path,
-                          const struct stat& src_stat) {
+static bool sparse_copy_seek_hole(int src_fd, int dst_fd, off_t file_size,
+                                  const std::string& src_path,
+                                  const std::string& dst_path) {
+#ifdef SEEK_HOLE
+  // Empty file: nothing to seek over. Just anchor dst size and return.
+  if (file_size == 0) {
+    if (::ftruncate(dst_fd, 0) < 0) {
+      throw std::runtime_error("Failed to ftruncate destination: " + dst_path);
+    }
+    return true;
+  }
+  // Probe support: on filesystems without SEEK_HOLE, lseek fails with EINVAL.
+  // ENXIO at offset 0 means "no data/hole past offset"; valid response on
+  // some platforms (e.g. macOS) for files that are entirely past EOF.
+  if (::lseek(src_fd, 0, SEEK_HOLE) == -1) {
+    if (errno == EINVAL || errno == ENOTSUP) {
+      return false;
+    }
+    if (errno == ENXIO) {
+      if (::ftruncate(dst_fd, file_size) < 0) {
+        throw std::runtime_error("Failed to ftruncate destination: " +
+                                 dst_path);
+      }
+      return true;
+    }
+    throw std::runtime_error("lseek(SEEK_HOLE) failed on " + src_path + ": " +
+                             std::strerror(errno));
+  }
+
+  std::unique_ptr<char[]> buffer(new char[COPY_BUFFER_SIZE]);
+  off_t off = 0;
+  while (off < file_size) {
+    off_t data_start = ::lseek(src_fd, off, SEEK_DATA);
+    if (data_start == -1) {
+      if (errno == ENXIO) {
+        break;  // no more data; remainder is hole.
+      }
+      throw std::runtime_error("lseek(SEEK_DATA) failed on " + src_path + ": " +
+                               std::strerror(errno));
+    }
+    off_t hole_start = ::lseek(src_fd, data_start, SEEK_HOLE);
+    if (hole_start == -1) {
+      hole_start = file_size;
+    }
+
+    if (::lseek(src_fd, data_start, SEEK_SET) == -1 ||
+        ::lseek(dst_fd, data_start, SEEK_SET) == -1) {
+      throw std::runtime_error("lseek failed during sparse copy of " +
+                               src_path + ": " + std::strerror(errno));
+    }
+
+    size_t remaining = static_cast<size_t>(hole_start - data_start);
+    while (remaining > 0) {
+      size_t to_read = std::min(remaining, COPY_BUFFER_SIZE);
+      ssize_t r = ::read(src_fd, buffer.get(), to_read);
+      if (r <= 0) {
+        throw std::runtime_error("Failed to read from source file: " +
+                                 src_path);
+      }
+      write_all(dst_fd, buffer.get(), static_cast<size_t>(r), dst_path);
+      remaining -= static_cast<size_t>(r);
+    }
+    off = hole_start;
+  }
+
+  if (::ftruncate(dst_fd, file_size) < 0) {
+    throw std::runtime_error("Failed to ftruncate destination: " + dst_path);
+  }
+  return true;
+#else
+  (void) src_fd;
+  (void) dst_fd;
+  (void) file_size;
+  (void) src_path;
+  (void) dst_path;
+  return false;
+#endif
+}
+
+/**
+ * @brief Sparse-aware fallback: read everything, but skip all-zero blocks
+ *        with lseek so the destination ends up sparse too.
+ *
+ * Used when SEEK_HOLE is unavailable. Still reads the whole source (pages
+ * back from cache fast for sparse holes), but avoids writing zero bytes.
+ */
+static void sparse_copy_zero_detect(int src_fd, int dst_fd, off_t file_size,
+                                    const std::string& src_path,
+                                    const std::string& dst_path) {
+  if (::lseek(src_fd, 0, SEEK_SET) == -1 ||
+      ::lseek(dst_fd, 0, SEEK_SET) == -1) {
+    throw std::runtime_error("lseek to start failed during copy of " +
+                             src_path);
+  }
+
+  std::unique_ptr<char[]> buffer(new char[COPY_BUFFER_SIZE]);
+  ssize_t r;
+  while ((r = ::read(src_fd, buffer.get(), COPY_BUFFER_SIZE)) > 0) {
+    if (is_block_zero(buffer.get(), static_cast<size_t>(r))) {
+      if (::lseek(dst_fd, r, SEEK_CUR) == -1) {
+        throw std::runtime_error("lseek over hole failed on " + dst_path);
+      }
+    } else {
+      write_all(dst_fd, buffer.get(), static_cast<size_t>(r), dst_path);
+    }
+  }
+  if (r < 0) {
+    throw std::runtime_error("Failed to read from source file: " + src_path);
+  }
+
+  if (::ftruncate(dst_fd, file_size) < 0) {
+    throw std::runtime_error("Failed to ftruncate destination: " + dst_path);
+  }
+}
+
+/**
+ * @brief Fallback file copy that preserves sparseness.
+ *
+ * Tries SEEK_DATA/SEEK_HOLE first to copy only allocated extents; if the
+ * filesystem doesn't support it, falls back to a read loop that skips
+ * all-zero blocks via lseek. Final size is anchored with ftruncate.
+ *
+ * Non-static so tests can call it directly (clonefile/FICLONE fast paths
+ * normally shadow this helper on supported filesystems).
+ */
+void fallback_copy(const std::string& src_path, const std::string& dst_path,
+                   const struct stat& src_stat) {
   int src_fd = ::open(src_path.c_str(), O_RDONLY);
   if (src_fd < 0) {
     throw std::runtime_error("Failed to open source file: " + src_path);
@@ -182,33 +355,25 @@ static void fallback_copy(const std::string& src_path,
     throw std::runtime_error("Failed to create destination file: " + dst_path);
   }
 
-  constexpr size_t BUFFER_SIZE = 64 * 1024;  // 64KB buffer
-  std::unique_ptr<char[]> buffer(new char[BUFFER_SIZE]);
+#ifdef POSIX_FADV_SEQUENTIAL
+  ::posix_fadvise(src_fd, 0, 0, POSIX_FADV_SEQUENTIAL);
+#endif
 
-  ssize_t bytes_read;
-  while ((bytes_read = ::read(src_fd, buffer.get(), BUFFER_SIZE)) > 0) {
-    ssize_t bytes_written = 0;
-    while (bytes_written < bytes_read) {
-      ssize_t written = ::write(dst_fd, buffer.get() + bytes_written,
-                                bytes_read - bytes_written);
-      if (written < 0) {
-        ::close(src_fd);
-        ::close(dst_fd);
-        ::unlink(dst_path.c_str());
-        throw std::runtime_error("Failed to write to destination file: " +
-                                 dst_path);
-      }
-      bytes_written += written;
+  try {
+    if (!sparse_copy_seek_hole(src_fd, dst_fd, src_stat.st_size, src_path,
+                               dst_path)) {
+      sparse_copy_zero_detect(src_fd, dst_fd, src_stat.st_size, src_path,
+                              dst_path);
     }
+  } catch (...) {
+    ::close(src_fd);
+    ::close(dst_fd);
+    ::unlink(dst_path.c_str());
+    throw;
   }
 
   ::close(src_fd);
   ::close(dst_fd);
-
-  if (bytes_read < 0) {
-    ::unlink(dst_path.c_str());
-    throw std::runtime_error("Failed to read from source file: " + src_path);
-  }
 
   copy_metadata(src_stat, dst_path);
 }

--- a/src/utils/file_utils.cc
+++ b/src/utils/file_utils.cc
@@ -125,10 +125,24 @@ static bool try_reflink(const std::string& src_path,
 }
 
 /**
+ * @brief Is the file sparse? True iff allocated blocks < logical size.
+ *
+ * `st_blocks` is always in 512-byte units regardless of FS block size.
+ */
+static bool is_sparse(const struct stat& st) {
+  return static_cast<off_t>(st.st_blocks) * 512 < st.st_size;
+}
+
+/**
  * @brief Try to use copy_file_range() syscall.
  *
  * Available on Linux 4.5+. May utilize COW on supported filesystems.
  * Performs server-side copy without data passing through userspace.
+ *
+ * WARNING: on non-COW filesystems (e.g. ext4) the kernel materializes
+ * source holes into physical zero blocks. Callers MUST skip this path
+ * for sparse sources — use is_sparse() — and fall through to the
+ * SEEK_HOLE/SEEK_DATA-aware fallback_copy instead.
  */
 static bool try_copy_file_range(const std::string& src_path,
                                 const std::string& dst_path,
@@ -188,10 +202,12 @@ static bool is_block_zero(const char* buf, size_t n) {
   const uint64_t* q = reinterpret_cast<const uint64_t*>(buf);
   size_t qcount = n / sizeof(uint64_t);
   for (size_t i = 0; i < qcount; ++i) {
-    if (q[i] != 0) return false;
+    if (q[i] != 0)
+      return false;
   }
   for (size_t i = qcount * sizeof(uint64_t); i < n; ++i) {
-    if (buf[i] != 0) return false;
+    if (buf[i] != 0)
+      return false;
   }
   return true;
 }
@@ -224,13 +240,16 @@ static bool sparse_copy_seek_hole(int src_fd, int dst_fd, off_t size,
   while (off < size) {
     off_t data = ::lseek(src_fd, off, SEEK_DATA);
     if (data == -1) {
-      if (errno == ENXIO) break;  // remainder is hole
-      if (errno == EINVAL || errno == ENOTSUP) return false;
+      if (errno == ENXIO)
+        break;  // remainder is hole
+      if (errno == EINVAL || errno == ENOTSUP)
+        return false;
       throw std::runtime_error("SEEK_DATA failed on " + src + ": " +
                                std::strerror(errno));
     }
     off_t hole = ::lseek(src_fd, data, SEEK_HOLE);
-    if (hole == -1) hole = size;
+    if (hole == -1)
+      hole = size;
 
     for (off_t cur = data; cur < hole;) {
       size_t to_read =
@@ -350,12 +369,15 @@ CopyResult copy_file(const std::string& src_path, const std::string& dst_path,
     return CopyResult::Reflink;
   }
 
-  // Try copy_file_range - may use server-side COW
-  if (try_copy_file_range(src_path, dst_path, src_stat)) {
+  // copy_file_range() materializes holes into zero blocks on non-COW
+  // filesystems (e.g. ext4). For sparse sources we MUST use the
+  // SEEK_HOLE/SEEK_DATA-aware fallback to avoid bloating dst from a few
+  // KB of real data into the full ftruncate-reserved logical size.
+  if (!is_sparse(src_stat) &&
+      try_copy_file_range(src_path, dst_path, src_stat)) {
     return CopyResult::CopyFileRange;
   }
 
-  // Fallback to traditional copy
   fallback_copy(src_path, dst_path, src_stat);
   return CopyResult::FallbackCopy;
 }

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -6,4 +6,5 @@ add_neug_test(
 	test_utils.cc
 	test_exception.cc
 	test_sniffer.cc
+	test_file_utils.cc
 	json_test.cpp)

--- a/tests/utils/test_file_utils.cc
+++ b/tests/utils/test_file_utils.cc
@@ -1,0 +1,322 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <filesystem>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "neug/utils/file_utils.h"
+
+// Non-static helper from file_utils.cc, exposed for direct testing of the
+// sparse-aware fallback path (otherwise shadowed by clonefile/FICLONE on
+// supported filesystems).
+namespace neug {
+namespace file_utils {
+void fallback_copy(const std::string& src_path, const std::string& dst_path,
+                   const struct stat& src_stat);
+}  // namespace file_utils
+}  // namespace neug
+
+namespace neug {
+namespace test {
+
+namespace {
+
+// ─── Fixtures and helpers ───────────────────────────────────────────────────
+
+struct ScopedFd {
+  int fd = -1;
+  ScopedFd() = default;
+  explicit ScopedFd(int f) : fd(f) {}
+  ScopedFd(const ScopedFd&) = delete;
+  ScopedFd& operator=(const ScopedFd&) = delete;
+  ScopedFd(ScopedFd&& o) noexcept : fd(o.fd) { o.fd = -1; }
+  ~ScopedFd() {
+    if (fd >= 0) ::close(fd);
+  }
+  int get() const { return fd; }
+};
+
+struct DataSegment {
+  off_t offset;
+  std::string data;
+};
+
+struct FileStats {
+  off_t logical;   // st_size
+  off_t physical;  // st_blocks * 512 — actual on-disk allocation
+};
+
+FileStats stat_file(const std::string& path) {
+  struct stat st {};
+  if (::stat(path.c_str(), &st) != 0) {
+    return {-1, -1};
+  }
+  return {st.st_size, static_cast<off_t>(st.st_blocks) * 512};
+}
+
+// Write each segment at its offset (gaps stay as holes), then optionally
+// truncate to `logical_size` to add a trailing hole.
+void make_file(const std::string& path,
+               const std::vector<DataSegment>& segments,
+               off_t logical_size = -1) {
+  ScopedFd fd(::open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644));
+  ASSERT_GE(fd.get(), 0) << "open(" << path << "): " << ::strerror(errno);
+  for (const auto& seg : segments) {
+    ssize_t n =
+        ::pwrite(fd.get(), seg.data.data(), seg.data.size(), seg.offset);
+    ASSERT_EQ(n, static_cast<ssize_t>(seg.data.size()))
+        << "pwrite(" << path << ", off=" << seg.offset
+        << "): " << ::strerror(errno);
+  }
+  if (logical_size >= 0) {
+    ASSERT_EQ(::ftruncate(fd.get(), logical_size), 0)
+        << "ftruncate(" << path << ", " << logical_size
+        << "): " << ::strerror(errno);
+  }
+}
+
+std::string read_at(const std::string& path, off_t offset, size_t len) {
+  std::string buf(len, '\0');
+  ScopedFd fd(::open(path.c_str(), O_RDONLY));
+  EXPECT_GE(fd.get(), 0) << "open(" << path << "): " << ::strerror(errno);
+  if (fd.get() < 0) return buf;
+  ssize_t n = ::pread(fd.get(), buf.data(), len, offset);
+  EXPECT_EQ(n, static_cast<ssize_t>(len))
+      << "pread(" << path << ", off=" << offset << ", len=" << len << ")";
+  return buf;
+}
+
+void expect_segments_match(const std::string& path,
+                           const std::vector<DataSegment>& expected) {
+  for (const auto& seg : expected) {
+    EXPECT_EQ(read_at(path, seg.offset, seg.data.size()), seg.data)
+        << "content mismatch at offset " << seg.offset;
+  }
+}
+
+void expect_zeros(const std::string& path, off_t offset, size_t len) {
+  std::string buf = read_at(path, offset, len);
+  for (size_t i = 0; i < buf.size(); ++i) {
+    ASSERT_EQ(buf[i], '\0')
+        << "non-zero byte at offset " << (offset + static_cast<off_t>(i))
+        << " in " << path;
+  }
+}
+
+// Common layout: three small data segments scattered through a 64MB file.
+std::vector<DataSegment> three_segments(off_t logical_size) {
+  return {
+      {0, "HEAD_DATA_AT_OFFSET_0"},
+      {logical_size / 2, "MID_DATA_NEAR_MIDDLE"},
+      {logical_size - 64, "TAIL_DATA_NEAR_EOF"},
+  };
+}
+
+}  // namespace
+
+class FileUtilsCopyTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+    tmp_dir_ = std::filesystem::temp_directory_path() /
+               (std::string("neug_fileutils_") + info->name() + "_" +
+                std::to_string(::getpid()));
+    std::filesystem::remove_all(tmp_dir_);
+    std::filesystem::create_directories(tmp_dir_);
+  }
+
+  void TearDown() override {
+    std::error_code ec;
+    std::filesystem::remove_all(tmp_dir_, ec);
+  }
+
+  std::string path(const std::string& name) const {
+    return (tmp_dir_ / name).string();
+  }
+
+  std::filesystem::path tmp_dir_;
+};
+
+// ─── Tests of the public copy_file() entry point ────────────────────────────
+
+TEST_F(FileUtilsCopyTest, SparseFile_PreservesContentAndSparseness) {
+  const off_t kLogical = 64LL << 20;
+  const auto segs = three_segments(kLogical);
+
+  const std::string src = path("src");
+  const std::string dst = path("dst");
+  ASSERT_NO_FATAL_FAILURE(make_file(src, segs, kLogical));
+
+  const auto src_stats = stat_file(src);
+  ASSERT_EQ(src_stats.logical, kLogical);
+
+  file_utils::copy_file(src, dst, /*overwrite=*/true);
+  const auto dst_stats = stat_file(dst);
+
+  EXPECT_EQ(dst_stats.logical, kLogical);
+  expect_segments_match(dst, segs);
+  expect_zeros(dst, 1LL << 20, 4096);
+
+  // If the underlying FS produced a sparse source, the copy must not
+  // explode it. (No assertion fires on filesystems that don't support
+  // sparse — st_blocks then matches st_size and the precondition fails.)
+  if (src_stats.physical < kLogical / 2) {
+    EXPECT_LT(dst_stats.physical, kLogical / 2)
+        << "Sparse source materialized into dense dst: dst_physical="
+        << dst_stats.physical << " logical=" << kLogical;
+  }
+}
+
+TEST_F(FileUtilsCopyTest, AllHoleFile_RemainsSparse) {
+  const off_t kLogical = 16LL << 20;
+  const std::string src = path("src");
+  const std::string dst = path("dst");
+  ASSERT_NO_FATAL_FAILURE(make_file(src, {}, kLogical));
+
+  file_utils::copy_file(src, dst, true);
+
+  const auto dst_stats = stat_file(dst);
+  EXPECT_EQ(dst_stats.logical, kLogical);
+  expect_zeros(dst, 0, 8192);
+  expect_zeros(dst, kLogical - 8192, 8192);
+
+  // A pure-hole file should occupy near-zero on disk on any sane FS.
+  const auto src_stats = stat_file(src);
+  if (src_stats.physical < 1LL << 20) {
+    EXPECT_LT(dst_stats.physical, 1LL << 20)
+        << "All-hole src (physical=" << src_stats.physical
+        << ") materialized into dst (physical=" << dst_stats.physical << ")";
+  }
+}
+
+TEST_F(FileUtilsCopyTest, DenseFile_MatchesByteByByte) {
+  std::string payload(128 * 1024, '\0');
+  std::mt19937 rng(42);
+  for (auto& b : payload) b = static_cast<char>(rng() & 0xFF);
+
+  const std::string src = path("src");
+  const std::string dst = path("dst");
+  ASSERT_NO_FATAL_FAILURE(make_file(src, {{0, payload}}));
+
+  file_utils::copy_file(src, dst, true);
+
+  EXPECT_EQ(stat_file(dst).logical, static_cast<off_t>(payload.size()));
+  EXPECT_EQ(read_at(dst, 0, payload.size()), payload);
+}
+
+TEST_F(FileUtilsCopyTest, EmptyFile_ProducesEmptyDst) {
+  const std::string src = path("src");
+  const std::string dst = path("dst");
+  ASSERT_NO_FATAL_FAILURE(make_file(src, {}));
+
+  file_utils::copy_file(src, dst, true);
+  EXPECT_EQ(stat_file(dst).logical, 0);
+}
+
+TEST_F(FileUtilsCopyTest, LeadingHole_DataAfterOffset) {
+  const off_t kLogical = 32LL << 20;
+  const off_t kDataOff = 8LL << 20;
+  const std::vector<DataSegment> segs = {
+      {kDataOff, "DATA_AFTER_LEADING_HOLE"}};
+
+  const std::string src = path("src");
+  const std::string dst = path("dst");
+  ASSERT_NO_FATAL_FAILURE(make_file(src, segs, kLogical));
+
+  file_utils::copy_file(src, dst, true);
+
+  EXPECT_EQ(stat_file(dst).logical, kLogical);
+  expect_segments_match(dst, segs);
+  expect_zeros(dst, 0, 4096);
+  expect_zeros(dst, kLogical - 4096, 4096);
+}
+
+// ─── Direct tests of fallback_copy() ───────────────────────────────────────
+// On macOS/APFS and Linux/Btrfs/XFS-reflink, the public copy_file() hits
+// clonefile/FICLONE first and never exercises fallback_copy. These tests
+// reach the helper directly so the sparse-aware fallback stays covered.
+
+class FallbackCopyTest : public FileUtilsCopyTest {};
+
+TEST_F(FallbackCopyTest, SparseFile_PreservesSparseness) {
+  const off_t kLogical = 64LL << 20;
+  const auto segs = three_segments(kLogical);
+
+  const std::string src = path("src");
+  const std::string dst = path("dst");
+  ASSERT_NO_FATAL_FAILURE(make_file(src, segs, kLogical));
+
+  struct stat src_st {};
+  ASSERT_EQ(::stat(src.c_str(), &src_st), 0);
+  const auto src_stats = stat_file(src);
+
+  ASSERT_NO_THROW(file_utils::fallback_copy(src, dst, src_st));
+  const auto dst_stats = stat_file(dst);
+
+  EXPECT_EQ(dst_stats.logical, kLogical);
+  expect_segments_match(dst, segs);
+  expect_zeros(dst, 1LL << 20, 4096);
+
+  if (src_stats.physical < kLogical / 2) {
+    EXPECT_LE(dst_stats.physical, src_stats.physical + (4LL << 20))
+        << "fallback_copy bloated dst: src_physical=" << src_stats.physical
+        << " dst_physical=" << dst_stats.physical;
+    EXPECT_LT(dst_stats.physical, kLogical / 4)
+        << "fallback_copy dst occupies >25% of its logical size";
+  }
+}
+
+TEST_F(FallbackCopyTest, AllHoleFile_StaysEmpty) {
+  const off_t kLogical = 16LL << 20;
+  const std::string src = path("src");
+  const std::string dst = path("dst");
+  ASSERT_NO_FATAL_FAILURE(make_file(src, {}, kLogical));
+
+  struct stat src_st {};
+  ASSERT_EQ(::stat(src.c_str(), &src_st), 0);
+
+  ASSERT_NO_THROW(file_utils::fallback_copy(src, dst, src_st));
+
+  const auto dst_stats = stat_file(dst);
+  EXPECT_EQ(dst_stats.logical, kLogical);
+  EXPECT_LT(dst_stats.physical, 1LL << 20)
+      << "fallback_copy materialized an all-hole file: physical="
+      << dst_stats.physical;
+}
+
+TEST_F(FallbackCopyTest, EmptyFile_HandlesZeroSize) {
+  const std::string src = path("src");
+  const std::string dst = path("dst");
+  ASSERT_NO_FATAL_FAILURE(make_file(src, {}));
+
+  struct stat src_st {};
+  ASSERT_EQ(::stat(src.c_str(), &src_st), 0);
+
+  ASSERT_NO_THROW(file_utils::fallback_copy(src, dst, src_st));
+  EXPECT_EQ(stat_file(dst).logical, 0);
+}
+
+}  // namespace test
+}  // namespace neug

--- a/tests/utils/test_file_utils.cc
+++ b/tests/utils/test_file_utils.cc
@@ -19,9 +19,7 @@
 
 #include <cstring>
 #include <filesystem>
-#include <random>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -43,95 +41,44 @@ namespace test {
 
 namespace {
 
-// ─── Fixtures and helpers ───────────────────────────────────────────────────
-
-struct ScopedFd {
-  int fd = -1;
-  ScopedFd() = default;
-  explicit ScopedFd(int f) : fd(f) {}
-  ScopedFd(const ScopedFd&) = delete;
-  ScopedFd& operator=(const ScopedFd&) = delete;
-  ScopedFd(ScopedFd&& o) noexcept : fd(o.fd) { o.fd = -1; }
-  ~ScopedFd() {
-    if (fd >= 0) ::close(fd);
-  }
-  int get() const { return fd; }
-};
-
 struct DataSegment {
   off_t offset;
   std::string data;
 };
-
-struct FileStats {
-  off_t logical;   // st_size
-  off_t physical;  // st_blocks * 512 — actual on-disk allocation
-};
-
-FileStats stat_file(const std::string& path) {
-  struct stat st {};
-  if (::stat(path.c_str(), &st) != 0) {
-    return {-1, -1};
-  }
-  return {st.st_size, static_cast<off_t>(st.st_blocks) * 512};
-}
 
 // Write each segment at its offset (gaps stay as holes), then optionally
 // truncate to `logical_size` to add a trailing hole.
 void make_file(const std::string& path,
                const std::vector<DataSegment>& segments,
                off_t logical_size = -1) {
-  ScopedFd fd(::open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644));
-  ASSERT_GE(fd.get(), 0) << "open(" << path << "): " << ::strerror(errno);
+  int fd = ::open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+  ASSERT_GE(fd, 0) << "open(" << path << "): " << ::strerror(errno);
   for (const auto& seg : segments) {
-    ssize_t n =
-        ::pwrite(fd.get(), seg.data.data(), seg.data.size(), seg.offset);
-    ASSERT_EQ(n, static_cast<ssize_t>(seg.data.size()))
-        << "pwrite(" << path << ", off=" << seg.offset
-        << "): " << ::strerror(errno);
+    ssize_t n = ::pwrite(fd, seg.data.data(), seg.data.size(), seg.offset);
+    ASSERT_EQ(n, static_cast<ssize_t>(seg.data.size())) << ::strerror(errno);
   }
   if (logical_size >= 0) {
-    ASSERT_EQ(::ftruncate(fd.get(), logical_size), 0)
-        << "ftruncate(" << path << ", " << logical_size
-        << "): " << ::strerror(errno);
+    ASSERT_EQ(::ftruncate(fd, logical_size), 0) << ::strerror(errno);
   }
+  ::close(fd);
 }
 
 std::string read_at(const std::string& path, off_t offset, size_t len) {
   std::string buf(len, '\0');
-  ScopedFd fd(::open(path.c_str(), O_RDONLY));
-  EXPECT_GE(fd.get(), 0) << "open(" << path << "): " << ::strerror(errno);
-  if (fd.get() < 0) return buf;
-  ssize_t n = ::pread(fd.get(), buf.data(), len, offset);
-  EXPECT_EQ(n, static_cast<ssize_t>(len))
-      << "pread(" << path << ", off=" << offset << ", len=" << len << ")";
+  int fd = ::open(path.c_str(), O_RDONLY);
+  EXPECT_GE(fd, 0) << ::strerror(errno);
+  if (fd < 0) return buf;
+  EXPECT_EQ(::pread(fd, buf.data(), len, offset),
+            static_cast<ssize_t>(len));
+  ::close(fd);
   return buf;
 }
 
-void expect_segments_match(const std::string& path,
-                           const std::vector<DataSegment>& expected) {
-  for (const auto& seg : expected) {
-    EXPECT_EQ(read_at(path, seg.offset, seg.data.size()), seg.data)
-        << "content mismatch at offset " << seg.offset;
-  }
-}
-
-void expect_zeros(const std::string& path, off_t offset, size_t len) {
-  std::string buf = read_at(path, offset, len);
-  for (size_t i = 0; i < buf.size(); ++i) {
-    ASSERT_EQ(buf[i], '\0')
-        << "non-zero byte at offset " << (offset + static_cast<off_t>(i))
-        << " in " << path;
-  }
-}
-
-// Common layout: three small data segments scattered through a 64MB file.
-std::vector<DataSegment> three_segments(off_t logical_size) {
-  return {
-      {0, "HEAD_DATA_AT_OFFSET_0"},
-      {logical_size / 2, "MID_DATA_NEAR_MIDDLE"},
-      {logical_size - 64, "TAIL_DATA_NEAR_EOF"},
-  };
+// {logical_size, physical_size_bytes}; physical is st_blocks * 512.
+std::pair<off_t, off_t> stat_sizes(const std::string& path) {
+  struct stat st {};
+  if (::stat(path.c_str(), &st) != 0) return {-1, -1};
+  return {st.st_size, static_cast<off_t>(st.st_blocks) * 512};
 }
 
 }  // namespace
@@ -159,154 +106,76 @@ class FileUtilsCopyTest : public ::testing::Test {
   std::filesystem::path tmp_dir_;
 };
 
-// ─── Tests of the public copy_file() entry point ────────────────────────────
-
-TEST_F(FileUtilsCopyTest, SparseFile_PreservesContentAndSparseness) {
+// End-to-end check of the public copy_file() wrapper on a sparse source.
+// On macOS/APFS this exercises the clonefile fast path; on Linux/Btrfs
+// it exercises FICLONE; elsewhere it falls through to fallback_copy.
+// All paths must preserve content and not blow up sparseness.
+TEST_F(FileUtilsCopyTest, CopyFile_SparseFilePreservesContentAndSparseness) {
   const off_t kLogical = 64LL << 20;
-  const auto segs = three_segments(kLogical);
-
+  const std::vector<DataSegment> segs = {
+      {0, "HEAD_DATA"},
+      {kLogical / 2, "MID_DATA"},
+      {kLogical - 64, "TAIL_DATA"},
+  };
   const std::string src = path("src");
   const std::string dst = path("dst");
   ASSERT_NO_FATAL_FAILURE(make_file(src, segs, kLogical));
-
-  const auto src_stats = stat_file(src);
-  ASSERT_EQ(src_stats.logical, kLogical);
 
   file_utils::copy_file(src, dst, /*overwrite=*/true);
-  const auto dst_stats = stat_file(dst);
 
-  EXPECT_EQ(dst_stats.logical, kLogical);
-  expect_segments_match(dst, segs);
-  expect_zeros(dst, 1LL << 20, 4096);
-
-  // If the underlying FS produced a sparse source, the copy must not
-  // explode it. (No assertion fires on filesystems that don't support
-  // sparse — st_blocks then matches st_size and the precondition fails.)
-  if (src_stats.physical < kLogical / 2) {
-    EXPECT_LT(dst_stats.physical, kLogical / 2)
-        << "Sparse source materialized into dense dst: dst_physical="
-        << dst_stats.physical << " logical=" << kLogical;
+  auto [dst_logical, dst_physical] = stat_sizes(dst);
+  auto [src_logical, src_physical] = stat_sizes(src);
+  EXPECT_EQ(dst_logical, kLogical);
+  for (const auto& seg : segs) {
+    EXPECT_EQ(read_at(dst, seg.offset, seg.data.size()), seg.data);
+  }
+  if (src_physical < kLogical / 2) {  // src is sparse on this FS
+    EXPECT_LT(dst_physical, kLogical / 2)
+        << "Sparse src materialized into dense dst (physical=" << dst_physical
+        << ", logical=" << kLogical << ")";
   }
 }
 
-TEST_F(FileUtilsCopyTest, AllHoleFile_RemainsSparse) {
-  const off_t kLogical = 16LL << 20;
-  const std::string src = path("src");
-  const std::string dst = path("dst");
-  ASSERT_NO_FATAL_FAILURE(make_file(src, {}, kLogical));
-
-  file_utils::copy_file(src, dst, true);
-
-  const auto dst_stats = stat_file(dst);
-  EXPECT_EQ(dst_stats.logical, kLogical);
-  expect_zeros(dst, 0, 8192);
-  expect_zeros(dst, kLogical - 8192, 8192);
-
-  // A pure-hole file should occupy near-zero on disk on any sane FS.
-  const auto src_stats = stat_file(src);
-  if (src_stats.physical < 1LL << 20) {
-    EXPECT_LT(dst_stats.physical, 1LL << 20)
-        << "All-hole src (physical=" << src_stats.physical
-        << ") materialized into dst (physical=" << dst_stats.physical << ")";
-  }
-}
-
-TEST_F(FileUtilsCopyTest, DenseFile_MatchesByteByByte) {
-  std::string payload(128 * 1024, '\0');
-  std::mt19937 rng(42);
-  for (auto& b : payload) b = static_cast<char>(rng() & 0xFF);
-
-  const std::string src = path("src");
-  const std::string dst = path("dst");
-  ASSERT_NO_FATAL_FAILURE(make_file(src, {{0, payload}}));
-
-  file_utils::copy_file(src, dst, true);
-
-  EXPECT_EQ(stat_file(dst).logical, static_cast<off_t>(payload.size()));
-  EXPECT_EQ(read_at(dst, 0, payload.size()), payload);
-}
-
-TEST_F(FileUtilsCopyTest, EmptyFile_ProducesEmptyDst) {
-  const std::string src = path("src");
-  const std::string dst = path("dst");
-  ASSERT_NO_FATAL_FAILURE(make_file(src, {}));
-
-  file_utils::copy_file(src, dst, true);
-  EXPECT_EQ(stat_file(dst).logical, 0);
-}
-
-TEST_F(FileUtilsCopyTest, LeadingHole_DataAfterOffset) {
-  const off_t kLogical = 32LL << 20;
-  const off_t kDataOff = 8LL << 20;
-  const std::vector<DataSegment> segs = {
-      {kDataOff, "DATA_AFTER_LEADING_HOLE"}};
-
-  const std::string src = path("src");
-  const std::string dst = path("dst");
-  ASSERT_NO_FATAL_FAILURE(make_file(src, segs, kLogical));
-
-  file_utils::copy_file(src, dst, true);
-
-  EXPECT_EQ(stat_file(dst).logical, kLogical);
-  expect_segments_match(dst, segs);
-  expect_zeros(dst, 0, 4096);
-  expect_zeros(dst, kLogical - 4096, 4096);
-}
-
-// ─── Direct tests of fallback_copy() ───────────────────────────────────────
-// On macOS/APFS and Linux/Btrfs/XFS-reflink, the public copy_file() hits
-// clonefile/FICLONE first and never exercises fallback_copy. These tests
-// reach the helper directly so the sparse-aware fallback stays covered.
-
-class FallbackCopyTest : public FileUtilsCopyTest {};
-
-TEST_F(FallbackCopyTest, SparseFile_PreservesSparseness) {
+// Direct test of fallback_copy on a sparse source. This is the core
+// regression test for issue #440 — without sparse-awareness, dst would
+// materialize the hole bytes and bloat to logical size. Necessary as a
+// dedicated test because clonefile/FICLONE will shadow this path in
+// the public copy_file() on most filesystems.
+TEST_F(FileUtilsCopyTest, FallbackCopy_SparseFilePreservesSparseness) {
   const off_t kLogical = 64LL << 20;
-  const auto segs = three_segments(kLogical);
-
+  const std::vector<DataSegment> segs = {
+      {0, "HEAD_DATA"},
+      {kLogical / 2, "MID_DATA"},
+      {kLogical - 64, "TAIL_DATA"},
+  };
   const std::string src = path("src");
   const std::string dst = path("dst");
   ASSERT_NO_FATAL_FAILURE(make_file(src, segs, kLogical));
 
   struct stat src_st {};
   ASSERT_EQ(::stat(src.c_str(), &src_st), 0);
-  const auto src_stats = stat_file(src);
-
   ASSERT_NO_THROW(file_utils::fallback_copy(src, dst, src_st));
-  const auto dst_stats = stat_file(dst);
 
-  EXPECT_EQ(dst_stats.logical, kLogical);
-  expect_segments_match(dst, segs);
-  expect_zeros(dst, 1LL << 20, 4096);
+  auto [dst_logical, dst_physical] = stat_sizes(dst);
+  auto [src_logical, src_physical] = stat_sizes(src);
+  EXPECT_EQ(dst_logical, kLogical);
+  for (const auto& seg : segs) {
+    EXPECT_EQ(read_at(dst, seg.offset, seg.data.size()), seg.data);
+  }
+  // A sample inside a hole reads back as zeros.
+  for (char c : read_at(dst, 1LL << 20, 4096)) EXPECT_EQ(c, '\0');
 
-  if (src_stats.physical < kLogical / 2) {
-    EXPECT_LE(dst_stats.physical, src_stats.physical + (4LL << 20))
-        << "fallback_copy bloated dst: src_physical=" << src_stats.physical
-        << " dst_physical=" << dst_stats.physical;
-    EXPECT_LT(dst_stats.physical, kLogical / 4)
-        << "fallback_copy dst occupies >25% of its logical size";
+  if (src_physical < kLogical / 2) {
+    EXPECT_LE(dst_physical, src_physical + (4LL << 20))
+        << "fallback_copy bloated dst: src_physical=" << src_physical
+        << " dst_physical=" << dst_physical;
   }
 }
 
-TEST_F(FallbackCopyTest, AllHoleFile_StaysEmpty) {
-  const off_t kLogical = 16LL << 20;
-  const std::string src = path("src");
-  const std::string dst = path("dst");
-  ASSERT_NO_FATAL_FAILURE(make_file(src, {}, kLogical));
-
-  struct stat src_st {};
-  ASSERT_EQ(::stat(src.c_str(), &src_st), 0);
-
-  ASSERT_NO_THROW(file_utils::fallback_copy(src, dst, src_st));
-
-  const auto dst_stats = stat_file(dst);
-  EXPECT_EQ(dst_stats.logical, kLogical);
-  EXPECT_LT(dst_stats.physical, 1LL << 20)
-      << "fallback_copy materialized an all-hole file: physical="
-      << dst_stats.physical;
-}
-
-TEST_F(FallbackCopyTest, EmptyFile_HandlesZeroSize) {
+// Guards the ENXIO edge case: on macOS, lseek(SEEK_HOLE) on an empty
+// file returns ENXIO because offset 0 is already past EOF. Without the
+// special-case for file_size==0, fallback_copy would throw here.
+TEST_F(FileUtilsCopyTest, FallbackCopy_EmptyFile) {
   const std::string src = path("src");
   const std::string dst = path("dst");
   ASSERT_NO_FATAL_FAILURE(make_file(src, {}));
@@ -315,7 +184,7 @@ TEST_F(FallbackCopyTest, EmptyFile_HandlesZeroSize) {
   ASSERT_EQ(::stat(src.c_str(), &src_st), 0);
 
   ASSERT_NO_THROW(file_utils::fallback_copy(src, dst, src_st));
-  EXPECT_EQ(stat_file(dst).logical, 0);
+  EXPECT_EQ(stat_sizes(dst).first, 0);
 }
 
 }  // namespace test

--- a/tests/utils/test_file_utils.cc
+++ b/tests/utils/test_file_utils.cc
@@ -110,6 +110,12 @@ class FileUtilsCopyTest : public ::testing::Test {
 // On macOS/APFS this exercises the clonefile fast path; on Linux/Btrfs
 // it exercises FICLONE; elsewhere it falls through to fallback_copy.
 // All paths must preserve content and not blow up sparseness.
+//
+// Regression for issue #440: previously, on non-COW filesystems (e.g.
+// Linux ext4), reflink would fail and copy_file_range would succeed —
+// but copy_file_range materializes holes into physical zero blocks,
+// bloating a sparse src (4K real / 102G logical) into a 102G dst. The
+// fix routes sparse sources straight to fallback_copy.
 TEST_F(FileUtilsCopyTest, CopyFile_SparseFilePreservesContentAndSparseness) {
   const off_t kLogical = 64LL << 20;
   const std::vector<DataSegment> segs = {
@@ -121,7 +127,7 @@ TEST_F(FileUtilsCopyTest, CopyFile_SparseFilePreservesContentAndSparseness) {
   const std::string dst = path("dst");
   ASSERT_NO_FATAL_FAILURE(make_file(src, segs, kLogical));
 
-  file_utils::copy_file(src, dst, /*overwrite=*/true);
+  auto result = file_utils::copy_file(src, dst, /*overwrite=*/true);
 
   auto [dst_logical, dst_physical] = stat_sizes(dst);
   auto [src_logical, src_physical] = stat_sizes(src);
@@ -130,6 +136,10 @@ TEST_F(FileUtilsCopyTest, CopyFile_SparseFilePreservesContentAndSparseness) {
     EXPECT_EQ(read_at(dst, seg.offset, seg.data.size()), seg.data);
   }
   if (src_physical < kLogical / 2) {  // src is sparse on this FS
+    // Sparse sources must never take the copy_file_range path — it
+    // bloats holes on non-COW filesystems.
+    EXPECT_NE(result, file_utils::CopyResult::CopyFileRange)
+        << "Sparse src took copy_file_range path; risks bloating dst";
     EXPECT_LT(dst_physical, kLogical / 2)
         << "Sparse src materialized into dense dst (physical=" << dst_physical
         << ", logical=" << kLogical << ")";


### PR DESCRIPTION
Fix #440 