### PR TITLE
ci: Use self-hosted runner

### DIFF
--- a/.github/workflows/build-extensions.yml
+++ b/.github/workflows/build-extensions.yml
@@ -74,8 +74,7 @@ jobs:
   build_linux_x86_64:
     needs: prepare
     if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
-    # runs-on: [self-hosted, daily, X64]
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, daily, X64]
     container:
       image: neug-registry.cn-hongkong.cr.aliyuncs.com/neug/neug-manylinux:v0.1.2-x86_64
     steps:
@@ -158,8 +157,7 @@ jobs:
   build_linux_arm64:
     needs: prepare
     if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
-    # runs-on: [self-hosted, daily, ARM64]
-    runs-on: ubuntu-22.04-arm
+    runs-on: [self-hosted, daily, ARM64]
     container:
       image: neug-registry.cn-hongkong.cr.aliyuncs.com/neug/neug-manylinux:v0.1.2-arm64
     steps:

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -22,8 +22,7 @@ jobs:
     # those from forks). Fork PRs are intentionally included to avoid the
     # GitHub-hosted runner queue. Other repositories (e.g. user forks running
     # this workflow on their own branches) fall back to ubuntu-22.04.
-    # runs-on: ${{ github.repository == 'alibaba/neug' && fromJSON('["self-hosted"]') || 'ubuntu-22.04' }}
-    runs-on: ubuntu-22.04
+    runs-on: ${{ github.repository == 'alibaba/neug' && fromJSON('["self-hosted"]') || 'ubuntu-22.04' }}
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -14,8 +14,7 @@ concurrency:
 
 jobs:
   triage:
-    # runs-on: [self-hosted, Linux, X64]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     if: github.event.issue.state == 'open'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ldbc-nightly-benchmark.yml
+++ b/.github/workflows/ldbc-nightly-benchmark.yml
@@ -18,8 +18,7 @@ concurrency:
 jobs:
   benchmark:
     name: Build, Load, Serve and Benchmark
-    # if: github.repository == 'alibaba/neug' && (github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main')
-    if: false
+    if: github.repository == 'alibaba/neug' && (github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main')
     runs-on: [self-hosted, ldbc-benchmark]
     timeout-minutes: 480
     steps:

--- a/.github/workflows/neug-extension-test.yml
+++ b/.github/workflows/neug-extension-test.yml
@@ -25,8 +25,7 @@ jobs:
   # Job 1: Build NeuG with extensions
   # ============================================================
   extension_tests_default:
-    # runs-on: [self-hosted, daily, linux]
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, daily, linux]
     container:
       image: neug-registry.cn-hongkong.cr.aliyuncs.com/neug/neug-dev:v0.1.2
     steps:
@@ -128,8 +127,7 @@ jobs:
         NEUG_RUN_EXTENSION_TESTS=true python3 -m pytest -sv tests/test_export.py -k "httpfs"
 
   extension_tests_wheel_linux_x86_64:
-    # runs-on: [self-hosted, daily, linux, x64]
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, daily, linux, x64]
     steps:
       - name: checkout
         id: checkout
@@ -207,8 +205,7 @@ jobs:
           NEUG_RUN_EXTENSION_TESTS=1 python3 tools/python_bind/example/complex_test.py
 
   extension_tests_wheel_linux_arm64:
-    # runs-on: [self-hosted, daily, linux, arm64]
-    runs-on: ubuntu-22.04-arm
+    runs-on: [self-hosted, daily, linux, arm64]
     steps:
       - name: checkout
         id: checkout

--- a/.github/workflows/neug-test.yml
+++ b/.github/workflows/neug-test.yml
@@ -61,11 +61,9 @@ jobs:
       matrix:
         include:
           - arch: x86_64
-            # runner: ${{ github.repository == 'alibaba/neug' && fromJSON('["self-hosted", "daily", "linux", "x64"]') || 'ubuntu-22.04' }}
-            runner: ubuntu-22.04
+            runner: ${{ github.repository == 'alibaba/neug' && fromJSON('["self-hosted", "daily", "linux", "x64"]') || 'ubuntu-22.04' }}
           - arch: arm64
-            # runner: ${{ github.repository == 'alibaba/neug' && fromJSON('["self-hosted", "daily", "linux", "arm64"]') || 'ubuntu-22.04-arm' }}
-            runner: ubuntu-22.04-arm
+            runner: ${{ github.repository == 'alibaba/neug' && fromJSON('["self-hosted", "daily", "linux", "arm64"]') || 'ubuntu-22.04-arm' }}
     runs-on: ${{ matrix.runner }}
     container:
       image: neug-registry.cn-hongkong.cr.aliyuncs.com/neug/neug-dev:v0.1.2

--- a/.github/workflows/pr-completeness.yml
+++ b/.github/workflows/pr-completeness.yml
@@ -9,8 +9,7 @@ permissions:
 
 jobs:
   pr-completeness:
-    # runs-on: ${{ github.repository == 'alibaba/neug' && fromJSON('["self-hosted", "Linux", "X64"]') || 'ubuntu-latest' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository == 'alibaba/neug' && fromJSON('["self-hosted", "Linux", "X64"]') || 'ubuntu-latest' }}
     steps:
       - name: Check PR completeness
         env:

--- a/.github/workflows/wheels-common.yml
+++ b/.github/workflows/wheels-common.yml
@@ -103,8 +103,7 @@ jobs:
   build_wheels_linux_x86_64:
     needs:
       - determine_python_versions
-    # runs-on: [self-hosted, daily, linux, x64]
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, daily, linux, x64]
     if: ${{
           (
             inputs.mode == 'release' &&
@@ -243,8 +242,7 @@ jobs:
   build_wheels_linux_arm64:
     needs:
       - determine_python_versions
-    # runs-on: [self-hosted, daily, linux, arm64]
-    runs-on: ubuntu-22.04-arm
+    runs-on: [self-hosted, daily, linux, arm64]
     if: ${{
           (
             inputs.mode == 'release' &&


### PR DESCRIPTION
Switch to self-hosted runner since now available.