### PR TITLE
fix: restore -DOPTIMIZE_FOR_HOST=OFF in dev-full target

### DIFF
--- a/tools/python_bind/Makefile
+++ b/tools/python_bind/Makefile
@@ -50,6 +50,7 @@ dev:  ## Fast incremental rebuild via cmake (no env-var forwarding)
 dev-full:  ## Configure root build + build neug_py_bind from scratch
 	cmake -S $(REPO_ROOT) -B $(ROOT_BUILD) -DBUILD_PYTHON=ON \
 	    -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
+	    -DOPTIMIZE_FOR_HOST=OFF \
 	    -DPython_EXECUTABLE=$(PYTHON) -DPYTHON_EXECUTABLE=$(PYTHON) \
 	    $(EXTRA_CMAKE_FLAGS)
 	cmake --build $(ROOT_BUILD) --target neug_py_bind -j$(JOBS)


### PR DESCRIPTION
## Related Issues
fix #593

## What does this PR do?

This PR fixes the `build-image.yml` CI failure that started on 2026-06-05 by restoring the `-DOPTIMIZE_FOR_HOST=OFF` flag in the `dev-full` target of `tools/python_bind/Makefile`.

## What changes in this PR?

- Added `-DOPTIMIZE_FOR_HOST=OFF` to the `dev-full` target in `tools/python_bind/Makefile`.

### Root Cause

PR #468 (`24bc4da`) refactored the build system, changing `make python-dev` from going through `setup.py build_ext` to calling cmake directly via the `dev-full` target. The old `setup.py` explicitly passed `-DOPTIMIZE_FOR_HOST=OFF`, but `dev-full` did not, causing `OPTIMIZE_FOR_HOST` to default to `ON` in `CMakeLists.txt`.

With `OPTIMIZE_FOR_HOST=ON`, `-march=native` is added to `CMAKE_CXX_FLAGS`. This flag propagates to Arrow's bundled snappy ExternalProject sub-build, where snappy's CMake detects SSE4.2 support and enables the SSE4.2 code path. However, `-march=native` does not correctly propagate to `snappy.cc`'s actual compilation command (ExternalProject flag passing issue), causing `_mm_crc32_u32` to be used without the SSE4.2 compiler flag, resulting in a `target specific option mismatch` error.

### Why normal PR CI (`neug-test.yml`) is unaffected

`neug-test.yml` sets `export CI=ON`, which triggers `NEUG_USE_SYSTEM_ARROW=ON` in `CMakeLists.txt`, using the pre-installed system Arrow and skipping the snappy rebuild entirely.

### Verification

The `setup.py` path (`build` target) already had `-DOPTIMIZE_FOR_HOST=OFF` at line 189. After this fix, both build paths (`dev-full` and `build`) consistently pass `-DOPTIMIZE_FOR_HOST=OFF`.
