### PR TITLE
ci: allow manual dispatch of LDBC nightly benchmark from any branch

### DIFF
--- a/.github/workflows/ldbc-nightly-benchmark.yml
+++ b/.github/workflows/ldbc-nightly-benchmark.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   benchmark:
     name: Build, Load, Serve and Benchmark
-    if: github.repository == 'alibaba/neug' && github.ref == 'refs/heads/main'
+    if: github.repository == 'alibaba/neug' && (github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main')
     runs-on: [self-hosted, ldbc-benchmark]
     timeout-minutes: 480
     steps:


### PR DESCRIPTION
## Summary
- Manual `workflow_dispatch` runs of the LDBC nightly benchmark from non-`main` branches were silently skipped because the job guard required `github.ref == 'refs/heads/main'` (see skipped run [26811476205](https://github.com/alibaba/neug/actions/runs/26811476205/job/79042294409)).
- Relax the guard to allow `workflow_dispatch` from any ref of `alibaba/neug` while keeping scheduled runs pinned to `main`.

Fixes #448
