### PR TITLE
fix: use dynamic cpu count instead of hardcoded max_thread_num=4

### DIFF
--- a/tools/nodejs_bind/tests/test_db_connection.js
+++ b/tools/nodejs_bind/tests/test_db_connection.js
@@ -80,7 +80,7 @@ test('test_open_after_close', () => {
 
 test('test_local_connection_params', () => {
   const dbDir = makeTmpDir('local_conn_param_db');
-  const db = new Database({ databasePath: dbDir, mode: 'w', maxThreadNum: 4 });
+  const db = new Database({ databasePath: dbDir, mode: 'w', maxThreadNum: Database.cpuCount() });
   const conn = db.connect();
   assert.ok(conn);
   conn.close();

--- a/tools/python_bind/tests/test_db_connection.py
+++ b/tools/python_bind/tests/test_db_connection.py
@@ -63,7 +63,7 @@ def test_open_after_close(tmp_path):
 def test_local_connection_params(tmp_path):
     shutil.rmtree("/tmp/local_conn_param_db", ignore_errors=True)
     db_dir = tmp_path / "local_conn_param_db"
-    db = Database(db_path=str(db_dir), mode="w", max_thread_num=4)
+    db = Database(db_path=str(db_dir), mode="w", max_thread_num=os.cpu_count())
     conn = db.connect()
     assert conn is not None
     conn.close()


### PR DESCRIPTION
## Summary

Replace hardcoded `maxThreadNum`/`max_thread_num=4` with dynamic CPU count to avoid failures on CI runners with limited vCPUs.

## Problem

The Node.js test on `macos-15` runner fails because GitHub's macOS 15 runner only provides 3 vCPUs, but the test hardcodes `maxThreadNum: 4`:

```
Error: Invalid argument: maxThreadNum: 4. Must be less than or equal to CPU cores: 3.
```

## Fix

- Node.js: `maxThreadNum: 4` → `maxThreadNum: Database.cpuCount()`
- Python: `max_thread_num=4` → `max_thread_num=os.cpu_count()`

Fix #544