### PR TITLE
refactor: Remove unnecessary configs about compaction, checkpoint will always compact.

### DIFF
--- a/doc/source/reference/cpp_api/neug_db.md
+++ b/doc/source/reference/cpp_api/neug_db.md
@@ -39,7 +39,7 @@ db.Close();
 **Resource Management:**
 - File locking prevents concurrent database access from multiple processes
 - Automatic WAL (Write-Ahead Log) for crash recovery
-- Configurable checkpoint and compaction on close
+- Configurable checkpoint on close
 
 ### Public Methods
 
@@ -53,7 +53,6 @@ Open(
     const std::string &planner_kind="gopt",
     bool enable_auto_compaction=false,
     bool compact_csr=true,
-    bool compact_on_close=true,
     bool checkpoint_on_close=true
 )
 ```
@@ -85,8 +84,7 @@ db.Open("/path/to/graph", 8, neug::DBMode::READ_WRITE, "gopt");
   - `planner_kind`: Query planner type: "gopt" (Graph Optimizer) or "greedy"
   - `enable_auto_compaction`: Enable background auto-compaction thread
   - `compact_csr`: Compact CSR structures during auto-compaction
-  - `compact_on_close`: Perform compaction when closing database
-  - `checkpoint_on_close`: Create checkpoint (persist data) when closing
+  - `checkpoint_on_close`: Create a checkpoint (persist data) when closing
 
 - **Notes:**
   - This overload is primarily designed for Python bindings.
@@ -126,8 +124,7 @@ db.Open(config);
 Close the database and release all resources.
 
 Performs a graceful shutdown of the database. Depending on configuration:
-- Creates checkpoint if checkpoint_on_close is enabled
-- Performs compaction if compact_on_close is enabled
+- Creates a checkpoint if checkpoint_on_close is enabled
 - Closes all open connections
 - Releases file locks
 

--- a/include/neug/config.h.in
+++ b/include/neug/config.h.in
@@ -99,9 +99,8 @@ struct NeugDBConfig {
         enable_auto_compaction(true),
         memory_level(MemoryLevel::kInMemory),
         compact_csr(true),
-        compact_on_close(true),
         checkpoint_on_close(false),
-        checkpoint_after_recovery(false),
+        checkpoint_on_recovery(false),
         storage_slot_num(DEFAULT_STORAGE_SLOT_NUM) {}
 
   /**
@@ -120,9 +119,8 @@ struct NeugDBConfig {
         enable_auto_compaction(true),
         memory_level(MemoryLevel::kInMemory),
         compact_csr(true),
-        compact_on_close(true),
         checkpoint_on_close(false),
-        checkpoint_after_recovery(false),
+        checkpoint_on_recovery(false),
         storage_slot_num(DEFAULT_STORAGE_SLOT_NUM) {}
 
   /// CSR storage reserve ratio for edge insertions (default: 1.2)
@@ -156,14 +154,11 @@ struct NeugDBConfig {
   /// Compact CSR structures during compaction
   bool compact_csr;
 
-  /// Perform compaction when closing database
-  bool compact_on_close;
-
   /// Create checkpoint (persist all data) when closing database
   bool checkpoint_on_close;
 
-  /// Create checkpoint after recovering from WAL
-  bool checkpoint_after_recovery;
+  /// Create a checkpoint after recovering from WAL
+  bool checkpoint_on_recovery;
 
   /// Storage slot number
   int storage_slot_num;

--- a/include/neug/main/neug_db.h
+++ b/include/neug/main/neug_db.h
@@ -97,7 +97,7 @@ class Schema;
  * **Resource Management:**
  * - File locking prevents concurrent database access from multiple processes
  * - Automatic WAL (Write-Ahead Log) for crash recovery
- * - Configurable checkpoint and compaction on close
+ * - Configurable checkpoint on close
  *
  * @note For query execution, obtain a Connection via Connect() method.
  * @note Always call Close() before destroying the NeugDB instance to ensure
@@ -147,7 +147,6 @@ class NeugDB {
    * "greedy"
    * @param enable_auto_compaction Enable background auto-compaction thread
    * @param compact_csr Compact CSR structures during auto-compaction
-   * @param compact_on_close Perform compaction when closing database
    * @param checkpoint_on_close Create checkpoint (persist data) when closing
    *
    * @return true if database opened successfully, false otherwise
@@ -164,7 +163,7 @@ class NeugDB {
             const DBMode mode = DBMode::READ_WRITE,
             const std::string& planner_kind = "gopt",
             bool enable_auto_compaction = false, bool compact_csr = true,
-            bool compact_on_close = true, bool checkpoint_on_close = true);
+            bool checkpoint_on_close = true);
 
   /**
    * @brief Open the database with a configuration object.
@@ -199,8 +198,7 @@ class NeugDB {
    * @brief Close the database and release all resources.
    *
    * Performs a graceful shutdown of the database. Depending on configuration:
-   * - Creates checkpoint if checkpoint_on_close is enabled
-   * - Performs compaction if compact_on_close is enabled
+   * - Creates a checkpoint if checkpoint_on_close is enabled
    * - Closes all open connections
    * - Releases file locks
    *
@@ -313,15 +311,14 @@ class NeugDB {
   void initPlannerAndQueryProcessor();
 
   /**
-   * @brief Create a checkpoint of the current graph.
-   * @param force_compaction Whether to force compaction before creating the
-   * checkpoint.
-   * @note force_compaction will override the config_.compact_on_close setting.
-   * force_compaction should be set to true after the database is recovered from
-   * wals to remove the tombstone type/data, otherwise the graph size will keep
-   * growing.
+   * @brief Create a checkpoint of the current graph. Must not be called while a
+   * NeugDBService is running.
+   *
+   * A durable checkpoint is a transaction timeline reset boundary: it always
+   * compacts storage timestamps before dumping, and a successful checkpoint
+   * resets last_ts_ to 0.
    */
-  void createCheckpoint(bool force_compaction = false, bool reopen = true);
+  void createCheckpoint(bool reopen = true);
 
   friend class NeugDBSession;
   friend class neug::NeugDBService;

--- a/src/main/neug_db.cc
+++ b/src/main/neug_db.cc
@@ -106,13 +106,12 @@ NeugDB::~NeugDB() {
 bool NeugDB::Open(const std::string& data_dir, int32_t max_thread_num,
                   const DBMode mode, const std::string& planner_kind,
                   bool enable_auto_compaction, bool compact_csr,
-                  bool compact_on_close, bool checkpoint_on_close) {
+                  bool checkpoint_on_close) {
   NeugDBConfig config(data_dir, max_thread_num);
   config.mode = mode;
   config.planner_kind = planner_kind;
   config.enable_auto_compaction = enable_auto_compaction;
   config.compact_csr = compact_csr;
-  config.compact_on_close = compact_on_close;
   config.checkpoint_on_close = checkpoint_on_close;
   return Open(config);
 }
@@ -136,9 +135,9 @@ bool NeugDB::Open(const NeugDBConfig& config) {
 
   LOG(INFO) << "NeugDB opened successfully";
   closed_.store(false);
-  if (last_ts_ > 0 && config.checkpoint_after_recovery) {
+  if (last_ts_ > 0 && config.checkpoint_on_recovery) {
     LOG(INFO) << "Creating checkpoint after recovery at ts " << last_ts_;
-    createCheckpoint(true);
+    createCheckpoint();
   }
   return true;
 }
@@ -162,7 +161,7 @@ void NeugDB::Close() {
   if (config_.checkpoint_on_close && config_.mode == DBMode::READ_WRITE) {
     VLOG(1) << "Creating checkpoint on close...";
     try {
-      createCheckpoint(false, false);
+      createCheckpoint(false);
     } catch (const std::exception& e) {
       LOG(ERROR) << "Checkpoint on close failed: " << e.what();
     }
@@ -321,14 +320,11 @@ void NeugDB::initPlannerAndQueryProcessor() {
       *snapshot_store_, planner_, query_processor_, config_);
 }
 
-void NeugDB::createCheckpoint(bool force_compaction, bool reopen) {
+void NeugDB::createCheckpoint(bool reopen) {
   std::unique_lock<std::mutex> lock(mutex_);
   SnapshotGuard guard(*snapshot_store_);
   auto& graph = *guard.get().mutable_graph();
-  if (config_.compact_on_close || force_compaction) {
-    graph.Compact(config_.compact_csr, config_.csr_reserve_ratio,
-                  MAX_TIMESTAMP);
-  }
+  graph.Compact(config_.compact_csr, config_.csr_reserve_ratio, MAX_TIMESTAMP);
   auto ckp_id = checkpoint_mgr_.CreateCheckpoint();
   auto ckp = checkpoint_mgr_.GetCheckpoint(ckp_id);
   try {
@@ -344,6 +340,7 @@ void NeugDB::createCheckpoint(bool force_compaction, bool reopen) {
     // points to the freshly loaded internal structures.
     guard.get().mutable_view().Rebuild(*guard.get().mutable_graph());
   }
+  last_ts_ = 0;  // Reset last_ts_ after checkpointing.
   VLOG(1) << "Finish checkpoint: " << ckp->path();
 }
 

--- a/src/main/neug_db.cc
+++ b/src/main/neug_db.cc
@@ -135,7 +135,8 @@ bool NeugDB::Open(const NeugDBConfig& config) {
 
   LOG(INFO) << "NeugDB opened successfully";
   closed_.store(false);
-  if (last_ts_ > 0 && config.checkpoint_on_recovery) {
+  if (last_ts_ > 0 && config.checkpoint_on_recovery &&
+      config_.mode == DBMode::READ_WRITE) {
     LOG(INFO) << "Creating checkpoint after recovery at ts " << last_ts_;
     createCheckpoint();
   }

--- a/tests/storage/test_checkpoint.cc
+++ b/tests/storage/test_checkpoint.cc
@@ -180,7 +180,6 @@ class CheckpointTestBase : public ::testing::Test {
     config.data_dir = data_dir;
     config.memory_level = kMemoryLevel;
     config.checkpoint_on_close = true;
-    config.compact_on_close = true;
     config.compact_csr = true;
     config.enable_auto_compaction = false;
     return config;
@@ -1068,7 +1067,6 @@ class CheckpointSafetyTest : public CheckpointTestBase<T> {
       const std::string& data_dir) {
     auto config = this->MakeConfig(data_dir);
     config.checkpoint_on_close = false;
-    config.compact_on_close = false;
     return config;
   }
 };

--- a/tests/storage/test_copy_temp.cc
+++ b/tests/storage/test_copy_temp.cc
@@ -74,7 +74,6 @@ class CopyTempTest : public ::testing::Test {
     NeugDBConfig config;
     config.data_dir = DB_DIR;
     config.checkpoint_on_close = true;
-    config.compact_on_close = true;
     config.compact_csr = true;
     config.enable_auto_compaction = false;
     db_->Open(config);
@@ -308,7 +307,6 @@ TEST_F(CopyTempTest, CleanupOnClose) {
     NeugDBConfig config;
     config.data_dir = DB_DIR;
     config.checkpoint_on_close = true;
-    config.compact_on_close = true;
     config.compact_csr = true;
     config.enable_auto_compaction = false;
     db2->Open(config);
@@ -376,7 +374,6 @@ TEST_F(CopyTempTest, PersistentSurvivesTempCleanup) {
     NeugDBConfig config;
     config.data_dir = DB_DIR;
     config.checkpoint_on_close = true;
-    config.compact_on_close = true;
     config.compact_csr = true;
     config.enable_auto_compaction = false;
     db2->Open(config);

--- a/tests/storage/test_open_graph.cc
+++ b/tests/storage/test_open_graph.cc
@@ -233,8 +233,7 @@ TEST(DatabaseTest, TestCompaction) {
       std::filesystem::remove_all(db_dir);
     }
     neug::NeugDB db;
-    db.Open(db_dir, 1, neug::DBMode::READ_WRITE, "gopt", false, false, true,
-            true);
+    db.Open(db_dir, 1, neug::DBMode::READ_WRITE, "gopt", false, false, true);
     auto conn = db.Connect();
     std::string flex_data_dir = std::getenv("FLEX_DATA_DIR");
     EXPECT_FALSE(flex_data_dir.empty());
@@ -276,7 +275,6 @@ TEST(DatabaseTest, TestCompaction) {
 
   {
     neug::NeugDB db3;
-    db3.Open(db_dir, 1, neug::DBMode::READ_WRITE, "gopt", false, false, true,
-             true);
+    db3.Open(db_dir, 1, neug::DBMode::READ_WRITE, "gopt", false, false, true);
   }
 }

--- a/tests/storage/test_recovery.cc
+++ b/tests/storage/test_recovery.cc
@@ -67,7 +67,6 @@ class NeugDBWALRecoveryTest : public ::testing::TestWithParam<bool> {
     NeugDBConfig db_config(data_dir_, std::thread::hardware_concurrency());
     db_config.checkpoint_on_close = GetParam();
     db_config.mode = DBMode::READ_WRITE;
-    db_config.compact_on_close = db_config.checkpoint_on_close;
     ASSERT_TRUE(db_->Open(db_config));
     neug::ServiceConfig config;
     config.host_str = neugdb_host_;
@@ -141,7 +140,6 @@ TEST_P(NeugDBWALRecoveryTest, WALRecoveryViaCypher) {
   // Then Open the DB in read-write mode
   neug::NeugDB db;
   neug::NeugDBConfig db_config(data_dir(), std::thread::hardware_concurrency());
-  db_config.compact_on_close = true;
   db_config.checkpoint_on_close = true;
   ASSERT_TRUE(db.Open(data_dir(), 4, neug::DBMode::READ_WRITE));
   db.Close();

--- a/tests/transaction/test_update_transaction.cc
+++ b/tests/transaction/test_update_transaction.cc
@@ -2195,8 +2195,7 @@ TEST_F(UpdateTransactionTest, TestReplayWal) {
   neug::NeugDBConfig config(db_dir);
   config.memory_level = neug::MemoryLevel::kInMemory;
   config.checkpoint_on_close = false;
-  config.compact_on_close = false;
-  config.checkpoint_after_recovery = true;
+  config.checkpoint_on_recovery = true;
   {
     neug::NeugDB db;
     db.Open(config);

--- a/tests/transaction/test_wal_replay.cc
+++ b/tests/transaction/test_wal_replay.cc
@@ -44,9 +44,8 @@ neug::NeugDBConfig make_config(const std::string& db_dir) {
   neug::NeugDBConfig config(db_dir, 1);
   config.memory_level = neug::MemoryLevel::kInMemory;
   config.enable_auto_compaction = false;
-  config.compact_on_close = false;
   config.checkpoint_on_close = false;
-  config.checkpoint_after_recovery = false;
+  config.checkpoint_on_recovery = false;
   return config;
 }
 
@@ -57,7 +56,6 @@ void assert_query_ok(neug::Connection& conn, const std::string& query) {
 
 void create_checkpointed_base_graph(const std::string& db_dir) {
   auto config = make_config(db_dir);
-  config.compact_on_close = true;
   config.checkpoint_on_close = true;
 
   neug::NeugDB db;
@@ -71,6 +69,13 @@ void create_checkpointed_base_graph(const std::string& db_dir) {
     assert_query_ok(*conn, query);
   }
   db.Close();
+}
+
+void create_person_schema(neug::NeugDB& db) {
+  auto conn = db.Connect();
+  assert_query_ok(
+      *conn,
+      "CREATE NODE TABLE person(id INT64, name STRING, PRIMARY KEY(id));");
 }
 
 bool replayed_graph_matches(neug::NeugDB& db) {
@@ -109,16 +114,24 @@ bool replayed_graph_matches(neug::NeugDB& db) {
   return matching_edges == 1;
 }
 
-void insert_person(neug::NeugDBService& service, int64_t id,
-                   const std::string& name) {
+neug::timestamp_t insert_person_and_return_ts(neug::NeugDBService& service,
+                                              int64_t id,
+                                              const std::string& name) {
   auto sess = service.AcquireSession();
   auto txn = sess->GetInsertTransaction();
+  const auto ts = txn.timestamp();
   neug::StorageTPInsertInterface interface(txn);
   const auto person_label = txn.schema().get_vertex_label_id("person");
   neug::vid_t vid = 0;
-  ASSERT_TRUE(interface.AddVertex(person_label, Value::INT64(id),
+  EXPECT_TRUE(interface.AddVertex(person_label, Value::INT64(id),
                                   {Value::STRING(name)}, vid));
-  ASSERT_TRUE(txn.Commit());
+  EXPECT_TRUE(txn.Commit());
+  return ts;
+}
+
+void insert_person(neug::NeugDBService& service, int64_t id,
+                   const std::string& name) {
+  (void) insert_person_and_return_ts(service, id, name);
 }
 
 void compact(neug::NeugDBService& service) {
@@ -144,6 +157,30 @@ void insert_knows_edge(neug::NeugDBService& service, int64_t src_id,
   ASSERT_TRUE(interface.AddEdge(person_label, src_vid, person_label, dst_vid,
                                 knows_label, {Value::INT64(since)}, prop));
   ASSERT_TRUE(txn.Commit());
+}
+
+size_t read_person_count(neug::NeugDBService& service) {
+  auto sess = service.AcquireSession();
+  auto txn = sess->GetReadTransaction();
+  neug::StorageReadInterface graph(txn.view(), txn.timestamp());
+  const auto person_label = graph.schema().get_vertex_label_id("person");
+  size_t count = 0;
+  graph.GetVertexSet(person_label).foreach_vertex([&](neug::vid_t) {
+    ++count;
+  });
+  EXPECT_TRUE(txn.Commit());
+  return count;
+}
+
+bool read_has_person(neug::NeugDBService& service, int64_t id) {
+  auto sess = service.AcquireSession();
+  auto txn = sess->GetReadTransaction();
+  neug::StorageReadInterface graph(txn.view(), txn.timestamp());
+  const auto person_label = graph.schema().get_vertex_label_id("person");
+  neug::vid_t vid = 0;
+  bool found = graph.GetVertexIndex(person_label, Value::INT64(id), vid);
+  EXPECT_TRUE(txn.Commit());
+  return found;
 }
 
 void create_wal_with_insert_compact_insert_collision(
@@ -236,6 +273,95 @@ TEST(WalReplayVersionManagerTest,
 TEST(WalReplayVersionManagerTest,
      RevertedCompactCompletesTimestampAndDoesNotReusePriorInsertTimestamp) {
   expect_compact_completes_timestamp_and_preserves_next_insert(false);
+}
+
+TEST_F(WalReplayTest, CloseCheckpointAlwaysResetsServiceTimeline) {
+  {
+    auto config = make_config(db_dir_);
+    config.checkpoint_on_close = true;
+
+    neug::NeugDB db;
+    ASSERT_TRUE(db.Open(config));
+    create_person_schema(db);
+    {
+      neug::NeugDBService service(db);
+      EXPECT_EQ(insert_person_and_return_ts(service, 1, "old"), 1);
+      EXPECT_EQ(read_person_count(service), 1);
+    }
+    db.Close();
+  }
+
+  {
+    neug::NeugDB db;
+    ASSERT_TRUE(db.Open(make_config(db_dir_)));
+    {
+      neug::NeugDBService service(db);
+      EXPECT_TRUE(read_has_person(service, 1));
+      EXPECT_EQ(insert_person_and_return_ts(service, 2, "new"), 1);
+      EXPECT_EQ(read_person_count(service), 2);
+    }
+    db.Close();
+  }
+}
+
+TEST_F(WalReplayTest, RecoveryWithoutCheckpointContinuesFromWalTimeline) {
+  create_checkpointed_base_graph(db_dir_);
+
+  neug::timestamp_t wal_ts = 0;
+  {
+    neug::NeugDB db;
+    ASSERT_TRUE(db.Open(make_config(db_dir_)));
+    {
+      neug::NeugDBService service(db);
+      wal_ts = insert_person_and_return_ts(service, 2, "wal");
+    }
+    db.Close();
+  }
+
+  {
+    auto config = make_config(db_dir_);
+    config.checkpoint_on_recovery = false;
+
+    neug::NeugDB db;
+    ASSERT_TRUE(db.Open(config));
+    {
+      neug::NeugDBService service(db);
+      EXPECT_TRUE(read_has_person(service, 2));
+      EXPECT_EQ(insert_person_and_return_ts(service, 3, "post-wal"),
+                wal_ts + 1);
+      EXPECT_EQ(read_person_count(service), 3);
+    }
+    db.Close();
+  }
+}
+
+TEST_F(WalReplayTest, RecoveryCheckpointResetsServiceTimeline) {
+  create_checkpointed_base_graph(db_dir_);
+
+  {
+    neug::NeugDB db;
+    ASSERT_TRUE(db.Open(make_config(db_dir_)));
+    {
+      neug::NeugDBService service(db);
+      EXPECT_EQ(insert_person_and_return_ts(service, 2, "wal"), 1);
+    }
+    db.Close();
+  }
+
+  {
+    auto config = make_config(db_dir_);
+    config.checkpoint_on_recovery = true;
+
+    neug::NeugDB db;
+    ASSERT_TRUE(db.Open(config));
+    {
+      neug::NeugDBService service(db);
+      EXPECT_TRUE(read_has_person(service, 2));
+      EXPECT_EQ(insert_person_and_return_ts(service, 3, "post-recovery"), 1);
+      EXPECT_EQ(read_person_count(service), 3);
+    }
+    db.Close();
+  }
 }
 
 TEST_F(WalReplayTest, ReopenReplaysInsertWalAcrossCompactionInDependencyOrder) {

--- a/tests/unittest/test_connection.cc
+++ b/tests/unittest/test_connection.cc
@@ -36,7 +36,6 @@ class ConnectionTest : public ::testing::Test {
     neug::NeugDBConfig config;
     config.data_dir = DB_DIR;
     config.checkpoint_on_close = true;
-    config.compact_on_close = true;
     config.compact_csr = true;
     config.enable_auto_compaction = false;  // TODO(zhanglei): very slow
     db_->Open(config);


### PR DESCRIPTION
Fix #654 