### PR TITLE
fix: reject partial from/to in COPY TEMP and auto_detect COPY FROM

### DIFF
--- a/src/compiler/binder/bind/copy/bind_copy_from.cpp
+++ b/src/compiler/binder/bind/copy/bind_copy_from.cpp
@@ -202,6 +202,11 @@ std::unique_ptr<BoundStatement> Binder::bindCopyFromClause(
     if (fromIt != boundOpts.end() && toIt != boundOpts.end()) {
       return bindCopyRelFromNoSchema(statement, boundOpts, /*temporary=*/true);
     }
+    if (fromIt != boundOpts.end() || toIt != boundOpts.end()) {
+      THROW_BINDER_EXCEPTION(
+          "Both 'from' and 'to' options are required to create a "
+          "relationship table.");
+    }
     return bindCopyNodeFromNoSchema(statement, boundOpts, /*temporary=*/true);
   }
 
@@ -265,6 +270,11 @@ std::unique_ptr<BoundStatement> Binder::bindCopyFromClause(
   auto toIt = boundOpts.find(CopyConstants::TO_OPTION_NAME);
   if (fromIt != boundOpts.end() && toIt != boundOpts.end()) {
     return bindCopyRelFromNoSchema(statement, boundOpts);
+  }
+  if (fromIt != boundOpts.end() || toIt != boundOpts.end()) {
+    THROW_BINDER_EXCEPTION(
+        "Both 'from' and 'to' options are required to create a "
+        "relationship table.");
   }
   return bindCopyNodeFromNoSchema(statement, boundOpts);
 }

--- a/tools/python_bind/tests/test_copy_temp.py
+++ b/tools/python_bind/tests/test_copy_temp.py
@@ -839,3 +839,38 @@ def test_copy_temp_rejected_in_session(tmp_path):
         db.stop_serving()
         db.close()
         shutil.rmtree(db_dir, ignore_errors=True)
+
+
+# ======================================================================
+# COPY TEMP / COPY FROM: partial from/to validation (#632)
+# ======================================================================
+class TestFromToValidation:
+    """Only 'from' or only 'to' must raise an error."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, tmp_path):
+        self.db_dir = str(tmp_path / "db")
+        self.db = Database(db_path=self.db_dir, mode="w")
+        self.conn = self.db.connect()
+        self.csv = os.path.join(str(tmp_path), "data.csv")
+        with open(self.csv, "w") as f:
+            f.write("id|name|age\n1|Alice|30\n2|Bob|25\n")
+        # Create a node table first so from/to refs could be valid
+        self.conn.execute(f'COPY TEMP TempUser FROM "{self.csv}" (header=true)')
+        yield
+        self.conn.close()
+        self.db.close()
+        shutil.rmtree(self.db_dir, ignore_errors=True)
+
+    def test_only_from_raises(self):
+        with pytest.raises(Exception, match="Both.*from.*to"):
+            self.conn.execute(
+                f'COPY TEMP TempEdge FROM "{self.csv}" '
+                f"(header=true, from='TempUser')"
+            )
+
+    def test_only_to_raises(self):
+        with pytest.raises(Exception, match="Both.*from.*to"):
+            self.conn.execute(
+                f'COPY TEMP TempEdge FROM "{self.csv}" ' f"(header=true, to='TempUser')"
+            )

--- a/tools/python_bind/tests/test_load.py
+++ b/tools/python_bind/tests/test_load.py
@@ -2251,3 +2251,39 @@ class TestCopyFrom:
         res = self.conn.execute("MATCH ()-[r:Knows]->() RETURN count(r);")
         count = next(res)[0]
         assert count == 1, f"Expected 1 edge, got {count}"
+
+    def test_auto_detect_only_from_raises(self):
+        """Auto-detect COPY FROM with only 'from' (no 'to') must raise."""
+        csv_node = self.tmp_path / "nodes.csv"
+        csv_node.write_text("id,name\n1,Alice\n2,Bob\n")
+        csv_edge = self.tmp_path / "edges.csv"
+        csv_edge.write_text("src,dst,weight\n1,2,1.0\n")
+
+        self.conn.execute(
+            "CREATE NODE TABLE Person(id INT64 PRIMARY KEY, name STRING);"
+        )
+        self.conn.execute(f'COPY Person FROM "{csv_node}" (HEADER=true, delim=",");')
+
+        with pytest.raises(Exception, match="Both.*from.*to"):
+            self.conn.execute(
+                f'COPY NewEdge FROM "{csv_edge}" '
+                f'(HEADER=true, delim=",", from="Person")'
+            )
+
+    def test_auto_detect_only_to_raises(self):
+        """Auto-detect COPY FROM with only 'to' (no 'from') must raise."""
+        csv_node = self.tmp_path / "nodes.csv"
+        csv_node.write_text("id,name\n1,Alice\n2,Bob\n")
+        csv_edge = self.tmp_path / "edges.csv"
+        csv_edge.write_text("src,dst,weight\n1,2,1.0\n")
+
+        self.conn.execute(
+            "CREATE NODE TABLE Person(id INT64 PRIMARY KEY, name STRING);"
+        )
+        self.conn.execute(f'COPY Person FROM "{csv_node}" (HEADER=true, delim=",");')
+
+        with pytest.raises(Exception, match="Both.*from.*to"):
+            self.conn.execute(
+                f'COPY NewEdge FROM "{csv_edge}" '
+                f'(HEADER=true, delim=",", to="Person")'
+            )


### PR DESCRIPTION
## Related Issues
fix #632

## What does this PR do?
When a user specifies only `from` or only `to` (but not both) in a `COPY TEMP` or auto-detect `COPY FROM` statement, the binder previously fell through silently to node table creation, ignoring the incomplete intent. This PR adds explicit validation that throws a clear error message instead.

## What changes in this PR?
- **`src/compiler/binder/bind/copy/bind_copy_from.cpp`**: Added `THROW_BINDER_EXCEPTION` in two paths:
  - COPY TEMP path (when `copyStatement.isTemporary()` is true)
  - Auto-detect COPY FROM path (when target table does not exist and auto_detect is enabled)
  
  Both throw: `"Both 'from' and 'to' options are required to create a relationship table."`

- **`tools/python_bind/tests/test_copy_temp.py`**: Added `TestFromToValidation` class with 2 tests covering the COPY TEMP path (`test_only_from_raises`, `test_only_to_raises`).

- **`tools/python_bind/tests/test_load.py`**: Added 2 tests in `TestCopyFrom` class covering the auto-detect COPY FROM path (`test_auto_detect_only_from_raises`, `test_auto_detect_only_to_raises`).