### PR TITLE
ci: add PR completeness check for feat/fix PRs

### DIFF
--- a/.github/workflows/pr-completeness.yml
+++ b/.github/workflows/pr-completeness.yml
@@ -8,7 +8,7 @@ permissions:
   pull-requests: read
 
 jobs:
-  check:
+  pr-completeness:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR completeness

--- a/.github/workflows/pr-completeness.yml
+++ b/.github/workflows/pr-completeness.yml
@@ -1,0 +1,88 @@
+name: PR Completeness Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, edited, labeled, unlabeled]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR completeness
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          # --- helpers ---
+          get_labels() {
+            gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+              --json labels --jq '.labels[].name'
+          }
+
+          get_changed_files() {
+            gh pr diff "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --name-only
+          }
+
+          # --- extract prefix (feat, fix, etc.) ---
+          PREFIX=$(echo "$PR_TITLE" | grep -oE '^[a-z]+' || true)
+
+          if [[ -z "$PREFIX" ]]; then
+            echo "⚠ PR title does not follow conventional format (feat:/fix:/refactor:/...). Skipping check."
+            exit 0
+          fi
+
+          echo "PR #$PR_NUMBER: prefix='$PREFIX'"
+
+          LABELS=$(get_labels)
+          FILES=$(get_changed_files)
+
+          errors=()
+
+          # --- Rule 1: feat → must include doc changes ---
+          if [[ "$PREFIX" == "feat" ]]; then
+            if echo "$LABELS" | grep -qx 'skip-check:docs'; then
+              echo "✓ Doc check skipped (skip-check:docs label)"
+            elif echo "$FILES" | grep -qE '^doc/source/'; then
+              echo "✓ Feature PR includes documentation updates"
+            else
+              errors+=("Feature PR is missing documentation. Add or update files under doc/source/, or add the 'skip-check:docs' label to bypass.")
+            fi
+          fi
+
+          # --- Rule 2: fix → must include test changes ---
+          if [[ "$PREFIX" == "fix" ]]; then
+            if echo "$LABELS" | grep -qx 'skip-check:tests'; then
+              echo "✓ Test check skipped (skip-check:tests label)"
+            else
+              # exempt if PR only touches CI/build infra
+              non_infra=$(echo "$FILES" | grep -cvE '^(\.github/|docker/|Makefile|CMakeLists\.txt|\.clang|\.gitignore|pre-commit/)' || true)
+              if [[ "$non_infra" -eq 0 ]]; then
+                echo "✓ Fix PR only touches CI/build infra — test not required"
+              elif echo "$FILES" | grep -qE '^(tests/|tools/python_bind/tests/|extension/[^/]+/tests/)'; then
+                echo "✓ Fix PR includes test changes"
+              else
+                errors+=("Bug-fix PR is missing tests. Add or update tests in tests/, tools/python_bind/tests/, or extension/*/tests/, or add the 'skip-check:tests' label to bypass.")
+              fi
+            fi
+          fi
+
+          # --- report ---
+          if [[ ${#errors[@]} -gt 0 ]]; then
+            echo ""
+            echo "============================================"
+            echo "❌ PR Completeness Check FAILED"
+            echo "============================================"
+            for err in "${errors[@]}"; do
+              echo "  • $err"
+            done
+            exit 1
+          fi
+
+          echo ""
+          echo "✅ PR completeness check passed"


### PR DESCRIPTION
## Summary

- Add a GitHub Actions workflow that enforces PR completeness rules:
  - `feat:` PRs must include documentation updates (`doc/source/`)
  - `fix:` PRs must include test changes (`tests/`, `tools/python_bind/tests/`, `extension/*/tests/`)
- Bypass labels: `skip-check:docs` and `skip-check:tests` for exceptional cases
- Auto-exempt `fix:` PRs that only touch CI/build infra files

## Test plan

- [x] Validated on fork [longbinlai/neug](https://github.com/longbinlai/neug) with 3 test PRs:
  - `feat:` without docs → ❌ FAIL (correct)
  - `fix:` without tests → ❌ FAIL (correct)
  - `fix:` with tests → ✅ PASS (correct)
- [ ] After merge, set `check` as required status check in branch protection rules
- [x] Create `skip-check:docs` and `skip-check:tests` labels

Closes #465

cc @lnfjpt 

🤖 Generated with [Claude Code](https://claude.com/claude-code)