### PR TITLE
fix: fix SSSP compiles failed on apple clang 15

### DIFF
--- a/extension/gds/src/impl/sssp_pred_impl.cc
+++ b/extension/gds/src/impl/sssp_pred_impl.cc
@@ -106,7 +106,8 @@ void SSSPPred::compute() {
       continue;
     }
 
-    auto relax = [&](auto& it, vid_t w, vid_t edge_src, vid_t edge_dst) {
+    auto relax = [&, dist = dist](auto& it, vid_t w, vid_t edge_src,
+                                  vid_t edge_dst) {
       if (!in_subgraph[w]) {
         return;
       }


### PR DESCRIPTION
## Summary
- Fix Apple Clang builds of SSSP predicate implementation by init-capturing the structured binding distance value in the relaxation lambda.

## Root cause
Apple Clang 15 rejects directly capturing a structured binding from the enclosing function scope in this lambda, even under C++20.

## Validation
- cmake --build build --target neug_gds_extension -j1 was started after the scoped change; the previous same-target build completed successfully before retrying with explicit -j1, with only the existing unused private field warning.

Fixes #629