### PR TITLE
fix: avoid GCC stringop-overread false positive in to_arrow

### DIFF
--- a/tools/python_bind/src/py_query_result.cc
+++ b/tools/python_bind/src/py_query_result.cc
@@ -737,7 +737,7 @@ pybind11::object PyQueryResult::to_arrow() const {
   auto array_holder = new OwnedArray();
   array_holder->response = response;  // root also holds a reference
   // Struct root has 1 buffer (validity – nullptr means all-valid).
-  array_holder->buffer_ptrs = {nullptr};
+  array_holder->buffer_ptrs.resize(1, nullptr);
   array_holder->children.resize(n_cols);
   array_holder->child_ptrs.resize(n_cols);
 


### PR DESCRIPTION
Replace brace-init assignment to buffer_ptrs with resize(1, nullptr) so PyQueryResult::to_arrow builds cleanly on GCC 13+ with -Werror.



Fixes #618 

