### PR TITLE
ci: switch issue triage to self-hosted runner

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   triage:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     if: github.event.issue.state == 'open'
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Switch issue triage workflow from `ubuntu-latest` to `[self-hosted, Linux, X64]`
- GitHub-hosted runners are stuck in `pending`/`queued` for `issues`-triggered workflows on this org, causing triage bot to never execute

## Evidence

All previous triage runs were stuck:
- Run 26935591262: `queued` → cancelled
- Run 26935308370: `queued` → cancelled  
- Run 26934582961: `queued` → cancelled

PR Completeness Check runs fine on `ubuntu-latest` (PR-triggered), but issue-triggered workflows do not get picked up.

## Test plan

- [ ] After merge, edit issue #480 title to trigger triage
- [ ] Verify bot posts comment with parent suggestion, type, and labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)