### PR TITLE
refactor: Refactor native arch build flags

### DIFF
--- a/.github/workflows/npm-build-test.yml
+++ b/.github/workflows/npm-build-test.yml
@@ -79,7 +79,7 @@ jobs:
             export PATH=/home/neug/.local/bin:$PATH
             . /home/neug/.neug_env
             cd /project/tools/nodejs_bind
-            make build EXTRA_CMAKE_FLAGS="-DOPTIMIZE_FOR_HOST=OFF -DCMAKE_PREFIX_PATH=/opt/neug/ -DOPENSSL_ROOT_DIR=/opt/neug"
+            make build EXTRA_CMAKE_FLAGS="-DCMAKE_PREFIX_PATH=/opt/neug/ -DOPENSSL_ROOT_DIR=/opt/neug"
           '
 
       - name: Pack
@@ -88,7 +88,7 @@ jobs:
             export PATH=/home/neug/.local/bin:$PATH
             . /home/neug/.neug_env
             cd /project/tools/nodejs_bind
-            make pack EXTRA_CMAKE_FLAGS="-DOPTIMIZE_FOR_HOST=OFF -DCMAKE_PREFIX_PATH=/opt/neug/ -DOPENSSL_ROOT_DIR=/opt/neug"
+            make pack EXTRA_CMAKE_FLAGS="-DCMAKE_PREFIX_PATH=/opt/neug/ -DOPENSSL_ROOT_DIR=/opt/neug"
           '
 
       - name: Prepare test data
@@ -171,7 +171,7 @@ jobs:
             export PATH=/home/neug/.local/bin:$PATH
             . /home/neug/.neug_env
             cd /project/tools/nodejs_bind
-            make build EXTRA_CMAKE_FLAGS="-DOPTIMIZE_FOR_HOST=OFF -DCMAKE_PREFIX_PATH=/opt/neug/ -DOPENSSL_ROOT_DIR=/opt/neug"
+            make build EXTRA_CMAKE_FLAGS="-DCMAKE_PREFIX_PATH=/opt/neug/ -DOPENSSL_ROOT_DIR=/opt/neug"
           '
 
       - name: Pack
@@ -180,7 +180,7 @@ jobs:
             export PATH=/home/neug/.local/bin:$PATH
             . /home/neug/.neug_env
             cd /project/tools/nodejs_bind
-            make pack EXTRA_CMAKE_FLAGS="-DOPTIMIZE_FOR_HOST=OFF -DCMAKE_PREFIX_PATH=/opt/neug/ -DOPENSSL_ROOT_DIR=/opt/neug"
+            make pack EXTRA_CMAKE_FLAGS="-DCMAKE_PREFIX_PATH=/opt/neug/ -DOPENSSL_ROOT_DIR=/opt/neug"
           '
 
       - name: Prepare test data
@@ -249,13 +249,13 @@ jobs:
         run: |
           source ~/.neug_env
           cd tools/nodejs_bind
-          make build EXTRA_CMAKE_FLAGS="-DOPTIMIZE_FOR_HOST=OFF -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0"
+          make build EXTRA_CMAKE_FLAGS="-DCMAKE_OSX_DEPLOYMENT_TARGET=11.0"
 
       - name: Pack
         run: |
           source ~/.neug_env
           cd tools/nodejs_bind
-          make pack EXTRA_CMAKE_FLAGS="-DOPTIMIZE_FOR_HOST=OFF -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0"
+          make pack EXTRA_CMAKE_FLAGS="-DCMAKE_OSX_DEPLOYMENT_TARGET=11.0"
 
       - name: Prepare test data
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,8 @@ EXTRA_CMAKE_FLAGS="-DBUILD_HTTP_SERVER=ON" make cpp-build   # extra flags
 - `BUILD_TEST=ON` — build test suites
 - `BUILD_PYTHON=ON` — build `neug_py_bind` target (off by default in pure C++ builds)
 - `NEUG_BUILD_DIR=<path>` — override the root build dir consumed by `setup.py` and the Python loader (default `<repo>/build`)
+- `NEUG_PACKAGE_BUILD=ON` — CMake option for portable distributable artifacts; package builds must keep `NEUG_NATIVE_ARCH=OFF`
+- `NEUG_NATIVE_ARCH=ON` — enable host-specific CPU tuning in local source builds; supported by root/Python/Node Makefiles
 - `DEBUG=ON` + `GLOG_v=10` — enable verbose C++ logging
 
 ### Running Tests
@@ -100,4 +102,3 @@ Cypher → ANTLR Parser → Binder → Logical Plan → gopt Converter → Physi
 
 - **C++**: C++20, clang-format (style=file)
 - **Python**: isort, black, flake8
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,8 @@ project (
 
 option(BUILD_TEST "Whether to build test" OFF)
 option(BUILD_DOC "Whether to build doc" OFF)
-option(OPTIMIZE_FOR_HOST "Whether to optimize on host" ON) # Whether to build optimized code on host
+option(NEUG_PACKAGE_BUILD "Whether to build portable distributable artifacts" OFF)
+option(NEUG_NATIVE_ARCH "Whether to enable host-specific CPU tuning for local builds" OFF)
 option(BUILD_EXECUTABLES "When to build executors" OFF) # Whether to build executables, default is OFF
 option(BUILD_HTTP_SERVER "Whether to build http server" OFF) # Whether to build http server, default is OFF
 option(WITH_MIMALLOC "Whether to use mimalloc" ON) # Whether to use mimalloc, default is ON
@@ -106,6 +107,8 @@ add_definitions(-DNEUG_CMAKE_VERSION="${CMAKE_PROJECT_VERSION}")
 
 include(CheckCXXCompilerFlag)
 include(cmake/neug_symbol_visibility.cmake)
+include(cmake/NeugNativeArch.cmake)
+neug_configure_native_arch()
 
 set(DEFAULT_BUILD_TYPE "Release")
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -185,11 +188,6 @@ int main() {
 
 if (HAVE_CHRONO_YMD)
     add_definitions(-DENABLE_CHRONO_YMD)
-endif()
-
-# -Wno-psabi for no warning about returning a pair in c++ function
-if (OPTIMIZE_FOR_HOST AND NOT APPLE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
 endif()
 
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -g")
@@ -930,6 +928,7 @@ endif()
 
 include_directories(SYSTEM third_party/expected)
 add_subdirectory(src)
+neug_apply_native_arch_to_directory("${CMAKE_CURRENT_SOURCE_DIR}/src")
 add_subdirectory(tools)
 if (BUILD_EXECUTABLES)
     add_subdirectory(bin)

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ SHELL := /bin/bash
 ROOT_BUILD         := $(CURDIR)/build
 BUILD_TYPE         ?= Release
 BUILD_TEST         ?= OFF
+NEUG_NATIVE_ARCH   ?= OFF
 EXTRA_CMAKE_FLAGS  ?=
 
 NPROC := $(shell { command -v nproc >/dev/null 2>&1 && nproc; } 2>/dev/null \
@@ -18,7 +19,7 @@ check-tools:
 	@command -v cmake >/dev/null 2>&1 || { echo >&2 "CMake is required but not found."; exit 1; }
 
 cpp-build: check-tools  ## Build C++ core only (no Python bindings)
-	cmake -S . -B $(ROOT_BUILD) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DBUILD_PYTHON=OFF -DBUILD_TEST=$(BUILD_TEST) $(EXTRA_CMAKE_FLAGS)
+	cmake -S . -B $(ROOT_BUILD) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DBUILD_PYTHON=OFF -DBUILD_TEST=$(BUILD_TEST) -DNEUG_NATIVE_ARCH=$(NEUG_NATIVE_ARCH) $(EXTRA_CMAKE_FLAGS)
 	cmake --build $(ROOT_BUILD) -j$(JOBS)
 
 python-dev: check-tools  ## Install Python dev environment (bootstraps root build)

--- a/cmake/NeugNativeArch.cmake
+++ b/cmake/NeugNativeArch.cmake
@@ -1,0 +1,57 @@
+function(neug_configure_native_arch)
+    if(NEUG_PACKAGE_BUILD AND NEUG_NATIVE_ARCH)
+        message(FATAL_ERROR
+            "NEUG_NATIVE_ARCH must be OFF when NEUG_PACKAGE_BUILD is ON. "
+            "Distributable NeuG packages must not depend on the build host CPU.")
+    endif()
+
+    set(NEUG_NATIVE_ARCH_CXX_FLAG "" CACHE INTERNAL "Native architecture C++ flag for NeuG targets" FORCE)
+    if(NOT NEUG_NATIVE_ARCH)
+        message(STATUS "NEUG_NATIVE_ARCH: OFF")
+        return()
+    endif()
+
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang)$")
+        set(NEUG_NATIVE_ARCH_CXX_FLAG "-march=native" CACHE INTERNAL "Native architecture C++ flag for NeuG targets" FORCE)
+        message(STATUS "NEUG_NATIVE_ARCH: ON (${NEUG_NATIVE_ARCH_CXX_FLAG})")
+    elseif(APPLE)
+        message(STATUS "NEUG_NATIVE_ARCH: ON, but no native CPU flag is applied on Apple platforms")
+    else()
+        message(WARNING "NEUG_NATIVE_ARCH is ON, but no native CPU flag is defined for ${CMAKE_SYSTEM_NAME}/${CMAKE_CXX_COMPILER_ID}")
+    endif()
+endfunction()
+
+function(neug_apply_native_arch_to_target target_name)
+    if(NOT NEUG_NATIVE_ARCH OR NOT NEUG_NATIVE_ARCH_CXX_FLAG)
+        return()
+    endif()
+    if(NOT TARGET ${target_name})
+        return()
+    endif()
+
+    get_target_property(_neug_target_type ${target_name} TYPE)
+    if(_neug_target_type STREQUAL "INTERFACE_LIBRARY" OR
+       _neug_target_type STREQUAL "UTILITY" OR
+       _neug_target_type STREQUAL "UNKNOWN_LIBRARY")
+        return()
+    endif()
+
+    target_compile_options(${target_name} PRIVATE
+        $<$<COMPILE_LANGUAGE:CXX>:${NEUG_NATIVE_ARCH_CXX_FLAG}>)
+endfunction()
+
+function(neug_apply_native_arch_to_directory dir)
+    if(NOT NEUG_NATIVE_ARCH OR NOT NEUG_NATIVE_ARCH_CXX_FLAG)
+        return()
+    endif()
+
+    get_property(_neug_targets DIRECTORY "${dir}" PROPERTY BUILDSYSTEM_TARGETS)
+    foreach(_neug_target IN LISTS _neug_targets)
+        neug_apply_native_arch_to_target(${_neug_target})
+    endforeach()
+
+    get_property(_neug_subdirs DIRECTORY "${dir}" PROPERTY SUBDIRECTORIES)
+    foreach(_neug_subdir IN LISTS _neug_subdirs)
+        neug_apply_native_arch_to_directory("${_neug_subdir}")
+    endforeach()
+endfunction()

--- a/doc/source/development/dev_guide.md
+++ b/doc/source/development/dev_guide.md
@@ -130,7 +130,7 @@ Equivalent raw cmake form:
 
 ```bash
 cmake -S . -B build -DBUILD_PYTHON=OFF
-cmake --build build -j
+cmake --build build -j$(nproc)
 cmake --install build   # optional: install to the system
 ```
 
@@ -147,6 +147,18 @@ export WITH_MIMALLOC=ON/OFF # Decide whether to use mimalloc instead of the defa
 export ENABLE_BACKTRACES=ON/OFF # Link NeuG libraries with cpptrace for detailed stack trace on exceptions
 export BUILD_TYPE=DEBUG/RELEASE # Set the CMake build type
 export BUILD_TEST=ON/OFF # Toggle the building of test suites
+```
+
+Distributable artifacts such as Python wheels, npm tarballs, and release images
+are built with `NEUG_PACKAGE_BUILD=ON` and `NEUG_NATIVE_ARCH=OFF`. Do not enable
+native CPU tuning for package builds.
+
+For local source builds only, enable host-specific CPU tuning with:
+
+```bash
+NEUG_NATIVE_ARCH=ON make cpp-build
+NEUG_PACKAGE_BUILD=OFF NEUG_NATIVE_ARCH=ON make -C tools/python_bind build
+NEUG_NATIVE_ARCH=ON make -C tools/nodejs_bind dev
 ```
 
 #### Debugging
@@ -227,6 +239,7 @@ const { Database } = require('neug');
 
 The npm package is written to `tools/nodejs_bind/neug-<version>-<platform>-<arch>.tgz`,
 which packs `neug_node_bind.node` and `libneug.{dylib, so}`.
+Package builds are always configured as portable builds.
 ```bash
 make node-pack
 # or:

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -14,6 +14,8 @@ MANYLINUXVERSION := 2014
 
 VERSION ?= latest
 PROFILE ?= release
+NEUG_PACKAGE_BUILD ?= ON
+NEUG_NATIVE_ARCH ?= OFF
 
 BUILD_PROGRESS  	?= auto
 
@@ -48,5 +50,7 @@ neug-dev:
 neug-release:
 	cd .. && \
 	docker build \
-	-t neug/neug:${ARCH} \
-	-f docker/neug-release.Dockerfile .
+		--build-arg NEUG_PACKAGE_BUILD=$(NEUG_PACKAGE_BUILD) \
+		--build-arg NEUG_NATIVE_ARCH=$(NEUG_NATIVE_ARCH) \
+		-t neug/neug:${ARCH} \
+		-f docker/neug-release.Dockerfile .

--- a/docker/README.md
+++ b/docker/README.md
@@ -48,3 +48,10 @@ bash ./manifest.sh neug-dev v0.1.3 hongkong create
 ```
 
 Ensure images are pushed to the registry before executing the manifest creation.
+
+## Package Build Compatibility
+
+The `neug-release` image builds and installs a Python wheel. That wheel is a
+portable package artifact, so the release image build passes
+`NEUG_PACKAGE_BUILD=ON` and `NEUG_NATIVE_ARCH=OFF`. Development and manylinux
+images are build environments and do not force package mode by themselves.

--- a/docker/neug-release.Dockerfile
+++ b/docker/neug-release.Dockerfile
@@ -1,5 +1,8 @@
 FROM neug-registry.cn-hongkong.cr.aliyuncs.com/neug/neug-dev:v0.1.3 as builder
 
+ARG NEUG_PACKAGE_BUILD=ON
+ARG NEUG_NATIVE_ARCH=OFF
+
 USER neug
 
 RUN mkdir -p /home/neug/neug
@@ -13,7 +16,7 @@ ENV WITH_MIMALLOC=ON
 ENV ENABLE_BACKTRACES=OFF
 ENV BUILD_TYPE=RELEASE
 ENV BUILD_TEST=OFF
-RUN bash -c "source /home/neug/.neug_env && make python-dev && make python-wheel"
+RUN bash -c "source /home/neug/.neug_env && make python-dev EXTRA_CMAKE_FLAGS=\"-DNEUG_PACKAGE_BUILD=${NEUG_PACKAGE_BUILD} -DNEUG_NATIVE_ARCH=${NEUG_NATIVE_ARCH}\" && make python-wheel"
 RUN bash -c "sudo apt install patchelf -y"
 RUN bash -c "pip install auditwheel && auditwheel repair -w tools/python_bind/dist/wheelhouse tools/python_bind/dist/*.whl"
 

--- a/tools/nodejs_bind/Makefile
+++ b/tools/nodejs_bind/Makefile
@@ -4,7 +4,9 @@ REPO_ROOT  := $(abspath $(CURDIR)/../..)
 ROOT_BUILD := $(REPO_ROOT)/build
 
 BUILD_TYPE         ?= Release
+NEUG_NATIVE_ARCH   ?= OFF
 EXTRA_CMAKE_FLAGS  ?=
+PACK_CMAKE_FLAGS   := -DNEUG_PACKAGE_BUILD=ON
 
 # Detect platform: {os}_{arch}
 #   OS:   Linux -> linux, Darwin -> osx
@@ -59,6 +61,7 @@ dev:  ## Build neug_node_bind (auto-bootstrap if needed)
 	    -DWITH_MIMALLOC=OFF \
 	    -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
 	    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+	    -DNEUG_NATIVE_ARCH=$(NEUG_NATIVE_ARCH) \
 	    $(EXTRA_CMAKE_FLAGS)
 	cmake --build $(ROOT_BUILD) --target neug_node_bind bulk_loader -j$(JOBS)
 	@$(MAKE) stage
@@ -76,7 +79,8 @@ stage:
 proto:  ## Regenerate lib/proto/error_pb.js from proto/error.proto
 	node scripts/generate_proto.js
 
-pack: build  ## Create per-platform npm tarball
+pack:  ## Create per-platform npm tarball
+	@$(MAKE) dev NEUG_NATIVE_ARCH=OFF EXTRA_CMAKE_FLAGS="$(EXTRA_CMAKE_FLAGS) $(PACK_CMAKE_FLAGS)"
 	@echo "Packing npm package for platform: $(PREBUILD_PLATFORM)"
 	@cp package.json package.json.orig
 	@node -e 'const fs=require("fs"); const p=JSON.parse(fs.readFileSync("package.json")); p.name="@graphscope-neug/$(OS_TAG)-$(ARCH_TAG)"; p.os=[process.platform]; p.cpu=[process.arch]; fs.writeFileSync("package.json", JSON.stringify(p,null,2)+"\n")'

--- a/tools/nodejs_bind/README.md
+++ b/tools/nodejs_bind/README.md
@@ -59,6 +59,10 @@ Create a self-contained, distributable npm package tarball (`.tgz`). This will:
    - `libmimalloc.so.2` — memory allocator
 3. Run `npm pack` to produce `neug-<version>.tgz`
 
+Npm package builds always force `NEUG_PACKAGE_BUILD=ON` and
+`NEUG_NATIVE_ARCH=OFF`.
+For local source builds, use `NEUG_NATIVE_ARCH=ON make dev`.
+
 The resulting tarball can be installed without a C++ build environment:
 
 ```bash

--- a/tools/python_bind/Makefile
+++ b/tools/python_bind/Makefile
@@ -5,6 +5,8 @@ ROOT_BUILD := $(REPO_ROOT)/build
 CACHE_FILE := $(ROOT_BUILD)/CMakeCache.txt
 
 BUILD_TYPE         ?= Release
+NEUG_PACKAGE_BUILD ?= ON
+NEUG_NATIVE_ARCH   ?= OFF
 EXTRA_CMAKE_FLAGS  ?=
 
 # `cmake --build -j` without N is unlimited parallelism — tanks memory-limited
@@ -35,7 +37,7 @@ proto:  ## Compile protobuf files
 # Honors all BUILD_*/WITH_*/CMAKE_* env vars on every invocation. CI uses this.
 # Run setup.py under $(PYTHON) so sys.executable matches the locked interpreter.
 build:  ## Build via setup.py (honors all BUILD_* env vars; CI entry)
-	$(CMAKE_PARALLEL) $(PYTHON) setup.py build_ext
+	$(CMAKE_PARALLEL) NEUG_PACKAGE_BUILD=$(NEUG_PACKAGE_BUILD) NEUG_NATIVE_ARCH=$(NEUG_NATIVE_ARCH) $(PYTHON) setup.py build_ext
 
 # Falls through to dev-full when the cache is missing or wasn't configured
 # with -DBUILD_PYTHON=ON (avoids cryptic "No rule to make target" errors).
@@ -50,13 +52,13 @@ dev:  ## Fast incremental rebuild via cmake (no env-var forwarding)
 dev-full:  ## Configure root build + build neug_py_bind from scratch
 	cmake -S $(REPO_ROOT) -B $(ROOT_BUILD) -DBUILD_PYTHON=ON \
 	    -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
-	    -DOPTIMIZE_FOR_HOST=OFF \
+	    -DNEUG_NATIVE_ARCH=$(NEUG_NATIVE_ARCH) \
 	    -DPython_EXECUTABLE=$(PYTHON) -DPYTHON_EXECUTABLE=$(PYTHON) \
 	    $(EXTRA_CMAKE_FLAGS)
 	cmake --build $(ROOT_BUILD) --target neug_py_bind -j$(JOBS)
 
 wheel:  ## Build the neug python wheel (honors BUILD_* env vars)
-	$(CMAKE_PARALLEL) $(PYTHON) setup.py bdist_wheel
+	$(CMAKE_PARALLEL) NEUG_PACKAGE_BUILD=ON NEUG_NATIVE_ARCH=OFF $(PYTHON) setup.py bdist_wheel
 
 clean:  ## Clean Python build artifacts (does NOT touch $(ROOT_BUILD))
 	rm -rf build/ dist/ *.egg-info neug.egg-info/ __pycache__/

--- a/tools/python_bind/README.md
+++ b/tools/python_bind/README.md
@@ -63,6 +63,9 @@ make wheel        # produces dist/neug-*.whl
 fallback if absent). The wheel bundles both `neug_py_bind*.so` and
 `libneug.{dylib,so}` into the `neug` package; they find each other at runtime
 via `@loader_path` (macOS) / `$ORIGIN` (Linux) RPATH.
+Wheel builds always force `NEUG_PACKAGE_BUILD=ON` and `NEUG_NATIVE_ARCH=OFF`.
+For local source builds via `setup.py build_ext`, override with
+`NEUG_PACKAGE_BUILD=OFF NEUG_NATIVE_ARCH=ON make build`.
 
 ## Python service API
 

--- a/tools/python_bind/setup.py
+++ b/tools/python_bind/setup.py
@@ -204,7 +204,6 @@ class CMakeBuild(build_ext):
             f"-DPYTHON_EXECUTABLE={sys.executable}",
             f"-DCMAKE_BUILD_TYPE={build_type}",
             "-DBUILD_PYTHON=ON",
-            "-DOPTIMIZE_FOR_HOST=OFF",
             "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
             *(
                 f"-D{name}={_on_off(name, default)}"
@@ -223,6 +222,11 @@ class CMakeBuild(build_ext):
             cmake_args.append(f"-DCMAKE_INSTALL_PREFIX={prefix}")
         if extra := os.environ.get("CMAKE_ARGS", "").split():
             cmake_args += extra
+
+        cmake_args += [
+            f"-DNEUG_PACKAGE_BUILD={_on_off('NEUG_PACKAGE_BUILD', 'ON')}",
+            f"-DNEUG_NATIVE_ARCH={_on_off('NEUG_NATIVE_ARCH', 'OFF')}",
+        ]
 
         cmake_generator = os.environ.get("CMAKE_GENERATOR", "")
         build_args: list[str] = []


### PR DESCRIPTION
## Summary

- replace OPTIMIZE_FOR_HOST with NEUG_PACKAGE_BUILD and NEUG_NATIVE_ARCH
- keep distributable Python wheel, npm, and release Docker builds portable by default
- scope host-specific native flags to NeuG src targets instead of global CMake flags

## Validation

- rg OPTIMIZE_FOR_HOST returned no matches in project-owned files
- git diff --cached --check passed before commit
- npm workflow YAML parsed successfully
- package/native conflict CMake configure fails as expected

Closes #604