### PR TITLE
refactor: fold CSR timestamp reset into compact and drop compact_csr.

### DIFF
--- a/doc/source/reference/cpp_api/neug_db.md
+++ b/doc/source/reference/cpp_api/neug_db.md
@@ -52,7 +52,6 @@ Open(
     const DBMode mode=DBMode::READ_WRITE,
     const std::string &planner_kind="gopt",
     bool enable_auto_compaction=false,
-    bool compact_csr=true,
     bool checkpoint_on_close=true
 )
 ```
@@ -83,7 +82,6 @@ db.Open("/path/to/graph", 8, neug::DBMode::READ_WRITE, "gopt");
   - `mode`: Database access mode (READ_ONLY or READ_WRITE)
   - `planner_kind`: Query planner type: "gopt" (Graph Optimizer) or "greedy"
   - `enable_auto_compaction`: Enable background auto-compaction thread
-  - `compact_csr`: Compact CSR structures during auto-compaction
   - `checkpoint_on_close`: Create a checkpoint (persist data) when closing
 
 - **Notes:**

--- a/include/neug/config.h.in
+++ b/include/neug/config.h.in
@@ -98,7 +98,6 @@ struct NeugDBConfig {
         max_thread_num(1),
         enable_auto_compaction(true),
         memory_level(MemoryLevel::kInMemory),
-        compact_csr(true),
         checkpoint_on_close(false),
         checkpoint_on_recovery(false),
         storage_slot_num(DEFAULT_STORAGE_SLOT_NUM) {}
@@ -118,7 +117,6 @@ struct NeugDBConfig {
         max_thread_num(max_thread_num_),
         enable_auto_compaction(true),
         memory_level(MemoryLevel::kInMemory),
-        compact_csr(true),
         checkpoint_on_close(false),
         checkpoint_on_recovery(false),
         storage_slot_num(DEFAULT_STORAGE_SLOT_NUM) {}
@@ -150,9 +148,6 @@ struct NeugDBConfig {
    * - 2: Prefer hugepages
    */
   MemoryLevel memory_level;
-
-  /// Compact CSR structures during compaction
-  bool compact_csr;
 
   /// Create checkpoint (persist all data) when closing database
   bool checkpoint_on_close;

--- a/include/neug/main/neug_db.h
+++ b/include/neug/main/neug_db.h
@@ -146,7 +146,6 @@ class NeugDB {
    * @param planner_kind Query planner type: "gopt" (Graph Optimizer) or
    * "greedy"
    * @param enable_auto_compaction Enable background auto-compaction thread
-   * @param compact_csr Compact CSR structures during auto-compaction
    * @param checkpoint_on_close Create checkpoint (persist data) when closing
    *
    * @return true if database opened successfully, false otherwise
@@ -162,7 +161,7 @@ class NeugDB {
   bool Open(const std::string& data_dir, int32_t max_thread_num = 0,
             const DBMode mode = DBMode::READ_WRITE,
             const std::string& planner_kind = "gopt",
-            bool enable_auto_compaction = false, bool compact_csr = true,
+            bool enable_auto_compaction = false,
             bool checkpoint_on_close = true);
 
   /**

--- a/include/neug/storages/csr/csr_base.h
+++ b/include/neug/storages/csr/csr_base.h
@@ -51,8 +51,6 @@ class CsrBase : public Module {
   // space, the reserved space will count as 0.
   virtual size_t edge_num() const = 0;
 
-  virtual void reset_timestamp() = 0;
-
   virtual void compact() = 0;
 
   virtual void resize(vid_t vnum) = 0;

--- a/include/neug/storages/csr/immutable_csr.h
+++ b/include/neug/storages/csr/immutable_csr.h
@@ -68,8 +68,6 @@ class ImmutableCsr : public TypedCsrBase<EDATA_T> {
   void Dump(Checkpoint& ckp, CheckpointManifest& meta,
             const std::string& key) override;
 
-  void reset_timestamp() override;
-
   void compact() override;
 
   void resize(vid_t vnum) override;
@@ -180,8 +178,6 @@ class SingleImmutableCsr : public TypedCsrBase<EDATA_T> {
 
   void Dump(Checkpoint& ckp, CheckpointManifest& meta,
             const std::string& key) override;
-
-  void reset_timestamp() override;
 
   void compact() override;
 

--- a/include/neug/storages/csr/mutable_csr.h
+++ b/include/neug/storages/csr/mutable_csr.h
@@ -83,8 +83,6 @@ class MutableCsr : public TypedCsrBase<EDATA_T> {
   void Dump(Checkpoint& ckp, CheckpointManifest& meta,
             const std::string& key) override;
 
-  void reset_timestamp() override;
-
   void compact() override;
 
   void resize(vid_t vnum) override;
@@ -290,8 +288,6 @@ class SingleMutableCsr : public TypedCsrBase<EDATA_T> {
   void Dump(Checkpoint& ckp, CheckpointManifest& meta,
             const std::string& key) override;
 
-  void reset_timestamp() override;
-
   void compact() override;
 
   void resize(vid_t vnum) override;
@@ -430,8 +426,6 @@ class EmptyCsr : public TypedCsrBase<EDATA_T> {
     desc.module_type = type_name();
     meta.set_module(key, desc);
   }
-
-  void reset_timestamp() override {}
 
   void compact() override {}
 

--- a/include/neug/storages/graph/edge_table.h
+++ b/include/neug/storages/graph/edge_table.h
@@ -173,8 +173,7 @@ class EdgeTable {
                           int32_t ie_offset, int32_t col_id,
                           const execution::Value& new_prop, timestamp_t ts);
 
-  void Compact(bool compact_csr,
-               const std::optional<std::string>& sort_key_for_nbr,
+  void Compact(const std::optional<std::string>& sort_key_for_nbr,
                timestamp_t ts);
 
   size_t PropTableSize() const;

--- a/include/neug/storages/graph/property_graph.h
+++ b/include/neug/storages/graph/property_graph.h
@@ -128,7 +128,7 @@ class PropertyGraph {
    */
   void Open(std::shared_ptr<Checkpoint> ckp, MemoryLevel memory_level);
 
-  void Compact(bool compact_csr, float reserve_ratio, timestamp_t ts);
+  void Compact(timestamp_t ts);
 
   /**
    * @brief Dump the current graph state to persistent storage.

--- a/include/neug/transaction/compact_transaction.h
+++ b/include/neug/transaction/compact_transaction.h
@@ -27,8 +27,7 @@ class IVersionManager;
 class CompactTransaction {
  public:
   CompactTransaction(GraphSnapshotStore& snapshot_store, IWalWriter& logger,
-                     IVersionManager& vm, bool compact_csr, float reserve_ratio,
-                     timestamp_t timestamp);
+                     IVersionManager& vm, timestamp_t timestamp);
   ~CompactTransaction();
 
   timestamp_t timestamp() const;
@@ -41,8 +40,6 @@ class CompactTransaction {
   SnapshotGuard guard_;
   IWalWriter& logger_;
   IVersionManager& vm_;
-  bool compact_csr_;
-  float reserve_ratio_;
   timestamp_t timestamp_;
 
   InArchive arc_;

--- a/src/main/neug_db.cc
+++ b/src/main/neug_db.cc
@@ -105,13 +105,11 @@ NeugDB::~NeugDB() {
 
 bool NeugDB::Open(const std::string& data_dir, int32_t max_thread_num,
                   const DBMode mode, const std::string& planner_kind,
-                  bool enable_auto_compaction, bool compact_csr,
-                  bool checkpoint_on_close) {
+                  bool enable_auto_compaction, bool checkpoint_on_close) {
   NeugDBConfig config(data_dir, max_thread_num);
   config.mode = mode;
   config.planner_kind = planner_kind;
   config.enable_auto_compaction = enable_auto_compaction;
-  config.compact_csr = compact_csr;
   config.checkpoint_on_close = checkpoint_on_close;
   return Open(config);
 }
@@ -283,8 +281,7 @@ void NeugDB::ingestWals(IWalParser& parser, PropertyGraph& graph) {
       IngestWalRange(graph, allocators_, parser, from_ts, to_ts);
     }
     if (update_wal.size == 0) {
-      graph.Compact(config_.compact_csr, config_.csr_reserve_ratio,
-                    update_wal.timestamp);
+      graph.Compact(update_wal.timestamp);
       last_compaction_ts_ = update_wal.timestamp;
     } else {
       UpdateTransaction::IngestWal(graph, to_ts, update_wal.ptr,
@@ -325,7 +322,7 @@ void NeugDB::createCheckpoint(bool reopen) {
   std::unique_lock<std::mutex> lock(mutex_);
   SnapshotGuard guard(*snapshot_store_);
   auto& graph = *guard.get().mutable_graph();
-  graph.Compact(config_.compact_csr, config_.csr_reserve_ratio, MAX_TIMESTAMP);
+  graph.Compact(MAX_TIMESTAMP);
   auto ckp_id = checkpoint_mgr_.CreateCheckpoint();
   auto ckp = checkpoint_mgr_.GetCheckpoint(ckp_id);
   try {

--- a/src/server/neug_db_session.cc
+++ b/src/server/neug_db_session.cc
@@ -219,8 +219,7 @@ int NeugDBSession::SessionId() const { return thread_id_; }
 neug::CompactTransaction NeugDBSession::GetCompactTransaction() {
   neug::timestamp_t ts = version_manager_->acquire_compact_timestamp();
   return neug::CompactTransaction(db_.graph_snapshot_store(), logger_,
-                                  *version_manager_, db_config_.compact_csr,
-                                  db_config_.csr_reserve_ratio, ts);
+                                  *version_manager_, ts);
 }
 
 double NeugDBSession::eval_duration() const {

--- a/src/storages/csr/immutable_csr.cc
+++ b/src/storages/csr/immutable_csr.cc
@@ -89,9 +89,6 @@ void ImmutableCsr<EDATA_T>::Dump(Checkpoint& ckp, CheckpointManifest& meta,
 }
 
 template <typename EDATA_T>
-void ImmutableCsr<EDATA_T>::reset_timestamp() {}
-
-template <typename EDATA_T>
 void ImmutableCsr<EDATA_T>::compact() {
   // For current adj_list where the dst vertex is invalid, swap it to the end.
   vid_t vnum = size();
@@ -409,9 +406,6 @@ void SingleImmutableCsr<EDATA_T>::Dump(Checkpoint& ckp,
   desc.set("edge_num", std::to_string(edge_num_.load()));
   meta.set_module(key, desc);
 }
-
-template <typename EDATA_T>
-void SingleImmutableCsr<EDATA_T>::reset_timestamp() {}
 
 template <typename EDATA_T>
 void SingleImmutableCsr<EDATA_T>::compact() {}

--- a/src/storages/csr/mutable_csr.cc
+++ b/src/storages/csr/mutable_csr.cc
@@ -170,28 +170,8 @@ void MutableCsr<EDATA_T>::Dump(Checkpoint& ckp, CheckpointManifest& meta,
 }
 
 template <typename EDATA_T>
-void MutableCsr<EDATA_T>::reset_timestamp() {
-  size_t vnum = vertex_capacity();
-  auto** buf_arr = reinterpret_cast<nbr_t**>(adj_list_buffer_->GetData());
-  auto* sz_arr = reinterpret_cast<std::atomic<int>*>(degree_list_->GetData());
-  for (size_t i = 0; i != vnum; ++i) {
-    nbr_t* nbrs = buf_arr[i];
-    if (nbrs == nullptr) {
-      continue;
-    }
-    size_t deg = sz_arr[i].load(std::memory_order_relaxed);
-    for (size_t j = 0; j != deg; ++j) {
-      if (nbrs[j].timestamp != INVALID_TIMESTAMP) {
-        nbrs[j].timestamp.store(0, std::memory_order_relaxed);
-      }
-    }
-  }
-}
-
-template <typename EDATA_T>
 void MutableCsr<EDATA_T>::compact() {
-  // We don't shrink the capacity of each adjacency list, but just remove the
-  // deleted edges.
+  // Remove deleted edges and reset timestamps on surviving edges.
   size_t vnum = vertex_capacity();
   auto** buf_arr = reinterpret_cast<nbr_t**>(adj_list_buffer_->GetData());
   auto* sz_arr = reinterpret_cast<std::atomic<int>*>(degree_list_->GetData());
@@ -210,6 +190,7 @@ void MutableCsr<EDATA_T>::compact() {
         if (removed) {
           *write_ptr = *read_ptr;
         }
+        write_ptr->timestamp.store(0, std::memory_order_relaxed);
         ++write_ptr;
       } else {
         ++removed;
@@ -576,7 +557,7 @@ void SingleMutableCsr<EDATA_T>::Dump(Checkpoint& ckp, CheckpointManifest& meta,
 }
 
 template <typename EDATA_T>
-void SingleMutableCsr<EDATA_T>::reset_timestamp() {
+void SingleMutableCsr<EDATA_T>::compact() {
   if (!nbr_list_) {
     return;
   }
@@ -588,9 +569,6 @@ void SingleMutableCsr<EDATA_T>::reset_timestamp() {
     }
   }
 }
-
-template <typename EDATA_T>
-void SingleMutableCsr<EDATA_T>::compact() {}
 
 template <typename EDATA_T>
 void SingleMutableCsr<EDATA_T>::resize(vid_t vnum) {

--- a/src/storages/graph/edge_table.cc
+++ b/src/storages/graph/edge_table.cc
@@ -803,17 +803,10 @@ void EdgeTable::BatchAddEdges(
   }
 }
 
-void EdgeTable::Compact(bool compact_csr,
-                        const std::optional<std::string>& sort_key_for_nbr,
+void EdgeTable::Compact(const std::optional<std::string>& sort_key_for_nbr,
                         timestamp_t ts) {
-  if (compact_csr) {
-    out_csr_->compact();
-    in_csr_->compact();
-  }
-  // must reset timestamp before sorting, otherwise the unsorted_since_ may not
-  // be properly setted
-  out_csr_->reset_timestamp();
-  in_csr_->reset_timestamp();
+  out_csr_->compact();
+  in_csr_->compact();
   if (sort_key_for_nbr.has_value()) {
     if (!meta_->is_bundled()) {
       THROW_INVALID_ARGUMENT_EXCEPTION(

--- a/src/storages/graph/property_graph.cc
+++ b/src/storages/graph/property_graph.cc
@@ -849,8 +849,7 @@ void PropertyGraph::compact_schema() {
   v_mutex_.resize(new_schema.vertex_label_frontier());
 }
 
-void PropertyGraph::Compact(bool compact_csr, float reserve_ratio,
-                            timestamp_t ts) {
+void PropertyGraph::Compact(timestamp_t ts) {
   /**
    * The compaction process includes two parts:
    * 1. Schema: remove the deleted properties and labels from
@@ -889,7 +888,7 @@ void PropertyGraph::Compact(bool compact_csr, float reserve_ratio,
               schema_.get_sort_key_for_nbr(src_label_i, dst_label_i, e_label_i);
           if (edge_tables_.count(index) > 0) {
             auto& edge_table = edge_tables_.at(index);
-            edge_table.Compact(compact_csr, sort_key_for_nbr, ts);
+            edge_table.Compact(sort_key_for_nbr, ts);
           }
         }
       }

--- a/src/storages/loader/abstract_property_graph_loader.cc
+++ b/src/storages/loader/abstract_property_graph_loader.cc
@@ -181,7 +181,7 @@ result<bool> AbstractPropertyGraphLoader::LoadFragment() {
   try {
     loadVertices();
     loadEdges();
-    graph_.Compact(false, 0.0, 1);
+    graph_.Compact(1);
     graph_.Dump(false);
 
   } catch (const std::exception& e) {

--- a/src/transaction/compact_transaction.cc
+++ b/src/transaction/compact_transaction.cc
@@ -28,13 +28,10 @@ namespace neug {
 
 CompactTransaction::CompactTransaction(GraphSnapshotStore& snapshot_store,
                                        IWalWriter& logger, IVersionManager& vm,
-                                       bool compact_csr, float reserve_ratio,
                                        timestamp_t timestamp)
     : guard_(snapshot_store),
       logger_(logger),
       vm_(vm),
-      compact_csr_(compact_csr),
-      reserve_ratio_(reserve_ratio),
       timestamp_(timestamp) {
   arc_.Resize(sizeof(WalHeader));
 }
@@ -60,7 +57,7 @@ bool CompactTransaction::Commit() {
     LOG(INFO) << "before compact - " << timestamp_;
     // In-place compact
     auto& slot = guard_.get();
-    slot.mutable_graph()->Compact(compact_csr_, reserve_ratio_, timestamp_);
+    slot.mutable_graph()->Compact(timestamp_);
     slot.mutable_view().Rebuild(*slot.mutable_graph());
     LOG(INFO) << "after compact - " << timestamp_;
 

--- a/src/transaction/compact_transaction.cc
+++ b/src/transaction/compact_transaction.cc
@@ -29,10 +29,7 @@ namespace neug {
 CompactTransaction::CompactTransaction(GraphSnapshotStore& snapshot_store,
                                        IWalWriter& logger, IVersionManager& vm,
                                        timestamp_t timestamp)
-    : guard_(snapshot_store),
-      logger_(logger),
-      vm_(vm),
-      timestamp_(timestamp) {
+    : guard_(snapshot_store), logger_(logger), vm_(vm), timestamp_(timestamp) {
   arc_.Resize(sizeof(WalHeader));
 }
 

--- a/tests/storage/test_checkpoint.cc
+++ b/tests/storage/test_checkpoint.cc
@@ -180,7 +180,6 @@ class CheckpointTestBase : public ::testing::Test {
     config.data_dir = data_dir;
     config.memory_level = kMemoryLevel;
     config.checkpoint_on_close = true;
-    config.compact_csr = true;
     config.enable_auto_compaction = false;
     return config;
   }

--- a/tests/storage/test_copy_temp.cc
+++ b/tests/storage/test_copy_temp.cc
@@ -74,7 +74,6 @@ class CopyTempTest : public ::testing::Test {
     NeugDBConfig config;
     config.data_dir = DB_DIR;
     config.checkpoint_on_close = true;
-    config.compact_csr = true;
     config.enable_auto_compaction = false;
     db_->Open(config);
   }
@@ -307,7 +306,6 @@ TEST_F(CopyTempTest, CleanupOnClose) {
     NeugDBConfig config;
     config.data_dir = DB_DIR;
     config.checkpoint_on_close = true;
-    config.compact_csr = true;
     config.enable_auto_compaction = false;
     db2->Open(config);
     auto conn2 = db2->Connect();
@@ -374,7 +372,6 @@ TEST_F(CopyTempTest, PersistentSurvivesTempCleanup) {
     NeugDBConfig config;
     config.data_dir = DB_DIR;
     config.checkpoint_on_close = true;
-    config.compact_csr = true;
     config.enable_auto_compaction = false;
     db2->Open(config);
     auto conn2 = db2->Connect();

--- a/tests/storage/test_edge_table.cc
+++ b/tests/storage/test_edge_table.cc
@@ -1018,7 +1018,7 @@ TEST_F(EdgeTableTest, TestEdgeTableCompaction) {
     }
   }
   this->ExpectBundledStats(edge_num - delete_count);
-  this->edge_table->Compact(true, std::nullopt, neug::MAX_TIMESTAMP);
+  this->edge_table->Compact(std::nullopt, neug::MAX_TIMESTAMP);
   this->ExpectBundledStats(edge_num - delete_count);
   size_t edge_count = 0;
   for (size_t i = 0; i < dst_lids.size(); ++i) {

--- a/tests/storage/test_immutable_csr.cc
+++ b/tests/storage/test_immutable_csr.cc
@@ -267,14 +267,12 @@ TYPED_TEST(IMMutableCsrTest, TestBasicFunction) {
   EXPECT_EQ(immutable_csr.size(), 500);
   EXPECT_EQ(immutable_csr.edge_num(), 10000);
   immutable_csr.compact();
-  immutable_csr.reset_timestamp();
 
   SingleImmutableCsr<TypeParam> single_immutable_csr;
   this->load_single_csr_data(single_immutable_csr);
   EXPECT_EQ(single_immutable_csr.size(), 500);
   EXPECT_EQ(single_immutable_csr.edge_num(), 500);
   single_immutable_csr.compact();
-  single_immutable_csr.reset_timestamp();
 }
 
 TYPED_TEST(IMMutableCsrTest, TestDumpAndOpen) {

--- a/tests/storage/test_mutable_csr.cc
+++ b/tests/storage/test_mutable_csr.cc
@@ -794,9 +794,9 @@ TYPED_TEST(MutableCsrTest, TestPutEdge) {
   EXPECT_EQ(single_mutable_csr.edge_num(), edge_num);
   EXPECT_EQ(empty_csr.edge_num(), 0);
 
-  mutable_csr.reset_timestamp();
-  single_mutable_csr.reset_timestamp();
-  empty_csr.reset_timestamp();
+  mutable_csr.compact();
+  single_mutable_csr.compact();
+  empty_csr.compact();
 }
 
 TEST(CsrToolTest, OpenNonExistFile) {
@@ -998,7 +998,7 @@ TEST_F(MutableCsrDumpDirtyTest, DirtyResetAcrossCheckpointCycles) {
   auto p2 = nbr_path(d2);
   EXPECT_EQ(inode_of(p1), inode_of(p2));
 
-  c2.reset_timestamp();
+  c2.compact();
   auto d3 = dump_module_descriptor(c2, *ckp, "c2");
   auto p3 = nbr_path(d3);
   EXPECT_EQ(inode_of(p2), inode_of(p3));

--- a/tests/storage/test_open_graph.cc
+++ b/tests/storage/test_open_graph.cc
@@ -204,7 +204,7 @@ TEST(DatabaseTest, TestPersist) {
       std::filesystem::remove_all(db_dir);
     }
     neug::NeugDB db;
-    db.Open(db_dir, 1, neug::DBMode::READ_WRITE, "gopt", false, false, true);
+    db.Open(db_dir, 1, neug::DBMode::READ_WRITE, "gopt", false, true);
     auto conn = db.Connect();
     std::string flex_data_dir = std::getenv("FLEX_DATA_DIR");
     EXPECT_FALSE(flex_data_dir.empty());
@@ -233,7 +233,7 @@ TEST(DatabaseTest, TestCompaction) {
       std::filesystem::remove_all(db_dir);
     }
     neug::NeugDB db;
-    db.Open(db_dir, 1, neug::DBMode::READ_WRITE, "gopt", false, false, true);
+    db.Open(db_dir, 1, neug::DBMode::READ_WRITE, "gopt", false, true);
     auto conn = db.Connect();
     std::string flex_data_dir = std::getenv("FLEX_DATA_DIR");
     EXPECT_FALSE(flex_data_dir.empty());
@@ -275,6 +275,6 @@ TEST(DatabaseTest, TestCompaction) {
 
   {
     neug::NeugDB db3;
-    db3.Open(db_dir, 1, neug::DBMode::READ_WRITE, "gopt", false, false, true);
+    db3.Open(db_dir, 1, neug::DBMode::READ_WRITE, "gopt", false, true);
   }
 }

--- a/tests/unittest/test_connection.cc
+++ b/tests/unittest/test_connection.cc
@@ -36,7 +36,6 @@ class ConnectionTest : public ::testing::Test {
     neug::NeugDBConfig config;
     config.data_dir = DB_DIR;
     config.checkpoint_on_close = true;
-    config.compact_csr = true;
     config.enable_auto_compaction = false;  // TODO(zhanglei): very slow
     db_->Open(config);
     auto conn = db_->Connect();


### PR DESCRIPTION
Merge reset_timestamp into CSR compact(), remove the separate API, and always compact CSR during graph compaction without the compact_csr config switch.

Fixes

