### PR TITLE
refactor: Avoid unnecessary value cast cost when setting properties from context column

### DIFF
--- a/include/neug/compiler/common/types/value/value.h
+++ b/include/neug/compiler/common/types/value/value.h
@@ -316,7 +316,8 @@ class Value {
  */
 template <>
 NEUG_API inline bool Value::getValue() const {
-  NEUG_ASSERT(getPhysicalType(dataType.id()) == PhysicalTypeID::BOOL);
+  NEUG_ASSERT(common::getPhysicalType(dataType.id()) ==
+              common::PhysicalTypeID::BOOL);
   return val.booleanVal;
 }
 
@@ -325,7 +326,8 @@ NEUG_API inline bool Value::getValue() const {
  */
 template <>
 NEUG_API inline int8_t Value::getValue() const {
-  NEUG_ASSERT(getPhysicalType(dataType.id()) == PhysicalTypeID::INT8);
+  NEUG_ASSERT(common::getPhysicalType(dataType.id()) ==
+              common::PhysicalTypeID::INT8);
   return val.int8Val;
 }
 
@@ -334,7 +336,8 @@ NEUG_API inline int8_t Value::getValue() const {
  */
 template <>
 NEUG_API inline int16_t Value::getValue() const {
-  NEUG_ASSERT(getPhysicalType(dataType.id()) == PhysicalTypeID::INT16);
+  NEUG_ASSERT(common::getPhysicalType(dataType.id()) ==
+              common::PhysicalTypeID::INT16);
   return val.int16Val;
 }
 
@@ -343,7 +346,8 @@ NEUG_API inline int16_t Value::getValue() const {
  */
 template <>
 NEUG_API inline int32_t Value::getValue() const {
-  NEUG_ASSERT(getPhysicalType(dataType.id()) == PhysicalTypeID::INT32);
+  NEUG_ASSERT(common::getPhysicalType(dataType.id()) ==
+              common::PhysicalTypeID::INT32);
   return val.int32Val;
 }
 
@@ -352,7 +356,8 @@ NEUG_API inline int32_t Value::getValue() const {
  */
 template <>
 NEUG_API inline int64_t Value::getValue() const {
-  NEUG_ASSERT(getPhysicalType(dataType.id()) == PhysicalTypeID::INT64);
+  NEUG_ASSERT(common::getPhysicalType(dataType.id()) ==
+              common::PhysicalTypeID::INT64);
   return val.int64Val;
 }
 
@@ -361,7 +366,8 @@ NEUG_API inline int64_t Value::getValue() const {
  */
 template <>
 NEUG_API inline uint64_t Value::getValue() const {
-  NEUG_ASSERT(getPhysicalType(dataType.id()) == PhysicalTypeID::UINT64);
+  NEUG_ASSERT(common::getPhysicalType(dataType.id()) ==
+              common::PhysicalTypeID::UINT64);
   return val.uint64Val;
 }
 
@@ -370,7 +376,8 @@ NEUG_API inline uint64_t Value::getValue() const {
  */
 template <>
 NEUG_API inline uint32_t Value::getValue() const {
-  NEUG_ASSERT(getPhysicalType(dataType.id()) == PhysicalTypeID::UINT32);
+  NEUG_ASSERT(common::getPhysicalType(dataType.id()) ==
+              common::PhysicalTypeID::UINT32);
   return val.uint32Val;
 }
 
@@ -379,7 +386,8 @@ NEUG_API inline uint32_t Value::getValue() const {
  */
 template <>
 NEUG_API inline uint16_t Value::getValue() const {
-  NEUG_ASSERT(getPhysicalType(dataType.id()) == PhysicalTypeID::UINT16);
+  NEUG_ASSERT(common::getPhysicalType(dataType.id()) ==
+              common::PhysicalTypeID::UINT16);
   return val.uint16Val;
 }
 
@@ -388,7 +396,8 @@ NEUG_API inline uint16_t Value::getValue() const {
  */
 template <>
 NEUG_API inline uint8_t Value::getValue() const {
-  NEUG_ASSERT(getPhysicalType(dataType.id()) == PhysicalTypeID::UINT8);
+  NEUG_ASSERT(common::getPhysicalType(dataType.id()) ==
+              common::PhysicalTypeID::UINT8);
   return val.uint8Val;
 }
 
@@ -397,7 +406,8 @@ NEUG_API inline uint8_t Value::getValue() const {
  */
 template <>
 NEUG_API inline int128_t Value::getValue() const {
-  NEUG_ASSERT(getPhysicalType(dataType.id()) == PhysicalTypeID::INT128);
+  NEUG_ASSERT(common::getPhysicalType(dataType.id()) ==
+              common::PhysicalTypeID::INT128);
   return val.int128Val;
 }
 
@@ -406,7 +416,8 @@ NEUG_API inline int128_t Value::getValue() const {
  */
 template <>
 NEUG_API inline float Value::getValue() const {
-  NEUG_ASSERT(getPhysicalType(dataType.id()) == PhysicalTypeID::FLOAT);
+  NEUG_ASSERT(common::getPhysicalType(dataType.id()) ==
+              common::PhysicalTypeID::FLOAT);
   return val.floatVal;
 }
 
@@ -415,7 +426,8 @@ NEUG_API inline float Value::getValue() const {
  */
 template <>
 NEUG_API inline double Value::getValue() const {
-  NEUG_ASSERT(getPhysicalType(dataType.id()) == PhysicalTypeID::DOUBLE);
+  NEUG_ASSERT(common::getPhysicalType(dataType.id()) ==
+              common::PhysicalTypeID::DOUBLE);
   return val.doubleVal;
 }
 
@@ -478,7 +490,8 @@ NEUG_API inline std::string Value::getValue() const {
  */
 template <>
 NEUG_API inline bool& Value::getValueReference() {
-  NEUG_ASSERT(getPhysicalType(dataType.id()) == PhysicalTypeID::BOOL);
+  NEUG_ASSERT(common::getPhysicalType(dataType.id()) ==
+              common::PhysicalTypeID::BOOL);
   return val.booleanVal;
 }
 
@@ -487,7 +500,8 @@ NEUG_API inline bool& Value::getValueReference() {
  */
 template <>
 NEUG_API inline int8_t& Value::getValueReference() {
-  NEUG_ASSERT(getPhysicalType(dataType.id()) == PhysicalTypeID::INT8);
+  NEUG_ASSERT(common::getPhysicalType(dataType.id()) ==
+              common::PhysicalTypeID::INT8);
   return val.int8Val;
 }
 
@@ -496,7 +510,8 @@ NEUG_API inline int8_t& Value::getValueReference() {
  */
 template <>
 NEUG_API inline int16_t& Value::getValueReference() {
-  NEUG_ASSERT(getPhysicalType(dataType.id()) == PhysicalTypeID::INT16);
+  NEUG_ASSERT(common::getPhysicalType(dataType.id()) ==
+              common::PhysicalTypeID::INT16);
   return val.int16Val;
 }
 
@@ -505,7 +520,8 @@ NEUG_API inline int16_t& Value::getValueReference() {
  */
 template <>
 NEUG_API inline int32_t& Value::getValueReference() {
-  NEUG_ASSERT(getPhysicalType(dataType.id()) == PhysicalTypeID::INT32);
+  NEUG_ASSERT(common::getPhysicalType(dataType.id()) ==
+              common::PhysicalTypeID::INT32);
   return val.int32Val;
 }
 
@@ -514,7 +530,8 @@ NEUG_API inline int32_t& Value::getValueReference() {
  */
 template <>
 NEUG_API inline int64_t& Value::getValueReference() {
-  NEUG_ASSERT(getPhysicalType(dataType.id()) == PhysicalTypeID::INT64);
+  NEUG_ASSERT(common::getPhysicalType(dataType.id()) ==
+              common::PhysicalTypeID::INT64);
   return val.int64Val;
 }
 
@@ -523,7 +540,8 @@ NEUG_API inline int64_t& Value::getValueReference() {
  */
 template <>
 NEUG_API inline uint8_t& Value::getValueReference() {
-  NEUG_ASSERT(getPhysicalType(dataType.id()) == PhysicalTypeID::UINT8);
+  NEUG_ASSERT(common::getPhysicalType(dataType.id()) ==
+              common::PhysicalTypeID::UINT8);
   return val.uint8Val;
 }
 
@@ -532,7 +550,8 @@ NEUG_API inline uint8_t& Value::getValueReference() {
  */
 template <>
 NEUG_API inline uint16_t& Value::getValueReference() {
-  NEUG_ASSERT(getPhysicalType(dataType.id()) == PhysicalTypeID::UINT16);
+  NEUG_ASSERT(common::getPhysicalType(dataType.id()) ==
+              common::PhysicalTypeID::UINT16);
   return val.uint16Val;
 }
 
@@ -541,7 +560,8 @@ NEUG_API inline uint16_t& Value::getValueReference() {
  */
 template <>
 NEUG_API inline uint32_t& Value::getValueReference() {
-  NEUG_ASSERT(getPhysicalType(dataType.id()) == PhysicalTypeID::UINT32);
+  NEUG_ASSERT(common::getPhysicalType(dataType.id()) ==
+              common::PhysicalTypeID::UINT32);
   return val.uint32Val;
 }
 
@@ -550,7 +570,8 @@ NEUG_API inline uint32_t& Value::getValueReference() {
  */
 template <>
 NEUG_API inline uint64_t& Value::getValueReference() {
-  NEUG_ASSERT(getPhysicalType(dataType.id()) == PhysicalTypeID::UINT64);
+  NEUG_ASSERT(common::getPhysicalType(dataType.id()) ==
+              common::PhysicalTypeID::UINT64);
   return val.uint64Val;
 }
 
@@ -559,7 +580,8 @@ NEUG_API inline uint64_t& Value::getValueReference() {
  */
 template <>
 NEUG_API inline int128_t& Value::getValueReference() {
-  NEUG_ASSERT(getPhysicalType(dataType.id()) == PhysicalTypeID::INT128);
+  NEUG_ASSERT(common::getPhysicalType(dataType.id()) ==
+              common::PhysicalTypeID::INT128);
   return val.int128Val;
 }
 
@@ -568,7 +590,8 @@ NEUG_API inline int128_t& Value::getValueReference() {
  */
 template <>
 NEUG_API inline float& Value::getValueReference() {
-  NEUG_ASSERT(getPhysicalType(dataType.id()) == PhysicalTypeID::FLOAT);
+  NEUG_ASSERT(common::getPhysicalType(dataType.id()) ==
+              common::PhysicalTypeID::FLOAT);
   return val.floatVal;
 }
 
@@ -577,7 +600,8 @@ NEUG_API inline float& Value::getValueReference() {
  */
 template <>
 NEUG_API inline double& Value::getValueReference() {
-  NEUG_ASSERT(getPhysicalType(dataType.id()) == PhysicalTypeID::DOUBLE);
+  NEUG_ASSERT(common::getPhysicalType(dataType.id()) ==
+              common::PhysicalTypeID::DOUBLE);
   return val.doubleVal;
 }
 

--- a/include/neug/storages/graph/vertex_table.h
+++ b/include/neug/storages/graph/vertex_table.h
@@ -302,7 +302,6 @@ class VertexTable {
       }
       EnsureCapacity(cap);
     }
-    std::shared_mutex rw_mutex;
     while (true) {
       auto chunk = supplier->GetNextChunk();
       if (chunk == nullptr) {
@@ -341,7 +340,7 @@ class VertexTable {
 
       for (size_t i = 0; i < prop_cols.size(); ++i) {
         auto col = table_->get_column_by_id(i);
-        set_properties_from_context_column(col, prop_cols[i], vids, rw_mutex);
+        set_properties_from_context_column(col, prop_cols[i], vids);
       }
       VLOG(10) << "Inserted " << chunk_rows
                << " vertices, current vertex num: " << VertexNum();

--- a/include/neug/storages/loader/loader_utils.h
+++ b/include/neug/storages/loader/loader_utils.h
@@ -114,6 +114,6 @@ void fillEdgeReaderMeta(label_t src_label_id, label_t dst_label_id,
 
 void set_properties_from_context_column(
     ColumnBase* col, const std::shared_ptr<IContextColumn>& ctx_col,
-    const std::vector<vid_t>& vids, std::shared_mutex& mutex);
+    const std::vector<vid_t>& vids);
 
 }  // namespace neug

--- a/src/storages/loader/loader_utils.cc
+++ b/src/storages/loader/loader_utils.cc
@@ -23,12 +23,17 @@
 #include <cctype>
 #include <limits>
 #include <memory>
+#include <mutex>
 #include <ostream>
+#include <shared_mutex>
 #include <sstream>
+#include <string_view>
+#include <type_traits>
 #include <unordered_set>
 
 #include "csv.hpp"
 #include "neug/common/columns/columns_utils.h"
+#include "neug/common/columns/value_columns.h"
 #include "neug/common/types/value.h"
 #include "neug/utils/datetime_parsers.h"
 #include "neug/utils/exception/exception.h"
@@ -950,62 +955,93 @@ void fillEdgeReaderMeta(label_t src_label_id, label_t dst_label_id,
   }
 }
 
-void set_properties_from_context_column(
-    neug::ColumnBase* col, const std::shared_ptr<IContextColumn>& ctx_col,
-    const std::vector<vid_t>& vids, std::shared_mutex& mutex) {
-  // Row-by-row via get_elem()
-  auto col_type = col->type();
-  for (size_t k = 0; k < vids.size(); ++k) {
-    if (vids[k] >= std::numeric_limits<vid_t>::max()) {
-      continue;
-    }
-    auto val = ctx_col->get_elem(k);
-    if (val.IsNull()) {
-      continue;
-    }
-    switch (col_type) {
-#define SET_TYPED_VALUE(enum_val, ctype)                  \
-  case DataTypeId::enum_val: {                            \
-    auto* typed = dynamic_cast<TypedColumn<ctype>*>(col); \
-    typed->set_value(vids[k], val.GetValue<ctype>());     \
-    break;                                                \
-  }
-      FOR_EACH_DATA_TYPE_PRIMITIVE(SET_TYPED_VALUE)
-#undef SET_TYPED_VALUE
-    case DataTypeId::kDate: {
-      auto* typed = dynamic_cast<TypedColumn<Date>*>(col);
-      typed->set_value(vids[k], val.GetValue<Date>());
-      break;
-    }
-    case DataTypeId::kTimestampMs: {
-      auto* typed = dynamic_cast<TypedColumn<DateTime>*>(col);
-      typed->set_value(vids[k], val.GetValue<DateTime>());
-      break;
-    }
-    case DataTypeId::kInterval: {
-      auto* typed = dynamic_cast<TypedColumn<Interval>*>(col);
-      typed->set_value(vids[k], val.GetValue<Interval>());
-      break;
-    }
-    case DataTypeId::kVarchar: {
-      auto* typed = dynamic_cast<TypedColumn<std::string_view>*>(col);
-      auto s = val.GetValue<std::string>();
-      std::shared_lock<std::shared_mutex> lock(mutex);
+namespace {
+
+template <typename SRC_T, typename COL_T = SRC_T>
+void set_column_from_value_column(
+    ColumnBase* col, const std::shared_ptr<IContextColumn>& ctx_col,
+    const std::vector<vid_t>& vids, std::shared_mutex* mutex = nullptr) {
+  auto* typed = dynamic_cast<TypedColumn<COL_T>*>(col);
+  CHECK(typed != nullptr)
+      << "Storage column type does not match expected type.";
+
+  auto value_col = std::dynamic_pointer_cast<ValueColumn<SRC_T>>(ctx_col);
+
+  if constexpr (std::is_same_v<COL_T, std::string_view>) {
+    // String writes require mutex-protected capacity management.
+    CHECK(mutex != nullptr) << "String column write requires a shared mutex.";
+    auto write = [&](vid_t vid, const auto& s) {
+      std::shared_lock<std::shared_mutex> lock(*mutex);
       if (typed->available_space() <= s.size()) {
         lock.unlock();
-        std::unique_lock<std::shared_mutex> w_lock(mutex);
+        std::unique_lock<std::shared_mutex> w_lock(*mutex);
         typed->resize(typed->size());
         w_lock.unlock();
         lock.lock();
       }
-      typed->set_value(vids[k], std::string_view(s));
-      break;
+      typed->set_value(vid, std::string_view(s));
+    };
+    for (size_t k = 0; k < vids.size(); ++k) {
+      if (vids[k] >= std::numeric_limits<vid_t>::max())
+        continue;
+      if (value_col) {
+        write(vids[k], value_col->data()[k]);
+      } else {
+        auto val = ctx_col->get_elem(k);
+        if (!val.IsNull())
+          write(vids[k], val.GetValue<std::string>());
+      }
     }
-    default:
-      THROW_NOT_SUPPORTED_EXCEPTION(
-          "set_properties_from_context_column: unsupported type " +
-          DataType(col_type).ToString());
+  } else {
+    for (size_t k = 0; k < vids.size(); ++k) {
+      if (vids[k] >= std::numeric_limits<vid_t>::max())
+        continue;
+      if (value_col) {
+        typed->set_value(vids[k], value_col->data()[k]);
+      } else {
+        auto val = ctx_col->get_elem(k);
+        if (!val.IsNull())
+          typed->set_value(vids[k], val.GetValue<COL_T>());
+      }
     }
+  }
+}
+
+}  // namespace
+
+void set_properties_from_context_column(
+    neug::ColumnBase* col, const std::shared_ptr<IContextColumn>& ctx_col,
+    const std::vector<vid_t>& vids, std::shared_mutex& mutex) {
+  auto col_type = col->type();
+  switch (col_type) {
+#define SET_TYPED_VALUE(enum_val, ctype)                     \
+  case DataTypeId::enum_val: {                               \
+    set_column_from_value_column<ctype>(col, ctx_col, vids); \
+    break;                                                   \
+  }
+    FOR_EACH_DATA_TYPE_PRIMITIVE(SET_TYPED_VALUE)
+#undef SET_TYPED_VALUE
+  case DataTypeId::kDate: {
+    set_column_from_value_column<Date>(col, ctx_col, vids);
+    break;
+  }
+  case DataTypeId::kTimestampMs: {
+    set_column_from_value_column<DateTime>(col, ctx_col, vids);
+    break;
+  }
+  case DataTypeId::kInterval: {
+    set_column_from_value_column<Interval>(col, ctx_col, vids);
+    break;
+  }
+  case DataTypeId::kVarchar: {
+    set_column_from_value_column<std::string, std::string_view>(col, ctx_col,
+                                                                vids, &mutex);
+    break;
+  }
+  default:
+    THROW_NOT_SUPPORTED_EXCEPTION(
+        "set_properties_from_context_column: unsupported type " +
+        DataType(col_type).ToString());
   }
 }
 

--- a/src/storages/loader/loader_utils.cc
+++ b/src/storages/loader/loader_utils.cc
@@ -960,7 +960,7 @@ namespace {
 template <typename SRC_T, typename COL_T = SRC_T>
 void set_column_from_value_column(
     ColumnBase* col, const std::shared_ptr<IContextColumn>& ctx_col,
-    const std::vector<vid_t>& vids, std::shared_mutex* mutex = nullptr) {
+    const std::vector<vid_t>& vids) {
   auto* typed = dynamic_cast<TypedColumn<COL_T>*>(col);
   CHECK(typed != nullptr)
       << "Storage column type does not match expected type.";
@@ -968,16 +968,9 @@ void set_column_from_value_column(
   auto value_col = std::dynamic_pointer_cast<ValueColumn<SRC_T>>(ctx_col);
 
   if constexpr (std::is_same_v<COL_T, std::string_view>) {
-    // String writes require mutex-protected capacity management.
-    CHECK(mutex != nullptr) << "String column write requires a shared mutex.";
     auto write = [&](vid_t vid, const auto& s) {
-      std::shared_lock<std::shared_mutex> lock(*mutex);
       if (typed->available_space() <= s.size()) {
-        lock.unlock();
-        std::unique_lock<std::shared_mutex> w_lock(*mutex);
         typed->resize(typed->size());
-        w_lock.unlock();
-        lock.lock();
       }
       typed->set_value(vid, std::string_view(s));
     };
@@ -1011,7 +1004,7 @@ void set_column_from_value_column(
 
 void set_properties_from_context_column(
     neug::ColumnBase* col, const std::shared_ptr<IContextColumn>& ctx_col,
-    const std::vector<vid_t>& vids, std::shared_mutex& mutex) {
+    const std::vector<vid_t>& vids) {
   auto col_type = col->type();
   switch (col_type) {
 #define SET_TYPED_VALUE(enum_val, ctype)                     \
@@ -1035,7 +1028,7 @@ void set_properties_from_context_column(
   }
   case DataTypeId::kVarchar: {
     set_column_from_value_column<std::string, std::string_view>(col, ctx_col,
-                                                                vids, &mutex);
+                                                                vids);
     break;
   }
   default:


### PR DESCRIPTION
Fixes #695
Fix #683 

Avoid unnecessary value cast cost when setting properties from context column by directly accessing the typed `ValueColumn<T>` data instead of going through the generic `Value` interface (`get_elem()` → `GetValue<ctype>()`).