### PR TITLE
refactor: make LFIndexer's indices a typed column

### DIFF
--- a/include/neug/storages/graph/vertex_table.h
+++ b/include/neug/storages/graph/vertex_table.h
@@ -87,15 +87,15 @@ class VertexTable {
         work_dir_("") {}
 
   VertexTable(std::shared_ptr<const VertexSchema> vertex_schema)
-      : indexer_(std::make_shared<IndexerType>()),
+      : indexer_(std::make_shared<IndexerType>(
+            std::get<0>(vertex_schema->primary_keys[0]))),
         table_(std::make_unique<Table>()),
+        pk_type_(std::get<0>(vertex_schema->primary_keys[0])),
         vertex_schema_(vertex_schema),
         v_ts_(std::make_shared<VertexTimestamp>()),
         memory_level_(MemoryLevel::kInMemory),
         work_dir_("") {
     assert(vertex_schema->primary_keys.size() == 1);
-    pk_type_ = std::get<0>(vertex_schema->primary_keys[0]);
-    indexer_->init(pk_type_.id());
   }
 
   VertexTable(VertexTable&& other)

--- a/include/neug/utils/id_indexer.h
+++ b/include/neug/utils/id_indexer.h
@@ -199,18 +199,22 @@ class LFIndexer {
   static constexpr INDEX_T sentinel = std::numeric_limits<INDEX_T>::max();
 
  public:
-  LFIndexer()
+  explicit LFIndexer(DataType pk_type = DataTypeId::kUnknown)
       : indices_(nullptr),
-        indices_size_(0),
         num_elements_(0),
         num_slots_minus_one_(0),
         keys_(nullptr),
-        hasher_() {}
+        pk_type_(pk_type),
+        hasher_() {
+    if (pk_type.id() != DataTypeId::kUnknown) {
+      init(pk_type);
+    }
+  }
   LFIndexer(LFIndexer&& rhs)
       : indices_(std::move(rhs.indices_)),
-        indices_size_(rhs.indices_size_),
         num_elements_(rhs.num_elements_.load()),
         num_slots_minus_one_(rhs.num_slots_minus_one_),
+        pk_type_(rhs.pk_type_),
         hasher_(rhs.hasher_) {
     if (keys_ != rhs.keys_) {
       keys_ = rhs.keys_;
@@ -225,49 +229,14 @@ class LFIndexer {
 
   void swap(LFIndexer& other) {
     indices_.swap(other.indices_);
-    std::swap(indices_size_, other.indices_size_);
     size_t temp_num = num_elements_.load();
     num_elements_.store(other.num_elements_.load());
     other.num_elements_.store(temp_num);
     std::swap(num_slots_minus_one_, other.num_slots_minus_one_);
     std::swap(keys_, other.keys_);
+    std::swap(pk_type_, other.pk_type_);
     hash_policy_.swap(other.hash_policy_);
     std::swap(hasher_, other.hasher_);
-  }
-
-  void init(const DataType& type) {
-    keys_ = nullptr;
-    switch (type.id()) {
-#define TYPE_DISPATCHER(enum_val, T)            \
-  case DataTypeId::enum_val: {                  \
-    keys_ = std::make_shared<TypedColumn<T>>(); \
-    break;                                      \
-  }
-      TYPE_DISPATCHER(kInt64, int64_t)
-      TYPE_DISPATCHER(kInt32, int32_t)
-      TYPE_DISPATCHER(kUInt64, uint64_t)
-      TYPE_DISPATCHER(kUInt32, uint32_t)
-#undef TYPE_DISPATCHER
-    case DataTypeId::kVarchar: {
-      uint16_t max_length = STRING_DEFAULT_MAX_LENGTH;
-      auto extra_type_info = type.RawExtraTypeInfo();
-      if (extra_type_info) {
-        auto str_type_info =
-            dynamic_cast<const StringTypeInfo*>(extra_type_info);
-        if (str_type_info) {
-          max_length = str_type_info->max_length;
-        }
-      }
-      keys_ = std::make_shared<StringColumn>(max_length);
-      break;
-    }
-    default: {
-      THROW_NOT_SUPPORTED_EXCEPTION(
-          "Only (u)int64/32 and string_view types for pk are supported, but "
-          "got: " +
-          type.ToString());
-    }
-    }
   }
 
   void reserve(size_t size) { rehash(std::max(size, num_elements_.load())); }
@@ -277,7 +246,7 @@ class LFIndexer {
     keys_->resize(size);
     size =
         static_cast<size_t>(std::ceil(size / id_indexer_impl::max_load_factor));
-    if (size == indices_size_) {
+    if (size == indices_->size()) {
       return;
     }
 
@@ -291,11 +260,9 @@ class LFIndexer {
     }
     auto new_prime_index = hash_policy_.next_size_over(size);
     hash_policy_.commit(new_prime_index);
-    indices_->Resize(size * sizeof(INDEX_T));
-    auto* indices_ptr = reinterpret_cast<INDEX_T*>(indices_->GetData());
-    indices_size_ = indices_->GetDataSize() / sizeof(INDEX_T);
-    CHECK(indices_size_ * sizeof(INDEX_T) == indices_->GetDataSize());
-    for (size_t k = 0; k != indices_size_; ++k) {
+    indices_->resize(size);
+    auto* indices_ptr = indices_->mutable_data();
+    for (size_t k = 0; k != size; ++k) {
       indices_ptr[k] = LFIndexer<INDEX_T>::sentinel;
     }
     num_slots_minus_one_ = size - 1;
@@ -339,7 +306,7 @@ class LFIndexer {
     }
     // may throw if insert_safe is false and reserved size is not enough
     keys_->set_any(ind, oid, insert_safe);
-    auto* indices_ptr = reinterpret_cast<INDEX_T*>(indices_->GetData());
+    auto* indices_ptr = indices_->mutable_data();
     size_t index =
         hash_policy_.index_for_hash(hasher_(oid), num_slots_minus_one_);
     while (true) {
@@ -354,7 +321,7 @@ class LFIndexer {
 
   INDEX_T get_index(const Property& oid) const {
     assert(oid.type() == get_type());
-    auto* indices_ptr = reinterpret_cast<const INDEX_T*>(indices_->GetData());
+    auto* indices_ptr = indices_->data();
     size_t index =
         hash_policy_.index_for_hash(hasher_(oid), num_slots_minus_one_);
     while (true) {
@@ -371,13 +338,13 @@ class LFIndexer {
   }
 
   bool get_index(const Property& oid, INDEX_T& ret) const {
-    if (indices_size_ <= 0) {
+    if (!indices_ || indices_->size() == 0) {
       return false;
     }
     if (oid.type() != get_type()) {
       return false;
     }
-    auto* indices_ptr = reinterpret_cast<const INDEX_T*>(indices_->GetData());
+    auto* indices_ptr = indices_->data();
     size_t index =
         hash_policy_.index_for_hash(hasher_(oid), num_slots_minus_one_);
     while (true) {
@@ -396,7 +363,7 @@ class LFIndexer {
 
   bool contains(const Property& oid) const {
     assert(oid.type() == get_type());
-    auto* indices_ptr = reinterpret_cast<const INDEX_T*>(indices_->GetData());
+    auto* indices_ptr = indices_->data();
     size_t index =
         hash_policy_.index_for_hash(hasher_(oid), num_slots_minus_one_);
     while (true) {
@@ -420,30 +387,27 @@ class LFIndexer {
     std::filesystem::create_directories(tmp_dir(work_dir));
     load_meta(checkpoint_dir + "/" + name + ".meta");
     keys_->open(name + ".keys", checkpoint_dir, tmp_dir(work_dir));
-    indices_ = OpenContainer(checkpoint_dir + "/" + name + ".indices",
-                             tmp_dir(work_dir) + "/" + name + ".indices",
-                             MemoryLevel::kSyncToFile);
-    indices_size_ = indices_->GetDataSize() / sizeof(INDEX_T);
+    indices_ = std::make_unique<TypedColumn<INDEX_T>>();
+    indices_->open(name + ".indices", checkpoint_dir, tmp_dir(work_dir));
   }
 
   void open_in_memory(const std::string& name) {
     load_meta(name + ".meta");
     keys_->open_in_memory(name + ".keys");
-    indices_ = OpenContainer(name + ".indices", "", MemoryLevel::kInMemory);
-    indices_size_ = indices_->GetDataSize() / sizeof(INDEX_T);
+    indices_ = std::make_unique<TypedColumn<INDEX_T>>();
+    indices_->open_in_memory(name + ".indices");
   }
 
   void open_with_hugepages(const std::string& name) {
     load_meta(name + ".meta");
     keys_->open_with_hugepages(name + ".keys");
-    indices_ =
-        OpenContainer(name + ".indices", "", MemoryLevel::kHugePagePreferred);
-    indices_size_ = indices_->GetDataSize() / sizeof(INDEX_T);
+    indices_ = std::make_unique<TypedColumn<INDEX_T>>();
+    indices_->open_with_hugepages(name + ".indices");
   }
 
   void dump(const std::string& name, const std::string& snapshot_dir) {
     keys_->dump(snapshot_dir + "/" + name + ".keys");
-    indices_->Dump(snapshot_dir + "/" + name + ".indices");
+    indices_->dump(snapshot_dir + "/" + name + ".indices");
     dump_meta(snapshot_dir + "/" + name + ".meta");
     close();
   }
@@ -453,9 +417,8 @@ class LFIndexer {
       keys_->close();
     }
     if (indices_) {
-      indices_->Close();
+      indices_->close();
     }
-    indices_size_ = 0;
   }
 
   void dump_meta(const std::string& filename) const {
@@ -497,13 +460,49 @@ class LFIndexer {
   const ColumnBase& get_keys() const { return *keys_; }
 
  private:
-  std::unique_ptr<IDataContainer> indices_;
-  // size() == indices_size_ == num_slots_minus_one_ +
-  // log(num_slots_minus_one_)
-  size_t indices_size_;
+  void init(const DataType& type) {
+    keys_ = nullptr;
+    switch (type.id()) {
+#define TYPE_DISPATCHER(enum_val, T)            \
+  case DataTypeId::enum_val: {                  \
+    keys_ = std::make_shared<TypedColumn<T>>(); \
+    break;                                      \
+  }
+      TYPE_DISPATCHER(kInt64, int64_t)
+      TYPE_DISPATCHER(kInt32, int32_t)
+      TYPE_DISPATCHER(kUInt64, uint64_t)
+      TYPE_DISPATCHER(kUInt32, uint32_t)
+#undef TYPE_DISPATCHER
+    case DataTypeId::kVarchar: {
+      uint16_t max_length = STRING_DEFAULT_MAX_LENGTH;
+      auto extra_type_info = type.RawExtraTypeInfo();
+      if (extra_type_info) {
+        auto str_type_info =
+            dynamic_cast<const StringTypeInfo*>(extra_type_info);
+        if (str_type_info) {
+          max_length = str_type_info->max_length;
+        }
+      }
+      keys_ = std::make_shared<StringColumn>(max_length);
+      break;
+    }
+    default: {
+      THROW_NOT_SUPPORTED_EXCEPTION(
+          "Only (u)int64/32 and string_view types for pk are supported, but "
+          "got: " +
+          type.ToString());
+    }
+    }
+  }
+
+  std::unique_ptr<TypedColumn<INDEX_T>> indices_;
   std::atomic<size_t> num_elements_;
   size_t num_slots_minus_one_;
   std::shared_ptr<ColumnBase> keys_;
+  /// PK type captured at construction.  Used to size keys_ up front so callers
+  /// don't need a separate init(type) step; runtime queries still go through
+  /// keys_->type().
+  DataType pk_type_;
 
   ska::ska::prime_number_hash_policy hash_policy_;
   GHash<Property> hasher_;

--- a/include/neug/utils/property/column.h
+++ b/include/neug/utils/property/column.h
@@ -172,6 +172,11 @@ class TypedColumn : public ColumnBase {
   const IDataContainer& buffer() const { return *buffer_; }
   size_t buffer_size() const { return size_; }
 
+  inline T* mutable_data() { return reinterpret_cast<T*>(buffer_->GetData()); }
+  inline const T* data() const {
+    return reinterpret_cast<const T*>(buffer_->GetData());
+  }
+
  private:
   std::unique_ptr<IDataContainer> buffer_;
   size_t size_;

--- a/tests/storage/test_edge_table.cc
+++ b/tests/storage/test_edge_table.cc
@@ -96,7 +96,10 @@ class EdgeTableTest : public ::testing::Test {
                      const std::string& name, const std::string& snapshot_dir,
                      const std::string& work_dir) {
     indexer.close();
-    indexer.init(DataTypeId::kInt64);
+    {
+      neug::LFIndexer<neug::vid_t> fresh(DataTypeId::kInt64);
+      indexer.swap(fresh);
+    }
     indexer.open(name, snapshot_dir, work_dir);
     indexer.reserve(num);
     for (neug::vid_t i = 0; i < num; ++i) {
@@ -1558,8 +1561,7 @@ TYPED_TEST(EdgeTableToolsTest, TestBatchAddEdges) {
   }
   EXPECT_EQ(suppliers.size(), 1);
 
-  LFIndexer<vid_t> indexer;
-  indexer.init(DataTypeId::kUInt32);
+  LFIndexer<vid_t> indexer(DataTypeId::kUInt32);
   indexer.open_in_memory("/tmp");
   indexer.reserve(10);
   for (uint32_t i = 0; i < 10; i++) {
@@ -1604,8 +1606,7 @@ TYPED_TEST(EdgeTableToolsTest, TestAddProperties) {
       file_path, column_types, csv_options);
   EXPECT_EQ(suppliers.size(), 1);
 
-  LFIndexer<vid_t> indexer;
-  indexer.init(DataTypeId::kUInt32);
+  LFIndexer<vid_t> indexer(DataTypeId::kUInt32);
   indexer.open_in_memory("/tmp");
   indexer.reserve(10);
   for (uint32_t i = 0; i < 10; i++) {

--- a/tests/unittest/test_indexer.cc
+++ b/tests/unittest/test_indexer.cc
@@ -111,10 +111,9 @@ TEST_F(LFIndexerTest, SupportsCoreMutableInterfacesInMemory) {
   const std::string base_path = test_dir_ + "/core_index";
   CreateEmptyIndicesFile(base_path);
 
-  LFIndexer<uint32_t> indexer;
+  LFIndexer<uint32_t> indexer(DataTypeId::kInt64);
   EXPECT_EQ(LFIndexer<uint32_t>::prefix(), "indexer");
 
-  indexer.init(DataTypeId::kInt64);
   EXPECT_EQ(indexer.get_type(), DataTypeId::kInt64);
   EXPECT_EQ(indexer.get_keys().type(), DataTypeId::kInt64);
 
@@ -157,8 +156,7 @@ TEST_F(LFIndexerTest, DumpsAndOpensAcrossBackends) {
   const std::string in_memory_base = test_dir_ + "/persisted_seed";
   CreateEmptyIndicesFile(in_memory_base);
 
-  LFIndexer<uint32_t> writable;
-  writable.init(DataTypeId::kInt64);
+  LFIndexer<uint32_t> writable(DataTypeId::kInt64);
   writable.open_in_memory(in_memory_base);
 
   std::vector<int64_t> values = {5, 10, 15, 20};
@@ -171,8 +169,7 @@ TEST_F(LFIndexerTest, DumpsAndOpensAcrossBackends) {
   EXPECT_TRUE(std::filesystem::exists(snapshot_dir_ + "/" + name + ".keys"));
   EXPECT_TRUE(std::filesystem::exists(snapshot_dir_ + "/" + name + ".indices"));
 
-  LFIndexer<uint32_t> copied_to_workdir;
-  copied_to_workdir.init(DataTypeId::kInt64);
+  LFIndexer<uint32_t> copied_to_workdir(DataTypeId::kInt64);
   copied_to_workdir.open(name, snapshot_dir_, work_dir_);
   ExpectInt64Values(copied_to_workdir, values);
   EXPECT_TRUE(
@@ -181,14 +178,12 @@ TEST_F(LFIndexerTest, DumpsAndOpensAcrossBackends) {
       std::filesystem::exists(tmp_dir(work_dir_) + "/" + name + ".indices"));
   copied_to_workdir.close();
 
-  LFIndexer<uint32_t> in_memory;
-  in_memory.init(DataTypeId::kInt64);
+  LFIndexer<uint32_t> in_memory(DataTypeId::kInt64);
   in_memory.open_in_memory(snapshot_dir_ + "/" + name);
   ExpectInt64Values(in_memory, values);
   in_memory.close();
 
-  LFIndexer<uint32_t> hugepage_indexer;
-  hugepage_indexer.init(DataTypeId::kInt64);
+  LFIndexer<uint32_t> hugepage_indexer(DataTypeId::kInt64);
   hugepage_indexer.open_with_hugepages(snapshot_dir_ + "/" + name);
   ExpectInt64Values(hugepage_indexer, values);
   hugepage_indexer.close();
@@ -201,14 +196,12 @@ TEST_F(LFIndexerTest, SupportsSwapAndVarcharKeys) {
   CreateEmptyIndicesFile(rhs_base);
 
   auto string_type_info = std::make_shared<StringTypeInfo>(64);
-  LFIndexer<uint32_t> lhs;
   DataType string_type(DataTypeId::kVarchar, string_type_info);
-  lhs.init(string_type);
+  LFIndexer<uint32_t> lhs(string_type);
   lhs.open_in_memory(lhs_base);
   lhs.reserve(4);
 
-  LFIndexer<uint32_t> rhs;
-  rhs.init(string_type);
+  LFIndexer<uint32_t> rhs(string_type);
   rhs.open_in_memory(rhs_base);
   rhs.reserve(4);
 
@@ -254,9 +247,8 @@ TEST_F(LFIndexerTest, VarcharReserveEnablesNonSafeInsert) {
   CreateEmptyIndicesFile(base);
 
   auto type_info = std::make_shared<StringTypeInfo>(64);
-  LFIndexer<uint32_t> indexer;
   DataType string_type(DataTypeId::kVarchar, type_info);
-  indexer.init(string_type);
+  LFIndexer<uint32_t> indexer(string_type);
   indexer.open_in_memory(base);
 
   constexpr size_t N = 8;
@@ -282,9 +274,8 @@ TEST_F(LFIndexerTest, VarcharReserveMaxWidthStrings) {
 
   constexpr uint16_t kMaxWidth = 16;
   auto type_info = std::make_shared<StringTypeInfo>(kMaxWidth);
-  LFIndexer<uint32_t> indexer;
   DataType string_type(DataTypeId::kVarchar, type_info);
-  indexer.init(string_type);
+  LFIndexer<uint32_t> indexer(string_type);
   indexer.open_in_memory(base);
 
   constexpr size_t N = 6;
@@ -311,9 +302,8 @@ TEST_F(LFIndexerTest, VarcharMultipleReservesAccumulateDataSpace) {
   CreateEmptyIndicesFile(base);
 
   auto type_info = std::make_shared<StringTypeInfo>(32);
-  LFIndexer<uint32_t> indexer;
   DataType string_type(DataTypeId::kVarchar, type_info);
-  indexer.init(string_type);
+  LFIndexer<uint32_t> indexer(string_type);
   indexer.open_in_memory(base);
 
   // First batch: reserve 4, insert 4 via insert() (non-safe).
@@ -346,9 +336,8 @@ TEST_F(LFIndexerTest, VarcharReserveSmallerThanCapacityIsNoop) {
   CreateEmptyIndicesFile(base);
 
   auto type_info = std::make_shared<StringTypeInfo>(32);
-  LFIndexer<uint32_t> indexer;
   DataType string_type(DataTypeId::kVarchar, type_info);
-  indexer.init(string_type);
+  LFIndexer<uint32_t> indexer(string_type);
   indexer.open_in_memory(base);
 
   indexer.reserve(16);
@@ -373,8 +362,7 @@ TEST_F(LFIndexerTest, VarcharRehashPreservesData) {
 
   auto type_info = std::make_shared<StringTypeInfo>(64);
   DataType string_type(DataTypeId::kVarchar, type_info);
-  LFIndexer<uint32_t> indexer;
-  indexer.init(string_type);
+  LFIndexer<uint32_t> indexer(string_type);
   indexer.open_in_memory(base);
 
   std::vector<std::string> values = {"foo",  "bar",   "baz",   "qux",
@@ -401,8 +389,7 @@ TEST_F(LFIndexerTest, VarcharReserveInsertDumpReload) {
 
   auto type_info = std::make_shared<StringTypeInfo>(64);
   DataType string_type(DataTypeId::kVarchar, type_info);
-  LFIndexer<uint32_t> writable;
-  writable.init(string_type);
+  LFIndexer<uint32_t> writable(string_type);
   writable.open_in_memory(base);
 
   constexpr size_t N = 5;
@@ -421,8 +408,7 @@ TEST_F(LFIndexerTest, VarcharReserveInsertDumpReload) {
       std::filesystem::exists(snapshot_dir_ + "/" + name + ".keys.data"));
 
   // Reload from snapshot and verify all entries survive the round-trip.
-  LFIndexer<uint32_t> reader;
-  reader.init(string_type);
+  LFIndexer<uint32_t> reader(string_type);
   reader.open_in_memory(snapshot_dir_ + "/" + name);
   ExpectStringValues(reader, values);
   reader.close();
@@ -451,8 +437,7 @@ TEST_F(LFIndexerTest, VarcharShortDumpReopenReserveThenInsertLong_InMemory) {
   // Phase 1: populate with short strings (avg 3 chars << kWidth), then dump.
   std::vector<std::string> short_values = {"a", "bb", "ccc"};
   {
-    LFIndexer<uint32_t> writer;
-    writer.init(string_type);
+    LFIndexer<uint32_t> writer(string_type);
     writer.open_in_memory(base);
     for (const auto& v : short_values) {
       writer.insert(Property::from_string_view(v), true);
@@ -461,8 +446,7 @@ TEST_F(LFIndexerTest, VarcharShortDumpReopenReserveThenInsertLong_InMemory) {
   }
 
   // Phase 2: reopen — data_buffer_ is now tight (= sum of short string bytes).
-  LFIndexer<uint32_t> indexer;
-  indexer.init(string_type);
+  LFIndexer<uint32_t> indexer(string_type);
   indexer.open_in_memory(snapshot_dir_ + "/" + name);
   ExpectStringValues(indexer, short_values);
 
@@ -502,8 +486,7 @@ TEST_F(LFIndexerTest, VarcharShortDumpReopenInsertSafeLong_InMemory) {
   // Phase 1: fill to capacity with 1-char strings, then dump.
   std::vector<std::string> short_values = {"x", "y", "z", "w"};
   {
-    LFIndexer<uint32_t> writer;
-    writer.init(string_type);
+    LFIndexer<uint32_t> writer(string_type);
     writer.open_in_memory(base);
     writer.reserve(short_values.size());
     for (const auto& v : short_values) {
@@ -513,8 +496,7 @@ TEST_F(LFIndexerTest, VarcharShortDumpReopenInsertSafeLong_InMemory) {
   }
 
   // Phase 2: reopen — capacity == short_values.size(), data_buffer_ tight.
-  LFIndexer<uint32_t> indexer;
-  indexer.init(string_type);
+  LFIndexer<uint32_t> indexer(string_type);
   indexer.open_in_memory(snapshot_dir_ + "/" + name);
   EXPECT_EQ(indexer.size(), short_values.size());
 
@@ -549,8 +531,7 @@ TEST_F(LFIndexerTest, VarcharShortDumpReopenReserveThenInsertLong_SyncToFile) {
   // Phase 1: insert 2-char strings to keep .data file tiny, then dump.
   std::vector<std::string> short_values = {"hi", "yo", "ok"};
   {
-    LFIndexer<uint32_t> writer;
-    writer.init(string_type);
+    LFIndexer<uint32_t> writer(string_type);
     writer.open_in_memory(base);
     for (const auto& v : short_values) {
       writer.insert(Property::from_string_view(v), true);
@@ -559,8 +540,7 @@ TEST_F(LFIndexerTest, VarcharShortDumpReopenReserveThenInsertLong_SyncToFile) {
   }
 
   // Phase 2: reopen via SyncToFile — data_buffer_ memory-maps the small file.
-  LFIndexer<uint32_t> indexer;
-  indexer.init(string_type);
+  LFIndexer<uint32_t> indexer(string_type);
   indexer.open(name, snapshot_dir_, work_dir_);
   ExpectStringValues(indexer, short_values);
 
@@ -591,9 +571,8 @@ TEST_F(LFIndexerTest, VarcharStringOverflow) {
 
   // Create indexer with max string length of 32
   auto type_info = std::make_shared<StringTypeInfo>(32);
-  LFIndexer<uint32_t> indexer;
   DataType string_type(DataTypeId::kVarchar, type_info);
-  indexer.init(string_type);
+  LFIndexer<uint32_t> indexer(string_type);
   indexer.open_in_memory(base);
   indexer.reserve(4);
   // Insert valid strings within the limit


### PR DESCRIPTION
## Summary

- Add `data()` / `mutable_data()` to `TypedColumn<T>` for raw pointer access (needed by `LFIndexer`'s lock-free CAS).
- Migrate `LFIndexer::indices_` from `unique_ptr<IDataContainer>` to `unique_ptr<TypedColumn<INDEX_T>>`. Drop the `indices_size_` shadow counter; size accounting lives in the typed column.
- Constructor now takes `DataType pk_type` and creates `keys_` up front; `init()` is now private. Migrates ~17 call sites in `vertex_table` / `test_indexer` / `test_edge_table` to the parameterized ctor.

Closes #459