### PR TITLE
refactor: Throw exception if replay WAL fails

### DIFF
--- a/include/neug/utils/exception/exception.h
+++ b/include/neug/utils/exception/exception.h
@@ -313,6 +313,13 @@ class NEUG_API TxStateConflictException : public Exception {
 #define THROW_STORAGE_EXCEPTION(msg) \
   THROW_EXCEPTION_WITH_FILE_LINE_AND_TYPE(StorageException, msg)
 
+#define THROW_STORAGE_EXCEPTION_STATUS(msg, status)                           \
+  do {                                                                        \
+    if (!(status).ok()) {                                                     \
+      THROW_STORAGE_EXCEPTION(std::string(msg) + ": " + (status).ToString()); \
+    }                                                                         \
+  } while (0)
+
 #define THROW_TEST_EXCEPTION(msg) \
   THROW_EXCEPTION_WITH_FILE_LINE_AND_TYPE(TestException, msg)
 

--- a/src/transaction/insert_transaction.cc
+++ b/src/transaction/insert_transaction.cc
@@ -206,10 +206,8 @@ void InsertTransaction::IngestWal(PropertyGraph& graph, uint32_t timestamp,
       vid_t vid;
       auto ret =
           graph.AddVertex(redo.label, redo.oid, redo.props, vid, timestamp);
-      if (!ret.ok()) {
-        THROW_STORAGE_EXCEPTION("Failed to add vertex during WAL ingestion: " +
-                                ret.ToString());
-      }
+      THROW_STORAGE_EXCEPTION_STATUS(
+          "Failed to add vertex during WAL ingestion", ret);
     } else if (op_type == OpType::kInsertEdge) {
       InsertEdgeRedo redo;
       arc >> redo;
@@ -220,9 +218,11 @@ void InsertTransaction::IngestWal(PropertyGraph& graph, uint32_t timestamp,
                                     timestamp));
       int32_t oe_offset_unused = 0;
       const void* prop_unused = nullptr;
-      graph.AddEdge(redo.src_label, src_lid, redo.dst_label, dst_lid,
-                    redo.edge_label, redo.properties, timestamp, alloc,
-                    oe_offset_unused, prop_unused);
+      auto ret = graph.AddEdge(redo.src_label, src_lid, redo.dst_label, dst_lid,
+                               redo.edge_label, redo.properties, timestamp,
+                               alloc, oe_offset_unused, prop_unused);
+      THROW_STORAGE_EXCEPTION_STATUS("Failed to add edge during WAL ingestion",
+                                     ret);
     } else {
       THROW_INTERNAL_EXCEPTION("Unexpected op-" +
                                std::to_string(static_cast<int>(op_type)));

--- a/src/transaction/update_transaction.cc
+++ b/src/transaction/update_transaction.cc
@@ -34,6 +34,7 @@
 #include "neug/transaction/transaction_utils.h"
 #include "neug/transaction/version_manager.h"
 #include "neug/transaction/wal/wal.h"
+#include "neug/utils/exception/exception.h"
 #include "neug/utils/file_utils.h"
 #include "neug/utils/id_indexer.h"
 #include "neug/utils/likely.h"
@@ -943,10 +944,14 @@ void UpdateTransaction::IngestWal(PropertyGraph& graph, uint32_t timestamp,
     arc >> op_type;
     if (op_type == OpType::kCreateVertexType) {
       CreateVertexTypeParam redo = CreateVertexTypeRedo::Deserialize(arc);
-      graph.CreateVertexType(redo);
+      auto ret = graph.CreateVertexType(redo);
+      THROW_STORAGE_EXCEPTION_STATUS("Failed to create vertex type in redo: ",
+                                     ret);
     } else if (op_type == OpType::kCreateEdgeType) {
       const auto& redo = CreateEdgeTypeRedo::Deserialize(arc);
-      graph.CreateEdgeType(redo);
+      auto ret = graph.CreateEdgeType(redo);
+      THROW_STORAGE_EXCEPTION_STATUS("Failed to create edge type in redo: ",
+                                     ret);
     } else if (op_type == OpType::kInsertVertex) {
       InsertVertexRedo redo;
       arc >> redo;
@@ -962,10 +967,7 @@ void UpdateTransaction::IngestWal(PropertyGraph& graph, uint32_t timestamp,
         }
         auto ret = graph.AddVertex(redo.label, redo.oid, redo.props, vid,
                                    timestamp, true);
-        if (!ret.ok()) {
-          THROW_STORAGE_EXCEPTION(
-              "Failed to add vertex during WAL ingestion: " + ret.ToString());
-        }
+        THROW_STORAGE_EXCEPTION_STATUS("Failed to add vertex in redo: ", ret);
       }
     } else if (op_type == OpType::kInsertEdge) {
       InsertEdgeRedo redo;
@@ -975,66 +977,90 @@ void UpdateTransaction::IngestWal(PropertyGraph& graph, uint32_t timestamp,
       CHECK(graph.get_lid(redo.dst_label, redo.dst, dst_vid, timestamp));
       int32_t oe_offset_unused = 0;
       const void* prop_unused = nullptr;
-      graph.AddEdge(redo.src_label, src_vid, redo.dst_label, dst_vid,
-                    redo.edge_label, redo.properties, timestamp, alloc,
-                    oe_offset_unused, prop_unused, true);
+      auto ret = graph.AddEdge(redo.src_label, src_vid, redo.dst_label, dst_vid,
+                               redo.edge_label, redo.properties, timestamp,
+                               alloc, oe_offset_unused, prop_unused, true);
+      THROW_STORAGE_EXCEPTION_STATUS("Failed to add edge in redo: ", ret);
     } else if (op_type == OpType::kUpdateVertexProp) {
       UpdateVertexPropRedo redo;
       arc >> redo;
       vid_t vid;
       CHECK(graph.get_lid(redo.label, redo.oid, vid, timestamp));
-      graph.get_vertex_table(redo.label)
-          .UpdateProperty(vid, redo.prop_id, redo.value, timestamp);
+      auto ret = graph.UpdateVertexProperty(redo.label, vid, redo.prop_id,
+                                            redo.value, timestamp);
+      THROW_STORAGE_EXCEPTION_STATUS(
+          "Failed to update vertex property in redo: ", ret);
     } else if (op_type == OpType::kUpdateEdgeProp) {
       UpdateEdgePropRedo redo;
       arc >> redo;
       vid_t src_vid, dst_vid;
       CHECK(graph.get_lid(redo.src_label, redo.src, src_vid, timestamp));
       CHECK(graph.get_lid(redo.dst_label, redo.dst, dst_vid, timestamp));
-      graph.UpdateEdgeProperty(redo.src_label, src_vid, redo.dst_label, dst_vid,
-                               redo.edge_label, redo.oe_offset, redo.ie_offset,
-                               redo.prop_id, redo.value, timestamp);
+      auto ret = graph.UpdateEdgeProperty(
+          redo.src_label, src_vid, redo.dst_label, dst_vid, redo.edge_label,
+          redo.oe_offset, redo.ie_offset, redo.prop_id, redo.value, timestamp);
+      THROW_STORAGE_EXCEPTION_STATUS("Failed to update edge property in redo: ",
+                                     ret);
     } else if (op_type == OpType::kRemoveVertex) {
       RemoveVertexRedo redo;
       arc >> redo;
       vid_t vid;
       CHECK(graph.get_lid(redo.label, redo.oid, vid, timestamp));
-      graph.DeleteVertex(redo.label, vid, timestamp);
+      auto ret = graph.DeleteVertex(redo.label, vid, timestamp);
+      THROW_STORAGE_EXCEPTION_STATUS("Failed to delete vertex in redo: ", ret);
     } else if (op_type == OpType::kRemoveEdge) {
       RemoveEdgeRedo redo;
       arc >> redo;
       vid_t src_vid, dst_vid;
       CHECK(graph.get_lid(redo.src_label, redo.src, src_vid, timestamp));
       CHECK(graph.get_lid(redo.dst_label, redo.dst, dst_vid, timestamp));
-      graph.DeleteEdge(redo.src_label, src_vid, redo.dst_label, dst_vid,
-                       redo.edge_label, redo.oe_offset, redo.ie_offset,
-                       timestamp);
+      auto ret = graph.DeleteEdge(redo.src_label, src_vid, redo.dst_label,
+                                  dst_vid, redo.edge_label, redo.oe_offset,
+                                  redo.ie_offset, timestamp);
+      THROW_STORAGE_EXCEPTION_STATUS("Failed to delete edge in redo: ", ret);
     } else if (op_type == OpType::kAddVertexProp) {
       auto config = AddVertexPropertiesRedo::Deserialize(arc);
-      graph.AddVertexProperties(config);
+      auto ret = graph.AddVertexProperties(config);
+      THROW_STORAGE_EXCEPTION_STATUS(
+          "Failed to add vertex properties in redo: ", ret);
     } else if (op_type == OpType::kAddEdgeProp) {
       auto config = AddEdgePropertiesRedo::Deserialize(arc);
-      graph.AddEdgeProperties(config);
+      auto ret = graph.AddEdgeProperties(config);
+      THROW_STORAGE_EXCEPTION_STATUS("Failed to add edge properties in redo: ",
+                                     ret);
     } else if (op_type == OpType::kRenameVertexProp) {
       auto config = RenameVertexPropertiesRedo::Deserialize(arc);
-      graph.RenameVertexProperties(config);
+      auto ret = graph.RenameVertexProperties(config);
+      THROW_STORAGE_EXCEPTION_STATUS(
+          "Failed to rename vertex properties in redo: ", ret);
     } else if (op_type == OpType::kRenameEdgeProp) {
       auto config = RenameEdgePropertiesRedo::Deserialize(arc);
-      graph.RenameEdgeProperties(config);
+      auto ret = graph.RenameEdgeProperties(config);
+      THROW_STORAGE_EXCEPTION_STATUS(
+          "Failed to rename edge properties in redo: ", ret);
     } else if (op_type == OpType::kDeleteVertexProp) {
       auto config = DeleteVertexPropertiesRedo::Deserialize(arc);
-      graph.DeleteVertexProperties(config);
+      auto ret = graph.DeleteVertexProperties(config);
+      THROW_STORAGE_EXCEPTION_STATUS(
+          "Failed to delete vertex properties in redo: ", ret);
     } else if (op_type == OpType::kDeleteEdgeProp) {
       auto config = DeleteEdgePropertiesRedo::Deserialize(arc);
-      graph.DeleteEdgeProperties(config);
+      auto ret = graph.DeleteEdgeProperties(config);
+      THROW_STORAGE_EXCEPTION_STATUS(
+          "Failed to delete edge properties in redo: ", ret);
     } else if (op_type == OpType::kDeleteVertexType) {
       DeleteVertexTypeRedo redo;
       arc >> redo;
-      graph.DeleteVertexType(redo.vertex_type);
+      auto ret = graph.DeleteVertexType(redo.vertex_type);
+      THROW_STORAGE_EXCEPTION_STATUS("Failed to delete vertex type in redo: ",
+                                     ret);
     } else if (op_type == OpType::kDeleteEdgeType) {
       DeleteEdgeTypeRedo redo;
       arc >> redo;
-      graph.DeleteEdgeType(redo.src_type, redo.dst_type, redo.edge_type);
+      auto ret =
+          graph.DeleteEdgeType(redo.src_type, redo.dst_type, redo.edge_type);
+      THROW_STORAGE_EXCEPTION_STATUS("Failed to delete edge type in redo: ",
+                                     ret);
     } else {
       THROW_NOT_SUPPORTED_EXCEPTION("Unexpected op_type: " +
                                     std::to_string(static_cast<int>(op_type)));

--- a/src/utils/reader/reader.cc
+++ b/src/utils/reader/reader.cc
@@ -120,10 +120,9 @@ std::shared_ptr<arrow::dataset::Scanner> ArrowReader::createScanner(
       auto fileSchema = inspected.ValueOrDie();
       for (const auto& field : scan_opts->dataset_schema->fields()) {
         if (!fileSchema->GetFieldByName(field->name())) {
-          THROW_SCHEMA_MISMATCH(
-              "Column '" + field->name() +
-              "' not found in file. Available columns: " +
-              fileSchema->ToString());
+          THROW_SCHEMA_MISMATCH("Column '" + field->name() +
+                                "' not found in file. Available columns: " +
+                                fileSchema->ToString());
         }
       }
     }

--- a/tests/transaction/test_acid.cc
+++ b/tests/transaction/test_acid.cc
@@ -554,7 +554,6 @@ int64_t G1B2(neug::NeugDBSession& db) {
 
 // Circular Information Flow
 
-
 int64_t G1C(neug::NeugDBSession& db, int64_t person1_id, int64_t person2_id,
             int64_t txn_id) {
   auto txn = db.GetUpdateTransaction();
@@ -595,7 +594,6 @@ int64_t G1C(neug::NeugDBSession& db, int64_t person1_id, int64_t person2_id,
 
 // Aborted Reads
 
-
 void G1A1(neug::NeugDBSession& db) {
   auto txn = db.GetUpdateTransaction();
   StorageTPUpdateInterface gui(txn);
@@ -626,7 +624,6 @@ int64_t G1A2(neug::NeugDBSession& db) {
 }
 
 // Item-Many-Preceders
-
 
 void IMP1(neug::NeugDBSession& db) {
   auto txn = db.GetUpdateTransaction();

--- a/tests/utils/test_reader.cc
+++ b/tests/utils/test_reader.cc
@@ -357,9 +357,9 @@ TEST_F(ReaderTest, TestBasicJsonRead) {
   std::vector<std::shared_ptr<::common::DataType>> columnTypes = {
       createInt64Type(), createStringType(), createDoubleType()};
 
-  auto sharedState = createJsonSharedState(
-      "test_json_basic.json", columnNames, columnTypes,
-      {{"batch_read", "false"}});
+  auto sharedState =
+      createJsonSharedState("test_json_basic.json", columnNames, columnTypes,
+                            {{"batch_read", "false"}});
   auto reader = createArrowJsonReader(sharedState);
 
   auto localState = std::make_shared<reader::ReadLocalState>();
@@ -379,9 +379,9 @@ TEST_F(ReaderTest, TestJsonNonExistentColumnThrows) {
   std::vector<std::shared_ptr<::common::DataType>> columnTypes = {
       createInt64Type(), createStringType(), createDoubleType()};
 
-  auto sharedState = createJsonSharedState(
-      "test_json_nonexist.json", columnNames, columnTypes,
-      {{"batch_read", "false"}});
+  auto sharedState =
+      createJsonSharedState("test_json_nonexist.json", columnNames, columnTypes,
+                            {{"batch_read", "false"}});
   auto reader = createArrowJsonReader(sharedState);
 
   auto localState = std::make_shared<reader::ReadLocalState>();


### PR DESCRIPTION
## Summary

- Capture return status from all storage operations during WAL replay and throw `StorageException` on failure — previously most operations silently discarded errors, risking silent data corruption after recovery
- Add `THROW_STORAGE_EXCEPTION_STATUS` macro to reduce boilerplate for status-checking patterns
- Apply to both `UpdateTransaction::IngestWal` (14 operations) and `InsertTransaction::IngestWal` (1 operation: `AddEdge`)

Fixes #512

## Test plan

- [ ] Existing `test_acid` tests pass (no behavioral change on success path)
- [ ] Verify WAL replay with a corrupted/inconsistent WAL throws `StorageException` instead of silently proceeding

🤖 Generated with [Claude Code](https://claude.com/claude-code)