### PR TITLE
ci: route format-check to self-hosted runners for trusted events

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -96,6 +96,7 @@ jobs:
         python-version: '3.10'
 
     - name: Setup Java and Maven
+      if: ${{ !contains(runner.labels, 'self-hosted') }}
       uses: s4u/setup-maven-action@v1.19.0
       with:
         java-version: '17'

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -17,11 +17,12 @@ concurrency:
 
 jobs:
   check-format:
-    # Use self-hosted runners for trusted events in alibaba/neug (push,
-    # workflow_dispatch, and PRs from non-fork branches). Fall back to
-    # GitHub-hosted runners for forks and other repositories so untrusted
-    # PR code never lands on self-hosted infrastructure.
-    runs-on: ${{ (github.repository == 'alibaba/neug' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)) && fromJSON('["self-hosted", "daily", "linux", "x64"]') || 'ubuntu-22.04' }}
+    # Run on the self-hosted pool whenever the workflow is executing in
+    # alibaba/neug (push, workflow_dispatch, and any pull_request including
+    # those from forks). Fork PRs are intentionally included to avoid the
+    # GitHub-hosted runner queue. Other repositories (e.g. user forks running
+    # this workflow on their own branches) fall back to ubuntu-22.04.
+    runs-on: ${{ github.repository == 'alibaba/neug' && fromJSON('["self-hosted", "daily", "linux", "x64"]') || 'ubuntu-22.04' }}
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -96,7 +96,7 @@ jobs:
         python-version: '3.10'
 
     - name: Setup Java and Maven
-      if: ${{ !contains(runner.labels, 'self-hosted') }}
+      if: ${{ runner.environment != 'self-hosted' }}
       uses: s4u/setup-maven-action@v1.19.0
       with:
         java-version: '17'

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -17,7 +17,11 @@ concurrency:
 
 jobs:
   check-format:
-    runs-on: ubuntu-22.04
+    # Use self-hosted runners for trusted events in alibaba/neug (push,
+    # workflow_dispatch, and PRs from non-fork branches). Fall back to
+    # GitHub-hosted runners for forks and other repositories so untrusted
+    # PR code never lands on self-hosted infrastructure.
+    runs-on: ${{ (github.repository == 'alibaba/neug' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository)) && fromJSON('["self-hosted", "daily", "linux", "x64"]') || 'ubuntu-22.04' }}
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- `format-check` is `runs-on: ubuntu-22.04`, which frequently queues on the GitHub-hosted runner pool and stalls every PR (see #450).
- Route the job to the existing `[self-hosted, daily, linux, x64]` pool whenever the workflow runs in `alibaba/neug`, for all events — `push`, `workflow_dispatch`, and `pull_request` (including PRs from forks).
- Keep `ubuntu-22.04` as the fallback for workflows running outside `alibaba/neug` (e.g. someone's fork running CI on their own branches).

Closes #450.

## Security trade-off

A fork PR can modify `.github/workflows/format-check.yml` (or any script the workflow shells out to) in its diff, and that modified workflow is what runs. Including fork PRs on the self-hosted pool means accepting that risk for this job. The mitigation, if needed later, is to layer in a label-gated approval pattern (require e.g. `safe-to-test` before self-hosted dispatch). For now, optimizing for PR wait time wins out.
