### PR TITLE
ci: support manual npm publish ci workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,6 +5,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 # Keep one publish run per tag.
 concurrency:

--- a/tools/nodejs_bind/assets/package.json
+++ b/tools/nodejs_bind/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphscope-neug/neug",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "NeuG Graph Database Node.js bindings - high performance embedded graph database with Cypher query support",
   "main": "index.js",
   "keywords": ["graph", "database", "embedded", "cypher", "neug", "native", "addon", "napi"],
@@ -13,8 +13,8 @@
   "engines": { "node": ">=16.0.0" },
   "publishConfig": { "access": "public" },
   "optionalDependencies": {
-    "@graphscope-neug/linux-x86_64": "0.1.2",
-    "@graphscope-neug/osx-arm64": "0.1.2"
+    "@graphscope-neug/linux-x86_64": "0.1.3",
+    "@graphscope-neug/osx-arm64": "0.1.3"
   },
   "files": ["index.js"]
 }


### PR DESCRIPTION
## Summary

Add a manual `workflow_dispatch` trigger to the npm publish workflow while keeping the existing release-tag trigger.

Fix #634

## Validation

Not run; CI workflow metadata-only change.
