### PR TITLE
refactor: Throw exception rather than LOG(FATAL) when encounter IO error

### DIFF
--- a/src/transaction/wal/local_wal_parser.cc
+++ b/src/transaction/wal/local_wal_parser.cc
@@ -19,6 +19,8 @@
 #include <sys/mman.h>
 #include <unistd.h>
 #include <algorithm>
+#include <cerrno>
+#include <cstring>
 #include <filesystem>
 #include <ostream>
 
@@ -50,14 +52,16 @@ void LocalWalParser::open(const std::string& wal_uri) {
     int fd = ::open(path.c_str(), O_RDONLY);
     if (fd == -1) {
       close();
-      THROW_IO_EXCEPTION("Failed to open wal file: " + path);
+      THROW_IO_EXCEPTION("Failed to open wal file: " + path + ": " +
+                         strerror(errno));
     }
     void* mmapped_buffer =
         ::mmap(NULL, file_size, PROT_READ, MAP_PRIVATE, fd, 0);
     if (mmapped_buffer == MAP_FAILED) {
       ::close(fd);
       close();
-      THROW_IO_EXCEPTION("Failed to mmap wal file: " + path);
+      THROW_IO_EXCEPTION("Failed to mmap wal file: " + path + ": " +
+                         strerror(errno));
     }
 
     fds_.push_back(fd);

--- a/src/transaction/wal/local_wal_parser.cc
+++ b/src/transaction/wal/local_wal_parser.cc
@@ -16,7 +16,6 @@
 #include "neug/transaction/wal/local_wal_parser.h"
 
 #include <fcntl.h>
-#include <glog/logging.h>
 #include <sys/mman.h>
 #include <unistd.h>
 #include <algorithm>
@@ -24,6 +23,7 @@
 #include <ostream>
 
 #include "neug/transaction/wal/wal.h"
+#include "neug/utils/exception/exception.h"
 
 namespace neug {
 
@@ -32,6 +32,7 @@ LocalWalParser::LocalWalParser(const std::string& wal_uri) {
 }
 
 void LocalWalParser::open(const std::string& wal_uri) {
+  close();
   auto wal_dir = get_wal_uri_path(wal_uri);
   if (!std::filesystem::exists(wal_dir)) {
     std::filesystem::create_directory(wal_dir);
@@ -47,9 +48,16 @@ void LocalWalParser::open(const std::string& wal_uri) {
       continue;
     }
     int fd = ::open(path.c_str(), O_RDONLY);
-    void* mmapped_buffer = mmap(NULL, file_size, PROT_READ, MAP_PRIVATE, fd, 0);
+    if (fd == -1) {
+      close();
+      THROW_IO_EXCEPTION("Failed to open wal file: " + path);
+    }
+    void* mmapped_buffer =
+        ::mmap(NULL, file_size, PROT_READ, MAP_PRIVATE, fd, 0);
     if (mmapped_buffer == MAP_FAILED) {
-      LOG(FATAL) << "mmap failed...";
+      ::close(fd);
+      close();
+      THROW_IO_EXCEPTION("Failed to mmap wal file: " + path);
     }
 
     fds_.push_back(fd);
@@ -103,6 +111,11 @@ void LocalWalParser::close() {
   for (auto fd : fds_) {
     ::close(fd);
   }
+  fds_.clear();
+  mmapped_ptrs_.clear();
+  mmapped_size_.clear();
+  update_wal_list_.clear();
+  last_ts_ = 0;
 }
 
 uint32_t LocalWalParser::last_ts() const { return last_ts_; }

--- a/tests/transaction/test_insert_transaction.cc
+++ b/tests/transaction/test_insert_transaction.cc
@@ -20,6 +20,16 @@
 #include "neug/storages/csr/csr_view_utils.h"
 #include "neug/storages/graph/graph_interface.h"
 #include "neug/transaction/insert_transaction.h"
+#include "neug/transaction/wal/local_wal_parser.h"
+#include "neug/transaction/wal/wal.h"
+#include "neug/utils/exception/exception.h"
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <filesystem>
+#include <string>
+#include <vector>
 
 #include "glog/logging.h"
 #include "gtest/gtest.h"
@@ -204,4 +214,131 @@ TEST_F(InsertTransactionTest, TestUnsupportedInterface) {
     EXPECT_EQ(interface.BatchAddEdges(0, 0, 0, nullptr).error_code(),
               neug::StatusCode::ERR_NOT_SUPPORTED);
   }
+}
+
+class LocalWalParserTest : public ::testing::Test {
+ protected:
+  std::string wal_dir_;
+
+  void SetUp() override {
+    auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+    auto dir_name = std::string("neug_wal_parser_test_") +
+                    std::to_string(::getpid()) + "_" + info->test_suite_name() +
+                    "_" + info->name();
+    wal_dir_ = (std::filesystem::temp_directory_path() / dir_name).string();
+    if (std::filesystem::exists(wal_dir_)) {
+      std::filesystem::remove_all(wal_dir_);
+    }
+    std::filesystem::create_directories(wal_dir_);
+  }
+
+  void TearDown() override {
+    if (std::filesystem::exists(wal_dir_)) {
+      std::filesystem::remove_all(wal_dir_);
+    }
+  }
+
+  // Write a single WAL entry (header + payload) into a buffer.
+  void AppendWalEntry(std::vector<char>& buf, uint32_t ts, uint8_t type,
+                      const std::string& payload) {
+    neug::WalHeader header;
+    header.timestamp = ts;
+    header.type = type;
+    header.length = static_cast<int32_t>(payload.size());
+    const char* hdr = reinterpret_cast<const char*>(&header);
+    buf.insert(buf.end(), hdr, hdr + sizeof(neug::WalHeader));
+    buf.insert(buf.end(), payload.begin(), payload.end());
+  }
+
+  // Append a terminator entry (timestamp=0) to mark end of WAL stream.
+  void AppendWalTerminator(std::vector<char>& buf) {
+    neug::WalHeader terminator;
+    terminator.timestamp = 0;
+    terminator.type = 0;
+    terminator.length = 0;
+    const char* hdr = reinterpret_cast<const char*>(&terminator);
+    buf.insert(buf.end(), hdr, hdr + sizeof(neug::WalHeader));
+  }
+
+  // Write buffer contents to a .wal file in the WAL directory.
+  void WriteWalFile(const std::string& filename, const std::vector<char>& buf) {
+    auto path = wal_dir_ + "/" + filename;
+    int fd = ::open(path.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0644);
+    ASSERT_NE(fd, -1);
+    ASSERT_EQ(static_cast<size_t>(write(fd, buf.data(), buf.size())),
+              buf.size());
+    ::close(fd);
+  }
+};
+
+// Test: LocalWalParser can correctly parse a valid WAL file.
+TEST_F(LocalWalParserTest, OpenAndParseValidWalFile) {
+  std::vector<char> buf;
+  std::string payload = "insert_vertex_data";
+  AppendWalEntry(buf, /*ts=*/1, /*type=*/0, payload);  // insert WAL
+  AppendWalTerminator(buf);
+  WriteWalFile("thread_0_0.wal", buf);
+
+  neug::LocalWalParser parser(wal_dir_);
+  EXPECT_EQ(parser.last_ts(), 1);
+  const auto& unit = parser.get_insert_wal(1);
+  EXPECT_EQ(unit.size, payload.size());
+  // The ptr should point to the payload data within the mmap region.
+  EXPECT_NE(unit.ptr, nullptr);
+  EXPECT_EQ(std::string(unit.ptr, unit.size), payload);
+}
+
+// Test: LocalWalParser throws IOException when ::open() on a WAL file fails
+// (e.g. permission denied). This covers the fd == -1 check.
+TEST_F(LocalWalParserTest, OpenUnreadableWalFileThrowsIOException) {
+  auto file_path = wal_dir_ + "/unreadable.wal";
+  int fd = ::open(file_path.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0644);
+  ASSERT_NE(fd, -1);
+  const char data[] = "some wal data";
+  ASSERT_EQ(static_cast<size_t>(write(fd, data, sizeof(data))), sizeof(data));
+  ::close(fd);
+
+  ASSERT_EQ(chmod(file_path.c_str(), 0000), 0);
+
+  try {
+    neug::LocalWalParser parser(wal_dir_);
+    FAIL() << "Expected IOException but none was thrown";
+  } catch (const neug::exception::IOException& e) {
+    EXPECT_NE(std::string(e.what()).find("Failed to open wal file"),
+              std::string::npos);
+  }
+
+  chmod(file_path.c_str(), 0644);
+}
+
+// Test: LocalWalParser throws IOException when mmap() fails.
+TEST_F(LocalWalParserTest, MmapFailureThrowsIOException) {
+  auto file_path = wal_dir_ + "/huge.wal";
+  int fd = ::open(file_path.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0644);
+  ASSERT_NE(fd, -1);
+
+  off_t huge_size =
+      static_cast<off_t>(128ULL * 1024ULL * 1024ULL * 1024ULL * 1024ULL);
+  ASSERT_EQ(ftruncate(fd, huge_size), 0);
+  ::close(fd);
+
+  try {
+    neug::LocalWalParser parser(wal_dir_);
+    FAIL() << "Expected IOException but none was thrown";
+  } catch (const neug::exception::IOException& e) {
+    EXPECT_NE(std::string(e.what()).find("Failed to mmap wal file"),
+              std::string::npos);
+  }
+
+  fd = ::open(file_path.c_str(), O_RDWR);
+  if (fd != -1) {
+    ftruncate(fd, 0);
+    ::close(fd);
+  }
+}
+
+// Test: Opening an empty WAL directory does not throw and last_ts is 0.
+TEST_F(LocalWalParserTest, OpenEmptyWalDirNoThrow) {
+  neug::LocalWalParser parser(wal_dir_);
+  EXPECT_EQ(parser.last_ts(), 0);
 }

--- a/tests/transaction/test_insert_transaction.cc
+++ b/tests/transaction/test_insert_transaction.cc
@@ -25,8 +25,10 @@
 #include "neug/utils/exception/exception.h"
 
 #include <fcntl.h>
+#include <sys/resource.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <cstring>
 #include <filesystem>
 #include <string>
 #include <vector>
@@ -265,8 +267,9 @@ class LocalWalParserTest : public ::testing::Test {
     auto path = wal_dir_ + "/" + filename;
     int fd = ::open(path.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0644);
     ASSERT_NE(fd, -1);
-    ASSERT_EQ(static_cast<size_t>(write(fd, buf.data(), buf.size())),
-              buf.size());
+    auto bytes_written = ::write(fd, buf.data(), buf.size());
+    ASSERT_NE(bytes_written, -1);
+    ASSERT_EQ(static_cast<size_t>(bytes_written), buf.size());
     ::close(fd);
   }
 };
@@ -290,15 +293,33 @@ TEST_F(LocalWalParserTest, OpenAndParseValidWalFile) {
 
 // Test: LocalWalParser throws IOException when ::open() on a WAL file fails
 // (e.g. permission denied). This covers the fd == -1 check.
+// Note: running as root or on permission-ignoring filesystems bypasses
+// chmod(0000), so we pre-flight the open() and skip when it still succeeds.
 TEST_F(LocalWalParserTest, OpenUnreadableWalFileThrowsIOException) {
+  // Root (euid 0) bypasses file-permission checks; skip early.
+  if (::geteuid() == 0) {
+    GTEST_SKIP() << "Running as root; chmod(0000) does not block open()";
+  }
+
   auto file_path = wal_dir_ + "/unreadable.wal";
   int fd = ::open(file_path.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0644);
   ASSERT_NE(fd, -1);
   const char data[] = "some wal data";
-  ASSERT_EQ(static_cast<size_t>(write(fd, data, sizeof(data))), sizeof(data));
+  auto bytes_written = ::write(fd, data, sizeof(data));
+  ASSERT_NE(bytes_written, -1);
+  ASSERT_EQ(static_cast<size_t>(bytes_written), sizeof(data));
   ::close(fd);
 
   ASSERT_EQ(chmod(file_path.c_str(), 0000), 0);
+
+  // Pre-flight: verify the OS actually denies O_RDONLY access.
+  // Some CI filesystems or capability sets may still allow the open.
+  int probe_fd = ::open(file_path.c_str(), O_RDONLY);
+  if (probe_fd != -1) {
+    ::close(probe_fd);
+    chmod(file_path.c_str(), 0644);
+    GTEST_SKIP() << "chmod(0000) did not block open() on this platform";
+  }
 
   try {
     neug::LocalWalParser parser(wal_dir_);
@@ -312,29 +333,48 @@ TEST_F(LocalWalParserTest, OpenUnreadableWalFileThrowsIOException) {
 }
 
 // Test: LocalWalParser throws IOException when mmap() fails.
+// Uses RLIMIT_AS to deterministically exhaust the virtual-address space
+// so mmap() reliably returns MAP_FAILED, avoiding the flakiness of the
+// sparse-file approach (many kernels accept such mappings via overcommit
+// and only fault on first access).
 TEST_F(LocalWalParserTest, MmapFailureThrowsIOException) {
-  auto file_path = wal_dir_ + "/huge.wal";
-  int fd = ::open(file_path.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0644);
-  ASSERT_NE(fd, -1);
-
-  off_t huge_size =
-      static_cast<off_t>(128ULL * 1024ULL * 1024ULL * 1024ULL * 1024ULL);
-  ASSERT_EQ(ftruncate(fd, huge_size), 0);
-  ::close(fd);
-
-  try {
-    neug::LocalWalParser parser(wal_dir_);
-    FAIL() << "Expected IOException but none was thrown";
-  } catch (const neug::exception::IOException& e) {
-    EXPECT_NE(std::string(e.what()).find("Failed to mmap wal file"),
-              std::string::npos);
-  }
-
-  fd = ::open(file_path.c_str(), O_RDWR);
-  if (fd != -1) {
-    ftruncate(fd, 0);
+  // Create a small but non-empty WAL file so mmap() is genuinely attempted.
+  auto file_path = wal_dir_ + "/mmap_fail_test.wal";
+  {
+    int fd = ::open(file_path.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0644);
+    ASSERT_NE(fd, -1);
+    const char data[] = "placeholder wal content";
+    auto bytes_written = ::write(fd, data, sizeof(data));
+    ASSERT_NE(bytes_written, -1);
+    ASSERT_EQ(static_cast<size_t>(bytes_written), sizeof(data));
     ::close(fd);
   }
+
+  // Clamp the virtual-address-space limit to 1 byte so any subsequent
+  // mmap() call is guaranteed to fail with ENOMEM / MAP_FAILED.
+  struct rlimit old_rlimit;
+  ASSERT_EQ(::getrlimit(RLIMIT_AS, &old_rlimit), 0);
+  const struct rlimit tight_rlimit = {1, old_rlimit.rlim_max};
+  if (::setrlimit(RLIMIT_AS, &tight_rlimit) != 0) {
+    GTEST_SKIP() << "Cannot lower RLIMIT_AS on this platform; skipping test";
+  }
+
+  bool threw = false;
+  bool msg_ok = false;
+  try {
+    neug::LocalWalParser parser(wal_dir_);
+  } catch (const neug::exception::IOException& e) {
+    threw = true;
+    // Use strstr (no heap allocation) while RLIMIT_AS is still clamped.
+    msg_ok = (std::strstr(e.what(), "Failed to mmap wal file") != nullptr);
+  }
+
+  // Restore RLIMIT_AS before any GTEST assertions that may heap-allocate.
+  ::setrlimit(RLIMIT_AS, &old_rlimit);
+
+  EXPECT_TRUE(threw) << "Expected IOException but none was thrown";
+  EXPECT_TRUE(msg_ok)
+      << "Exception message did not contain 'Failed to mmap wal file'";
 }
 
 // Test: Opening an empty WAL directory does not throw and last_ts is 0.


### PR DESCRIPTION
Fix #514 