### PR TITLE
docs: document that data I/O operations are embedded-mode only

### DIFF
--- a/doc/source/data_io/index.md
+++ b/doc/source/data_io/index.md
@@ -28,16 +28,9 @@ External Files (CSV, JSON, Parquet, ...)
 
 ## Embedded Mode Only
 
-> **Important:** `LOAD FROM`, `COPY FROM`, and `COPY TO` are supported **only in embedded mode**. They are not available when NeuG is running as a service (HTTP/TP mode).
+> **Important:** `LOAD FROM`, `COPY FROM`, and `COPY TO` are supported **only in embedded mode**. They are not available when NeuG is running as a service (HTTP/TP mode). This is a current limitation; support for bulk loading in service mode is planned for a future release.
 
-NeuG operates in two modes — [embedded mode](../overview/introduction) for analytics and ETL, and service mode for high-throughput transactional processing (OLTP). Bulk file I/O operations (`LOAD FROM`, `COPY FROM`, `COPY TO`) involve reading or writing large files, which are long-running, I/O-intensive operations that would block the transaction processing pipeline. For this reason, they are restricted to embedded mode.
-
-**To load data before starting a service:**
-
-1. **Embedded mode + serve:** Open the database in embedded mode, load data with `COPY FROM`, then call `db.serve()` to start the HTTP service on the pre-populated database.
-2. **Standalone bulk loader:** Use the `bulk_loader` command-line tool to create a pre-populated database directory, then open it with `db.serve()`.
-
-Once the service is running, you can still insert individual records via `CREATE` statements, modify data with `MERGE`/`SET`/`DELETE`, and manage schema with `CREATE/DROP/ALTER TABLE` — but bulk file import/export is not available. This is a current limitation; support for bulk loading in service mode is planned for a future release.
+Bulk file I/O operations (`LOAD FROM`, `COPY FROM`, `COPY TO`) involve reading or writing large files, which are long-running, I/O-intensive operations that would block the transaction processing pipeline. For this reason, they are restricted to embedded mode.  Once the service is running, you can still insert individual records via `CREATE` statements, modify data with `MERGE`/`SET`/`DELETE`, and manage schema with `CREATE/DROP/ALTER TABLE`.
 
 ## Supported Formats
 

--- a/doc/source/data_io/index.md
+++ b/doc/source/data_io/index.md
@@ -26,6 +26,19 @@ External Files (CSV, JSON, Parquet, ...)
 
 **`COPY TO`** works in the opposite direction — it exports query results to external file formats.
 
+## Embedded Mode Only
+
+> **Important:** `LOAD FROM`, `COPY FROM`, and `COPY TO` are supported **only in embedded mode**. They are not available when NeuG is running as a service (HTTP/TP mode).
+
+NeuG operates in two modes — [embedded mode](../overview/introduction) for analytics and ETL, and service mode for high-throughput transactional processing (OLTP). Bulk file I/O operations (`LOAD FROM`, `COPY FROM`, `COPY TO`) involve reading or writing large files, which are long-running, I/O-intensive operations that would block the transaction processing pipeline. For this reason, they are restricted to embedded mode.
+
+**To load data before starting a service:**
+
+1. **Embedded mode + serve:** Open the database in embedded mode, load data with `COPY FROM`, then call `db.serve()` to start the HTTP service on the pre-populated database.
+2. **Standalone bulk loader:** Use the `bulk_loader` command-line tool to create a pre-populated database directory, then open it with `db.serve()`.
+
+Once the service is running, you can still insert individual records via `CREATE` statements, modify data with `MERGE`/`SET`/`DELETE`, and manage schema with `CREATE/DROP/ALTER TABLE` — but bulk file import/export is not available. This is a current limitation; support for bulk loading in service mode is planned for a future release.
+
 ## Supported Formats
 
 | Format | Supported | Availability |

--- a/doc/source/tutorials/data-pipeline.md
+++ b/doc/source/tutorials/data-pipeline.md
@@ -74,6 +74,8 @@ result = conn.execute('''
 
 ## Step 3: Import Nodes — One Line, No DDL
 
+> **Note:** `COPY FROM` is only supported in [embedded mode](../data_io/index.md#embedded-mode-only), not in service mode.
+
 Traditionally, importing data into a graph database requires you to first define the schema (column names, types, primary key) with a `CREATE NODE TABLE` statement. In NeuG v0.1.2, you can skip all of that:
 
 ```python


### PR DESCRIPTION
## Summary

- Document that `LOAD FROM`, `COPY FROM`, and `COPY TO` are only supported in embedded mode, not in service mode (HTTP/TP mode)
- Add "Embedded Mode Only" section to `data_io/index.md` explaining the rationale: bulk file I/O would block the transaction processing pipeline
- Add notes at the first `COPY FROM`, `LOAD FROM`, and `COPY TO` examples pointing to the embedded-mode-only section
- Describe two workflows for loading data before starting a service (embedded mode + `db.serve()`, or standalone `bulk_loader` tool)

Closes #596.

## Test plan

- [ ] Verify docs render correctly on the documentation site
- [ ] Verify internal links point to the correct sections