### PR TITLE
ci: install gh CLI on self-hosted runner for issue triage

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -23,6 +23,14 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install gh CLI
+        run: |
+          if ! command -v gh &> /dev/null; then
+            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+            sudo apt-get update -qq && sudo apt-get install -y -qq gh
+          fi
+
       - name: Install deps
         run: pip install --quiet pyyaml requests
 


### PR DESCRIPTION
## Summary
- Self-hosted runner doesn't have `gh` CLI pre-installed
- Triage script crashes with `FileNotFoundError: 'gh'` when trying to check parent issues, set type/labels, or post comments
- Adds a step to install `gh` if not already present (idempotent)

## Test plan
- [ ] Merge and edit issue #484 to trigger re-run
- [ ] Verify triage bot posts comment with umbrella suggestion, type, and labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)