### PR TITLE
ci: trigger graphscope/web doc sync on documentation changes

### DIFF
--- a/.github/workflows/trigger-docs-sync.yml
+++ b/.github/workflows/trigger-docs-sync.yml
@@ -1,0 +1,19 @@
+name: Trigger Doc Site Sync
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'doc/**'
+
+jobs:
+  trigger-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger graphscope/web NeuG site build
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GRAPHSCOPE_WEB_TOKEN }}
+          repository: graphscope/web
+          event-type: neug-docs-updated


### PR DESCRIPTION
## Summary
- Add a workflow that triggers `graphscope/web`'s `Build NeuG Site` workflow via `repository_dispatch` when doc files are pushed to `main`
- Requires a `GRAPHSCOPE_WEB_TOKEN` secret with repo dispatch permission on `graphscope/web`

Closes #493

## Test plan
- [ ] Verify `GRAPHSCOPE_WEB_TOKEN` secret is configured in alibaba/neug repo settings
- [ ] Merge a doc change to `main` and confirm the `graphscope/web` build is triggered
- [ ] Confirm `graphscope/web` `build-neug-site.yml` handles the `neug-docs-updated` event type

🤖 Generated with [Claude Code](https://claude.com/claude-code)