### PR TITLE
docs: update UpdateTransaction concurrency model

### DIFF
--- a/doc/source/transaction/transaction.md
+++ b/doc/source/transaction/transaction.md
@@ -115,20 +115,22 @@ Schema constraints and referential integrity are enforced. All concurrent operat
 
 #### Isolation
 
-NeuG uses **Multi-Version Concurrency Control (MVCC)** to provide serializable isolation, with operation-specific concurrency rules:
+NeuG uses **Multi-Version Concurrency Control (MVCC)** plus copy-on-write (COW) snapshots to provide serializable isolation, with operation-specific concurrency rules:
 
 | Operation Type | Concurrency Behavior |
 |----------------|---------------------|
-| Read | Concurrent with all reads and inserts |
-| Insert | Concurrent with reads and other inserts |
-| Update | Acquires global write lock, blocks all operations |
-| Schema (DDL) | Acquires global write lock, blocks all operations |
-| Checkpoint | Acquires global write lock, blocks all operations |
+| Read | Concurrent with reads, inserts, and the update execution phase. New reads wait only during the update commit publish window or compaction. Already-acquired reads continue on their pinned snapshot. |
+| Insert | Concurrent with reads and other inserts while no update or compaction is active. Blocked during update execution, update commit, and compaction. |
+| Update | Serialized: only one update can be open. The execution phase waits for in-flight inserts, blocks new inserts/updates, and mutates a COW snapshot while reads continue. The commit phase briefly blocks new reads/inserts while publishing the COW snapshot; existing reads continue. |
+| Schema (DDL) | Uses the same two-phase `UpdateTransaction` path as update operations. |
+| Checkpoint | Uses the `UpdateTransaction` path in TP service: reads continue during checkpoint execution, while new reads/inserts wait during the commit publish window. |
+| Compaction | Requires a quiescent point: waits for active readers/inserters and blocks new reads, inserts, and updates until compaction completes. |
 
 **Design Rationale:** This hybrid approach reflects the reality of graph workloads:
 
 - **Reads and inserts** are the dominant operations in most graph applications (social networks, knowledge graphs, recommendation systems)
-- **Updates and schema changes** are relatively rare and can tolerate exclusive locking
+- **Updates and schema changes** are relatively rare and are serialized with other writes, but COW snapshots let long-running reads continue without blocking update execution or commit
+- The short **update commit** window gates new reads and inserts so timestamp visibility and the published snapshot advance in the same order
 - Full MVCC for all write types would add significant complexity with minimal benefit for typical graph workloads
 
 ```python
@@ -142,7 +144,8 @@ session2 = Session("http://localhost:10000/")
 session1.execute("MATCH (p:Person) RETURN count(p)", access_mode="read")
 session2.execute("CREATE (p:Person {name: 'Bob'})", access_mode="insert")
 
-# This will block other operations (update takes global lock)
+# This is serialized with inserts and other updates. Existing reads continue
+# on their pinned snapshots; new reads may wait briefly during commit.
 session1.execute("MATCH (p:Person) SET p.updated = true", access_mode="update")
 ```
 
@@ -170,7 +173,7 @@ When executing queries, you can specify an `access_mode` to control transaction 
 **Access Mode Hierarchy:** Access modes follow a hierarchy where higher modes provide stronger guarantees but lower concurrency:
 
 ```
-read < insert < update ≈ schema
+read < insert < update ~= schema
 ```
 
 - **Upward compatibility**: Using a higher access mode than required always works (e.g., `update` mode for a read-only query), but may reduce throughput due to stronger locking
@@ -182,15 +185,15 @@ read < insert < update ≈ schema
 | `read` | insert/update | ❌ Error |
 | `insert` | read/insert | ✅ OK |
 | `insert` | update/schema | ❌ Error |
-| `update`/`schema` | any | ✅ OK (global lock) |
+| `update`/`schema` | any | ✅ OK (serialized update path) |
 
 ```python
 # Optimal: match access mode to operation for best concurrency
 conn.execute("MATCH (n) RETURN n", access_mode="read")        # read lock only
 conn.execute("CREATE (p:Person {name: 'Alice'})", access_mode="insert")  # insert lock
 
-# Works but suboptimal: update mode for read query (takes global lock)
-conn.execute("MATCH (n) RETURN n", access_mode="update")      # works, but blocks other operations
+# Works but suboptimal: update mode for read query enters the update path
+conn.execute("MATCH (n) RETURN n", access_mode="update")      # works, but reduces write concurrency
 ```
 
 ## Data Persistence
@@ -245,10 +248,14 @@ session.close()
 ```
 
 **Service Mode Checkpoint:**
-- Temporarily blocks all operations
+- Uses the same two-phase `UpdateTransaction` path as update operations
+- Blocks new inserts and other updates while the checkpoint transaction is open
+- Lets reads continue during checkpoint execution; already-acquired reads continue through commit
+- Briefly blocks new reads and inserts during the commit publish window
 - Consolidates WAL entries into a unified checkpoint
 - Clears processed WAL entries to reclaim storage
 - Does not affect the automatic durability of individual statements
+- Background compaction, when enabled, is stricter: it waits for active readers and inserters to finish, then blocks new transactions while compacting
 
 ## Error Recovery
 
@@ -331,7 +338,8 @@ try:
     # Reads don't block inserts
     result = session.execute("MATCH (p:Person) RETURN count(p)", access_mode="read")
     
-    # Updates take global lock - use sparingly in high-concurrency scenarios
+    # Updates are serialized with inserts and other updates. Reads continue
+    # on snapshots, but keep update transactions short in high-concurrency scenarios.
     session.execute("MATCH (p:Person) WHERE p.name = 'Alice' SET p.verified = true", 
                    access_mode="update")
     
@@ -348,11 +356,11 @@ finally:
 |----------|-------------------|-------------------|
 | **Atomicity** | Partial (checkpoint-based recovery) | Full (automatic rollback) |
 | **Consistency** | Schema constraints enforced | Schema constraints enforced |
-| **Isolation** | Exclusive write locks | MVCC for read/insert, exclusive lock for update/DDL |
+| **Isolation** | Exclusive write locks | MVCC for read/insert, COW two-phase update/DDL, exclusive compaction |
 | **Durability** | Explicit CHECKPOINT or close | Automatic WAL persistence |
 | **Concurrent Reads** | Yes | Yes |
-| **Concurrent Inserts** | No | Yes |
-| **Concurrent Updates** | No | No (global lock) |
+| **Concurrent Inserts** | No | Yes, unless an update/compaction is active |
+| **Concurrent Updates** | No | No, updates are serialized while reads continue on snapshots |
 | **Recovery** | Manual (checkpoint reload) | Automatic (WAL replay) |
 
 ## Roadmap
@@ -367,4 +375,3 @@ finally:
 - Delta checkpointing for efficient incremental persistence
 - Reduced checkpoint blocking time for large datasets
 - Automatic checkpoint
-

--- a/doc/source/transaction/transaction.md
+++ b/doc/source/transaction/transaction.md
@@ -115,21 +115,23 @@ Schema constraints and referential integrity are enforced. All concurrent operat
 
 #### Isolation
 
-Service mode provides serializable isolation with operation-specific concurrency rules:
+NeuG uses **Multi-Version Concurrency Control (MVCC)** to provide serializable isolation, with operation-specific concurrency rules:
 
 | Operation Type | Concurrency Behavior |
 |----------------|---------------------|
-| Read | Concurrent with reads, inserts, and updates. Reads observe a consistent snapshot and do not wait for active updates. |
-| Insert | Concurrent with reads and other inserts while no update is active. Inserts wait until the active update finishes. |
-| Update | Only one update at a time. Reads continue on a consistent snapshot. Inserts and other updates wait until the update finishes. |
-| Schema (DDL) | Serialized like updates. Reads continue on a consistent snapshot; inserts and updates wait until the schema change finishes. |
-| Checkpoint | Serialized like updates. Reads continue on a consistent snapshot; inserts and updates wait until the checkpoint finishes. |
+| Read | Reads a consistent snapshot and continues during active inserts/updates. |
+| Insert | Concurrent with reads and other inserts. Waits if an update is in progress. |
+| Update | One at a time. Reads continue on a consistent snapshot. Inserts and other updates wait until the update finishes. |
+| Schema (DDL) | Same concurrency behavior as update. |
+| Checkpoint | Same concurrency behavior as update. |
+
+> Note: A read that arrives while an update is finishing may wait briefly,
+> typically at millisecond scale.
 
 **Design Rationale:** This hybrid approach reflects the reality of graph workloads:
 
 - **Reads and inserts** are the dominant operations in most graph applications (social networks, knowledge graphs, recommendation systems)
-- **Updates, schema changes, and checkpoints** are relatively rare and are serialized with other writes
-- Reads continue to observe a consistent snapshot while updates are running
+- **Updates, schema changes, and checkpoints** are relatively rare and are serialized, while reads continue on a consistent snapshot with only brief waits when they arrive as a write is finishing
 - Full MVCC for all write types would add significant complexity with minimal benefit for typical graph workloads
 
 ```python
@@ -249,9 +251,9 @@ session.close()
 ```
 
 **Service Mode Checkpoint:**
-- Serialized like update operations
-- Blocks new inserts and other updates while the checkpoint is running
-- Lets reads continue on a consistent snapshot
+- Does not block active reads
+- Briefly waits for in-flight inserts before starting
+- New reads and inserts wait briefly during checkpoint finalization
 - Consolidates WAL entries into a unified checkpoint
 - Clears processed WAL entries to reclaim storage
 - Does not affect the automatic durability of individual statements
@@ -355,7 +357,7 @@ finally:
 |----------|-------------------|-------------------|
 | **Atomicity** | Partial (checkpoint-based recovery) | Full (automatic rollback) |
 | **Consistency** | Schema constraints enforced | Schema constraints enforced |
-| **Isolation** | Exclusive write locks | MVCC for reads/inserts, serialized updates/DDL |
+| **Isolation** | Exclusive write locks | MVCC for reads/inserts; serialized updates/DDL/checkpoints |
 | **Durability** | Explicit CHECKPOINT or close | Automatic WAL persistence |
 | **Concurrent Reads** | Yes | Yes |
 | **Concurrent Inserts** | No | Yes, unless an update is active |

--- a/doc/source/transaction/transaction.md
+++ b/doc/source/transaction/transaction.md
@@ -115,21 +115,21 @@ Schema constraints and referential integrity are enforced. All concurrent operat
 
 #### Isolation
 
-NeuG uses **Multi-Version Concurrency Control (MVCC)** plus copy-on-write (COW) snapshots to provide serializable isolation, with operation-specific concurrency rules:
+Service mode provides serializable isolation with operation-specific concurrency rules:
 
 | Operation Type | Concurrency Behavior |
 |----------------|---------------------|
-| Read | Concurrent with reads, inserts, and the update execution phase. New reads wait only during the update commit publish window. Already-acquired reads continue on their pinned snapshot. |
-| Insert | Concurrent with reads and other inserts while no update is active. Blocked during update execution and update commit. |
-| Update | Serialized: only one update can be open. The execution phase waits for in-flight inserts, blocks new inserts/updates, and mutates a COW snapshot while reads continue. The commit phase briefly blocks new reads/inserts while publishing the COW snapshot; existing reads continue. |
-| Schema (DDL) | Uses the same two-phase `UpdateTransaction` path as update operations. |
-| Checkpoint | Uses the `UpdateTransaction` path in TP service: reads continue during checkpoint execution, while new reads/inserts wait during the commit publish window. |
+| Read | Concurrent with reads, inserts, and updates. Reads observe a consistent snapshot and do not wait for active updates. |
+| Insert | Concurrent with reads and other inserts while no update is active. Inserts wait until the active update finishes. |
+| Update | Only one update at a time. Reads continue on a consistent snapshot. Inserts and other updates wait until the update finishes. |
+| Schema (DDL) | Serialized like updates. Reads continue on a consistent snapshot; inserts and updates wait until the schema change finishes. |
+| Checkpoint | Serialized like updates. Reads continue on a consistent snapshot; inserts and updates wait until the checkpoint finishes. |
 
 **Design Rationale:** This hybrid approach reflects the reality of graph workloads:
 
 - **Reads and inserts** are the dominant operations in most graph applications (social networks, knowledge graphs, recommendation systems)
-- **Updates and schema changes** are relatively rare and are serialized with other writes, but COW snapshots let long-running reads continue without blocking update execution or commit
-- The short **update commit** window gates new reads and inserts so timestamp visibility and the published snapshot advance in the same order
+- **Updates, schema changes, and checkpoints** are relatively rare and are serialized with other writes
+- Reads continue to observe a consistent snapshot while updates are running
 - Full MVCC for all write types would add significant complexity with minimal benefit for typical graph workloads
 
 ```python
@@ -143,8 +143,8 @@ session2 = Session("http://localhost:10000/")
 session1.execute("MATCH (p:Person) RETURN count(p)", access_mode="read")
 session2.execute("CREATE (p:Person {name: 'Bob'})", access_mode="insert")
 
-# This is serialized with inserts and other updates. Existing reads continue
-# on their pinned snapshots; new reads may wait briefly during commit.
+# This is serialized with inserts and other updates. Reads continue on a
+# consistent snapshot while the update runs.
 session1.execute("MATCH (p:Person) SET p.updated = true", access_mode="update")
 ```
 
@@ -249,10 +249,9 @@ session.close()
 ```
 
 **Service Mode Checkpoint:**
-- Uses the same two-phase `UpdateTransaction` path as update operations
-- Blocks new inserts and other updates while the checkpoint transaction is open
-- Lets reads continue during checkpoint execution; already-acquired reads continue through commit
-- Briefly blocks new reads and inserts during the commit publish window
+- Serialized like update operations
+- Blocks new inserts and other updates while the checkpoint is running
+- Lets reads continue on a consistent snapshot
 - Consolidates WAL entries into a unified checkpoint
 - Clears processed WAL entries to reclaim storage
 - Does not affect the automatic durability of individual statements
@@ -338,8 +337,8 @@ try:
     # Reads don't block inserts
     result = session.execute("MATCH (p:Person) RETURN count(p)", access_mode="read")
     
-    # Updates are serialized with inserts and other updates. Reads continue
-    # on snapshots, but keep update transactions short in high-concurrency scenarios.
+    # Updates are serialized with inserts and other updates. Reads continue on
+    # consistent snapshots, but keep updates short in high-concurrency scenarios.
     session.execute("MATCH (p:Person) WHERE p.name = 'Alice' SET p.verified = true", 
                    access_mode="update")
     
@@ -356,11 +355,11 @@ finally:
 |----------|-------------------|-------------------|
 | **Atomicity** | Partial (checkpoint-based recovery) | Full (automatic rollback) |
 | **Consistency** | Schema constraints enforced | Schema constraints enforced |
-| **Isolation** | Exclusive write locks | MVCC for read/insert, COW two-phase update/DDL |
+| **Isolation** | Exclusive write locks | MVCC for reads/inserts, serialized updates/DDL |
 | **Durability** | Explicit CHECKPOINT or close | Automatic WAL persistence |
 | **Concurrent Reads** | Yes | Yes |
 | **Concurrent Inserts** | No | Yes, unless an update is active |
-| **Concurrent Updates** | No | No, updates are serialized while reads continue on snapshots |
+| **Concurrent Updates** | No | No, updates are serialized while reads continue on consistent snapshots |
 | **Recovery** | Manual (checkpoint reload) | Automatic (WAL replay) |
 
 ## Roadmap

--- a/doc/source/transaction/transaction.md
+++ b/doc/source/transaction/transaction.md
@@ -172,8 +172,10 @@ When executing queries, you can specify an `access_mode` to control transaction 
 **Access Mode Hierarchy:** Access modes follow a hierarchy where higher modes provide stronger guarantees but lower concurrency:
 
 ```
-read < insert < update ~= schema
+read < insert < update
 ```
+
+`schema` uses the same serialized update path as `update`.
 
 - **Upward compatibility**: Using a higher access mode than required always works (e.g., `update` mode for a read-only query), but may reduce throughput due to stronger locking
 - **Downward restriction**: Using a lower access mode than required causes an error (e.g., `read` mode for an insert operation)

--- a/doc/source/transaction/transaction.md
+++ b/doc/source/transaction/transaction.md
@@ -119,12 +119,11 @@ NeuG uses **Multi-Version Concurrency Control (MVCC)** plus copy-on-write (COW) 
 
 | Operation Type | Concurrency Behavior |
 |----------------|---------------------|
-| Read | Concurrent with reads, inserts, and the update execution phase. New reads wait only during the update commit publish window or compaction. Already-acquired reads continue on their pinned snapshot. |
-| Insert | Concurrent with reads and other inserts while no update or compaction is active. Blocked during update execution, update commit, and compaction. |
+| Read | Concurrent with reads, inserts, and the update execution phase. New reads wait only during the update commit publish window. Already-acquired reads continue on their pinned snapshot. |
+| Insert | Concurrent with reads and other inserts while no update is active. Blocked during update execution and update commit. |
 | Update | Serialized: only one update can be open. The execution phase waits for in-flight inserts, blocks new inserts/updates, and mutates a COW snapshot while reads continue. The commit phase briefly blocks new reads/inserts while publishing the COW snapshot; existing reads continue. |
 | Schema (DDL) | Uses the same two-phase `UpdateTransaction` path as update operations. |
 | Checkpoint | Uses the `UpdateTransaction` path in TP service: reads continue during checkpoint execution, while new reads/inserts wait during the commit publish window. |
-| Compaction | Requires a quiescent point: waits for active readers/inserters and blocks new reads, inserts, and updates until compaction completes. |
 
 **Design Rationale:** This hybrid approach reflects the reality of graph workloads:
 
@@ -255,7 +254,6 @@ session.close()
 - Consolidates WAL entries into a unified checkpoint
 - Clears processed WAL entries to reclaim storage
 - Does not affect the automatic durability of individual statements
-- Background compaction, when enabled, is stricter: it waits for active readers and inserters to finish, then blocks new transactions while compacting
 
 ## Error Recovery
 
@@ -356,10 +354,10 @@ finally:
 |----------|-------------------|-------------------|
 | **Atomicity** | Partial (checkpoint-based recovery) | Full (automatic rollback) |
 | **Consistency** | Schema constraints enforced | Schema constraints enforced |
-| **Isolation** | Exclusive write locks | MVCC for read/insert, COW two-phase update/DDL, exclusive compaction |
+| **Isolation** | Exclusive write locks | MVCC for read/insert, COW two-phase update/DDL |
 | **Durability** | Explicit CHECKPOINT or close | Automatic WAL persistence |
 | **Concurrent Reads** | Yes | Yes |
-| **Concurrent Inserts** | No | Yes, unless an update/compaction is active |
+| **Concurrent Inserts** | No | Yes, unless an update is active |
 | **Concurrent Updates** | No | No, updates are serialized while reads continue on snapshots |
 | **Recovery** | Manual (checkpoint reload) | Automatic (WAL replay) |
 

--- a/include/neug/transaction/README.md
+++ b/include/neug/transaction/README.md
@@ -48,7 +48,7 @@ The `VersionManager` state machine has three effective states for read, insert, 
 
 When an `UpdateTransaction` is created, it enters the update-exec phase (`update_state_`: `0 -> 1`). It waits for all in-flight insert transactions to finish, but does not block or wait for read transactions. New insert transactions and new update transactions are blocked during this phase; existing and new reads continue.
 
-When `begin_update_commit` is called, the update enters the commit phase (`update_state_`: `1 -> 2`). New reads and new inserts are blocked until the `UpdateTransaction` is committed or aborted. Already-acquired reads continue unaffected on their pinned snapshot.
+When `VersionManager::begin_update_commit` is called, the update enters the commit phase (`update_state_`: `1 -> 2`). New reads and new inserts are blocked until the `UpdateTransaction` is committed or aborted. Already-acquired reads continue unaffected on their pinned snapshot.
 
 ## Serializability
 

--- a/include/neug/transaction/README.md
+++ b/include/neug/transaction/README.md
@@ -38,20 +38,17 @@ When reading graph data with a `ReadTransaction` or `UpdateTransaction`, only re
 
 There is no synchronization between read and insert transactions in the normal state. All read and insert transactions can be executed concurrently.
 
-The `VersionManager` state machine has four effective states:
+The `VersionManager` state machine has three effective states for read, insert, and update transactions:
 
 | State | Meaning | New Reads | New Inserts | New Updates | Existing Reads |
 |-------|---------|-----------|-------------|-------------|----------------|
 | `0` | Normal | allowed | allowed | allowed | continue |
 | `1` | Update execution | allowed | blocked | blocked | continue |
 | `2` from update | Update commit | blocked | blocked | blocked | continue |
-| `2` from compact | Compaction | blocked | blocked | blocked | drained before compaction |
 
 When an `UpdateTransaction` is created, it enters the update-exec phase (`update_state_`: `0 -> 1`). It waits for all in-flight insert transactions to finish, but does not block or wait for read transactions. New insert transactions and new update transactions are blocked during this phase; existing and new reads continue.
 
 When `begin_update_commit` is called, the update enters the commit phase (`update_state_`: `1 -> 2`). New reads and new inserts are blocked until the `UpdateTransaction` is committed or aborted. Already-acquired reads continue unaffected on their pinned snapshot.
-
-When a `CompactTransaction` is created, it enters state `2` directly. It waits for all active insert and read transactions to finish, and blocks new read, insert, update, and compact transactions until compaction commits or aborts.
 
 ## Serializability
 

--- a/include/neug/transaction/README.md
+++ b/include/neug/transaction/README.md
@@ -1,5 +1,9 @@
 # Transactions
 
+> Note: This file documents internal transaction implementation details. For
+> application-facing behavior, see
+> [Transaction Management](../../../doc/source/transaction/transaction.md).
+
 ## Read Transaction
 
 With an `ReadTransaction`, a specific version of the graph can be read. The version is determined by the timestamp of the transaction.
@@ -27,12 +31,6 @@ After insertion and update, the transaction can be committed by calling `UpdateT
 `UpdateTransaction` mutates a copy-on-write `PropertyGraph` clone. Its changes are invisible until commit publishes the clone through `GraphSnapshotStore`.
 
 # Version Management
-
-> Note: The user-facing transaction guide (`doc/source/transaction/transaction.md`)
-> intentionally omits the implementation details in this section. It describes
-> only application-observable concurrency behavior; `VersionManager` states,
-> timestamp visibility rules, and storage mechanics belong in this developer
-> documentation.
 
 ## Visibility
 

--- a/include/neug/transaction/README.md
+++ b/include/neug/transaction/README.md
@@ -24,24 +24,37 @@ Also, `UpdateTransaction` provides interfaces to insert and update vertices and 
 
 After insertion and update, the transaction can be committed by calling `UpdateTransaction::Commit()` or be aborted by calling `UpdateTransaction::Abort()`.
 
+`UpdateTransaction` mutates a copy-on-write `PropertyGraph` clone. Its changes are invisible until commit publishes the clone through `GraphSnapshotStore`.
+
 # Version Management
 
 ## Visibility
 
-Each edge is associated with a timestamp, which is the timestamp of the transaction that inserts the edge.
+Graph records that participate in MVCC visibility are associated with a timestamp, which is the timestamp of the transaction that creates or publishes the record version.
 
-When read graph with a `ReadTransaction` or `UpdateTransaction`, only edges with timestamp less than or equal to the timestamp of the transaction will be returned.
+When reading graph data with a `ReadTransaction` or `UpdateTransaction`, only records with timestamp less than or equal to the transaction timestamp are visible.
 
 ## Synchronization
 
-There is no synchronization between read and insert transactions. All read and insert transactions can be executed concurrently.
+There is no synchronization between read and insert transactions in the normal state. All read and insert transactions can be executed concurrently.
 
-When an `UpdateTransaction` is created, it enters the update-exec phase (VersionManager update_state_: 0→1). It waits for all in-flight insert transactions to finish, but does NOT block or wait for read transactions. New insert transactions are blocked during this phase; existing and new reads continue.
+The `VersionManager` state machine has four effective states:
 
-When `begin_update_commit` is called, the update enters the commit phase (update_state_: 1→2). New reads and new inserts are blocked until the `UpdateTransaction` is committed or aborted. Already-acquired reads continue unaffected.
+| State | Meaning | New Reads | New Inserts | New Updates | Existing Reads |
+|-------|---------|-----------|-------------|-------------|----------------|
+| `0` | Normal | allowed | allowed | allowed | continue |
+| `1` | Update execution | allowed | blocked | blocked | continue |
+| `2` from update | Update commit | blocked | blocked | blocked | continue |
+| `2` from compact | Compaction | blocked | blocked | blocked | drained before compaction |
+
+When an `UpdateTransaction` is created, it enters the update-exec phase (`update_state_`: `0 -> 1`). It waits for all in-flight insert transactions to finish, but does not block or wait for read transactions. New insert transactions and new update transactions are blocked during this phase; existing and new reads continue.
+
+When `begin_update_commit` is called, the update enters the commit phase (`update_state_`: `1 -> 2`). New reads and new inserts are blocked until the `UpdateTransaction` is committed or aborted. Already-acquired reads continue unaffected on their pinned snapshot.
+
+When a `CompactTransaction` is created, it enters state `2` directly. It waits for all active insert and read transactions to finish, and blocks new read, insert, update, and compact transactions until compaction commits or aborts.
 
 ## Serializability
 
-For a `ReadTransaction`, it will be assigned with a timestamp of the graph, all insert or update transactions with timestamp less than or equal to the timestamp have been committed.
+For a `ReadTransaction`, it will be assigned a graph timestamp. All insert or update transactions with timestamp less than or equal to that timestamp have been committed and are visible through timestamp filtering and the pinned snapshot.
 
 For each `InsertTransaction` or `UpdateTransaction`, a unique timestamp will be assigned. When committing, a write-ahead log will be written to the disk and all modifications will be applied to the graph atomically.

--- a/include/neug/transaction/README.md
+++ b/include/neug/transaction/README.md
@@ -28,6 +28,12 @@ After insertion and update, the transaction can be committed by calling `UpdateT
 
 # Version Management
 
+> Note: The user-facing transaction guide (`doc/source/transaction/transaction.md`)
+> intentionally omits the implementation details in this section. It describes
+> only application-observable concurrency behavior; `VersionManager` states,
+> timestamp visibility rules, and storage mechanics belong in this developer
+> documentation.
+
 ## Visibility
 
 Graph records that participate in MVCC visibility are associated with a timestamp, which is the timestamp of the transaction that creates or publishes the record version.

--- a/include/neug/transaction/update_transaction.h
+++ b/include/neug/transaction/update_transaction.h
@@ -60,6 +60,14 @@ class Schema;
  * GraphSnapshotStore::PublishSnapshot()
  * - Abort discards the COW copy (no effect on original)
  *
+ * **Concurrency contract** (VersionManager state machine):
+ * - Acquisition enters update-exec (`update_state_ == 1`): waits for
+ *   in-flight inserts, blocks new inserts/updates/compaction, and lets reads
+ *   continue on their pinned snapshots.
+ * - Commit calls begin_update_commit (`update_state_ == 2`): briefly blocks
+ *   new reads and inserts while the COW snapshot is published. Existing reads
+ *   continue unaffected.
+ *
  * @since v0.1.0
  */
 class UpdateTransaction {

--- a/include/neug/transaction/update_transaction.h
+++ b/include/neug/transaction/update_transaction.h
@@ -61,12 +61,12 @@ class Schema;
  * - Abort discards the COW copy (no effect on original)
  *
  * **Concurrency contract** (VersionManager state machine):
- * - Acquisition enters update-exec (`update_state_ == 1`): waits for
- *   in-flight inserts, blocks new inserts/updates, and lets reads
- *   continue on their pinned snapshots.
- * - Commit calls begin_update_commit (`update_state_ == 2`): briefly blocks
- *   new reads and inserts while the COW snapshot is published. Existing reads
- *   continue unaffected.
+ * - Acquisition enters the update-exec phase: waits for in-flight inserts,
+ *   blocks new inserts/updates, and lets reads continue on their pinned
+ *   snapshots.
+ * - Commit calls VersionManager::begin_update_commit to enter the update-commit
+ *   phase: briefly blocks new reads and inserts while the COW snapshot is
+ *   published. Existing reads continue unaffected.
  *
  * @since v0.1.0
  */

--- a/include/neug/transaction/update_transaction.h
+++ b/include/neug/transaction/update_transaction.h
@@ -62,7 +62,7 @@ class Schema;
  *
  * **Concurrency contract** (VersionManager state machine):
  * - Acquisition enters update-exec (`update_state_ == 1`): waits for
- *   in-flight inserts, blocks new inserts/updates/compaction, and lets reads
+ *   in-flight inserts, blocks new inserts/updates, and lets reads
  *   continue on their pinned snapshots.
  * - Commit calls begin_update_commit (`update_state_ == 2`): briefly blocks
  *   new reads and inserts while the COW snapshot is published. Existing reads


### PR DESCRIPTION
## Summary
- update Service Mode transaction docs to describe the COW-based two-phase UpdateTransaction concurrency model
- document checkpoint behavior separately from stricter background compaction
- add developer-facing VersionManager state details and UpdateTransaction concurrency comments

## Why
The transaction documentation still described updates, schema changes, and checkpoints as acquiring a global write lock and blocking all operations. After the UpdateTransaction refactor, update execution now runs on a COW snapshot while reads continue, and only the commit publish window blocks new reads/inserts.

Closes #602