### PR TITLE
refactor: WAL append returns false on I/O failure instead of throwing (#385)

### DIFF
--- a/src/transaction/wal/local_wal_writer.cc
+++ b/src/transaction/wal/local_wal_writer.cc
@@ -81,8 +81,8 @@ bool LocalWalWriter::append(const char* data, size_t length) {
   if (expected_size > file_size_) {
     size_t new_file_size = (expected_size / TRUNC_SIZE + 1) * TRUNC_SIZE;
     if (ftruncate(fd_, new_file_size) != 0) {
-      THROW_IO_EXCEPTION("Failed to truncate wal file " +
-                         std::string(strerror(errno)));
+      LOG(ERROR) << "Failed to truncate wal file " << strerror(errno);
+      return false;
     }
     file_size_ = new_file_size;
   }
@@ -90,26 +90,21 @@ bool LocalWalWriter::append(const char* data, size_t length) {
   file_used_ += length;
 
   if (static_cast<size_t>(write(fd_, data, length)) != length) {
-    THROW_IO_EXCEPTION("Failed to write wal file " +
-                       std::string(strerror(errno)));
+    LOG(ERROR) << "Failed to write wal file " << strerror(errno);
+    return false;
   }
 
 #if 1
 #ifdef F_FULLFSYNC
   if (fcntl(fd_, F_FULLFSYNC) != 0) {
-#ifdef __APPLE__
-    THROW_IO_EXCEPTION("Failed to fcntl sync wal file " +
-                       std::string(strerror(errno)));
-#else
-    THROW_IO_EXCEPTION("Failed to fcntl sync wal file " +
-                       std::string(strerrno(errno)));
-#endif
+    LOG(ERROR) << "Failed to fcntl sync wal file " << strerror(errno);
+    return false;
   }
 #else
   // if (fsync(fd_) != 0) {
   if (fdatasync(fd_) != 0) {
-    THROW_IO_EXCEPTION("Failed to fsync wal file " +
-                       std::string(strerror(errno)));
+    LOG(ERROR) << "Failed to fsync wal file " << strerror(errno);
+    return false;
   }
 #endif
 #endif


### PR DESCRIPTION
## Summary
- `LocalWalWriter::append` declared `bool` but threw `IOException` from `ftruncate` / `write` / `fsync` failure paths. Its callers (`UpdateTransaction::Commit`, `InsertTransaction::Commit`, `CompactTransaction::Commit`) only branch on the bool return and do not catch exceptions, so a real I/O failure unwound past the `Abort()` cleanup and left timestamps un-invalidated.
- Replace the `THROW_IO_EXCEPTION` calls in `append()` with `LOG(ERROR) + return false` so the existing caller error paths run.
- Drop a dead non-Apple branch under `F_FULLFSYNC` that contained a `strerrno` typo (`F_FULLFSYNC` is Apple-only, so that branch was unreachable).

Fixes #385.
