### PR TITLE
ci: make triage model configurable via repo variable

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -32,5 +32,5 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_EVENT_PATH: ${{ github.event_path }}
           CONFIG_PATH: .github/issue-triage-config.yml
-          QWEN_MODEL: ${{ vars.QWEN_MODEL || 'qwen3.7-plus' }}
+          QWEN_MODEL: ${{ vars.QWEN_MODEL || 'qwen-plus' }}
         run: python .github/scripts/triage_issue.py

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -32,5 +32,5 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_EVENT_PATH: ${{ github.event_path }}
           CONFIG_PATH: .github/issue-triage-config.yml
-          QWEN_MODEL: qwen3-plus
+          QWEN_MODEL: qwen3.7-plus
         run: python .github/scripts/triage_issue.py

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -32,5 +32,5 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_EVENT_PATH: ${{ github.event_path }}
           CONFIG_PATH: .github/issue-triage-config.yml
-          QWEN_MODEL: qwen3.7-plus
+          QWEN_MODEL: ${{ vars.QWEN_MODEL || 'qwen3.7-plus' }}
         run: python .github/scripts/triage_issue.py


### PR DESCRIPTION
## Summary
- Make the model configurable via GitHub repo variable `QWEN_MODEL` (falls back to `qwen-plus` if not set)

This lets maintainers change the Qwen model without a code change — just update the repo variable in **Settings → Secrets and variables → Actions → Variables**.

## Test plan
- [ ] Merge and verify triage bot triggers on a new issue
- [ ] Optionally set `QWEN_MODEL` repo variable to a different model and confirm it's picked up

🤖 Generated with [Claude Code](https://claude.com/claude-code)