### PR TITLE
refactor: Avoid dump to new file when nbr_list not modified

### DIFF
--- a/include/neug/storages/csr/mutable_csr.h
+++ b/include/neug/storages/csr/mutable_csr.h
@@ -136,7 +136,6 @@ class MutableCsr : public TypedCsrBase<EDATA_T> {
     nbr.data = data;
     nbr.timestamp.store(ts);
     edge_num_.fetch_add(1);
-    nbr_data_dirty_ = true;
     // invalidate sort flag
     if (ts < unsorted_since_) {
       unsorted_since_ = 0;
@@ -193,7 +192,6 @@ class MutableCsr : public TypedCsrBase<EDATA_T> {
   std::unique_ptr<IDataContainer> nbr_list_;
   timestamp_t unsorted_since_;
   std::atomic<uint64_t> edge_num_{0};
-  bool nbr_data_dirty_ = false;
 
   size_t vertex_capacity() const {
     if (!degree_list_) {

--- a/include/neug/storages/csr/mutable_csr.h
+++ b/include/neug/storages/csr/mutable_csr.h
@@ -136,6 +136,7 @@ class MutableCsr : public TypedCsrBase<EDATA_T> {
     nbr.data = data;
     nbr.timestamp.store(ts);
     edge_num_.fetch_add(1);
+    nbr_data_dirty_ = true;
     // invalidate sort flag
     if (ts < unsorted_since_) {
       unsorted_since_ = 0;
@@ -192,6 +193,7 @@ class MutableCsr : public TypedCsrBase<EDATA_T> {
   std::unique_ptr<IDataContainer> nbr_list_;
   timestamp_t unsorted_since_;
   std::atomic<uint64_t> edge_num_{0};
+  bool nbr_data_dirty_ = false;
 
   size_t vertex_capacity() const {
     if (!degree_list_) {

--- a/src/storages/csr/mutable_csr.cc
+++ b/src/storages/csr/mutable_csr.cc
@@ -84,7 +84,27 @@ void MutableCsr<EDATA_T>::Open(Checkpoint& ckp,
         " but degree list implies " + std::to_string(edge_count) +
         ", desc: " + descriptor.ToJsonString());
   }
-  nbr_data_dirty_ = false;
+}
+
+template <typename NBR_T>
+bool is_nbr_list_unmodified(MD5_CTX& ctx, FileHeader& header,
+                            const IDataContainer* nbr_container,
+                            const NBR_T* const* adj_lists, const int* cap_arr,
+                            size_t vnum) {
+  MD5_Init(&ctx);
+  for (size_t i = 0; i < vnum; ++i) {
+    const char* data = reinterpret_cast<const char*>(adj_lists[i]);
+    size_t len = cap_arr[i] * sizeof(NBR_T);
+    MD5_Update(&ctx, data, len);
+  }
+  MD5_Final(header.data_md5, &ctx);
+  auto casted = dynamic_cast<const MMapContainer*>(nbr_container);
+  if (casted && !casted->GetPath().empty() && casted->GetHeader()) {
+    return memcmp(casted->GetHeader()->data_md5, header.data_md5,
+                  sizeof(header.data_md5)) == 0;
+  } else {
+    return false;
+  }
 }
 
 template <typename EDATA_T>
@@ -101,18 +121,18 @@ ModuleDescriptor MutableCsr<EDATA_T>::Dump(Checkpoint& ckp) {
   descriptor.set_path(ModuleDescriptor::kDegreeListPath,
                       ckp.Commit(*degree_list_));
 
-  if (!nbr_data_dirty_ && nbr_list_ != nullptr) {
-    // Fast path: no writes since last Dump/Open, reuse existing file.
-    descriptor.set_path(ModuleDescriptor::kNbrListPath,
-                        ckp.Commit(*nbr_list_));
-  } else {
-    // Slow path: serialize adjacency lists with MD5 checksum.
-    const nbr_t* const* adj_lists =
-        reinterpret_cast<const nbr_t* const*>(adj_list_buffer_->GetData());
-    const int* cap_arr = reinterpret_cast<const int*>(cap_list_->GetData());
+  const nbr_t* const* adj_lists =
+      reinterpret_cast<const nbr_t* const*>(adj_list_buffer_->GetData());
+  const int* cap_arr = reinterpret_cast<const int*>(cap_list_->GetData());
 
+  MD5_CTX ctx;
+  FileHeader header{};
+  if (is_nbr_list_unmodified(ctx, header, nbr_list_.get(), adj_lists, cap_arr,
+                             vnum)) {
+    // If the neighbor list is unmodified, we can reuse the existing file.
+    descriptor.set_path(ModuleDescriptor::kNbrListPath, nbr_list_->GetPath());
+  } else {
     std::string nbr_path_committed;
-    FileHeader header{};
 
     auto runtime_uuid = ckp.CreateRuntimeObject();
     auto nbr_path = ckp.runtime_dir() + "/" + runtime_uuid;
@@ -120,28 +140,17 @@ ModuleDescriptor MutableCsr<EDATA_T>::Dump(Checkpoint& ckp) {
     if (!nbr_out.is_open()) {
       THROW_IO_EXCEPTION("Failed to open file for writing: " + nbr_path);
     }
-
     nbr_out.write(reinterpret_cast<const char*>(&header), sizeof(header));
-
-    MD5_CTX ctx;
-    MD5_Init(&ctx);
     for (size_t i = 0; i < vnum; ++i) {
       const char* data = reinterpret_cast<const char*>(adj_lists[i]);
       size_t len = cap_arr[i] * sizeof(nbr_t);
       nbr_out.write(data, len);
-      MD5_Update(&ctx, data, len);
     }
-
-    MD5_Final(header.data_md5, &ctx);
-    // Update the header with the correct MD5 after writing all data
-    nbr_out.seekp(0);
-    nbr_out.write(reinterpret_cast<const char*>(&header), sizeof(header));
     nbr_out.flush();
     nbr_out.close();
     nbr_path_committed = ckp.CommitRuntimeObject(runtime_uuid);
 
     descriptor.set_path(ModuleDescriptor::kNbrListPath, nbr_path_committed);
-    nbr_data_dirty_ = false;
   }
 
   descriptor.set_path(ModuleDescriptor::kCapacityListPath,
@@ -166,7 +175,6 @@ void MutableCsr<EDATA_T>::reset_timestamp() {
       }
     }
   }
-  nbr_data_dirty_ = true;
 }
 
 template <typename EDATA_T>
@@ -209,7 +217,6 @@ void MutableCsr<EDATA_T>::compact() {
         std::to_string(edge_num_.load()) + ", actual " +
         std::to_string(total_edge_num));
   }
-  nbr_data_dirty_ = true;
 }
 
 template <typename EDATA_T>
@@ -233,7 +240,6 @@ void MutableCsr<EDATA_T>::resize(vid_t vnum) {
       cap_arr[i] = 0;
     }
     locks_ = std::make_unique<SpinLock[]>(vnum);
-    nbr_data_dirty_ = true;
   } else {
     adj_list_buffer_->Resize(vnum * sizeof(nbr_t*));
     degree_list_->Resize(vnum * sizeof(int));
@@ -274,7 +280,6 @@ void MutableCsr<EDATA_T>::batch_sort_by_edge_data(timestamp_t ts) {
     }
   }
   unsorted_since_ = ts;
-  nbr_data_dirty_ = true;
 }
 
 template <typename EDATA_T>
@@ -326,7 +331,6 @@ void MutableCsr<EDATA_T>::batch_delete_vertices(
     sz_arr[src] -= removed;
   }
   unsorted_since_ = 0;
-  nbr_data_dirty_ = true;
 }
 
 template <typename EDATA_T>
@@ -359,7 +363,6 @@ void MutableCsr<EDATA_T>::batch_delete_edges(
     }
   }
   unsorted_since_ = 0;
-  nbr_data_dirty_ = true;
 }
 
 template <typename EDATA_T>
@@ -391,7 +394,6 @@ void MutableCsr<EDATA_T>::batch_delete_edges(
     }
   }
   unsorted_since_ = 0;
-  nbr_data_dirty_ = true;
 }
 
 template <typename EDATA_T>
@@ -417,7 +419,6 @@ void MutableCsr<EDATA_T>::delete_edge(vid_t src, int32_t offset,
     LOG(ERROR) << "Attempting to delete edge with timestamp " << old_ts
                << " using older timestamp " << ts;
   }
-  nbr_data_dirty_ = true;
 }
 
 template <typename EDATA_T>
@@ -444,7 +445,6 @@ void MutableCsr<EDATA_T>::revert_delete_edge(vid_t src, vid_t nbr,
     THROW_INVALID_ARGUMENT_EXCEPTION(
         "Attempting to revert delete on edge that is not deleted.");
   }
-  nbr_data_dirty_ = true;
 }
 
 template <typename EDATA_T>
@@ -521,7 +521,6 @@ void MutableCsr<EDATA_T>::batch_put_edges(const std::vector<vid_t>& src_list,
   if (ts < unsorted_since_) {
     unsorted_since_ = 0;
   }
-  nbr_data_dirty_ = true;
 }
 
 template <typename EDATA_T>

--- a/src/storages/csr/mutable_csr.cc
+++ b/src/storages/csr/mutable_csr.cc
@@ -130,7 +130,8 @@ ModuleDescriptor MutableCsr<EDATA_T>::Dump(Checkpoint& ckp) {
   if (is_nbr_list_unmodified(ctx, header, nbr_list_.get(), adj_lists, cap_arr,
                              vnum)) {
     // If the neighbor list is unmodified, we can reuse the existing file.
-    descriptor.set_path(ModuleDescriptor::kNbrListPath, nbr_list_->GetPath());
+    descriptor.set_path(ModuleDescriptor::kNbrListPath,
+                        ckp.LinkToSnapshot(nbr_list_->GetPath()));
   } else {
     std::string nbr_path_committed;
 

--- a/src/storages/csr/mutable_csr.cc
+++ b/src/storages/csr/mutable_csr.cc
@@ -84,6 +84,7 @@ void MutableCsr<EDATA_T>::Open(Checkpoint& ckp,
         " but degree list implies " + std::to_string(edge_count) +
         ", desc: " + descriptor.ToJsonString());
   }
+  nbr_data_dirty_ = false;
 }
 
 template <typename EDATA_T>
@@ -100,40 +101,49 @@ ModuleDescriptor MutableCsr<EDATA_T>::Dump(Checkpoint& ckp) {
   descriptor.set_path(ModuleDescriptor::kDegreeListPath,
                       ckp.Commit(*degree_list_));
 
-  const nbr_t* const* adj_lists =
-      reinterpret_cast<const nbr_t* const*>(adj_list_buffer_->GetData());
-  const int* cap_arr = reinterpret_cast<const int*>(cap_list_->GetData());
+  if (!nbr_data_dirty_ && nbr_list_ != nullptr) {
+    // Fast path: no writes since last Dump/Open, reuse existing file.
+    descriptor.set_path(ModuleDescriptor::kNbrListPath,
+                        ckp.Commit(*nbr_list_));
+  } else {
+    // Slow path: serialize adjacency lists with MD5 checksum.
+    const nbr_t* const* adj_lists =
+        reinterpret_cast<const nbr_t* const*>(adj_list_buffer_->GetData());
+    const int* cap_arr = reinterpret_cast<const int*>(cap_list_->GetData());
 
-  std::string nbr_path_committed;
-  FileHeader header{};
+    std::string nbr_path_committed;
+    FileHeader header{};
 
-  auto runtime_uuid = ckp.CreateRuntimeObject();
-  auto nbr_path = ckp.runtime_dir() + "/" + runtime_uuid;
-  std::ofstream nbr_out(nbr_path, std::ios::binary);
-  if (!nbr_out.is_open()) {
-    THROW_IO_EXCEPTION("Failed to open file for writing: " + nbr_path);
+    auto runtime_uuid = ckp.CreateRuntimeObject();
+    auto nbr_path = ckp.runtime_dir() + "/" + runtime_uuid;
+    std::ofstream nbr_out(nbr_path, std::ios::binary);
+    if (!nbr_out.is_open()) {
+      THROW_IO_EXCEPTION("Failed to open file for writing: " + nbr_path);
+    }
+
+    nbr_out.write(reinterpret_cast<const char*>(&header), sizeof(header));
+
+    MD5_CTX ctx;
+    MD5_Init(&ctx);
+    for (size_t i = 0; i < vnum; ++i) {
+      const char* data = reinterpret_cast<const char*>(adj_lists[i]);
+      size_t len = cap_arr[i] * sizeof(nbr_t);
+      nbr_out.write(data, len);
+      MD5_Update(&ctx, data, len);
+    }
+
+    MD5_Final(header.data_md5, &ctx);
+    // Update the header with the correct MD5 after writing all data
+    nbr_out.seekp(0);
+    nbr_out.write(reinterpret_cast<const char*>(&header), sizeof(header));
+    nbr_out.flush();
+    nbr_out.close();
+    nbr_path_committed = ckp.CommitRuntimeObject(runtime_uuid);
+
+    descriptor.set_path(ModuleDescriptor::kNbrListPath, nbr_path_committed);
+    nbr_data_dirty_ = false;
   }
 
-  nbr_out.write(reinterpret_cast<const char*>(&header), sizeof(header));
-
-  MD5_CTX ctx;
-  MD5_Init(&ctx);
-  for (size_t i = 0; i < vnum; ++i) {
-    const char* data = reinterpret_cast<const char*>(adj_lists[i]);
-    size_t len = cap_arr[i] * sizeof(nbr_t);
-    nbr_out.write(data, len);
-    MD5_Update(&ctx, data, len);
-  }
-
-  MD5_Final(header.data_md5, &ctx);
-  // Update the header with the correct MD5 after writing all data
-  nbr_out.seekp(0);
-  nbr_out.write(reinterpret_cast<const char*>(&header), sizeof(header));
-  nbr_out.flush();
-  nbr_out.close();
-  nbr_path_committed = ckp.CommitRuntimeObject(runtime_uuid);
-
-  descriptor.set_path(ModuleDescriptor::kNbrListPath, nbr_path_committed);
   descriptor.set_path(ModuleDescriptor::kCapacityListPath,
                       ckp.Commit(*cap_list_));
   return descriptor;
@@ -156,6 +166,7 @@ void MutableCsr<EDATA_T>::reset_timestamp() {
       }
     }
   }
+  nbr_data_dirty_ = true;
 }
 
 template <typename EDATA_T>
@@ -198,6 +209,7 @@ void MutableCsr<EDATA_T>::compact() {
         std::to_string(edge_num_.load()) + ", actual " +
         std::to_string(total_edge_num));
   }
+  nbr_data_dirty_ = true;
 }
 
 template <typename EDATA_T>
@@ -221,6 +233,7 @@ void MutableCsr<EDATA_T>::resize(vid_t vnum) {
       cap_arr[i] = 0;
     }
     locks_ = std::make_unique<SpinLock[]>(vnum);
+    nbr_data_dirty_ = true;
   } else {
     adj_list_buffer_->Resize(vnum * sizeof(nbr_t*));
     degree_list_->Resize(vnum * sizeof(int));
@@ -261,6 +274,7 @@ void MutableCsr<EDATA_T>::batch_sort_by_edge_data(timestamp_t ts) {
     }
   }
   unsorted_since_ = ts;
+  nbr_data_dirty_ = true;
 }
 
 template <typename EDATA_T>
@@ -312,6 +326,7 @@ void MutableCsr<EDATA_T>::batch_delete_vertices(
     sz_arr[src] -= removed;
   }
   unsorted_since_ = 0;
+  nbr_data_dirty_ = true;
 }
 
 template <typename EDATA_T>
@@ -344,6 +359,7 @@ void MutableCsr<EDATA_T>::batch_delete_edges(
     }
   }
   unsorted_since_ = 0;
+  nbr_data_dirty_ = true;
 }
 
 template <typename EDATA_T>
@@ -375,6 +391,7 @@ void MutableCsr<EDATA_T>::batch_delete_edges(
     }
   }
   unsorted_since_ = 0;
+  nbr_data_dirty_ = true;
 }
 
 template <typename EDATA_T>
@@ -400,6 +417,7 @@ void MutableCsr<EDATA_T>::delete_edge(vid_t src, int32_t offset,
     LOG(ERROR) << "Attempting to delete edge with timestamp " << old_ts
                << " using older timestamp " << ts;
   }
+  nbr_data_dirty_ = true;
 }
 
 template <typename EDATA_T>
@@ -426,6 +444,7 @@ void MutableCsr<EDATA_T>::revert_delete_edge(vid_t src, vid_t nbr,
     THROW_INVALID_ARGUMENT_EXCEPTION(
         "Attempting to revert delete on edge that is not deleted.");
   }
+  nbr_data_dirty_ = true;
 }
 
 template <typename EDATA_T>
@@ -502,6 +521,7 @@ void MutableCsr<EDATA_T>::batch_put_edges(const std::vector<vid_t>& src_list,
   if (ts < unsorted_since_) {
     unsorted_since_ = 0;
   }
+  nbr_data_dirty_ = true;
 }
 
 template <typename EDATA_T>

--- a/tests/storage/test_mutable_csr.cc
+++ b/tests/storage/test_mutable_csr.cc
@@ -14,6 +14,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <sys/stat.h>
 #include <chrono>
 #include <iostream>
 #include <optional>
@@ -691,5 +692,120 @@ TYPED_TEST(MutableCsrTest, TestDeleteEdge) {
   empty_csr.delete_edge(0, 0, 0);
   empty_csr.revert_delete_edge(0, 0, 0, 0);
 }
+// ---------------------------------------------------------------------------
+// DumpDirty: validates nbr_data_dirty_ fast-path in MutableCsr::Dump.
+// After Open, nbr_list_ is file-backed+clean; when nbr_data_dirty_==false,
+// Dump calls ckp.Commit(*nbr_list_) → hardlink (zero-copy) instead of
+// manual serialisation + MD5.
+// ---------------------------------------------------------------------------
+class MutableCsrDumpDirtyTest : public ::testing::Test {
+ protected:
+  using CsrT = MutableCsr<int64_t>;
+  static constexpr const char* TEST_DIR = "/tmp/mutable_csr_dump_dirty_test";
+  static constexpr vid_t VNUM = 5;
+  const std::vector<vid_t> src_ = {0, 0, 1, 2, 4};
+  const std::vector<vid_t> dst_ = {3, 4, 2, 1, 0};
+  const std::vector<int64_t> data_ = {10, 20, 30, 40, 50};
+
+  void SetUp() override {
+    if (std::filesystem::exists(TEST_DIR))
+      std::filesystem::remove_all(TEST_DIR);
+    std::filesystem::create_directories(TEST_DIR);
+    ws_.Open(TEST_DIR);
+    alloc_ = std::make_unique<Allocator>(MemoryLevel::kInMemory, "");
+  }
+  void TearDown() override {
+    ws_.Close();
+    if (std::filesystem::exists(TEST_DIR))
+      std::filesystem::remove_all(TEST_DIR);
+  }
+
+  std::shared_ptr<Checkpoint> prepare(CsrT& csr, ModuleDescriptor& desc) {
+    CsrT orig;
+    auto ckp = make_checkpoint(ws_);
+    orig.Open(*ckp, ModuleDescriptor(), MemoryLevel::kInMemory);
+    orig.resize(VNUM);
+    orig.batch_put_edges(src_, dst_, data_);
+    desc = orig.Dump(*ckp);
+    csr.Open(*ckp, desc, MemoryLevel::kInMemory);
+    return ckp;
+  }
+
+  static ino_t inode_of(const std::string& path) {
+    struct stat st {};
+    EXPECT_EQ(stat(path.c_str(), &st), 0) << "stat: " << path;
+    return st.st_ino;
+  }
+  std::string nbr_path(const ModuleDescriptor& d) {
+    return d.get_path(ModuleDescriptor::kNbrListPath).value();
+  }
+  void expect_slow_after(const std::string& label,
+                         std::function<void(CsrT&)> mutate) {
+    CsrT csr;
+    ModuleDescriptor orig_desc;
+    auto ckp = prepare(csr, orig_desc);
+    auto orig_inode = inode_of(nbr_path(orig_desc));
+    mutate(csr);
+    auto new_inode = inode_of(nbr_path(csr.Dump(*ckp)));
+    EXPECT_NE(orig_inode, new_inode) << label << " should mark dirty";
+  }
+
+  CheckpointManager ws_;
+  std::unique_ptr<Allocator> alloc_;
+};
+
+TEST_F(MutableCsrDumpDirtyTest, FastAndSlowPath) {
+  CsrT csr;
+  ModuleDescriptor orig_desc;
+  auto ckp = prepare(csr, orig_desc);
+  auto orig = inode_of(nbr_path(orig_desc));
+  EXPECT_EQ(orig, inode_of(nbr_path(csr.Dump(*ckp))));
+  int64_t val = 999;
+  csr.put_edge(0, 2, val, 1, *alloc_);
+  EXPECT_NE(orig, inode_of(nbr_path(csr.Dump(*ckp))));
+}
+
+TEST_F(MutableCsrDumpDirtyTest, FastPath_DataIntegrity) {
+  CsrT csr;
+  ModuleDescriptor desc;
+  auto ckp = prepare(csr, desc);
+  auto fast_desc = csr.Dump(*ckp);
+  CsrT restored;
+  restored.Open(*ckp, fast_desc, MemoryLevel::kInMemory);
+  EXPECT_EQ(restored.edge_num(), src_.size());
+}
+
+TEST_F(MutableCsrDumpDirtyTest, DirtyResetAcrossCheckpointCycles) {
+  CsrT orig;
+  auto ckp = make_checkpoint(ws_);
+  orig.Open(*ckp, ModuleDescriptor(), MemoryLevel::kInMemory);
+  orig.resize(VNUM);
+  orig.batch_put_edges(src_, dst_, data_);
+  auto d1 = orig.Dump(*ckp);
+  auto p1 = nbr_path(d1);
+
+  CsrT c2;
+  c2.Open(*ckp, d1, MemoryLevel::kInMemory);
+  auto p2 = nbr_path(c2.Dump(*ckp));
+  EXPECT_EQ(inode_of(p1), inode_of(p2));
+
+  c2.reset_timestamp();
+  auto d3 = c2.Dump(*ckp);
+  auto p3 = nbr_path(d3);
+  EXPECT_NE(inode_of(p2), inode_of(p3));
+
+  CsrT c3;
+  c3.Open(*ckp, d3, MemoryLevel::kInMemory);
+  auto p4 = nbr_path(c3.Dump(*ckp));
+  EXPECT_EQ(inode_of(p3), inode_of(p4));
+}
+
+TEST_F(MutableCsrDumpDirtyTest, VariousMutationsSetDirty) {
+  expect_slow_after("delete_edge", [](CsrT& c) { c.delete_edge(0, 0, 1); });
+  expect_slow_after("reset_timestamp", [](CsrT& c) { c.reset_timestamp(); });
+  expect_slow_after("compact", [](CsrT& c) { c.compact(); });
+  expect_slow_after("batch_sort", [](CsrT& c) { c.batch_sort_by_edge_data(10); });
+}
+
 }  // namespace test
 }  // namespace neug

--- a/tests/storage/test_mutable_csr.cc
+++ b/tests/storage/test_mutable_csr.cc
@@ -18,10 +18,30 @@
 #include <chrono>
 #include <iostream>
 #include <optional>
+#include <random>
 #include <string>
 #include "neug/storages/csr/csr_view_utils.h"
 #include "neug/storages/csr/mutable_csr.h"
 #include "unittest/utils.h"
+
+namespace {
+
+// Creates a unique temporary directory for a single test instance.
+// Uses the system temp dir + a PID-based prefix + random suffix to avoid
+// collisions under parallel test execution or concurrent CI jobs.
+std::filesystem::path make_unique_test_dir(const std::string& test_name) {
+  std::mt19937_64 rng(
+      std::chrono::steady_clock::now().time_since_epoch().count() ^
+      static_cast<uint64_t>(::getpid()));
+  std::uniform_int_distribution<uint64_t> dist;
+  auto unique_dir = std::filesystem::temp_directory_path() /
+                    (test_name + "_" + std::to_string(::getpid()) + "_" +
+                     std::to_string(dist(rng)));
+  std::filesystem::create_directories(unique_dir);
+  return unique_dir;
+}
+
+}  // namespace
 
 static const size_t src_v_num = 5;
 static const size_t single_src_v_num = 10;
@@ -80,12 +100,18 @@ using Datatypes =
 template <typename EDATA_T>
 class MutableCsrTest : public ::testing::Test {
  protected:
-  static constexpr const char* TEST_DIR = "/tmp/mutable_csr_test";
-
   void SetUp() override {
+    test_dir_ = make_unique_test_dir("mutable_csr_test");
     allocators.emplace_back(
         std::make_unique<Allocator>(MemoryLevel::kInMemory, ""));
-    ws_.Open(TEST_DIR);
+    ws_.Open(test_dir_.string());
+  }
+
+  void TearDown() override {
+    ws_.Close();
+    if (std::filesystem::exists(test_dir_)) {
+      std::filesystem::remove_all(test_dir_);
+    }
   }
 
   size_t count_edge_num(MutableCsr<EDATA_T>& csr) {
@@ -102,15 +128,15 @@ class MutableCsrTest : public ::testing::Test {
 
   std::shared_ptr<Checkpoint> load_csr_data(MutableCsr<EDATA_T>& csr,
                                             MemoryLevel memory_level) {
-    if (std::filesystem::exists(TEST_DIR)) {
-      std::filesystem::remove_all(TEST_DIR);
+    if (std::filesystem::exists(test_dir_)) {
+      std::filesystem::remove_all(test_dir_);
     }
-    std::filesystem::create_directories(TEST_DIR);
+    std::filesystem::create_directories(test_dir_);
     // The previous helper invocation left checkpoints in ws_; the directory
     // wipe above made them stale, so re-sync the workspace with disk before
     // creating a new checkpoint.
     ws_.Close();
-    ws_.Open(TEST_DIR);
+    ws_.Open(test_dir_.string());
 
     auto ckp = make_checkpoint(ws_);
     csr.Open(*ckp, ModuleDescriptor(), memory_level);
@@ -143,15 +169,15 @@ class MutableCsrTest : public ::testing::Test {
 
   std::shared_ptr<Checkpoint> load_single_csr_data(
       SingleMutableCsr<EDATA_T>& csr, MemoryLevel memory_level) {
-    if (std::filesystem::exists(TEST_DIR)) {
-      std::filesystem::remove_all(TEST_DIR);
+    if (std::filesystem::exists(test_dir_)) {
+      std::filesystem::remove_all(test_dir_);
     }
-    std::filesystem::create_directories(TEST_DIR);
+    std::filesystem::create_directories(test_dir_);
     // The previous helper invocation left checkpoints in ws_; the directory
     // wipe above made them stale, so re-sync the workspace with disk before
     // creating a new checkpoint.
     ws_.Close();
-    ws_.Open(TEST_DIR);
+    ws_.Open(test_dir_.string());
 
     auto ckp = make_checkpoint(ws_);
     csr.Open(*ckp, ModuleDescriptor(), memory_level);
@@ -345,6 +371,7 @@ class MutableCsrTest : public ::testing::Test {
 
   std::vector<std::unique_ptr<neug::Allocator>> allocators;
   CheckpointManager& workspace() { return ws_; }
+  std::filesystem::path test_dir_;
   CheckpointManager ws_;
 };
 TYPED_TEST_SUITE(MutableCsrTest, Datatypes);
@@ -699,23 +726,20 @@ TYPED_TEST(MutableCsrTest, TestDeleteEdge) {
 class MutableCsrDumpDirtyTest : public ::testing::Test {
  protected:
   using CsrT = MutableCsr<int64_t>;
-  static constexpr const char* TEST_DIR = "/tmp/mutable_csr_dump_dirty_test";
   static constexpr vid_t VNUM = 5;
   const std::vector<vid_t> src_ = {0, 0, 1, 2, 4};
   const std::vector<vid_t> dst_ = {3, 4, 2, 1, 0};
   const std::vector<int64_t> data_ = {10, 20, 30, 40, 50};
 
   void SetUp() override {
-    if (std::filesystem::exists(TEST_DIR))
-      std::filesystem::remove_all(TEST_DIR);
-    std::filesystem::create_directories(TEST_DIR);
-    ws_.Open(TEST_DIR);
+    test_dir_ = make_unique_test_dir("mutable_csr_dump_dirty_test");
+    ws_.Open(test_dir_.string());
     alloc_ = std::make_unique<Allocator>(MemoryLevel::kInMemory, "");
   }
   void TearDown() override {
     ws_.Close();
-    if (std::filesystem::exists(TEST_DIR))
-      std::filesystem::remove_all(TEST_DIR);
+    if (std::filesystem::exists(test_dir_))
+      std::filesystem::remove_all(test_dir_);
   }
 
   std::shared_ptr<Checkpoint> prepare(CsrT& csr, ModuleDescriptor& desc) {
@@ -729,9 +753,15 @@ class MutableCsrDumpDirtyTest : public ::testing::Test {
     return ckp;
   }
 
+  // Returns the inode number of the file at `path`.
+  // Throws std::runtime_error on stat() failure so that any follow-on
+  // inode comparisons are never made against an uninitialized value.
   static ino_t inode_of(const std::string& path) {
-    struct stat st {};
-    EXPECT_EQ(stat(path.c_str(), &st), 0) << "stat: " << path;
+    struct stat st{};
+    if (stat(path.c_str(), &st) != 0) {
+      throw std::runtime_error("stat() failed for path: " + path + " — " +
+                               std::strerror(errno));
+    }
     return st.st_ino;
   }
   std::string nbr_path(const ModuleDescriptor& d) {
@@ -748,6 +778,7 @@ class MutableCsrDumpDirtyTest : public ::testing::Test {
     EXPECT_NE(orig_inode, new_inode) << label << " should mark dirty";
   }
 
+  std::filesystem::path test_dir_;
   CheckpointManager ws_;
   std::unique_ptr<Allocator> alloc_;
 };

--- a/tests/storage/test_mutable_csr.cc
+++ b/tests/storage/test_mutable_csr.cc
@@ -693,10 +693,8 @@ TYPED_TEST(MutableCsrTest, TestDeleteEdge) {
   empty_csr.revert_delete_edge(0, 0, 0, 0);
 }
 // ---------------------------------------------------------------------------
-// DumpDirty: validates nbr_data_dirty_ fast-path in MutableCsr::Dump.
-// After Open, nbr_list_ is file-backed+clean; when nbr_data_dirty_==false,
-// Dump calls ckp.Commit(*nbr_list_) → hardlink (zero-copy) instead of
-// manual serialisation + MD5.
+// DumpDirty: Validate fast vs. slow path of Dump() and that mutations mark the
+// CSR dirty as expected.
 // ---------------------------------------------------------------------------
 class MutableCsrDumpDirtyTest : public ::testing::Test {
  protected:
@@ -792,7 +790,7 @@ TEST_F(MutableCsrDumpDirtyTest, DirtyResetAcrossCheckpointCycles) {
   c2.reset_timestamp();
   auto d3 = c2.Dump(*ckp);
   auto p3 = nbr_path(d3);
-  EXPECT_NE(inode_of(p2), inode_of(p3));
+  EXPECT_EQ(inode_of(p2), inode_of(p3));
 
   CsrT c3;
   c3.Open(*ckp, d3, MemoryLevel::kInMemory);
@@ -802,9 +800,12 @@ TEST_F(MutableCsrDumpDirtyTest, DirtyResetAcrossCheckpointCycles) {
 
 TEST_F(MutableCsrDumpDirtyTest, VariousMutationsSetDirty) {
   expect_slow_after("delete_edge", [](CsrT& c) { c.delete_edge(0, 0, 1); });
-  expect_slow_after("reset_timestamp", [](CsrT& c) { c.reset_timestamp(); });
-  expect_slow_after("compact", [](CsrT& c) { c.compact(); });
-  expect_slow_after("batch_sort", [](CsrT& c) { c.batch_sort_by_edge_data(10); });
+  expect_slow_after("batch_put_edges",
+                    [](CsrT& c) { c.batch_put_edges({0}, {1}, {123}); });
+  expect_slow_after(
+      "put_edge", [this](CsrT& c) { c.put_edge(0, 1, 123, 1, *this->alloc_); });
+  expect_slow_after("batch_delete_edges",
+                    [](CsrT& c) { c.batch_delete_edges({0}, {3}); });
 }
 
 }  // namespace test


### PR DESCRIPTION
Fix #535 