### PR TITLE
feat: CSV array type support via string-to-list post-processing

### DIFF
--- a/include/neug/utils/reader/arrow_type_cast.h
+++ b/include/neug/utils/reader/arrow_type_cast.h
@@ -1,0 +1,121 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <arrow/api.h>
+#include <arrow/record_batch.h>
+#include <arrow/table.h>
+#include <arrow/type.h>
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace neug {
+namespace reader {
+
+/**
+ * @brief Casts Arrow columns from one type to another using registered
+ *        conversion functions.
+ *
+ * Primary use case: CSV files cannot represent Arrow list types natively.
+ * List columns are read as strings (e.g. "[1,2,3]") and then converted to
+ * the target list type by this caster.
+ */
+class ArrowTypeCaster {
+ public:
+  using CastFunc = std::function<std::shared_ptr<arrow::Array>(
+      const std::shared_ptr<arrow::Array>&,
+      const std::shared_ptr<arrow::DataType>&)>;
+
+  void registerCast(arrow::Type::type from, arrow::Type::type to,
+                    CastFunc func);
+
+  std::shared_ptr<arrow::Table> castTable(
+      const std::shared_ptr<arrow::Table>& table,
+      const std::shared_ptr<arrow::Schema>& expectedSchema) const;
+
+  std::shared_ptr<arrow::RecordBatch> castBatch(
+      const std::shared_ptr<arrow::RecordBatch>& batch,
+      const std::shared_ptr<arrow::Schema>& expectedSchema) const;
+
+  std::shared_ptr<arrow::Array> castArray(
+      const std::shared_ptr<arrow::Array>& array,
+      const std::shared_ptr<arrow::DataType>& targetType) const;
+
+  static std::shared_ptr<ArrowTypeCaster> createDefault();
+
+ private:
+  std::shared_ptr<arrow::ChunkedArray> castChunkedArray(
+      const std::shared_ptr<arrow::ChunkedArray>& array,
+      const std::shared_ptr<arrow::DataType>& targetType) const;
+
+  std::map<std::pair<arrow::Type::type, arrow::Type::type>, CastFunc> casters_;
+};
+
+/**
+ * @brief A RecordBatch subclass that lazily converts columns on first access.
+ *
+ * Instead of eagerly converting all columns when the batch is obtained,
+ * this class defers type casting until column(i) is actually called.
+ * This preserves the lazy evaluation design of batch_read where data
+ * construction is delayed until the consumer requests it.
+ */
+class LazyTypeCastRecordBatch : public arrow::RecordBatch {
+ public:
+  LazyTypeCastRecordBatch(std::shared_ptr<arrow::RecordBatch> inner,
+                          std::shared_ptr<ArrowTypeCaster> caster,
+                          std::shared_ptr<arrow::Schema> expectedSchema);
+
+  std::shared_ptr<arrow::Array> column(int i) const override;
+  const std::vector<std::shared_ptr<arrow::Array>>& columns() const override;
+  std::shared_ptr<arrow::ArrayData> column_data(int i) const override;
+  const arrow::ArrayDataVector& column_data() const override;
+
+  arrow::Result<std::shared_ptr<arrow::RecordBatch>> AddColumn(
+      int i, const std::shared_ptr<arrow::Field>& field,
+      const std::shared_ptr<arrow::Array>& column) const override;
+  arrow::Result<std::shared_ptr<arrow::RecordBatch>> SetColumn(
+      int i, const std::shared_ptr<arrow::Field>& field,
+      const std::shared_ptr<arrow::Array>& column) const override;
+  arrow::Result<std::shared_ptr<arrow::RecordBatch>> RemoveColumn(
+      int i) const override;
+  std::shared_ptr<arrow::RecordBatch> ReplaceSchemaMetadata(
+      const std::shared_ptr<const arrow::KeyValueMetadata>& metadata)
+      const override;
+  std::shared_ptr<arrow::RecordBatch> Slice(int64_t offset,
+                                            int64_t length) const override;
+  const std::shared_ptr<arrow::Device::SyncEvent>& GetSyncEvent()
+      const override;
+  arrow::DeviceAllocationType device_type() const override;
+
+ private:
+  void materializeColumn(int i) const;
+  void materializeAll() const;
+
+  std::shared_ptr<arrow::RecordBatch> inner_;
+  std::shared_ptr<ArrowTypeCaster> caster_;
+  std::shared_ptr<arrow::Schema> expectedSchema_;
+  mutable std::vector<std::shared_ptr<arrow::Array>> cachedColumns_;
+  mutable arrow::ArrayDataVector cachedColumnData_;
+  mutable std::vector<bool> materialized_;
+  mutable bool allMaterialized_ = false;
+};
+
+}  // namespace reader
+}  // namespace neug

--- a/include/neug/utils/reader/arrow_type_cast.h
+++ b/include/neug/utils/reader/arrow_type_cast.h
@@ -50,10 +50,6 @@ class ArrowTypeCaster {
       const std::shared_ptr<arrow::Table>& table,
       const std::shared_ptr<arrow::Schema>& expectedSchema) const;
 
-  std::shared_ptr<arrow::RecordBatch> castBatch(
-      const std::shared_ptr<arrow::RecordBatch>& batch,
-      const std::shared_ptr<arrow::Schema>& expectedSchema) const;
-
   std::shared_ptr<arrow::Array> castArray(
       const std::shared_ptr<arrow::Array>& array,
       const std::shared_ptr<arrow::DataType>& targetType) const;

--- a/include/neug/utils/reader/options.h
+++ b/include/neug/utils/reader/options.h
@@ -246,7 +246,7 @@ class ArrowOptionsBuilder : public OptionsBuilder<ArrowOptions> {
    * @param state The shared read state containing schema and configuration
    */
   explicit ArrowOptionsBuilder(std::shared_ptr<ReadSharedState> state)
-      : OptionsBuilder<ArrowOptions>(state) {};
+      : OptionsBuilder<ArrowOptions>(state){};
 
   virtual ~ArrowOptionsBuilder() override = default;
 
@@ -305,7 +305,7 @@ class ArrowCsvOptionsBuilder : public ArrowOptionsBuilder {
    * @param state The shared read state containing CSV schema and configuration
    */
   explicit ArrowCsvOptionsBuilder(std::shared_ptr<ReadSharedState> state)
-      : ArrowOptionsBuilder(state) {};
+      : ArrowOptionsBuilder(state){};
 
   virtual ArrowOptions build() const override;
 

--- a/include/neug/utils/reader/options.h
+++ b/include/neug/utils/reader/options.h
@@ -246,7 +246,7 @@ class ArrowOptionsBuilder : public OptionsBuilder<ArrowOptions> {
    * @param state The shared read state containing schema and configuration
    */
   explicit ArrowOptionsBuilder(std::shared_ptr<ReadSharedState> state)
-      : OptionsBuilder<ArrowOptions>(state){};
+      : OptionsBuilder<ArrowOptions>(state) {};
 
   virtual ~ArrowOptionsBuilder() override = default;
 
@@ -305,9 +305,11 @@ class ArrowCsvOptionsBuilder : public ArrowOptionsBuilder {
    * @param state The shared read state containing CSV schema and configuration
    */
   explicit ArrowCsvOptionsBuilder(std::shared_ptr<ReadSharedState> state)
-      : ArrowOptionsBuilder(state){};
+      : ArrowOptionsBuilder(state) {};
 
   virtual ArrowOptions build() const override;
+
+  bool projectColumns(ArrowOptions& options) override;
 
  protected:
   /**

--- a/include/neug/utils/reader/reader.h
+++ b/include/neug/utils/reader/reader.h
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include "neug/execution/common/context.h"
+#include "neug/utils/reader/arrow_type_cast.h"
 #include "neug/utils/reader/options.h"
 #include "neug/utils/reader/schema.h"
 
@@ -191,14 +192,16 @@ class ArrowReader : public Reader<arrow::fs::FileSystem> {
                        std::shared_ptr<arrow::fs::FileSystem> fileSystem)
       : Reader(std::move(sharedState), std::move(fileSystem)),
         optionsBuilder(std::move(optionsBuilder)),
-        datasetBuilder(std::make_shared<DatasetBuilder>()) {}
+        datasetBuilder(std::make_shared<DatasetBuilder>()),
+        typeCaster_(ArrowTypeCaster::createDefault()) {}
   explicit ArrowReader(std::shared_ptr<ReadSharedState> sharedState,
                        std::unique_ptr<ArrowOptionsBuilder> optionsBuilder,
                        std::shared_ptr<arrow::fs::FileSystem> fileSystem,
                        std::shared_ptr<DatasetBuilder> datasetBuilder)
       : Reader(std::move(sharedState), std::move(fileSystem)),
         optionsBuilder(std::move(optionsBuilder)),
-        datasetBuilder(datasetBuilder) {}
+        datasetBuilder(datasetBuilder),
+        typeCaster_(ArrowTypeCaster::createDefault()) {}
   virtual ~ArrowReader() override = default;
 
   void read(std::shared_ptr<ReadLocalState> localState,
@@ -241,8 +244,11 @@ class ArrowReader : public Reader<arrow::fs::FileSystem> {
                   execution::Context& output);
 
  protected:
+  std::shared_ptr<arrow::Schema> computeExpectedSchema() const;
+
   std::unique_ptr<ArrowOptionsBuilder> optionsBuilder;
   std::shared_ptr<DatasetBuilder> datasetBuilder;
+  std::shared_ptr<ArrowTypeCaster> typeCaster_;
 };
 
 }  // namespace reader

--- a/src/execution/common/columns/arrow_context_column.cc
+++ b/src/execution/common/columns/arrow_context_column.cc
@@ -22,6 +22,7 @@
 #include <arrow/type.h>
 #include <glog/logging.h>
 #include <unordered_map>
+#include "neug/common/extra_type_info.h"
 #include "neug/execution/common/columns/columns_utils.h"
 #include "neug/utils/exception/exception.h"
 
@@ -75,6 +76,13 @@ DataType arrow_type_to_rt_type(const std::shared_ptr<arrow::DataType>& type) {
     return DataType(DataTypeId::kTimestampMs);
   } else if (type->Equals(arrow::timestamp(arrow::TimeUnit::NANO))) {
     return DataType(DataTypeId::kTimestampMs);
+  } else if (type->id() == arrow::Type::LIST ||
+             type->id() == arrow::Type::LARGE_LIST ||
+             type->id() == arrow::Type::FIXED_SIZE_LIST) {
+    auto valueType = type->field(0)->type();
+    auto childType = arrow_type_to_rt_type(valueType);
+    auto typeInfo = std::make_shared<ListTypeInfo>(childType);
+    return DataType(DataTypeId::kList, typeInfo);
   } else {
     THROW_NOT_SUPPORTED_EXCEPTION("Unexpected arrow type: " + type->ToString());
   }

--- a/src/execution/common/columns/arrow_context_column.cc
+++ b/src/execution/common/columns/arrow_context_column.cc
@@ -16,6 +16,7 @@
 #include "neug/execution/common/columns/arrow_context_column.h"
 
 #include <arrow/array/array_binary.h>
+#include <arrow/array/array_nested.h>
 #include <arrow/array/builder_binary.h>
 #include <arrow/array/builder_primitive.h>
 #include <arrow/array/builder_time.h>
@@ -320,6 +321,79 @@ std::shared_ptr<IContextColumn> ArrowArrayContextColumn::shuffle(
   return col_builder.finish();
 }
 
+static Value get_arrow_scalar_value(const std::shared_ptr<arrow::Array>& array,
+                                    int64_t idx) {
+  auto arrow_type = array->type();
+  if (arrow_type->Equals(arrow::int64())) {
+    return Value::INT64(
+        std::static_pointer_cast<arrow::Int64Array>(array)->Value(idx));
+  } else if (arrow_type->Equals(arrow::int32())) {
+    return Value::INT32(
+        std::static_pointer_cast<arrow::Int32Array>(array)->Value(idx));
+  } else if (arrow_type->Equals(arrow::uint32())) {
+    return Value::UINT32(
+        std::static_pointer_cast<arrow::UInt32Array>(array)->Value(idx));
+  } else if (arrow_type->Equals(arrow::uint64())) {
+    return Value::UINT64(
+        std::static_pointer_cast<arrow::UInt64Array>(array)->Value(idx));
+  } else if (arrow_type->Equals(arrow::float32())) {
+    return Value::FLOAT(
+        std::static_pointer_cast<arrow::FloatArray>(array)->Value(idx));
+  } else if (arrow_type->Equals(arrow::float64())) {
+    return Value::DOUBLE(
+        std::static_pointer_cast<arrow::DoubleArray>(array)->Value(idx));
+  } else if (arrow_type->Equals(arrow::boolean())) {
+    return Value::BOOLEAN(
+        std::static_pointer_cast<arrow::BooleanArray>(array)->Value(idx));
+  } else if (arrow_type->Equals(arrow::utf8())) {
+    auto str_view =
+        std::static_pointer_cast<arrow::StringArray>(array)->GetView(idx);
+    return Value::STRING(std::string(str_view));
+  } else if (arrow_type->Equals(arrow::large_utf8())) {
+    auto str_view =
+        std::static_pointer_cast<arrow::LargeStringArray>(array)->GetView(idx);
+    return Value::STRING(std::string(str_view));
+  } else if (arrow_type->Equals(arrow::date32())) {
+    Date d;
+    d.from_num_days(
+        std::static_pointer_cast<arrow::Date32Array>(array)->Value(idx));
+    return Value::DATE(d);
+  } else if (arrow_type->Equals(arrow::date64())) {
+    return Value::DATE(
+        Date(std::static_pointer_cast<arrow::Date64Array>(array)->Value(idx)));
+  } else if (arrow_type->id() == arrow::Type::TIMESTAMP) {
+    return Value::TIMESTAMPMS(DateTime(
+        std::static_pointer_cast<arrow::TimestampArray>(array)->Value(idx)));
+  } else if (arrow_type->id() == arrow::Type::LIST) {
+    auto list_arr = std::static_pointer_cast<arrow::ListArray>(array);
+    auto child_type = arrow_type_to_rt_type(list_arr->value_type());
+    auto values_arr = list_arr->values();
+    int32_t start = list_arr->value_offset(idx);
+    int32_t length = list_arr->value_length(idx);
+    std::vector<Value> list_values;
+    list_values.reserve(length);
+    for (int32_t j = start; j < start + length; ++j) {
+      list_values.push_back(get_arrow_scalar_value(values_arr, j));
+    }
+    return Value::LIST(child_type, std::move(list_values));
+  } else if (arrow_type->id() == arrow::Type::FIXED_SIZE_LIST) {
+    auto list_arr = std::static_pointer_cast<arrow::FixedSizeListArray>(array);
+    auto child_type = arrow_type_to_rt_type(list_arr->value_type());
+    auto values_arr = list_arr->values();
+    int32_t start = list_arr->value_offset(idx);
+    int32_t length = list_arr->value_length(idx);
+    std::vector<Value> list_values;
+    list_values.reserve(length);
+    for (int32_t j = start; j < start + length; ++j) {
+      list_values.push_back(get_arrow_scalar_value(values_arr, j));
+    }
+    return Value::LIST(child_type, std::move(list_values));
+  } else {
+    THROW_NOT_SUPPORTED_EXCEPTION("Unsupported arrow type in list element: " +
+                                  arrow_type->ToString());
+  }
+}
+
 Value ArrowArrayContextColumn::get_elem(size_t idx) const {
   CHECK(idx < size_) << "Index out of range: " << idx << " >= " << size_;
 
@@ -330,49 +404,32 @@ Value ArrowArrayContextColumn::get_elem(size_t idx) const {
   // Get value according to arrow type and convert to RTAny.
   auto arrow_type = array->type();
 
-  if (arrow_type->Equals(arrow::int64())) {
-    auto casted = std::static_pointer_cast<arrow::Int64Array>(array);
-    return Value::INT64(casted->Value(offset));
-  } else if (arrow_type->Equals(arrow::int32())) {
-    auto casted = std::static_pointer_cast<arrow::Int32Array>(array);
-    return Value::INT32(casted->Value(offset));
-  } else if (arrow_type->Equals(arrow::uint32())) {
-    auto casted = std::static_pointer_cast<arrow::UInt32Array>(array);
-    return Value::UINT32(casted->Value(offset));
-  } else if (arrow_type->Equals(arrow::uint64())) {
-    auto casted = std::static_pointer_cast<arrow::UInt64Array>(array);
-    return Value::UINT64(casted->Value(offset));
-  } else if (arrow_type->Equals(arrow::float32())) {
-    auto casted = std::static_pointer_cast<arrow::FloatArray>(array);
-    return Value::FLOAT(casted->Value(offset));
-  } else if (arrow_type->Equals(arrow::float64())) {
-    auto casted = std::static_pointer_cast<arrow::DoubleArray>(array);
-    return Value::DOUBLE(casted->Value(offset));
-  } else if (arrow_type->Equals(arrow::boolean())) {
-    auto casted = std::static_pointer_cast<arrow::BooleanArray>(array);
-    return Value::BOOLEAN(casted->Value(offset));
-  } else if (arrow_type->Equals(arrow::utf8())) {
-    auto casted = std::static_pointer_cast<arrow::StringArray>(array);
-    auto str_view = casted->GetView(offset);
-    return Value::STRING(std::string(str_view));
-  } else if (arrow_type->Equals(arrow::large_utf8())) {
-    auto casted = std::static_pointer_cast<arrow::LargeStringArray>(array);
-    auto str_view = casted->GetView(offset);
-    return Value::STRING(std::string(str_view));
-  } else if (arrow_type->Equals(arrow::date32())) {
-    auto casted = std::static_pointer_cast<arrow::Date32Array>(array);
-    Date d;
-    d.from_num_days(casted->Value(offset));
-    return Value::DATE(d);
-  } else if (arrow_type->Equals(arrow::date64())) {
-    auto casted = std::static_pointer_cast<arrow::Date64Array>(array);
-    return Value::DATE(Date(casted->Value(offset)));
-  } else if (arrow_type->id() == arrow::Type::TIMESTAMP) {
-    auto casted = std::static_pointer_cast<arrow::TimestampArray>(array);
-    return Value::TIMESTAMPMS(DateTime(casted->Value(offset)));
-  } else {  // todo: support interval type
-    THROW_NOT_SUPPORTED_EXCEPTION("Unsupported arrow type: " +
-                                  arrow_type->ToString());
+  if (arrow_type->id() == arrow::Type::LIST) {
+    auto list_arr = std::static_pointer_cast<arrow::ListArray>(array);
+    auto child_type = arrow_type_to_rt_type(list_arr->value_type());
+    auto values_arr = list_arr->values();
+    int32_t start = list_arr->value_offset(offset);
+    int32_t length = list_arr->value_length(offset);
+    std::vector<Value> list_values;
+    list_values.reserve(length);
+    for (int32_t j = start; j < start + length; ++j) {
+      list_values.push_back(get_arrow_scalar_value(values_arr, j));
+    }
+    return Value::LIST(child_type, std::move(list_values));
+  } else if (arrow_type->id() == arrow::Type::FIXED_SIZE_LIST) {
+    auto list_arr = std::static_pointer_cast<arrow::FixedSizeListArray>(array);
+    auto child_type = arrow_type_to_rt_type(list_arr->value_type());
+    auto values_arr = list_arr->values();
+    int32_t start = list_arr->value_offset(offset);
+    int32_t length = list_arr->value_length(offset);
+    std::vector<Value> list_values;
+    list_values.reserve(length);
+    for (int32_t j = start; j < start + length; ++j) {
+      list_values.push_back(get_arrow_scalar_value(values_arr, j));
+    }
+    return Value::LIST(child_type, std::move(list_values));
+  } else {
+    return get_arrow_scalar_value(array, offset);
   }
 }
 

--- a/src/execution/common/columns/arrow_context_column.cc
+++ b/src/execution/common/columns/arrow_context_column.cc
@@ -396,41 +396,8 @@ static Value get_arrow_scalar_value(const std::shared_ptr<arrow::Array>& array,
 
 Value ArrowArrayContextColumn::get_elem(size_t idx) const {
   CHECK(idx < size_) << "Index out of range: " << idx << " >= " << size_;
-
-  // Locate the array and offset for the given index.
   auto [array_idx, offset] = locate_array_and_offset(columns_, size_, idx);
-  const auto& array = columns_[array_idx];
-
-  // Get value according to arrow type and convert to RTAny.
-  auto arrow_type = array->type();
-
-  if (arrow_type->id() == arrow::Type::LIST) {
-    auto list_arr = std::static_pointer_cast<arrow::ListArray>(array);
-    auto child_type = arrow_type_to_rt_type(list_arr->value_type());
-    auto values_arr = list_arr->values();
-    int32_t start = list_arr->value_offset(offset);
-    int32_t length = list_arr->value_length(offset);
-    std::vector<Value> list_values;
-    list_values.reserve(length);
-    for (int32_t j = start; j < start + length; ++j) {
-      list_values.push_back(get_arrow_scalar_value(values_arr, j));
-    }
-    return Value::LIST(child_type, std::move(list_values));
-  } else if (arrow_type->id() == arrow::Type::FIXED_SIZE_LIST) {
-    auto list_arr = std::static_pointer_cast<arrow::FixedSizeListArray>(array);
-    auto child_type = arrow_type_to_rt_type(list_arr->value_type());
-    auto values_arr = list_arr->values();
-    int32_t start = list_arr->value_offset(offset);
-    int32_t length = list_arr->value_length(offset);
-    std::vector<Value> list_values;
-    list_values.reserve(length);
-    for (int32_t j = start; j < start + length; ++j) {
-      list_values.push_back(get_arrow_scalar_value(values_arr, j));
-    }
-    return Value::LIST(child_type, std::move(list_values));
-  } else {
-    return get_arrow_scalar_value(array, offset);
-  }
+  return get_arrow_scalar_value(columns_[array_idx], offset);
 }
 
 std::shared_ptr<IContextColumn> ArrowArrayContextColumn::cast_to_value_column()

--- a/src/utils/reader/arrow_type_cast.cc
+++ b/src/utils/reader/arrow_type_cast.cc
@@ -371,30 +371,6 @@ std::shared_ptr<arrow::Table> ArrowTypeCaster::castTable(
                             table->num_rows());
 }
 
-std::shared_ptr<arrow::RecordBatch> ArrowTypeCaster::castBatch(
-    const std::shared_ptr<arrow::RecordBatch>& batch,
-    const std::shared_ptr<arrow::Schema>& expectedSchema) const {
-  bool needsCast = false;
-  for (int i = 0; i < batch->num_columns(); ++i) {
-    if (!batch->column(i)->type()->Equals(expectedSchema->field(i)->type())) {
-      needsCast = true;
-      break;
-    }
-  }
-  if (!needsCast) {
-    return batch;
-  }
-
-  std::vector<std::shared_ptr<arrow::Array>> newColumns;
-  newColumns.reserve(batch->num_columns());
-  for (int i = 0; i < batch->num_columns(); ++i) {
-    auto expectedType = expectedSchema->field(i)->type();
-    newColumns.push_back(castArray(batch->column(i), expectedType));
-  }
-  return arrow::RecordBatch::Make(expectedSchema, batch->num_rows(),
-                                  std::move(newColumns));
-}
-
 // --- LazyTypeCastRecordBatch implementation ---
 
 LazyTypeCastRecordBatch::LazyTypeCastRecordBatch(

--- a/src/utils/reader/arrow_type_cast.cc
+++ b/src/utils/reader/arrow_type_cast.cc
@@ -1,0 +1,537 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "neug/utils/reader/arrow_type_cast.h"
+
+#include <arrow/array.h>
+#include <arrow/builder.h>
+#include <arrow/type.h>
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "neug/compiler/common/types/timestamp_t.h"
+#include "neug/utils/exception/exception.h"
+
+namespace neug {
+namespace reader {
+
+namespace {
+
+// Trim leading/trailing whitespace from a string_view
+std::string_view trim(std::string_view sv) {
+  while (!sv.empty() && std::isspace(static_cast<unsigned char>(sv.front()))) {
+    sv.remove_prefix(1);
+  }
+  while (!sv.empty() && std::isspace(static_cast<unsigned char>(sv.back()))) {
+    sv.remove_suffix(1);
+  }
+  return sv;
+}
+
+// Get string_view from a string or large_string array at index i
+std::string_view getStringView(const arrow::Array* array, int64_t i) {
+  if (array->type_id() == arrow::Type::LARGE_STRING) {
+    return static_cast<const arrow::LargeStringArray*>(array)->GetView(i);
+  }
+  return static_cast<const arrow::StringArray*>(array)->GetView(i);
+}
+
+// Split a string by delimiter, respecting nested brackets
+std::vector<std::string_view> splitElements(std::string_view content) {
+  std::vector<std::string_view> elements;
+  int depth = 0;
+  size_t start = 0;
+  for (size_t i = 0; i < content.size(); ++i) {
+    char c = content[i];
+    if (c == '[') {
+      ++depth;
+    } else if (c == ']') {
+      --depth;
+    } else if (c == ',' && depth == 0) {
+      elements.push_back(trim(content.substr(start, i - start)));
+      start = i + 1;
+    }
+  }
+  auto last = trim(content.substr(start));
+  if (!last.empty()) {
+    elements.push_back(last);
+  }
+  return elements;
+}
+
+// Parse a single scalar value and append to the appropriate builder
+void appendScalarValue(arrow::ArrayBuilder* builder, std::string_view value,
+                       const std::shared_ptr<arrow::DataType>& valueType) {
+  std::string val_str(value);
+
+  switch (valueType->id()) {
+  case arrow::Type::INT8: {
+    auto* b = static_cast<arrow::Int8Builder*>(builder);
+    THROW_IF_ARROW_NOT_OK(b->Append(static_cast<int8_t>(std::stoi(val_str))));
+    break;
+  }
+  case arrow::Type::INT16: {
+    auto* b = static_cast<arrow::Int16Builder*>(builder);
+    THROW_IF_ARROW_NOT_OK(b->Append(static_cast<int16_t>(std::stoi(val_str))));
+    break;
+  }
+  case arrow::Type::INT32: {
+    auto* b = static_cast<arrow::Int32Builder*>(builder);
+    THROW_IF_ARROW_NOT_OK(b->Append(std::stoi(val_str)));
+    break;
+  }
+  case arrow::Type::INT64: {
+    auto* b = static_cast<arrow::Int64Builder*>(builder);
+    THROW_IF_ARROW_NOT_OK(b->Append(std::stoll(val_str)));
+    break;
+  }
+  case arrow::Type::UINT8: {
+    auto* b = static_cast<arrow::UInt8Builder*>(builder);
+    THROW_IF_ARROW_NOT_OK(b->Append(static_cast<uint8_t>(std::stoul(val_str))));
+    break;
+  }
+  case arrow::Type::UINT16: {
+    auto* b = static_cast<arrow::UInt16Builder*>(builder);
+    THROW_IF_ARROW_NOT_OK(
+        b->Append(static_cast<uint16_t>(std::stoul(val_str))));
+    break;
+  }
+  case arrow::Type::UINT32: {
+    auto* b = static_cast<arrow::UInt32Builder*>(builder);
+    THROW_IF_ARROW_NOT_OK(
+        b->Append(static_cast<uint32_t>(std::stoul(val_str))));
+    break;
+  }
+  case arrow::Type::UINT64: {
+    auto* b = static_cast<arrow::UInt64Builder*>(builder);
+    THROW_IF_ARROW_NOT_OK(b->Append(std::stoull(val_str)));
+    break;
+  }
+  case arrow::Type::FLOAT: {
+    auto* b = static_cast<arrow::FloatBuilder*>(builder);
+    THROW_IF_ARROW_NOT_OK(b->Append(std::stof(val_str)));
+    break;
+  }
+  case arrow::Type::DOUBLE: {
+    auto* b = static_cast<arrow::DoubleBuilder*>(builder);
+    THROW_IF_ARROW_NOT_OK(b->Append(std::stod(val_str)));
+    break;
+  }
+  case arrow::Type::BOOL: {
+    auto* b = static_cast<arrow::BooleanBuilder*>(builder);
+    std::string lower = val_str;
+    std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+    bool bval = (lower == "true" || lower == "1");
+    THROW_IF_ARROW_NOT_OK(b->Append(bval));
+    break;
+  }
+  case arrow::Type::STRING: {
+    auto* b = static_cast<arrow::StringBuilder*>(builder);
+    THROW_IF_ARROW_NOT_OK(b->Append(val_str));
+    break;
+  }
+  case arrow::Type::LARGE_STRING: {
+    auto* b = static_cast<arrow::LargeStringBuilder*>(builder);
+    THROW_IF_ARROW_NOT_OK(b->Append(val_str));
+    break;
+  }
+  case arrow::Type::DATE32: {
+    // Parse ISO date string "YYYY-MM-DD" -> days since epoch
+    auto* b = static_cast<arrow::Date32Builder*>(builder);
+    auto d = ::neug::common::Date::fromCString(val_str.c_str(), val_str.size());
+    THROW_IF_ARROW_NOT_OK(b->Append(d.days));
+    break;
+  }
+  case arrow::Type::DATE64: {
+    // Parse ISO date string "YYYY-MM-DD" -> milliseconds since epoch
+    auto* b = static_cast<arrow::Date64Builder*>(builder);
+    auto d = ::neug::common::Date::fromCString(val_str.c_str(), val_str.size());
+    THROW_IF_ARROW_NOT_OK(
+        b->Append(static_cast<int64_t>(d.days) * 86400LL * 1000LL));
+    break;
+  }
+  case arrow::Type::TIMESTAMP: {
+    // Parse ISO timestamp string "YYYY-MM-DD hh:mm:ss" -> value in
+    // microseconds; convert to the target unit.
+    auto* b = static_cast<arrow::TimestampBuilder*>(builder);
+    auto ts =
+        ::neug::common::Timestamp::fromCString(val_str.c_str(), val_str.size());
+    auto tsType = std::static_pointer_cast<arrow::TimestampType>(valueType);
+    int64_t v;
+    switch (tsType->unit()) {
+    case arrow::TimeUnit::SECOND:
+      v = ts.value / 1000000LL;
+      break;
+    case arrow::TimeUnit::MILLI:
+      v = ts.value / 1000LL;
+      break;
+    case arrow::TimeUnit::MICRO:
+      v = ts.value;
+      break;
+    case arrow::TimeUnit::NANO:
+      v = ts.value * 1000LL;
+      break;
+    }
+    THROW_IF_ARROW_NOT_OK(b->Append(v));
+    break;
+  }
+  case arrow::Type::DURATION: {
+    auto* b = static_cast<arrow::DurationBuilder*>(builder);
+    THROW_IF_ARROW_NOT_OK(b->Append(std::stoll(val_str)));
+    break;
+  }
+  case arrow::Type::LIST:
+  case arrow::Type::LARGE_LIST: {
+    // Nested list: directly parse the string into the existing builder
+    // without creating temporary arrays, avoiding memory copies.
+    auto* listBuilder = static_cast<arrow::ListBuilder*>(builder);
+    auto childType =
+        std::static_pointer_cast<arrow::BaseListType>(valueType)->value_type();
+    auto* childBuilder = listBuilder->value_builder();
+
+    THROW_IF_ARROW_NOT_OK(listBuilder->Append());
+
+    // Parse the inner content: strip brackets and split elements
+    std::string_view sv(value);
+    sv = trim(sv);
+    if (sv.empty() || sv == "[]") {
+      break;  // empty list, already appended list start
+    }
+    if (sv.front() == '[' && sv.back() == ']') {
+      sv = sv.substr(1, sv.size() - 2);
+    }
+    sv = trim(sv);
+    if (sv.empty()) {
+      break;
+    }
+    auto elements = splitElements(sv);
+    for (const auto& elem : elements) {
+      appendScalarValue(childBuilder, elem, childType);
+    }
+    break;
+  }
+  case arrow::Type::FIXED_SIZE_LIST: {
+    auto* fslBuilder = static_cast<arrow::FixedSizeListBuilder*>(builder);
+    auto fslType =
+        std::static_pointer_cast<arrow::FixedSizeListType>(valueType);
+    auto childType = fslType->value_type();
+    int32_t listSize = fslType->list_size();
+    auto* childBuilder = fslBuilder->value_builder();
+
+    THROW_IF_ARROW_NOT_OK(fslBuilder->Append());
+
+    std::string_view sv(value);
+    sv = trim(sv);
+    if (sv.front() == '[' && sv.back() == ']') {
+      sv = sv.substr(1, sv.size() - 2);
+    }
+    sv = trim(sv);
+    auto elements = splitElements(sv);
+    if (static_cast<int32_t>(elements.size()) != listSize) {
+      THROW_CONVERSION_EXCEPTION(
+          "FixedSizeList expects " + std::to_string(listSize) +
+          " elements but got " + std::to_string(elements.size()));
+    }
+    for (const auto& elem : elements) {
+      appendScalarValue(childBuilder, elem, childType);
+    }
+    break;
+  }
+  default:
+    THROW_CONVERSION_EXCEPTION(
+        "Unsupported list element type for CSV array parsing: " +
+        valueType->ToString());
+  }
+}
+
+// Parse a string array into a ListArray by delegating to appendScalarValue
+std::shared_ptr<arrow::Array> parseStringToList(
+    const std::shared_ptr<arrow::Array>& stringArray,
+    const std::shared_ptr<arrow::DataType>& listType) {
+  auto builderResult = arrow::MakeBuilder(listType);
+  THROW_IF_ARROW_NOT_OK(builderResult.status());
+  auto builder = std::move(builderResult).ValueOrDie();
+
+  int64_t length = stringArray->length();
+  for (int64_t i = 0; i < length; ++i) {
+    if (stringArray->IsNull(i)) {
+      THROW_IF_ARROW_NOT_OK(builder->AppendNull());
+      continue;
+    }
+    auto sv = getStringView(stringArray.get(), i);
+    appendScalarValue(builder.get(), sv, listType);
+  }
+
+  auto result = builder->Finish();
+  THROW_IF_ARROW_NOT_OK(result.status());
+  return result.ValueOrDie();
+}
+
+// Parse a string array into a FixedSizeListArray by delegating to
+// appendScalarValue
+std::shared_ptr<arrow::Array> parseStringToFixedSizeList(
+    const std::shared_ptr<arrow::Array>& stringArray,
+    const std::shared_ptr<arrow::DataType>& listType) {
+  auto builderResult = arrow::MakeBuilder(listType);
+  THROW_IF_ARROW_NOT_OK(builderResult.status());
+  auto builder = std::move(builderResult).ValueOrDie();
+
+  int64_t length = stringArray->length();
+  for (int64_t i = 0; i < length; ++i) {
+    if (stringArray->IsNull(i)) {
+      THROW_IF_ARROW_NOT_OK(builder->AppendNull());
+      continue;
+    }
+    auto sv = getStringView(stringArray.get(), i);
+    appendScalarValue(builder.get(), sv, listType);
+  }
+
+  auto result = builder->Finish();
+  THROW_IF_ARROW_NOT_OK(result.status());
+  return result.ValueOrDie();
+}
+
+}  // namespace
+
+void ArrowTypeCaster::registerCast(arrow::Type::type from, arrow::Type::type to,
+                                   CastFunc func) {
+  casters_[{from, to}] = std::move(func);
+}
+
+std::shared_ptr<arrow::Array> ArrowTypeCaster::castArray(
+    const std::shared_ptr<arrow::Array>& array,
+    const std::shared_ptr<arrow::DataType>& targetType) const {
+  if (array->type()->Equals(targetType)) {
+    return array;
+  }
+
+  auto key = std::make_pair(array->type_id(), targetType->id());
+  auto it = casters_.find(key);
+  if (it == casters_.end()) {
+    THROW_CONVERSION_EXCEPTION("No registered cast from " +
+                               array->type()->ToString() + " to " +
+                               targetType->ToString());
+  }
+  return it->second(array, targetType);
+}
+
+std::shared_ptr<arrow::ChunkedArray> ArrowTypeCaster::castChunkedArray(
+    const std::shared_ptr<arrow::ChunkedArray>& array,
+    const std::shared_ptr<arrow::DataType>& targetType) const {
+  if (array->type()->Equals(targetType)) {
+    return array;
+  }
+
+  std::vector<std::shared_ptr<arrow::Array>> newChunks;
+  newChunks.reserve(array->num_chunks());
+  for (int c = 0; c < array->num_chunks(); ++c) {
+    newChunks.push_back(castArray(array->chunk(c), targetType));
+  }
+  return std::make_shared<arrow::ChunkedArray>(std::move(newChunks),
+                                               targetType);
+}
+
+std::shared_ptr<arrow::Table> ArrowTypeCaster::castTable(
+    const std::shared_ptr<arrow::Table>& table,
+    const std::shared_ptr<arrow::Schema>& expectedSchema) const {
+  bool needsCast = false;
+  for (int i = 0; i < table->num_columns(); ++i) {
+    if (!table->column(i)->type()->Equals(expectedSchema->field(i)->type())) {
+      needsCast = true;
+      break;
+    }
+  }
+  if (!needsCast) {
+    return table;
+  }
+
+  std::vector<std::shared_ptr<arrow::ChunkedArray>> newColumns;
+  newColumns.reserve(table->num_columns());
+  for (int i = 0; i < table->num_columns(); ++i) {
+    auto expectedType = expectedSchema->field(i)->type();
+    newColumns.push_back(castChunkedArray(table->column(i), expectedType));
+  }
+  return arrow::Table::Make(expectedSchema, std::move(newColumns),
+                            table->num_rows());
+}
+
+std::shared_ptr<arrow::RecordBatch> ArrowTypeCaster::castBatch(
+    const std::shared_ptr<arrow::RecordBatch>& batch,
+    const std::shared_ptr<arrow::Schema>& expectedSchema) const {
+  bool needsCast = false;
+  for (int i = 0; i < batch->num_columns(); ++i) {
+    if (!batch->column(i)->type()->Equals(expectedSchema->field(i)->type())) {
+      needsCast = true;
+      break;
+    }
+  }
+  if (!needsCast) {
+    return batch;
+  }
+
+  std::vector<std::shared_ptr<arrow::Array>> newColumns;
+  newColumns.reserve(batch->num_columns());
+  for (int i = 0; i < batch->num_columns(); ++i) {
+    auto expectedType = expectedSchema->field(i)->type();
+    newColumns.push_back(castArray(batch->column(i), expectedType));
+  }
+  return arrow::RecordBatch::Make(expectedSchema, batch->num_rows(),
+                                  std::move(newColumns));
+}
+
+// --- LazyTypeCastRecordBatch implementation ---
+
+LazyTypeCastRecordBatch::LazyTypeCastRecordBatch(
+    std::shared_ptr<arrow::RecordBatch> inner,
+    std::shared_ptr<ArrowTypeCaster> caster,
+    std::shared_ptr<arrow::Schema> expectedSchema)
+    : RecordBatch(expectedSchema, inner->num_rows()),
+      inner_(std::move(inner)),
+      caster_(std::move(caster)),
+      expectedSchema_(expectedSchema),
+      cachedColumns_(expectedSchema->num_fields()),
+      materialized_(expectedSchema->num_fields(), false) {}
+
+void LazyTypeCastRecordBatch::materializeColumn(int i) const {
+  if (materialized_[i])
+    return;
+  auto srcCol = inner_->column(i);
+  auto expectedType = expectedSchema_->field(i)->type();
+  if (!srcCol->type()->Equals(expectedType)) {
+    cachedColumns_[i] = caster_->castArray(srcCol, expectedType);
+  } else {
+    cachedColumns_[i] = srcCol;
+  }
+  materialized_[i] = true;
+}
+
+void LazyTypeCastRecordBatch::materializeAll() const {
+  if (allMaterialized_)
+    return;
+  for (int i = 0; i < num_columns(); ++i) {
+    materializeColumn(i);
+  }
+  allMaterialized_ = true;
+}
+
+std::shared_ptr<arrow::Array> LazyTypeCastRecordBatch::column(int i) const {
+  materializeColumn(i);
+  return cachedColumns_[i];
+}
+
+const std::vector<std::shared_ptr<arrow::Array>>&
+LazyTypeCastRecordBatch::columns() const {
+  materializeAll();
+  return cachedColumns_;
+}
+
+std::shared_ptr<arrow::ArrayData> LazyTypeCastRecordBatch::column_data(
+    int i) const {
+  materializeColumn(i);
+  return cachedColumns_[i]->data();
+}
+
+const arrow::ArrayDataVector& LazyTypeCastRecordBatch::column_data() const {
+  materializeAll();
+  cachedColumnData_.resize(cachedColumns_.size());
+  for (size_t i = 0; i < cachedColumns_.size(); ++i) {
+    cachedColumnData_[i] = cachedColumns_[i]->data();
+  }
+  return cachedColumnData_;
+}
+
+arrow::Result<std::shared_ptr<arrow::RecordBatch>>
+LazyTypeCastRecordBatch::AddColumn(
+    int i, const std::shared_ptr<arrow::Field>& field,
+    const std::shared_ptr<arrow::Array>& col) const {
+  return inner_->AddColumn(i, field, col);
+}
+
+arrow::Result<std::shared_ptr<arrow::RecordBatch>>
+LazyTypeCastRecordBatch::SetColumn(
+    int i, const std::shared_ptr<arrow::Field>& field,
+    const std::shared_ptr<arrow::Array>& col) const {
+  return inner_->SetColumn(i, field, col);
+}
+
+arrow::Result<std::shared_ptr<arrow::RecordBatch>>
+LazyTypeCastRecordBatch::RemoveColumn(int i) const {
+  return inner_->RemoveColumn(i);
+}
+
+std::shared_ptr<arrow::RecordBatch>
+LazyTypeCastRecordBatch::ReplaceSchemaMetadata(
+    const std::shared_ptr<const arrow::KeyValueMetadata>& metadata) const {
+  return inner_->ReplaceSchemaMetadata(metadata);
+}
+
+std::shared_ptr<arrow::RecordBatch> LazyTypeCastRecordBatch::Slice(
+    int64_t offset, int64_t length) const {
+  return inner_->Slice(offset, length);
+}
+
+const std::shared_ptr<arrow::Device::SyncEvent>&
+LazyTypeCastRecordBatch::GetSyncEvent() const {
+  return inner_->GetSyncEvent();
+}
+
+arrow::DeviceAllocationType LazyTypeCastRecordBatch::device_type() const {
+  return inner_->device_type();
+}
+
+std::shared_ptr<ArrowTypeCaster> ArrowTypeCaster::createDefault() {
+  auto caster = std::make_shared<ArrowTypeCaster>();
+
+  // Register large_string -> list conversion
+  caster->registerCast(arrow::Type::LARGE_STRING, arrow::Type::LIST,
+                       [](const std::shared_ptr<arrow::Array>& array,
+                          const std::shared_ptr<arrow::DataType>& targetType)
+                           -> std::shared_ptr<arrow::Array> {
+                         return parseStringToList(array, targetType);
+                       });
+
+  // Register string -> list conversion
+  caster->registerCast(arrow::Type::STRING, arrow::Type::LIST,
+                       [](const std::shared_ptr<arrow::Array>& array,
+                          const std::shared_ptr<arrow::DataType>& targetType)
+                           -> std::shared_ptr<arrow::Array> {
+                         return parseStringToList(array, targetType);
+                       });
+
+  // Register large_string -> fixed_size_list conversion
+  caster->registerCast(arrow::Type::LARGE_STRING, arrow::Type::FIXED_SIZE_LIST,
+                       [](const std::shared_ptr<arrow::Array>& array,
+                          const std::shared_ptr<arrow::DataType>& targetType)
+                           -> std::shared_ptr<arrow::Array> {
+                         return parseStringToFixedSizeList(array, targetType);
+                       });
+
+  // Register string -> fixed_size_list conversion
+  caster->registerCast(arrow::Type::STRING, arrow::Type::FIXED_SIZE_LIST,
+                       [](const std::shared_ptr<arrow::Array>& array,
+                          const std::shared_ptr<arrow::DataType>& targetType)
+                           -> std::shared_ptr<arrow::Array> {
+                         return parseStringToFixedSizeList(array, targetType);
+                       });
+
+  return caster;
+}
+
+}  // namespace reader
+}  // namespace neug

--- a/src/utils/reader/arrow_type_cast.cc
+++ b/src/utils/reader/arrow_type_cast.cc
@@ -25,8 +25,8 @@
 #include <string>
 #include <vector>
 
-#include "neug/compiler/common/types/timestamp_t.h"
 #include "neug/utils/exception/exception.h"
+#include "neug/utils/property/types.h"
 
 namespace neug {
 namespace reader {
@@ -154,38 +154,37 @@ void appendScalarValue(arrow::ArrayBuilder* builder, std::string_view value,
   case arrow::Type::DATE32: {
     // Parse ISO date string "YYYY-MM-DD" -> days since epoch
     auto* b = static_cast<arrow::Date32Builder*>(builder);
-    auto d = ::neug::common::Date::fromCString(val_str.c_str(), val_str.size());
-    THROW_IF_ARROW_NOT_OK(b->Append(d.days));
+    ::neug::Date d(val_str);
+    THROW_IF_ARROW_NOT_OK(b->Append(d.to_num_days()));
     break;
   }
   case arrow::Type::DATE64: {
     // Parse ISO date string "YYYY-MM-DD" -> milliseconds since epoch
     auto* b = static_cast<arrow::Date64Builder*>(builder);
-    auto d = ::neug::common::Date::fromCString(val_str.c_str(), val_str.size());
+    ::neug::Date d(val_str);
     THROW_IF_ARROW_NOT_OK(
-        b->Append(static_cast<int64_t>(d.days) * 86400LL * 1000LL));
+        b->Append(static_cast<int64_t>(d.to_num_days()) * 86400LL * 1000LL));
     break;
   }
   case arrow::Type::TIMESTAMP: {
     // Parse ISO timestamp string "YYYY-MM-DD hh:mm:ss" -> value in
-    // microseconds; convert to the target unit.
+    // milliseconds; convert to the target unit.
     auto* b = static_cast<arrow::TimestampBuilder*>(builder);
-    auto ts =
-        ::neug::common::Timestamp::fromCString(val_str.c_str(), val_str.size());
+    ::neug::DateTime dt(val_str);
     auto tsType = std::static_pointer_cast<arrow::TimestampType>(valueType);
     int64_t v;
     switch (tsType->unit()) {
     case arrow::TimeUnit::SECOND:
-      v = ts.value / 1000000LL;
+      v = dt.milli_second / 1000LL;
       break;
     case arrow::TimeUnit::MILLI:
-      v = ts.value / 1000LL;
+      v = dt.milli_second;
       break;
     case arrow::TimeUnit::MICRO:
-      v = ts.value;
+      v = dt.milli_second * 1000LL;
       break;
     case arrow::TimeUnit::NANO:
-      v = ts.value * 1000LL;
+      v = dt.milli_second * 1000000LL;
       break;
     }
     THROW_IF_ARROW_NOT_OK(b->Append(v));

--- a/src/utils/reader/options.cc
+++ b/src/utils/reader/options.cc
@@ -119,6 +119,81 @@ bool ArrowOptionsBuilder::skipRows(ArrowOptions& options) {
   return true;
 }
 
+namespace {
+
+// Create a schema with list/fixed_size_list types replaced by large_utf8,
+// matching what the CSV reader actually produces.
+std::shared_ptr<arrow::Schema> createCsvSafeSchema(
+    const EntrySchema& entrySchema) {
+  auto schema = createSchema(entrySchema);
+  bool needsSubstitution = false;
+  for (int i = 0; i < schema->num_fields(); ++i) {
+    auto id = schema->field(i)->type()->id();
+    if (id == arrow::Type::LIST || id == arrow::Type::FIXED_SIZE_LIST) {
+      needsSubstitution = true;
+      break;
+    }
+  }
+  if (!needsSubstitution) {
+    return schema;
+  }
+  std::vector<std::shared_ptr<arrow::Field>> fields;
+  fields.reserve(schema->num_fields());
+  for (int i = 0; i < schema->num_fields(); ++i) {
+    auto field = schema->field(i);
+    auto id = field->type()->id();
+    if (id == arrow::Type::LIST || id == arrow::Type::FIXED_SIZE_LIST) {
+      fields.push_back(
+          arrow::field(field->name(), arrow::large_utf8(), field->nullable()));
+    } else {
+      fields.push_back(field);
+    }
+  }
+  return std::make_shared<arrow::Schema>(fields);
+}
+
+}  // namespace
+
+bool ArrowCsvOptionsBuilder::projectColumns(ArrowOptions& options) {
+  if (state->projectColumns.empty()) {
+    return true;
+  }
+
+  if (!options.scanOptions) {
+    THROW_INVALID_ARGUMENT_EXCEPTION("ScanOptions is null in ArrowOptions");
+  }
+
+  if (!state->schema.entry) {
+    THROW_INVALID_ARGUMENT_EXCEPTION("Entry schema is null");
+  }
+
+  const EntrySchema& entrySchema = *state->schema.entry;
+  const auto& columns = state->projectColumns;
+  const auto& allColumnNames = entrySchema.columnNames;
+  for (const auto& column : columns) {
+    if (std::find(allColumnNames.begin(), allColumnNames.end(), column) ==
+        allColumnNames.end()) {
+      THROW_INVALID_ARGUMENT_EXCEPTION("Column not found in entry schema: " +
+                                       column);
+    }
+  }
+
+  // Use CSV-safe schema (list types replaced by string) for projection,
+  // since the CSV reader reads list columns as strings.
+  auto dataset_schema = createCsvSafeSchema(entrySchema);
+  auto project_desc =
+      arrow::dataset::ProjectionDescr::FromNames(columns, *dataset_schema);
+  if (!project_desc.ok()) {
+    LOG(ERROR) << "Failed to build projection: "
+               << project_desc.status().message();
+    return false;
+  }
+
+  options.scanOptions->projection = project_desc.ValueOrDie().expression;
+  options.scanOptions->projected_schema = project_desc.ValueOrDie().schema;
+  return true;
+}
+
 ArrowOptions ArrowCsvOptionsBuilder::build() const {
   if (!state) {
     THROW_INVALID_ARGUMENT_EXCEPTION("State is null");
@@ -240,7 +315,14 @@ ArrowCsvOptionsBuilder::buildFragmentOptions() const {
         THROW_INVALID_ARGUMENT_EXCEPTION("Duplicate column name found: " +
                                          columnName);
       }
-      convert_options.column_types[columnName] = arrowType;
+      // CSV Reader cannot parse list types natively; read them as strings
+      // for post-processing conversion in ArrowTypeCaster.
+      if (arrowType->id() == arrow::Type::LIST ||
+          arrowType->id() == arrow::Type::FIXED_SIZE_LIST) {
+        convert_options.column_types[columnName] = arrow::large_utf8();
+      } else {
+        convert_options.column_types[columnName] = arrowType;
+      }
     }
   }
   fragment_scan_options->convert_options = convert_options;

--- a/src/utils/reader/reader.cc
+++ b/src/utils/reader/reader.cc
@@ -42,10 +42,43 @@
 #include "neug/execution/common/context.h"
 #include "neug/storages/loader/loader_utils.h"
 #include "neug/utils/exception/exception.h"
+#include "neug/utils/reader/arrow_type_cast.h"
 #include "neug/utils/reader/options.h"
 
 namespace neug {
 namespace reader {
+
+namespace {
+
+class TypeCastingRecordBatchSupplier : public IRecordBatchSupplier {
+ public:
+  TypeCastingRecordBatchSupplier(std::shared_ptr<IRecordBatchSupplier> inner,
+                                 std::shared_ptr<ArrowTypeCaster> caster,
+                                 std::shared_ptr<arrow::Schema> expectedSchema)
+      : inner_(std::move(inner)),
+        caster_(std::move(caster)),
+        expectedSchema_(std::move(expectedSchema)) {}
+
+  std::shared_ptr<arrow::RecordBatch> GetNextBatch() override {
+    auto batch = inner_->GetNextBatch();
+    if (!batch) {
+      return nullptr;
+    }
+    // Return a lazy batch that defers type conversion until column(i) is
+    // accessed, preserving the lazy evaluation design of batch_read.
+    return std::make_shared<LazyTypeCastRecordBatch>(std::move(batch), caster_,
+                                                     expectedSchema_);
+  }
+
+  int64_t RowNum() const override { return inner_->RowNum(); }
+
+ private:
+  std::shared_ptr<IRecordBatchSupplier> inner_;
+  std::shared_ptr<ArrowTypeCaster> caster_;
+  std::shared_ptr<arrow::Schema> expectedSchema_;
+};
+
+}  // namespace
 
 void ArrowReader::read(std::shared_ptr<ReadLocalState> localState,
                        execution::Context& ctx) {
@@ -140,6 +173,26 @@ std::shared_ptr<arrow::dataset::Scanner> ArrowReader::createScanner(
   return scanner_result.ValueOrDie();
 }
 
+std::shared_ptr<arrow::Schema> ArrowReader::computeExpectedSchema() const {
+  if (!sharedState || !sharedState->schema.entry) {
+    return nullptr;
+  }
+  const auto& entrySchema = *sharedState->schema.entry;
+  auto fullSchema = createSchema(entrySchema);
+  if (sharedState->projectColumns.empty()) {
+    return fullSchema;
+  }
+  // Build projected schema from projected column names
+  std::vector<std::shared_ptr<arrow::Field>> fields;
+  for (const auto& col : sharedState->projectColumns) {
+    auto field = fullSchema->GetFieldByName(col);
+    if (field) {
+      fields.push_back(field);
+    }
+  }
+  return std::make_shared<arrow::Schema>(fields);
+}
+
 void ArrowReader::full_read(std::shared_ptr<arrow::dataset::Scanner> scanner,
                             execution::Context& output) {
   if (!sharedState) {
@@ -157,6 +210,14 @@ void ArrowReader::full_read(std::shared_ptr<arrow::dataset::Scanner> scanner,
                        table_result.status().message());
   }
   auto table = table_result.ValueOrDie();
+
+  // Post-processing type cast (e.g. string -> list for CSV array columns)
+  if (typeCaster_) {
+    auto expectedSchema = computeExpectedSchema();
+    if (expectedSchema) {
+      table = typeCaster_->castTable(table, expectedSchema);
+    }
+  }
 
   int num_cols = sharedState->columnNum();
   if (num_cols != table->num_columns()) {
@@ -206,8 +267,18 @@ void ArrowReader::batch_read(std::shared_ptr<arrow::dataset::Scanner> scanner,
   }
   auto batch_reader = batch_reader_result.ValueOrDie();
 
-  auto batch_supplier = std::make_shared<neug::ArrowRecordBatchStreamSupplier>(
-      batch_reader, row_num);
+  std::shared_ptr<IRecordBatchSupplier> batch_supplier =
+      std::make_shared<neug::ArrowRecordBatchStreamSupplier>(batch_reader,
+                                                             row_num);
+
+  // Wrap with type casting if needed (e.g. string -> list for CSV arrays)
+  if (typeCaster_) {
+    auto expectedSchema = computeExpectedSchema();
+    if (expectedSchema) {
+      batch_supplier = std::make_shared<TypeCastingRecordBatchSupplier>(
+          std::move(batch_supplier), typeCaster_, expectedSchema);
+    }
+  }
 
   int num_cols = sharedState->columnNum();
   output.clear();

--- a/tests/utils/test_reader.cc
+++ b/tests/utils/test_reader.cc
@@ -346,6 +346,455 @@ TEST_F(ReaderTest, TestMultiColumnAndFilterPushdown) {
   EXPECT_EQ(ctx.row_num(), 2);
 }
 
+// =============== CSV Array Type Tests ===============
+
+// Test 12: CSV with list<int64> column (full_read mode)
+TEST_F(ReaderTest, TestCsvWithListInt64FullRead) {
+  createCsvFile("test_list_int64.csv",
+                "id|name|scores\n"
+                "1|Alice|[90, 85, 92]\n"
+                "2|Bob|[78, 88]\n"
+                "3|Charlie|[95]\n");
+
+  std::vector<std::string> columnNames = {"id", "name", "scores"};
+  std::vector<std::shared_ptr<::common::DataType>> columnTypes = {
+      createInt32Type(), createStringType(),
+      createArrayType(createInt64Type())};
+
+  auto sharedState =
+      createSharedState("test_list_int64.csv", columnNames, columnTypes,
+                        {{"skip_rows", "1"}, {"batch_read", "false"}});
+  auto reader = createArrowReader(sharedState);
+
+  auto localState = std::make_shared<reader::ReadLocalState>();
+  execution::Context ctx;
+
+  reader->read(localState, ctx);
+
+  EXPECT_EQ(ctx.col_num(), 3);
+  EXPECT_EQ(ctx.row_num(), 3);
+
+  // Verify the third column (scores) is a list type
+  auto column2 = ctx.columns[2];
+  ASSERT_EQ(column2->column_type(), execution::ContextColumnType::kArrowArray);
+  auto arrayColumn2 =
+      std::dynamic_pointer_cast<execution::ArrowArrayContextColumn>(column2);
+  auto arrowType2 = arrayColumn2->GetArrowType();
+  EXPECT_EQ(arrowType2->id(), arrow::Type::LIST)
+      << "Expected list type, but got: " << arrowType2->ToString();
+
+  // Verify the list element type is int64
+  auto listType = std::static_pointer_cast<arrow::ListType>(arrowType2);
+  EXPECT_TRUE(listType->value_type()->Equals(arrow::int64()))
+      << "Expected int64 elements, but got: "
+      << listType->value_type()->ToString();
+}
+
+// Test 13: CSV with list<double> column (full_read mode)
+TEST_F(ReaderTest, TestCsvWithListDoubleFullRead) {
+  createCsvFile("test_list_double.csv",
+                "id|values\n"
+                "1|[1.5, 2.5, 3.5]\n"
+                "2|[4.0]\n");
+
+  std::vector<std::string> columnNames = {"id", "values"};
+  std::vector<std::shared_ptr<::common::DataType>> columnTypes = {
+      createInt32Type(), createArrayType(createDoubleType())};
+
+  auto sharedState =
+      createSharedState("test_list_double.csv", columnNames, columnTypes,
+                        {{"skip_rows", "1"}, {"batch_read", "false"}});
+  auto reader = createArrowReader(sharedState);
+
+  auto localState = std::make_shared<reader::ReadLocalState>();
+  execution::Context ctx;
+
+  reader->read(localState, ctx);
+
+  EXPECT_EQ(ctx.col_num(), 2);
+  EXPECT_EQ(ctx.row_num(), 2);
+
+  auto column1 = ctx.columns[1];
+  ASSERT_EQ(column1->column_type(), execution::ContextColumnType::kArrowArray);
+  auto arrayColumn1 =
+      std::dynamic_pointer_cast<execution::ArrowArrayContextColumn>(column1);
+  auto arrowType1 = arrayColumn1->GetArrowType();
+  EXPECT_EQ(arrowType1->id(), arrow::Type::LIST);
+  auto listType = std::static_pointer_cast<arrow::ListType>(arrowType1);
+  EXPECT_TRUE(listType->value_type()->Equals(arrow::float64()));
+}
+
+// Test 14: CSV with list<string> column (full_read mode)
+TEST_F(ReaderTest, TestCsvWithListStringFullRead) {
+  createCsvFile("test_list_string.csv",
+                "id|tags\n"
+                "1|[hello, world]\n"
+                "2|[foo]\n");
+
+  std::vector<std::string> columnNames = {"id", "tags"};
+  std::vector<std::shared_ptr<::common::DataType>> columnTypes = {
+      createInt32Type(), createArrayType(createStringType())};
+
+  auto sharedState =
+      createSharedState("test_list_string.csv", columnNames, columnTypes,
+                        {{"skip_rows", "1"}, {"batch_read", "false"}});
+  auto reader = createArrowReader(sharedState);
+
+  auto localState = std::make_shared<reader::ReadLocalState>();
+  execution::Context ctx;
+
+  reader->read(localState, ctx);
+
+  EXPECT_EQ(ctx.col_num(), 2);
+  EXPECT_EQ(ctx.row_num(), 2);
+
+  auto column1 = ctx.columns[1];
+  ASSERT_EQ(column1->column_type(), execution::ContextColumnType::kArrowArray);
+  auto arrayColumn1 =
+      std::dynamic_pointer_cast<execution::ArrowArrayContextColumn>(column1);
+  auto arrowType1 = arrayColumn1->GetArrowType();
+  EXPECT_EQ(arrowType1->id(), arrow::Type::LIST);
+}
+
+// Test 15: CSV with list column (batch_read mode)
+TEST_F(ReaderTest, TestCsvWithListBatchRead) {
+  std::string content = "id|scores\n";
+  for (int i = 1; i <= 50; ++i) {
+    content += std::to_string(i) + "|[" + std::to_string(i * 10) + ", " +
+               std::to_string(i * 20) + "]\n";
+  }
+  createCsvFile("test_list_batch.csv", content);
+
+  std::vector<std::string> columnNames = {"id", "scores"};
+  std::vector<std::shared_ptr<::common::DataType>> columnTypes = {
+      createInt32Type(), createArrayType(createInt64Type())};
+
+  auto sharedState = createSharedState(
+      "test_list_batch.csv", columnNames, columnTypes,
+      {{"skip_rows", "1"}, {"batch_read", "true"}, {"batch_size", "1024"}});
+  auto reader = createArrowReader(sharedState);
+
+  auto localState = std::make_shared<reader::ReadLocalState>();
+  execution::Context ctx;
+
+  reader->read(localState, ctx);
+
+  EXPECT_EQ(ctx.col_num(), 2);
+  int64_t totalRows = count_batch_row_num(ctx);
+  EXPECT_EQ(totalRows, 50);
+}
+
+// Test 16: CSV with empty list "[]"
+TEST_F(ReaderTest, TestCsvWithEmptyList) {
+  createCsvFile("test_empty_list.csv",
+                "id|values\n"
+                "1|[10, 20]\n"
+                "2|[]\n"
+                "3|[30]\n");
+
+  std::vector<std::string> columnNames = {"id", "values"};
+  std::vector<std::shared_ptr<::common::DataType>> columnTypes = {
+      createInt32Type(), createArrayType(createInt64Type())};
+
+  auto sharedState =
+      createSharedState("test_empty_list.csv", columnNames, columnTypes,
+                        {{"skip_rows", "1"}, {"batch_read", "false"}});
+  auto reader = createArrowReader(sharedState);
+
+  auto localState = std::make_shared<reader::ReadLocalState>();
+  execution::Context ctx;
+
+  reader->read(localState, ctx);
+
+  EXPECT_EQ(ctx.col_num(), 2);
+  EXPECT_EQ(ctx.row_num(), 3);
+}
+
+// Test 17: CSV with list column + column pruning
+TEST_F(ReaderTest, TestCsvWithListAndColumnPruning) {
+  createCsvFile("test_list_prune.csv",
+                "id|name|scores\n"
+                "1|Alice|[90, 85]\n"
+                "2|Bob|[78]\n");
+
+  std::vector<std::string> columnNames = {"id", "name", "scores"};
+  std::vector<std::shared_ptr<::common::DataType>> columnTypes = {
+      createInt32Type(), createStringType(),
+      createArrayType(createInt64Type())};
+
+  std::vector<std::string> projectColumns = {"id", "scores"};
+  auto sharedState = createSharedState(
+      "test_list_prune.csv", columnNames, columnTypes,
+      {{"skip_rows", "1"}, {"batch_read", "false"}}, projectColumns);
+  auto reader = createArrowReader(sharedState);
+
+  auto localState = std::make_shared<reader::ReadLocalState>();
+  execution::Context ctx;
+
+  reader->read(localState, ctx);
+
+  EXPECT_EQ(ctx.col_num(), 2);
+  EXPECT_EQ(ctx.row_num(), 2);
+
+  // Verify the second column (scores) is a list type
+  auto column1 = ctx.columns[1];
+  ASSERT_EQ(column1->column_type(), execution::ContextColumnType::kArrowArray);
+  auto arrayColumn1 =
+      std::dynamic_pointer_cast<execution::ArrowArrayContextColumn>(column1);
+  auto arrowType1 = arrayColumn1->GetArrowType();
+  EXPECT_EQ(arrowType1->id(), arrow::Type::LIST);
+}
+
+// Test 18: CSV with list<float32> column
+TEST_F(ReaderTest, TestCsvWithListFloat32FullRead) {
+  createCsvFile("test_list_float32.csv",
+                "id|values\n"
+                "1|[1.5, 2.5, 3.5]\n"
+                "2|[4.0]\n");
+
+  std::vector<std::string> columnNames = {"id", "values"};
+  std::vector<std::shared_ptr<::common::DataType>> columnTypes = {
+      createInt32Type(), createArrayType(createFloatType())};
+
+  auto sharedState =
+      createSharedState("test_list_float32.csv", columnNames, columnTypes,
+                        {{"skip_rows", "1"}, {"batch_read", "false"}});
+  auto reader = createArrowReader(sharedState);
+
+  auto localState = std::make_shared<reader::ReadLocalState>();
+  execution::Context ctx;
+  reader->read(localState, ctx);
+
+  EXPECT_EQ(ctx.col_num(), 2);
+  EXPECT_EQ(ctx.row_num(), 2);
+
+  auto column1 = ctx.columns[1];
+  ASSERT_EQ(column1->column_type(), execution::ContextColumnType::kArrowArray);
+  auto arrayColumn1 =
+      std::dynamic_pointer_cast<execution::ArrowArrayContextColumn>(column1);
+  auto arrowType1 = arrayColumn1->GetArrowType();
+  EXPECT_EQ(arrowType1->id(), arrow::Type::LIST);
+  auto listType = std::static_pointer_cast<arrow::ListType>(arrowType1);
+  EXPECT_TRUE(listType->value_type()->Equals(arrow::float32()));
+}
+
+// Test 19: CSV with list<float64> column (alias for double, verify explicit)
+TEST_F(ReaderTest, TestCsvWithListFloat64FullRead) {
+  createCsvFile("test_list_float64.csv",
+                "id|values\n"
+                "1|[1.123456789, 2.987654321]\n"
+                "2|[3.141592653589793]\n");
+
+  std::vector<std::string> columnNames = {"id", "values"};
+  std::vector<std::shared_ptr<::common::DataType>> columnTypes = {
+      createInt32Type(), createArrayType(createDoubleType())};
+
+  auto sharedState =
+      createSharedState("test_list_float64.csv", columnNames, columnTypes,
+                        {{"skip_rows", "1"}, {"batch_read", "false"}});
+  auto reader = createArrowReader(sharedState);
+
+  auto localState = std::make_shared<reader::ReadLocalState>();
+  execution::Context ctx;
+  reader->read(localState, ctx);
+
+  EXPECT_EQ(ctx.col_num(), 2);
+  EXPECT_EQ(ctx.row_num(), 2);
+
+  auto column1 = ctx.columns[1];
+  ASSERT_EQ(column1->column_type(), execution::ContextColumnType::kArrowArray);
+  auto arrayColumn1 =
+      std::dynamic_pointer_cast<execution::ArrowArrayContextColumn>(column1);
+  auto arrowType1 = arrayColumn1->GetArrowType();
+  EXPECT_EQ(arrowType1->id(), arrow::Type::LIST);
+  auto listType = std::static_pointer_cast<arrow::ListType>(arrowType1);
+  EXPECT_TRUE(listType->value_type()->Equals(arrow::float64()));
+
+  // Verify actual values
+  auto arrays = arrayColumn1->GetColumns();
+  ASSERT_FALSE(arrays.empty());
+  auto listArray = std::static_pointer_cast<arrow::ListArray>(arrays[0]);
+  // First row: [1.123456789, 2.987654321]
+  auto slice0 = listArray->value_slice(0);
+  auto doubles0 = std::static_pointer_cast<arrow::DoubleArray>(slice0);
+  EXPECT_EQ(doubles0->length(), 2);
+  EXPECT_DOUBLE_EQ(doubles0->Value(0), 1.123456789);
+  EXPECT_DOUBLE_EQ(doubles0->Value(1), 2.987654321);
+}
+
+// Test 20: CSV with list<date32> column (ISO date strings)
+TEST_F(ReaderTest, TestCsvWithListDate32FullRead) {
+  createCsvFile("test_list_date32.csv",
+                "id|dates\n"
+                "1|[2012-01-02, 2023-06-15]\n"
+                "2|[1970-01-01]\n");
+
+  std::vector<std::string> columnNames = {"id", "dates"};
+  std::vector<std::shared_ptr<::common::DataType>> columnTypes = {
+      createInt32Type(), createArrayType(createDate32Type())};
+
+  auto sharedState =
+      createSharedState("test_list_date32.csv", columnNames, columnTypes,
+                        {{"skip_rows", "1"}, {"batch_read", "false"}});
+  auto reader = createArrowReader(sharedState);
+
+  auto localState = std::make_shared<reader::ReadLocalState>();
+  execution::Context ctx;
+  reader->read(localState, ctx);
+
+  EXPECT_EQ(ctx.col_num(), 2);
+  EXPECT_EQ(ctx.row_num(), 2);
+
+  auto column1 = ctx.columns[1];
+  ASSERT_EQ(column1->column_type(), execution::ContextColumnType::kArrowArray);
+  auto arrayColumn1 =
+      std::dynamic_pointer_cast<execution::ArrowArrayContextColumn>(column1);
+  auto arrowType1 = arrayColumn1->GetArrowType();
+  EXPECT_EQ(arrowType1->id(), arrow::Type::LIST);
+  auto listType = std::static_pointer_cast<arrow::ListType>(arrowType1);
+  EXPECT_EQ(listType->value_type()->id(), arrow::Type::DATE32);
+
+  // Verify: 1970-01-01 should be day 0
+  auto arrays = arrayColumn1->GetColumns();
+  ASSERT_FALSE(arrays.empty());
+  auto listArray = std::static_pointer_cast<arrow::ListArray>(arrays[0]);
+  auto slice1 = listArray->value_slice(1);
+  auto dates1 = std::static_pointer_cast<arrow::Date32Array>(slice1);
+  EXPECT_EQ(dates1->length(), 1);
+  EXPECT_EQ(dates1->Value(0), 0);  // 1970-01-01 = day 0
+}
+
+// Test 21: CSV with list<timestamp> column (ISO datetime strings)
+TEST_F(ReaderTest, TestCsvWithListTimestampFullRead) {
+  createCsvFile("test_list_timestamp.csv",
+                "id|timestamps\n"
+                "1|[2012-01-02 00:00:02, 2023-06-15 12:30:00]\n"
+                "2|[1970-01-01 00:00:00]\n");
+
+  std::vector<std::string> columnNames = {"id", "timestamps"};
+  std::vector<std::shared_ptr<::common::DataType>> columnTypes = {
+      createInt32Type(), createArrayType(createTimestampType())};
+
+  auto sharedState =
+      createSharedState("test_list_timestamp.csv", columnNames, columnTypes,
+                        {{"skip_rows", "1"}, {"batch_read", "false"}});
+  auto reader = createArrowReader(sharedState);
+
+  auto localState = std::make_shared<reader::ReadLocalState>();
+  execution::Context ctx;
+  reader->read(localState, ctx);
+
+  EXPECT_EQ(ctx.col_num(), 2);
+  EXPECT_EQ(ctx.row_num(), 2);
+
+  auto column1 = ctx.columns[1];
+  ASSERT_EQ(column1->column_type(), execution::ContextColumnType::kArrowArray);
+  auto arrayColumn1 =
+      std::dynamic_pointer_cast<execution::ArrowArrayContextColumn>(column1);
+  auto arrowType1 = arrayColumn1->GetArrowType();
+  EXPECT_EQ(arrowType1->id(), arrow::Type::LIST);
+  auto listType = std::static_pointer_cast<arrow::ListType>(arrowType1);
+  EXPECT_EQ(listType->value_type()->id(), arrow::Type::TIMESTAMP);
+
+  // Verify: 1970-01-01 00:00:00 should be 0 ms
+  auto arrays = arrayColumn1->GetColumns();
+  ASSERT_FALSE(arrays.empty());
+  auto listArray = std::static_pointer_cast<arrow::ListArray>(arrays[0]);
+  auto slice1 = listArray->value_slice(1);
+  auto ts1 = std::static_pointer_cast<arrow::TimestampArray>(slice1);
+  EXPECT_EQ(ts1->length(), 1);
+  EXPECT_EQ(ts1->Value(0), 0);  // 1970-01-01 00:00:00 = 0 ms
+}
+
+// Test 22: CSV with list<interval> column (stored as list<string>)
+// Interval maps to large_utf8 in type_converter, so list<interval>
+// becomes list<large_utf8>
+TEST_F(ReaderTest, TestCsvWithListIntervalFullRead) {
+  createCsvFile("test_list_interval.csv",
+                "id|durations\n"
+                "1|[1 year, 2 months 3 days]\n"
+                "2|[10 hours]\n");
+
+  std::vector<std::string> columnNames = {"id", "durations"};
+  std::vector<std::shared_ptr<::common::DataType>> columnTypes = {
+      createInt32Type(), createArrayType(createIntervalType())};
+
+  auto sharedState =
+      createSharedState("test_list_interval.csv", columnNames, columnTypes,
+                        {{"skip_rows", "1"}, {"batch_read", "false"}});
+  auto reader = createArrowReader(sharedState);
+
+  auto localState = std::make_shared<reader::ReadLocalState>();
+  execution::Context ctx;
+  reader->read(localState, ctx);
+
+  EXPECT_EQ(ctx.col_num(), 2);
+  EXPECT_EQ(ctx.row_num(), 2);
+
+  auto column1 = ctx.columns[1];
+  ASSERT_EQ(column1->column_type(), execution::ContextColumnType::kArrowArray);
+  auto arrayColumn1 =
+      std::dynamic_pointer_cast<execution::ArrowArrayContextColumn>(column1);
+  auto arrowType1 = arrayColumn1->GetArrowType();
+  EXPECT_EQ(arrowType1->id(), arrow::Type::LIST);
+  auto listType = std::static_pointer_cast<arrow::ListType>(arrowType1);
+  // Interval maps to large_utf8
+  EXPECT_EQ(listType->value_type()->id(), arrow::Type::LARGE_STRING);
+}
+
+// Test 23: CSV with nested list (list<list<int64>>)
+TEST_F(ReaderTest, TestCsvWithNestedListFullRead) {
+  createCsvFile("test_nested_list.csv",
+                "id|matrix\n"
+                "1|[[1, 2], [3, 4]]\n"
+                "2|[[5]]\n");
+
+  std::vector<std::string> columnNames = {"id", "matrix"};
+  auto innerListType = createArrayType(createInt64Type());
+  auto outerListType = createArrayType(innerListType);
+  std::vector<std::shared_ptr<::common::DataType>> columnTypes = {
+      createInt32Type(), outerListType};
+
+  auto sharedState =
+      createSharedState("test_nested_list.csv", columnNames, columnTypes,
+                        {{"skip_rows", "1"}, {"batch_read", "false"}});
+  auto reader = createArrowReader(sharedState);
+
+  auto localState = std::make_shared<reader::ReadLocalState>();
+  execution::Context ctx;
+  reader->read(localState, ctx);
+
+  EXPECT_EQ(ctx.col_num(), 2);
+  EXPECT_EQ(ctx.row_num(), 2);
+
+  auto column1 = ctx.columns[1];
+  ASSERT_EQ(column1->column_type(), execution::ContextColumnType::kArrowArray);
+  auto arrayColumn1 =
+      std::dynamic_pointer_cast<execution::ArrowArrayContextColumn>(column1);
+  auto arrowType1 = arrayColumn1->GetArrowType();
+  EXPECT_EQ(arrowType1->id(), arrow::Type::LIST);
+  auto outerType = std::static_pointer_cast<arrow::ListType>(arrowType1);
+  EXPECT_EQ(outerType->value_type()->id(), arrow::Type::LIST);
+  auto innerType =
+      std::static_pointer_cast<arrow::ListType>(outerType->value_type());
+  EXPECT_TRUE(innerType->value_type()->Equals(arrow::int64()));
+
+  // Verify actual nested values: row 0 = [[1,2],[3,4]]
+  auto arrays = arrayColumn1->GetColumns();
+  ASSERT_FALSE(arrays.empty());
+  auto outerArray = std::static_pointer_cast<arrow::ListArray>(arrays[0]);
+  // outer row 0 has 2 inner lists
+  auto outerSlice0 = outerArray->value_slice(0);
+  auto innerArray = std::static_pointer_cast<arrow::ListArray>(outerSlice0);
+  EXPECT_EQ(innerArray->length(), 2);
+  // inner list 0 = [1, 2]
+  auto inner0 = innerArray->value_slice(0);
+  auto ints0 = std::static_pointer_cast<arrow::Int64Array>(inner0);
+  EXPECT_EQ(ints0->length(), 2);
+  EXPECT_EQ(ints0->Value(0), 1);
+  EXPECT_EQ(ints0->Value(1), 2);
+}
+
 // =============== Type Converter ===============
 class ArrowTypeConverterTest : public ::testing::Test {
  public:

--- a/tests/utils/test_reader.h
+++ b/tests/utils/test_reader.h
@@ -164,6 +164,48 @@ class ReaderTest : public ::testing::Test {
     return type;
   }
 
+  std::shared_ptr<::common::DataType> createFloatType() {
+    auto type = std::make_shared<::common::DataType>();
+    type->set_primitive_type(::common::PrimitiveType::DT_FLOAT);
+    return type;
+  }
+
+  std::shared_ptr<::common::DataType> createDate32Type() {
+    auto type = std::make_shared<::common::DataType>();
+    type->mutable_temporal()->mutable_date32();
+    return type;
+  }
+
+  std::shared_ptr<::common::DataType> createDateType() {
+    auto type = std::make_shared<::common::DataType>();
+    type->mutable_temporal()->mutable_date();
+    return type;
+  }
+
+  std::shared_ptr<::common::DataType> createTimestampType() {
+    auto type = std::make_shared<::common::DataType>();
+    type->mutable_temporal()->mutable_timestamp();
+    return type;
+  }
+
+  std::shared_ptr<::common::DataType> createIntervalType() {
+    auto type = std::make_shared<::common::DataType>();
+    type->mutable_temporal()->mutable_interval();
+    return type;
+  }
+
+  std::shared_ptr<::common::DataType> createArrayType(
+      std::shared_ptr<::common::DataType> componentType,
+      int64_t maxLength = -1) {
+    auto type = std::make_shared<::common::DataType>();
+    auto* array = type->mutable_array();
+    *array->mutable_component_type() = *componentType;
+    if (maxLength > 0) {
+      array->set_max_length(maxLength);
+    }
+    return type;
+  }
+
   // Helper function to create a simple expression: column > value
   // Expression in natural order: [var, GT, const]
   std::shared_ptr<::common::Expression> createFilterExpression(

--- a/tests/utils/test_sniffer.cc
+++ b/tests/utils/test_sniffer.cc
@@ -56,5 +56,32 @@ TEST_F(SnifferTest, TestSniffBasic) {
             ::common::PrimitiveType::DT_DOUBLE);
 }
 
+TEST_F(SnifferTest, TestSniffCsvWithListColumn) {
+  createCsvFile("test_sniff_list.csv",
+                "id|values\n"
+                "1|[1, 2, 3]\n"
+                "2|[4, 5]\n");
+
+  auto sharedState = createSharedState("test_sniff_list.csv", {}, {});
+
+  auto reader = createArrowReader(sharedState);
+  auto sniffer = reader::ArrowSniffer(reader);
+  auto schema = sniffer.sniff().value();
+
+  EXPECT_EQ(schema->type(), reader::EntrySchemaType::TABLE);
+
+  auto& columnNames = schema->columnNames;
+  EXPECT_EQ(columnNames.size(), 2);
+  EXPECT_EQ(columnNames[0], "id");
+  EXPECT_EQ(columnNames[1], "values");
+
+  auto& columnTypes = schema->columnTypes;
+  EXPECT_EQ(columnTypes.size(), 2);
+  EXPECT_EQ(columnTypes[0]->primitive_type(),
+            ::common::PrimitiveType::DT_SIGNED_INT64);
+  // CSV sniffer cannot infer list types; list-like strings remain strings
+  EXPECT_TRUE(columnTypes[1]->has_string());
+}
+
 }  // namespace test
 }  // namespace neug

--- a/tools/python_bind/neug/database.py
+++ b/tools/python_bind/neug/database.py
@@ -345,6 +345,8 @@ class Database(object):
         """
         Close the database connection.
         """
+        if not self._database:
+            return
         if self._db_path and self._db_path.strip() != "":
             logger.info(f"Closing database {self._db_path}.")
         # Close all connections
@@ -360,9 +362,8 @@ class Database(object):
                     async_conn.close()
                 except Exception as e:
                     logger.warning(f"Failed to close async connection: {e}")
-        if self._database:
-            self._database.close()
-            self._database = None
+        self._database.close()
+        self._database = None
         # Don't clear the connections list, because the connections may be held by the user.
 
     def load_builtin_dataset(self, dataset_name: str) -> None:

--- a/tools/python_bind/tests/test_load_array.py
+++ b/tools/python_bind/tests/test_load_array.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020 Alibaba Group Holding Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""End-to-end tests for CSV LOAD FROM with array (list) type columns via CAST syntax."""
+
+import os
+import shutil
+import sys
+
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
+
+from neug import Database
+
+
+class TestLoadArray:
+    """Test cases for LOAD FROM CSV with CAST to array types."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, tmp_path):
+        """Setup test database and CSV directory."""
+        self.db_dir = str(tmp_path / "test_load_array_db")
+        self.csv_dir = str(tmp_path / "csv_data")
+        shutil.rmtree(self.db_dir, ignore_errors=True)
+        os.makedirs(self.csv_dir, exist_ok=True)
+        self.db = Database(db_path=self.db_dir, mode="w")
+        self.conn = self.db.connect()
+        yield
+        self.conn.close()
+        self.db.close()
+        shutil.rmtree(self.db_dir, ignore_errors=True)
+
+    def _write_csv(self, filename, content):
+        """Write a CSV file to the temp directory and return its path."""
+        path = os.path.join(self.csv_dir, filename)
+        with open(path, "w") as f:
+            f.write(content)
+        return path
+
+    def test_cast_float_array(self):
+        """LOAD FROM CSV with CAST(col, 'FLOAT[]')."""
+        csv_path = self._write_csv(
+            "float_array.csv",
+            "id|values\n" "1|[1.5, 2.5, 3.5]\n" "2|[4.0, 5.0]\n" "3|[]\n",
+        )
+        query = f"""
+        LOAD FROM "{csv_path}" (delim='|')
+        RETURN id, CAST(values, 'FLOAT[]')
+        """
+        result = list(self.conn.execute(query))
+        assert len(result) == 3
+
+        # Row 1: [1.5, 2.5, 3.5]
+        assert len(result[0][1]) == 3
+        assert abs(result[0][1][0] - 1.5) < 1e-5
+        assert abs(result[0][1][1] - 2.5) < 1e-5
+        assert abs(result[0][1][2] - 3.5) < 1e-5
+
+        # Row 2: [4.0, 5.0]
+        assert len(result[1][1]) == 2
+        assert abs(result[1][1][0] - 4.0) < 1e-5
+
+        # Row 3: empty list
+        assert len(result[2][1]) == 0
+
+    def test_cast_double_array(self):
+        """LOAD FROM CSV with CAST(col, 'DOUBLE[]')."""
+        csv_path = self._write_csv(
+            "double_array.csv",
+            "id|values\n" "1|[1.111111111, 2.222222222]\n" "2|[3.333333333]\n",
+        )
+        query = f"""
+        LOAD FROM "{csv_path}" (delim='|')
+        RETURN id, CAST(values, 'DOUBLE[]')
+        """
+        result = list(self.conn.execute(query))
+        assert len(result) == 2
+
+        assert len(result[0][1]) == 2
+        assert abs(result[0][1][0] - 1.111111111) < 1e-9
+        assert abs(result[0][1][1] - 2.222222222) < 1e-9
+
+        assert len(result[1][1]) == 1
+        assert abs(result[1][1][0] - 3.333333333) < 1e-9
+
+    def test_cast_int32_array(self):
+        """LOAD FROM CSV with CAST(col, 'INT32[]')."""
+        csv_path = self._write_csv(
+            "int32_array.csv",
+            "id|nums\n" "1|[10, 20, 30]\n" "2|[-1, 0, 1]\n",
+        )
+        query = f"""
+        LOAD FROM "{csv_path}" (delim='|')
+        RETURN id, CAST(nums, 'INT32[]')
+        """
+        result = list(self.conn.execute(query))
+        assert len(result) == 2
+        assert result[0][1] == [10, 20, 30]
+        assert result[1][1] == [-1, 0, 1]
+
+    def test_cast_int64_array(self):
+        """LOAD FROM CSV with CAST(col, 'INT64[]')."""
+        csv_path = self._write_csv(
+            "int64_array.csv",
+            "id|nums\n" "1|[100000000000, 200000000000]\n" "2|[0]\n",
+        )
+        query = f"""
+        LOAD FROM "{csv_path}" (delim='|')
+        RETURN id, CAST(nums, 'INT64[]')
+        """
+        result = list(self.conn.execute(query))
+        assert len(result) == 2
+        assert result[0][1] == [100000000000, 200000000000]
+        assert result[1][1] == [0]
+
+    def test_cast_string_array(self):
+        """LOAD FROM CSV with CAST(col, 'STRING[]')."""
+        csv_path = self._write_csv(
+            "string_array.csv",
+            "id|tags\n" "1|[hello, world]\n" "2|[foo, bar, baz]\n",
+        )
+        query = f"""
+        LOAD FROM "{csv_path}" (delim='|')
+        RETURN id, CAST(tags, 'STRING[]')
+        """
+        result = list(self.conn.execute(query))
+        assert len(result) == 2
+        assert result[0][1] == ["hello", "world"]
+        assert result[1][1] == ["foo", "bar", "baz"]
+
+    def test_cast_nested_int32_array(self):
+        """LOAD FROM CSV with CAST(col, 'INT32[][]') — nested list."""
+        csv_path = self._write_csv(
+            "nested_int_array.csv",
+            "id|matrix\n" "1|[[1, 2], [3, 4]]\n" "2|[[5], [6, 7, 8]]\n",
+        )
+        query = f"""
+        LOAD FROM "{csv_path}" (delim='|')
+        RETURN id, CAST(matrix, 'INT32[][]')
+        """
+        result = list(self.conn.execute(query))
+        assert len(result) == 2
+        assert result[0][1] == [[1, 2], [3, 4]]
+        assert result[1][1] == [[5], [6, 7, 8]]
+
+    def test_cast_nested_string_array(self):
+        """LOAD FROM CSV with CAST(col, 'STRING[][]') — nested string list."""
+        csv_path = self._write_csv(
+            "nested_string_array.csv",
+            "id|data\n" "1|[[a, b], [c]]\n" "2|[[x, y, z]]\n",
+        )
+        query = f"""
+        LOAD FROM "{csv_path}" (delim='|')
+        RETURN id, CAST(data, 'STRING[][]')
+        """
+        result = list(self.conn.execute(query))
+        assert len(result) == 2
+        assert result[0][1] == [["a", "b"], ["c"]]
+        assert result[1][1] == [["x", "y", "z"]]
+
+    def test_cast_date_array(self):
+        """LOAD FROM CSV with CAST(col, 'DATE[]')."""
+        csv_path = self._write_csv(
+            "date_array.csv",
+            "id|dates\n" "1|[1970-01-01, 2023-06-15]\n" "2|[2000-01-01]\n",
+        )
+        query = f"""
+        LOAD FROM "{csv_path}" (delim='|')
+        RETURN id, CAST(dates, 'DATE[]')
+        """
+        result = list(self.conn.execute(query))
+        assert len(result) == 2
+        assert len(result[0][1]) == 2
+        # Verify dates are returned (as date objects or strings)
+        assert str(result[0][1][0]) == "1970-01-01"
+        assert str(result[0][1][1]) == "2023-06-15"
+        assert len(result[1][1]) == 1
+        assert str(result[1][1][0]) == "2000-01-01"
+
+    def test_cast_timestamp_array(self):
+        """LOAD FROM CSV with CAST(col, 'TIMESTAMP[]')."""
+        csv_path = self._write_csv(
+            "timestamp_array.csv",
+            "id|times\n"
+            "1|[1970-01-01 00:00:00, 2023-06-15 12:30:00]\n"
+            "2|[2000-01-01 00:00:00]\n",
+        )
+        query = f"""
+        LOAD FROM "{csv_path}" (delim='|')
+        RETURN id, CAST(times, 'TIMESTAMP[]')
+        """
+        result = list(self.conn.execute(query))
+        assert len(result) == 2
+        assert len(result[0][1]) == 2
+        # Verify epoch timestamp
+        assert "1970-01-01" in str(result[0][1][0])
+        assert "2023-06-15" in str(result[0][1][1])
+        assert len(result[1][1]) == 1
+        assert "2000-01-01" in str(result[1][1][0])
+
+    def test_cast_interval_array(self):
+        """LOAD FROM CSV with CAST(col, 'INTERVAL[]')."""
+        csv_path = self._write_csv(
+            "interval_array.csv",
+            "id|durations\n" "1|[2 days, 3 hours]\n" "2|[1 year 2 months]\n",
+        )
+        query = f"""
+        LOAD FROM "{csv_path}" (delim='|')
+        RETURN id, CAST(durations, 'INTERVAL[]')
+        """
+        result = list(self.conn.execute(query))
+        assert len(result) == 2
+        assert len(result[0][1]) == 2
+        assert len(result[1][1]) == 1
+
+    def test_cast_multiple_array_columns(self):
+        """LOAD FROM CSV with multiple CAST array columns."""
+        csv_path = self._write_csv(
+            "multi_array.csv",
+            "id|ints|floats\n" "1|[1, 2, 3]|[1.1, 2.2]\n" "2|[4, 5]|[3.3]\n",
+        )
+        query = f"""
+        LOAD FROM "{csv_path}" (delim='|')
+        RETURN id, CAST(ints, 'INT64[]'), CAST(floats, 'DOUBLE[]')
+        """
+        result = list(self.conn.execute(query))
+        assert len(result) == 2
+        assert result[0][1] == [1, 2, 3]
+        assert len(result[0][2]) == 2
+        assert abs(result[0][2][0] - 1.1) < 1e-9
+        assert result[1][1] == [4, 5]

--- a/tools/python_bind/tests/test_load_array.py
+++ b/tools/python_bind/tests/test_load_array.py
@@ -21,6 +21,8 @@
 import os
 import shutil
 import sys
+from datetime import date
+from datetime import datetime
 
 import pytest
 
@@ -187,11 +189,11 @@ class TestLoadArray:
         result = list(self.conn.execute(query))
         assert len(result) == 2
         assert len(result[0][1]) == 2
-        # Verify dates are returned (as date objects or strings)
-        assert str(result[0][1][0]) == "1970-01-01"
-        assert str(result[0][1][1]) == "2023-06-15"
+        # Verify dates are returned as datetime.date objects
+        assert result[0][1][0] == date(1970, 1, 1)
+        assert result[0][1][1] == date(2023, 6, 15)
         assert len(result[1][1]) == 1
-        assert str(result[1][1][0]) == "2000-01-01"
+        assert result[1][1][0] == date(2000, 1, 1)
 
     def test_cast_timestamp_array(self):
         """LOAD FROM CSV with CAST(col, 'TIMESTAMP[]')."""
@@ -208,11 +210,11 @@ class TestLoadArray:
         result = list(self.conn.execute(query))
         assert len(result) == 2
         assert len(result[0][1]) == 2
-        # Verify epoch timestamp
-        assert "1970-01-01" in str(result[0][1][0])
-        assert "2023-06-15" in str(result[0][1][1])
+        # Verify timestamps are returned as datetime.datetime objects
+        assert result[0][1][0] == datetime(1970, 1, 1, 0, 0)
+        assert result[0][1][1] == datetime(2023, 6, 15, 12, 30)
         assert len(result[1][1]) == 1
-        assert "2000-01-01" in str(result[1][1][0])
+        assert result[1][1][0] == datetime(2000, 1, 1, 0, 0)
 
     def test_cast_interval_array(self):
         """LOAD FROM CSV with CAST(col, 'INTERVAL[]')."""
@@ -226,8 +228,9 @@ class TestLoadArray:
         """
         result = list(self.conn.execute(query))
         assert len(result) == 2
-        assert len(result[0][1]) == 2
-        assert len(result[1][1]) == 1
+        # Verify intervals are returned as strings
+        assert result[0][1] == ["2 days", "3 hours"]
+        assert result[1][1] == ["1 year 2 months"]
 
     def test_cast_multiple_array_columns(self):
         """LOAD FROM CSV with multiple CAST array columns."""

--- a/tools/python_bind/tests/test_sniffer.py
+++ b/tools/python_bind/tests/test_sniffer.py
@@ -155,6 +155,23 @@ class TestLoadSniffer:
         # CSV map is not inferred as map, remains string.
         assert isinstance(rows[0][0], str)
 
+    @pytest.mark.xfail(reason="TODO: support CAST to list type in CSV LOAD FROM.")
+    def test_csv_cast_list(self):
+        """CSV sniffer infers list column as string; CAST to INT64[] should parse it."""
+        csv_path = self.data_dir / "csv_cast_list.csv"
+        csv_path.write_text("id|list_col\n1|[1, 2, 3]\n2|[4, 5]\n")
+
+        result = self.conn.execute(
+            f"""
+            LOAD FROM "{csv_path}" (header=true, delim="|")
+            RETURN id, CAST(list_col, 'INT64[]')
+            """
+        )
+        rows = list(result)
+        assert len(rows) == 2
+        assert rows[0][1] == [1, 2, 3]
+        assert rows[1][1] == [4, 5]
+
     def test_csv_cast_numeric_conversions(self):
         csv_path = self.data_dir / "csv_cast_numeric.csv"
         csv_path.write_text("i_col,d_col\n42,3.25\n")

--- a/tools/python_bind/tests/test_sniffer.py
+++ b/tools/python_bind/tests/test_sniffer.py
@@ -155,7 +155,6 @@ class TestLoadSniffer:
         # CSV map is not inferred as map, remains string.
         assert isinstance(rows[0][0], str)
 
-    @pytest.mark.xfail(reason="TODO: support CAST to list type in CSV LOAD FROM.")
     def test_csv_cast_list(self):
         """CSV sniffer infers list column as string; CAST to INT64[] should parse it."""
         csv_path = self.data_dir / "csv_cast_list.csv"


### PR DESCRIPTION
## Summary
- Implement CSV array type support by post-processing string columns into Arrow list arrays, enabling `COPY FROM` with array-typed columns
- Add Arrow list type support in the execution layer for proper CAST handling of list columns
- Refactor `appendScalarValue` to use `neug::Date/DateTime` and simplify `get_elem` by reusing `get_arrow_scalar_value`
- Guard `Database.close()` against double-close errors

## Changes
- **`src/utils/reader/arrow_type_cast.cc`** + **`include/neug/utils/reader/arrow_type_cast.h`**: New string-to-list type cast logic for CSV array parsing
- **`src/utils/reader/reader.cc`**: Integrate post-processing step after CSV read to convert string columns to list types
- **`src/utils/reader/options.cc`** + **`include/neug/utils/reader/options.h`**: Add list type options for CSV format
- **`src/execution/common/columns/arrow_context_column.cc`**: Add list type handling in Arrow context column
- **`tools/python_bind/neug/database.py`**: Guard against double-close in `Database.close()`
- **`tests/`**: Add comprehensive C++ and Python tests for array loading and sniffer

## Test plan
- [x] New `test_load_array.py` with 250+ lines covering various array type scenarios
- [x] New `test_reader.cc` with C++ unit tests for arrow type cast
- [x] Sniffer tests for array type detection
- [x] Existing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #441 