### PR TITLE
docs: update What's Next section with shipped features and links

### DIFF
--- a/doc/source/overview/introduction.md
+++ b/doc/source/overview/introduction.md
@@ -70,11 +70,14 @@ NeuG is developed by the [GraphScope](https://graphscope.io) team at Alibaba, br
 
 ## What's Next
 
-NeuG is actively evolving. Here's what we're working on for v0.2:
+NeuG is actively evolving. Recent additions:
 
-- **Node.js Binding** — AI Agent integration ready
-- **Graph Algorithms** — In particular Leiden community detection for AI applications
-- **Data Lake Support** — S3/OSS + Parquet integration
+- **[Node.js Client](../../reference/nodejs_api/)** — Available since v0.1.3, AI Agent integration ready
+- **[Graph Algorithms](../../extensions/load_gds/)** — Available since v0.1.3, including Leiden community detection for AI applications
+- **[Data Lake Support](../../extensions/load_httpfs/)** — Available since v0.1.2, [S3/OSS](../../extensions/load_httpfs/) + [Parquet](../../extensions/load_parquet/) integration
+
+Upcoming for v0.2:
+
 - **Vector DB Extension** — RAG & GraphRAG support
 
 Star us on [GitHub](https://github.com/alibaba/neug) to stay updated on new releases.


### PR DESCRIPTION
## Summary

Update the "What's Next" section in `overview/introduction.md` to reflect features that have already shipped:

- **Node.js Client** — available since v0.1.3 (was listed as upcoming)
- **Graph Algorithms** — available since v0.1.3, including Leiden (was listed as upcoming)
- **Data Lake Support** — available since v0.1.2, with separate links to HTTPFS (S3/OSS) and Parquet extensions

Only **Vector DB Extension** remains in the v0.2 roadmap.