### PR TITLE
ci: improve issue triage workflow with type/label assignment and bug fixes

### DIFF
--- a/.github/scripts/triage_issue.py
+++ b/.github/scripts/triage_issue.py
@@ -36,21 +36,44 @@ QWEN_MODEL = os.getenv("QWEN_MODEL", "qwen3-max")
 
 CONFIDENCE_LEVELS = {"high": 3, "medium": 2, "low": 1}
 
+ISSUE_TYPES = {"Bug": 242038, "Feature": 242040, "Task": 242035}
+
+SUBSYSTEM_LABELS = [
+    "compiler", "executor", "store", "transaction",
+    "extension", "client", "ci",
+]
+
 SYSTEM_PROMPT = """\
 You are an issue-triage assistant for the NeuG graph database project.
 
-Given a new GitHub issue and a list of tracking umbrellas (each with scope_in
-and scope_out), choose the single best umbrella, OR return null if no umbrella
-clearly fits.
+Given a new GitHub issue, you must determine THREE things:
 
-Rules:
+## 1. Parent umbrella
+Choose the single best umbrella from the provided list, OR return null if none fits.
 - Match against scope_in. If the issue matches another umbrella's scope_out, exclude it.
 - Prefer the most specific fit. Use #257 (Adhoc) only when nothing else fits.
-- If the issue is itself a tracking/umbrella issue, return {"umbrella": null, "confidence": "n/a", "reason": "looks like an umbrella issue itself"}.
+- If the issue is itself a tracking/umbrella issue, set umbrella to null.
 - Confidence: "high" = unambiguous; "medium" = good fit but some overlap; "low" = unclear.
 
+## 2. Issue type
+Classify as exactly one of:
+- "Bug" — something is broken, crashes, produces wrong results, memory leaks
+- "Feature" — new capability, new API, new extension, new format support
+- "Task" — refactoring, cleanup, performance optimization, documentation, CI/build improvement
+
+## 3. Subsystem labels
+Pick one or more from: compiler, executor, store, transaction, extension, client, ci.
+- "compiler" — ANTLR parser, binder, logical/physical planner, gopt converter
+- "executor" — physical operators, scan, filter, project, join, aggregation, runtime
+- "store" — CSR storage, schema, property columns, vertex/edge tables, indexer
+- "transaction" — COW, WAL, rollback, concurrency, UpdateTransaction
+- "extension" — httpfs, parquet, JSON, GDS algorithm extensions
+- "client" — Python/Java/Node.js bindings, SDK
+- "ci" — CI/CD, build system, testing infrastructure, GitHub Actions
+Return an empty list if none clearly applies.
+
 Output ONLY a JSON object:
-{"umbrella": <number_or_null>, "confidence": "high"|"medium"|"low"|"n/a", "reason": "<one sentence>"}
+{"umbrella": <number_or_null>, "confidence": "high"|"medium"|"low"|"n/a", "reason": "<one sentence>", "type": "Bug"|"Feature"|"Task", "labels": ["label1", ...]}
 """
 
 
@@ -123,35 +146,95 @@ def link_sub_issue(repo: str, parent_number: int, child_issue_id: int) -> bool:
     return True
 
 
-def render_comment(cfg: dict, result: dict, auto_linked: bool) -> str:
+def render_comment(cfg: dict, result: dict, auto_linked: bool,
+                   type_set: bool, labels_set: list[str]) -> str:
     umbrella = result.get("umbrella")
     confidence = result.get("confidence", "low")
     reason = result.get("reason", "")
+    issue_type = result.get("type", "")
+    labels = result.get("labels", [])
+
+    lines = []
+
+    # umbrella section
     if umbrella is None:
-        return (
-            f"🤖 **Auto-triage**: could not confidently classify this issue under any "
-            f"current v0.2 umbrella.\n\n"
-            f"_Reason_: {reason}\n\n"
-            f"Maintainers: please pick a parent manually, or close if out of scope."
+        lines.append(
+            "🤖 **Auto-triage**: could not confidently classify this issue "
+            "under any current v0.2 umbrella."
         )
-    match = next((u for u in cfg["umbrellas"] if u["number"] == umbrella), None)
-    label = match["title"] if match else "(unknown)"
+    else:
+        match = next((u for u in cfg["umbrellas"] if u["number"] == umbrella), None)
+        title = match["title"] if match else "(unknown)"
+        if auto_linked:
+            lines.append(
+                f"🤖 **Auto-triage**: linked as sub-issue of "
+                f"**#{umbrella} — {title}** (confidence: `{confidence}`)."
+            )
+        else:
+            lines.append(
+                f"🤖 **Auto-triage suggestion**: this looks like a sub-issue of "
+                f"**#{umbrella} — {title}** (confidence: `{confidence}`)."
+            )
+
+    lines.append(f"\n_Reason_: {reason}")
+
+    # type & labels section
+    actions = []
+    if type_set:
+        actions.append(f"type → **{issue_type}**")
+    if labels_set:
+        actions.append(f"labels → {', '.join(f'`{l}`' for l in labels_set)}")
+    if actions:
+        lines.append(f"\n_Auto-applied_: {'; '.join(actions)}")
+
+    # footer
     if auto_linked:
-        return (
-            f"🤖 **Auto-triage**: linked as sub-issue of "
-            f"**#{umbrella} — {label}** (confidence: `{confidence}`).\n\n"
-            f"_Reason_: {reason}\n\n"
-            f"If this is wrong, please unlink and re-assign — your correction "
-            f"improves this bot."
+        lines.append(
+            "\nIf this is wrong, please unlink and re-assign — "
+            "your correction improves this bot."
         )
-    return (
-        f"🤖 **Auto-triage suggestion**: this looks like a sub-issue of "
-        f"**#{umbrella} — {label}** (confidence: `{confidence}`).\n\n"
-        f"_Reason_: {reason}\n\n"
-        f"If this is correct, a maintainer can link it via the GitHub UI "
-        f"(Sub-issues → Add). If wrong, please correct — your correction is "
-        f"the training signal that improves this bot."
+    elif umbrella is not None:
+        lines.append(
+            "\nIf this is correct, a maintainer can link it via the GitHub UI "
+            "(Sub-issues → Add). If wrong, please correct — your correction is "
+            "the training signal that improves this bot."
+        )
+    else:
+        lines.append(
+            "\nMaintainers: please pick a parent manually, or close if out of scope."
+        )
+
+    return "\n".join(lines)
+
+
+def set_issue_type(repo: str, number: int, type_name: str) -> bool:
+    type_id = ISSUE_TYPES.get(type_name)
+    if not type_id:
+        print(f"Unknown issue type: {type_name}")
+        return False
+    result = subprocess.run(
+        ["gh", "issue", "edit", str(number), "--repo", repo,
+         "--type", type_name],
+        capture_output=True, text=True,
     )
+    if result.returncode != 0:
+        print(f"Failed to set issue type: {result.stderr.strip()}")
+        return False
+    return True
+
+
+def set_issue_labels(repo: str, number: int, labels: list[str]) -> bool:
+    valid = [l for l in labels if l in SUBSYSTEM_LABELS]
+    if not valid:
+        return False
+    cmd = ["gh", "issue", "edit", str(number), "--repo", repo]
+    for label in valid:
+        cmd.extend(["--add-label", label])
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Failed to set labels: {result.stderr.strip()}")
+        return False
+    return True
 
 
 def post_comment(repo: str, number: int, body: str) -> None:
@@ -199,7 +282,24 @@ def main() -> int:
         if auto_linked:
             print(f"Auto-linked #{number} as sub-issue of #{umbrella}")
 
-    comment = render_comment(cfg, result, auto_linked)
+    # set issue type
+    issue_type = result.get("type", "")
+    type_set = False
+    if issue_type in ISSUE_TYPES:
+        type_set = set_issue_type(repo, number, issue_type)
+        if type_set:
+            print(f"Set issue type to {issue_type}")
+
+    # set subsystem labels
+    pred_labels = result.get("labels", [])
+    labels_set = [l for l in pred_labels if l in SUBSYSTEM_LABELS]
+    if labels_set:
+        if set_issue_labels(repo, number, labels_set):
+            print(f"Set labels: {labels_set}")
+        else:
+            labels_set = []
+
+    comment = render_comment(cfg, result, auto_linked, type_set, labels_set)
     post_comment(repo, number, comment)
     print(f"Posted triage comment on #{number}")
     return 0

--- a/.github/scripts/triage_issue.py
+++ b/.github/scripts/triage_issue.py
@@ -276,28 +276,49 @@ def main() -> int:
     confidence = result.get("confidence", "low")
     auto_linked = False
 
-    if umbrella and should_auto_link(cfg, confidence):
+    # check if issue already has a parent
+    has_parent = bool(issue.get("sub_issue_summary") or issue.get("parent"))
+    if not has_parent:
+        # sub_issue_summary/parent may not be in the event payload; check via API
+        parent_check = subprocess.run(
+            ["gh", "api", f"repos/{repo}/issues/{number}",
+             "--jq", ".parent // empty"],
+            capture_output=True, text=True,
+        )
+        has_parent = bool(parent_check.stdout.strip())
+
+    if has_parent:
+        print(f"Issue #{number} already has a parent; skipping auto-link")
+    elif umbrella and should_auto_link(cfg, confidence):
         child_id = issue["id"]
         auto_linked = link_sub_issue(repo, umbrella, child_id)
         if auto_linked:
             print(f"Auto-linked #{number} as sub-issue of #{umbrella}")
 
-    # set issue type
+    # set issue type (skip if already assigned)
     issue_type = result.get("type", "")
     type_set = False
-    if issue_type in ISSUE_TYPES:
+    existing_type = issue.get("type")
+    if existing_type:
+        print(f"Issue already has type '{existing_type.get('name', '')}'; skipping type assignment")
+    elif issue_type in ISSUE_TYPES:
         type_set = set_issue_type(repo, number, issue_type)
         if type_set:
             print(f"Set issue type to {issue_type}")
 
-    # set subsystem labels
+    # set subsystem labels (only add labels not already present)
     pred_labels = result.get("labels", [])
-    labels_set = [l for l in pred_labels if l in SUBSYSTEM_LABELS]
-    if labels_set:
-        if set_issue_labels(repo, number, labels_set):
+    existing_labels = {l["name"] for l in issue.get("labels", [])}
+    labels_to_add = [l for l in pred_labels if l in SUBSYSTEM_LABELS and l not in existing_labels]
+    labels_set = []
+    if labels_to_add:
+        if set_issue_labels(repo, number, labels_to_add):
+            labels_set = labels_to_add
             print(f"Set labels: {labels_set}")
-        else:
-            labels_set = []
+    elif pred_labels:
+        already = [l for l in pred_labels if l in existing_labels]
+        if already:
+            print(f"Labels already present: {already}; skipping")
 
     comment = render_comment(cfg, result, auto_linked, type_set, labels_set)
     post_comment(repo, number, comment)

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   triage:
     runs-on: ubuntu-latest
-    if: github.event.issue.state == 'open' && secrets.DASHSCOPE_API_KEY != ''
+    if: github.event.issue.state == 'open'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -32,5 +32,5 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_EVENT_PATH: ${{ github.event_path }}
           CONFIG_PATH: .github/issue-triage-config.yml
-          QWEN_MODEL: qwen3-max
+          QWEN_MODEL: qwen3-plus
         run: python .github/scripts/triage_issue.py


### PR DESCRIPTION
## Summary

- **Fix invalid workflow**: remove `secrets` reference from `jobs.<id>.if` (GitHub Actions does not support this)
- **Switch model**: `qwen3-max` → `qwen3-plus` (cheaper, more stable for classification)
- **Auto-assign issue type**: Bug / Feature / Task — skips if already set
- **Auto-assign subsystem labels**: compiler, executor, store, transaction, extension, client, ci — only adds missing labels
- **Skip logic**: does not overwrite existing parent issue, type, or labels

## Files changed

- `.github/workflows/issue-triage.yml` — fix `if` condition, change model
- `.github/scripts/triage_issue.py` — add type/label prediction, skip-if-exists logic

## Validation

- Workflow fix validated on fork (longbinlai/neug#4)
- Type/label classification uses the same single LLM call, no additional API cost

🤖 Generated with [Claude Code](https://claude.com/claude-code)