### PR TITLE
fix: gtest EXPECT_THROW macro parsing issue in ArrayValue debug test on clang/macOS

### DIFF
--- a/tests/unittest/test_column.cc
+++ b/tests/unittest/test_column.cc
@@ -85,22 +85,25 @@ void expect_signature_eq(const ColumnCowSignature& lhs,
 TEST(ArrayValueTest, ConstructorValidatesPayloadShapeInDebug) {
   auto array_type = DataType::Array(DataType::INT32, 2);
 
-  EXPECT_THROW(
-      {
-        std::vector<execution::Value> values = {execution::Value::INT32(1)};
-        auto value = execution::Value::ARRAY(array_type, std::move(values));
-        (void) value;
-      },
-      exception::InvalidArgumentException);
+  auto build_invalid_array_wrong_size = [&array_type]() {
+    std::vector<execution::Value> values;
+    values.emplace_back(execution::Value::INT32(1));
+    auto value = execution::Value::ARRAY(array_type, std::move(values));
+    (void) value;
+  };
 
-  EXPECT_THROW(
-      {
-        std::vector<execution::Value> values = {execution::Value::INT32(1),
-                                                execution::Value::INT64(2)};
-        auto value = execution::Value::ARRAY(array_type, std::move(values));
-        (void) value;
-      },
-      exception::InvalidArgumentException);
+  auto build_invalid_array_wrong_type = [&array_type]() {
+    std::vector<execution::Value> values;
+    values.emplace_back(execution::Value::INT32(1));
+    values.emplace_back(execution::Value::INT64(2));
+    auto value = execution::Value::ARRAY(array_type, std::move(values));
+    (void) value;
+  };
+
+  EXPECT_THROW(build_invalid_array_wrong_size(),
+               exception::InvalidArgumentException);
+  EXPECT_THROW(build_invalid_array_wrong_type(),
+               exception::InvalidArgumentException);
 }
 #endif
 


### PR DESCRIPTION
Fixes a gtest macro parsing issue in ArrayValueTest on clang/macOS by replacing inline statement blocks with lambda callables.

The previous form used initializer lists inside macro arguments, which could be misparsed by the preprocessor and fail compilation (too many arguments provided to function-like macro invocation). This change keeps test behavior the same while making the test compile reliably across environments.

No production code is changed; test-only refactor.