### PR TITLE
ci: Add npm publish workflow

### DIFF
--- a/.github/workflows/npm-build-test.yml
+++ b/.github/workflows/npm-build-test.yml
@@ -1,6 +1,7 @@
 name: NPM Test
 
 on:
+  workflow_call: {}
   workflow_dispatch: {}
   schedule:
     # Trigger at 03:00 CST (19:00 UTC) every day
@@ -8,8 +9,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v*'
     paths: &npm_paths
       - 'cmake/**'
       - 'src/**'
@@ -27,12 +26,12 @@ on:
     paths: *npm_paths
 
 concurrency:
-  group: ${{ github.repository }}-${{ github.event.number || github.head_ref || github.sha }}-${{ github.workflow }}
+  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.number || github.head_ref || github.ref || github.sha }}
   cancel-in-progress: true
 
 jobs:
   format_check:
-    if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'workflow_call'
     uses: ./.github/workflows/format-check.yml
     with:
       is_pull_request: ${{ github.event_name == 'pull_request' }}
@@ -130,7 +129,7 @@ jobs:
 
   build_npm_linux_arm64:
     needs: format_check
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
@@ -222,7 +221,7 @@ jobs:
 
   build_npm_macos_aarch64:
     needs: format_check
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+    if: github.event_name == 'workflow_call' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: macos-15
     steps:
       - name: checkout
@@ -272,6 +271,6 @@ jobs:
       - name: Upload npm tarball
         uses: actions/upload-artifact@v4
         with:
-          name: nodejs-macos-arm64-${{ github.run_id }}
+          name: nodejs-osx-arm64-${{ github.run_id }}
           path: ./tools/nodejs_bind/graphscope-neug-osx-arm64-*.tgz
           if-no-files-found: error

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,99 @@
+name: NPM Publish
+
+# Release tags drive npm publishing.
+on:
+  push:
+    tags:
+      - 'v*'
+
+# Keep one publish run per tag.
+concurrency:
+  group: ${{ github.repository }}-${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  # Reuse the npm build/test workflow so release artifacts come from the tested build.
+  build:
+    uses: ./.github/workflows/npm-build-test.yml
+
+  publish:
+    name: Publish npm packages
+    needs: build
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      # Needed for main package assets and validation scripts.
+      - name: checkout
+        uses: actions/checkout@v4
+
+      # Configure npm registry auth; publish uses NODE_AUTH_TOKEN below.
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      # Download artifact containers uploaded by npm-build-test; their contents are .tgz files.
+      - name: Download npm tarballs
+        uses: actions/download-artifact@v4
+        with:
+          pattern: nodejs-*-${{ github.run_id }}
+          path: dist/npm
+          merge-multiple: true
+
+      # Show the actual npm tarballs after artifact extraction.
+      - name: List npm tarballs
+        run: |
+          find dist/npm -maxdepth 2 -name '*.tgz' -print | sort
+
+      # Assemble the pure-JS main package that depends on platform packages.
+      - name: Prepare main package
+        run: |
+          MAIN_DIR="dist/npm-main"
+          mkdir -p "$MAIN_DIR"
+          cp tools/nodejs_bind/assets/package.json "$MAIN_DIR/package.json"
+          cp tools/nodejs_bind/assets/index.js "$MAIN_DIR/index.js"
+
+      # Validate package metadata, unpack platform packages, then publish all packages.
+      - name: Publish npm packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # These names are npm pack outputs inside the downloaded artifact containers.
+          linux_x86_64=(dist/npm/graphscope-neug-linux-x86_64-*.tgz)
+          osx_arm64=(dist/npm/graphscope-neug-osx-arm64-*.tgz)
+
+          # Fail early if a required platform package was not built or downloaded.
+          if [ ! -f "${linux_x86_64[0]}" ]; then
+            echo "No linux-x86_64 npm tarball found."
+            exit 1
+          fi
+
+          if [ ! -f "${osx_arm64[0]}" ]; then
+            echo "No osx-arm64 npm tarball found."
+            exit 1
+          fi
+
+          # The tag version must match every package version before publish is attempted.
+          VERSION="${GITHUB_REF_NAME#v}"
+          python3 tools/nodejs_bind/scripts/validate_npm_version.py \
+            "${linux_x86_64[0]}" '@graphscope-neug/linux-x86_64' "$VERSION"
+          python3 tools/nodejs_bind/scripts/validate_npm_version.py \
+            "${osx_arm64[0]}" '@graphscope-neug/osx-arm64' "$VERSION"
+          python3 tools/nodejs_bind/scripts/validate_npm_version.py \
+            dist/npm-main '@graphscope-neug/neug' "$VERSION" \
+            --optional-dependency '@graphscope-neug/linux-x86_64' \
+            --optional-dependency '@graphscope-neug/osx-arm64'
+
+          # npm publish must run from package directories, so unpack platform tarballs first.
+          mkdir -p dist/npm-packages/linux-x86_64 dist/npm-packages/osx-arm64
+          tar -xzf "${linux_x86_64[0]}" -C dist/npm-packages/linux-x86_64
+          tar -xzf "${osx_arm64[0]}" -C dist/npm-packages/osx-arm64
+
+          npm publish dist/npm-packages/linux-x86_64/package --access public --provenance
+          npm publish dist/npm-packages/osx-arm64/package --access public --provenance
+          npm publish dist/npm-main --access public --provenance

--- a/tools/nodejs_bind/assets/index.js
+++ b/tools/nodejs_bind/assets/index.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const OS_MAP = { linux: 'linux', darwin: 'osx' };
+const ARCH_MAP = { x64: 'x86_64', arm64: 'arm64' };
+
+const os = OS_MAP[process.platform];
+const arch = ARCH_MAP[process.arch];
+if (!os || !arch) {
+  throw new Error(`NeuG: unsupported platform ${process.platform}-${process.arch}`);
+}
+
+const optionalPkg = `@graphscope-neug/${os}-${arch}`;
+
+let binding;
+try {
+  binding = require(optionalPkg);
+} catch (err) {
+  throw new Error(
+    `NeuG: failed to load platform package "${optionalPkg}".\n` +
+    `Original error: ${err.message}`
+  );
+}
+
+module.exports = binding;

--- a/tools/nodejs_bind/assets/package.json
+++ b/tools/nodejs_bind/assets/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@graphscope-neug/neug",
+  "version": "0.1.2",
+  "description": "NeuG Graph Database Node.js bindings - high performance embedded graph database with Cypher query support",
+  "main": "index.js",
+  "keywords": ["graph", "database", "embedded", "cypher", "neug", "native", "addon", "napi"],
+  "author": "GraphScope Team",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alibaba/neug.git"
+  },
+  "engines": { "node": ">=16.0.0" },
+  "publishConfig": { "access": "public" },
+  "optionalDependencies": {
+    "@graphscope-neug/linux-x86_64": "0.1.2",
+    "@graphscope-neug/osx-arm64": "0.1.2"
+  },
+  "files": ["index.js"]
+}

--- a/tools/nodejs_bind/scripts/validate_npm_version.py
+++ b/tools/nodejs_bind/scripts/validate_npm_version.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Validate npm package versions in a tarball or package directory."""
+
+import argparse
+import json
+import sys
+import tarfile
+from pathlib import Path
+
+
+def load_package_json(package_path: str) -> dict:
+    path = Path(package_path)
+    if path.is_dir():
+        with (path / "package.json").open() as package_json:
+            return json.load(package_json)
+
+    with tarfile.open(path, "r:gz") as archive:
+        package_json = archive.extractfile("package/package.json")
+        if package_json is None:
+            raise FileNotFoundError("package/package.json")
+        return json.load(package_json)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate package versions in an npm tarball or package directory."
+    )
+    parser.add_argument("package_path")
+    parser.add_argument("expected_name")
+    parser.add_argument("expected_version")
+    parser.add_argument(
+        "--optional-dependency",
+        action="append",
+        default=[],
+        metavar="PACKAGE",
+        help="Optional dependency package that must use the expected version.",
+    )
+    args = parser.parse_args()
+
+    try:
+        package = load_package_json(args.package_path)
+    except Exception as exc:
+        print(f"{args.package_path}: failed to read package.json: {exc}", file=sys.stderr)
+        return 1
+
+    actual_name = package.get("name")
+    actual_version = package.get("version")
+    if actual_name != args.expected_name or actual_version != args.expected_version:
+        print(
+            f"{args.package_path}: expected {args.expected_name}@{args.expected_version}, "
+            f"got {actual_name}@{actual_version}",
+            file=sys.stderr,
+        )
+        return 1
+
+    optional_dependencies = package.get("optionalDependencies", {})
+    for dependency in args.optional_dependency:
+        actual_dependency_version = optional_dependencies.get(dependency)
+        if actual_dependency_version != args.expected_version:
+            print(
+                f"{args.package_path}: expected optional dependency "
+                f"{dependency}@{args.expected_version}, got {actual_dependency_version}",
+                file=sys.stderr,
+            )
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add an npm publish workflow triggered by release tags
- reuse the npm build/test workflow to publish tested linux-x86_64 and osx-arm64 artifacts
- add a pure JS main package wrapper and version validation before publishing

## Validation
- git diff --staged --check
- python3 -m py_compile tools/nodejs_bind/scripts/validate_npm_version.py
- node --check tools/nodejs_bind/assets/index.js
- YAML parse check for npm workflows

Closes #634