### PR TITLE
refactor: move auto_compaction from NeugDBConfig to serve/ServiceConfig 

### DIFF
--- a/bin/benchmark.cc
+++ b/bin/benchmark.cc
@@ -256,7 +256,6 @@ int main(int argc, char** argv) {
   neug::NeugDBConfig config(data_path, max_thread_num);
   config.memory_level = memory_level;
 
-  config.enable_auto_compaction = false;
   db.Open(config);
   auto compiler = db.GetPlanner();
   auto svc = std::make_shared<neug::NeugDBService>(db);

--- a/bin/rt_server.cc
+++ b/bin/rt_server.cc
@@ -74,9 +74,6 @@ int main(int argc, char** argv) {
   neug::NeugDB db;
   neug::NeugDBConfig config(data_path, thread_num);
   config.memory_level = memory_level;
-  if (config.memory_level == neug::MemoryLevel::kHugePagePreferred) {
-    config.enable_auto_compaction = true;
-  }
   db.Open(config);
 
   auto end = std::chrono::high_resolution_clock::now();
@@ -92,6 +89,9 @@ int main(int argc, char** argv) {
   service_config.host_str =
       vm.count("host") ? vm["host"].as<std::string>() : "127.0.0.1";
   service_config.query_port = http_port;
+  if (memory_level == neug::MemoryLevel::kHugePagePreferred) {
+    service_config.auto_compaction = true;
+  }
   neug::NeugDBService service(db, service_config);
 
   service.run_and_wait_for_exit();

--- a/bin/rt_server.cc
+++ b/bin/rt_server.cc
@@ -89,9 +89,6 @@ int main(int argc, char** argv) {
   service_config.host_str =
       vm.count("host") ? vm["host"].as<std::string>() : "127.0.0.1";
   service_config.query_port = http_port;
-  if (memory_level == neug::MemoryLevel::kHugePagePreferred) {
-    service_config.auto_compaction = true;
-  }
   neug::NeugDBService service(db, service_config);
 
   service.run_and_wait_for_exit();

--- a/doc/source/reference/cpp_api/neug_db.md
+++ b/doc/source/reference/cpp_api/neug_db.md
@@ -51,7 +51,6 @@ Open(
     int32_t max_thread_num=0,
     const DBMode mode=DBMode::READ_WRITE,
     const std::string &planner_kind="gopt",
-    bool enable_auto_compaction=false,
     bool checkpoint_on_close=true
 )
 ```
@@ -81,7 +80,6 @@ db.Open("/path/to/graph", 8, neug::DBMode::READ_WRITE, "gopt");
     back to `1` if the runtime cannot detect it.
   - `mode`: Database access mode (READ_ONLY or READ_WRITE)
   - `planner_kind`: Query planner type: "gopt" (Graph Optimizer) or "greedy"
-  - `enable_auto_compaction`: Enable background auto-compaction thread
   - `checkpoint_on_close`: Create a checkpoint (persist data) when closing
 
 - **Notes:**
@@ -105,7 +103,6 @@ config.data_dir = "/path/to/graph";
 config.max_thread_num = 8;
 config.mode = neug::DBMode::READ_WRITE;
 config.memory_level = 1;  // Use memory-mapped virtual memory
-config.enable_auto_compaction = true;
 neug::NeugDB db;
 db.Open(config);
 ```

--- a/doc/source/reference/cpp_api/service.md
+++ b/doc/source/reference/cpp_api/service.md
@@ -20,6 +20,7 @@ int main() {
   config.query_port = 10000;
   config.host_str = "0.0.0.0";
   config.thread_num = 0;  // Auto-select service threads from database max_thread_num.
+  config.auto_compaction = true;
   // 3. Start HTTP service
   neug::NeugDBService service(db, config);
   std::string url = service.Start();
@@ -44,6 +45,9 @@ count. The default `0` auto-selects from the database `max_thread_num`. If set
 explicitly, it must be less than or equal to the database `max_thread_num`. With
 the default database thread setting, `max_thread_num` is resolved from hardware
 concurrency and falls back to `1` if the runtime cannot detect it.
+
+**Auto Compaction:** `ServiceConfig::auto_compaction` controls whether a
+background auto-compaction thread runs while serving. Default is `true`.
 
 ### Constructors & Destructors
 

--- a/doc/source/reference/python_api/database.md
+++ b/doc/source/reference/python_api/database.md
@@ -143,7 +143,8 @@ Connect to the database.
 def serve(port: int = 10000,
           host: str = "localhost",
           blocking: bool = True,
-          thread_num: int = 0)
+          thread_num: int = 0,
+          auto_compaction: bool = True)
 ```
 
 Start the database server for handling remote connections(TP mode).
@@ -167,6 +168,8 @@ documentation of Session.
     `max_thread_num`. With the default database thread setting,
     `max_thread_num` is resolved from hardware concurrency and falls back to
     `1` if the runtime cannot detect it.
+  - `auto_compaction` (bool)
+    Enable background auto-compaction while serving. Default is `True`.
 
 - **Returns:**
   - `uri` (str)
@@ -184,6 +187,7 @@ documentation of Session.
   - **Make sure to close all connections before starting the server.**
   - **After starting the server, no new connections to the local database will be allowed.**
   - **`thread_num` controls server-side service threads; client-side `Session(..., num_threads=...)` controls the HTTP connection pool used by that client.**
+  - **`auto_compaction` controls serve-time background compaction behavior.**
 
 <a id="neug.database.Database.stop_serving"></a>
 

--- a/include/neug/config.h.in
+++ b/include/neug/config.h.in
@@ -66,7 +66,6 @@ enum class MemoryLevel : uint8_t {
  * config.max_thread_num = 8;
  * config.mode = neug::DBMode::READ_WRITE;
  * config.memory_level = 1;  // Use memory-mapped virtual memory
- * config.enable_auto_compaction = true;
  * config.checkpoint_on_close = true;
  *
  * neug::NeugDB db;
@@ -96,7 +95,6 @@ struct NeugDBConfig {
         mode(DBMode::READ_WRITE),
         planner_kind("gopt"),
         max_thread_num(1),
-        enable_auto_compaction(true),
         memory_level(MemoryLevel::kInMemory),
         checkpoint_on_close(false),
         checkpoint_on_recovery(false),
@@ -115,7 +113,6 @@ struct NeugDBConfig {
         data_dir(data_dir_),
         planner_kind("gopt"),
         max_thread_num(max_thread_num_),
-        enable_auto_compaction(true),
         memory_level(MemoryLevel::kInMemory),
         checkpoint_on_close(false),
         checkpoint_on_recovery(false),
@@ -136,9 +133,6 @@ struct NeugDBConfig {
   /// Maximum database thread count. 0 means auto-select from hardware
   /// concurrency.
   int max_thread_num;
-
-  /// Enable background auto-compaction thread
-  bool enable_auto_compaction;
 
   /**
    * @brief Memory usage level.

--- a/include/neug/main/neug_db.h
+++ b/include/neug/main/neug_db.h
@@ -145,7 +145,6 @@ class NeugDB {
    * @param mode Database access mode (READ_ONLY or READ_WRITE)
    * @param planner_kind Query planner type: "gopt" (Graph Optimizer) or
    * "greedy"
-   * @param enable_auto_compaction Enable background auto-compaction thread
    * @param checkpoint_on_close Create checkpoint (persist data) when closing
    *
    * @return true if database opened successfully, false otherwise
@@ -161,7 +160,6 @@ class NeugDB {
   bool Open(const std::string& data_dir, int32_t max_thread_num = 0,
             const DBMode mode = DBMode::READ_WRITE,
             const std::string& planner_kind = "gopt",
-            bool enable_auto_compaction = false,
             bool checkpoint_on_close = true);
 
   /**
@@ -177,7 +175,6 @@ class NeugDB {
    * config.max_thread_num = 8;
    * config.mode = neug::DBMode::READ_WRITE;
    * config.memory_level = 1;  // Use memory-mapped virtual memory
-   * config.enable_auto_compaction = true;
    *
    * neug::NeugDB db;
    * db.Open(config);

--- a/include/neug/server/neug_db_service.h
+++ b/include/neug/server/neug_db_service.h
@@ -230,7 +230,7 @@ class NeugDBService {
 
  private:
   NeugDBService() = delete;
-  void startCompactThreadIfNeeded();
+  void startCompactThread();
   void stopCompactThread();
 
   /**

--- a/include/neug/server/neug_db_service.h
+++ b/include/neug/server/neug_db_service.h
@@ -17,8 +17,13 @@
 #include <yaml-cpp/yaml.h>
 #include <cctype>
 
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <memory>
+#include <mutex>
 #include <string>
+#include <thread>
 
 #include "neug/compiler/planner/gopt_planner.h"
 #include "neug/compiler/planner/graph_planner.h"
@@ -99,7 +104,7 @@ class NeugDBService {
    * @note The database should be opened and ready before creating the service
    */
   NeugDBService(neug::NeugDB& db, const ServiceConfig& config = ServiceConfig())
-      : db_(db), db_config_(db_.config()), compact_thread_running_(false) {
+      : db_(db), db_config_(db_.config()) {
     db_.CloseAllConnection();
     init(config);
   }
@@ -226,6 +231,7 @@ class NeugDBService {
  private:
   NeugDBService() = delete;
   void startCompactThreadIfNeeded();
+  void stopCompactThread();
 
   /**
    * @brief Initializes the service with configuration settings
@@ -250,7 +256,9 @@ class NeugDBService {
   std::unique_ptr<IServiceManager> hdl_mgr_;
 
   std::thread compact_thread_;
-  bool compact_thread_running_ = false;
+  std::atomic<bool> compact_thread_running_{false};
+  std::mutex compact_mtx_;
+  std::condition_variable compact_cv_;
 
   std::atomic<bool> running_{false};
   std::mutex mtx_;

--- a/include/neug/utils/service_manager.h
+++ b/include/neug/utils/service_manager.h
@@ -40,6 +40,7 @@ namespace neug {
  * neug::ServiceConfig config;
  * config.query_port = 8080;       // Listen on port 8080
  * config.host_str = "0.0.0.0";    // Accept connections from any interface
+ * config.auto_compaction = true;
  *
  * neug::NeugDBService service(db, config);
  * service.Start();
@@ -63,6 +64,8 @@ struct ServiceConfig {
   /// Host address to bind (default: "127.0.0.1", use "0.0.0.0" for all
   /// interfaces)
   std::string host_str;
+  /// Enable background auto-compaction thread while serving
+  bool auto_compaction;
 
   /**
    * @brief Constructs ServiceConfig with default values.
@@ -71,11 +74,13 @@ struct ServiceConfig {
    * - query_port: 10000
    * - thread_num: 0 (auto-select from database max_thread_num)
    * - host_str: "127.0.0.1" (localhost only)
+   * - auto_compaction: true
    */
   ServiceConfig()
       : query_port(DEFAULT_QUERY_PORT),
         thread_num(DEFAULT_THREAD_NUM),
-        host_str("127.0.0.1") {}
+        host_str("127.0.0.1"),
+        auto_compaction(true) {}
 };
 
 class IServiceManager {

--- a/src/main/neug_db.cc
+++ b/src/main/neug_db.cc
@@ -105,11 +105,10 @@ NeugDB::~NeugDB() {
 
 bool NeugDB::Open(const std::string& data_dir, int32_t max_thread_num,
                   const DBMode mode, const std::string& planner_kind,
-                  bool enable_auto_compaction, bool checkpoint_on_close) {
+                  bool checkpoint_on_close) {
   NeugDBConfig config(data_dir, max_thread_num);
   config.mode = mode;
   config.planner_kind = planner_kind;
-  config.enable_auto_compaction = enable_auto_compaction;
   config.checkpoint_on_close = checkpoint_on_close;
   return Open(config);
 }

--- a/src/server/neug_db_service.cc
+++ b/src/server/neug_db_service.cc
@@ -22,6 +22,11 @@
 
 namespace neug {
 
+namespace {
+constexpr auto kCompactInterval = std::chrono::seconds(30);
+constexpr size_t kCompactQueryThreshold = 100000;
+}  // namespace
+
 void NeugDBService::init(const ServiceConfig& config) {
   if (db_.IsClosed()) {
     THROW_RUNTIME_ERROR("NeugDB instance is not ready for serving!");
@@ -57,10 +62,7 @@ void NeugDBService::init(const ServiceConfig& config) {
 }
 
 NeugDBService::~NeugDBService() {
-  if (compact_thread_running_) {
-    compact_thread_running_ = false;
-    compact_thread_.join();
-  }
+  stopCompactThread();
   if (hdl_mgr_) {
     hdl_mgr_->Stop();
     hdl_mgr_.reset();
@@ -91,23 +93,23 @@ neug::result<std::string> NeugDBService::service_status() {
 }
 
 void NeugDBService::run_and_wait_for_exit() {
-  startCompactThreadIfNeeded();
   if (IsRunning()) {
     THROW_RUNTIME_ERROR("NeugDB service has already been started!");
   }
-  if (hdl_mgr_) {
-    running_.store(true, std::memory_order_relaxed);
-    try {
-      hdl_mgr_->RunAndWaitForExit();
-      running_.store(false, std::memory_order_relaxed);
-    } catch (...) {
-      running_.store(false, std::memory_order_relaxed);
-      throw;
-    }
-  } else {
+  if (!hdl_mgr_) {
     THROW_RUNTIME_ERROR("Query handler has not been inited!");
   }
-  return;
+  startCompactThreadIfNeeded();
+  running_.store(true, std::memory_order_relaxed);
+  try {
+    hdl_mgr_->RunAndWaitForExit();
+    running_.store(false, std::memory_order_relaxed);
+  } catch (...) {
+    running_.store(false, std::memory_order_relaxed);
+    stopCompactThread();
+    throw;
+  }
+  stopCompactThread();
 }
 
 void NeugDBService::Stop() {
@@ -119,6 +121,7 @@ void NeugDBService::Stop() {
   if (hdl_mgr_) {
     hdl_mgr_->Stop();
     running_.store(false, std::memory_order_relaxed);
+    stopCompactThread();
     return;
   } else {
     THROW_RUNTIME_ERROR("Query handler has not been inited!");
@@ -131,9 +134,15 @@ std::string NeugDBService::Start() {
     THROW_RUNTIME_ERROR("NeugDB service has already been started!");
   }
   if (hdl_mgr_) {
-    auto ret = hdl_mgr_->Start();
-    running_.store(true, std::memory_order_relaxed);
-    return ret;
+    startCompactThreadIfNeeded();
+    try {
+      auto ret = hdl_mgr_->Start();
+      running_.store(true, std::memory_order_relaxed);
+      return ret;
+    } catch (...) {
+      stopCompactThread();
+      throw;
+    }
   } else {
     THROW_RUNTIME_ERROR("Query handler has not been inited!");
   }
@@ -143,24 +152,40 @@ size_t NeugDBService::getExecutedQueryNum() const {
   return session_pool_->getExecutedQueryNum();
 }
 
+void NeugDBService::stopCompactThread() {
+  if (!compact_thread_.joinable()) {
+    return;
+  }
+  compact_thread_running_.store(false, std::memory_order_relaxed);
+  compact_cv_.notify_all();
+  compact_thread_.join();
+}
+
 void NeugDBService::startCompactThreadIfNeeded() {
-  if (service_config_.auto_compaction) {
-    if (compact_thread_running_) {
-      compact_thread_running_ = false;
-      compact_thread_.join();
-    }
-    compact_thread_running_ = true;
-    compact_thread_ = std::thread([&]() {
-      size_t last_compaction_at = 0;
-      while (compact_thread_running_) {
-        size_t query_num_before = getExecutedQueryNum();
-        sleep(30);
-        if (!compact_thread_running_) {
+  if (!service_config_.auto_compaction) {
+    return;
+  }
+  stopCompactThread();
+  compact_thread_running_.store(true, std::memory_order_relaxed);
+  compact_thread_ = std::thread([this]() {
+    size_t last_compaction_at = 0;
+    while (compact_thread_running_.load(std::memory_order_relaxed)) {
+      size_t query_num_before = getExecutedQueryNum();
+      {
+        std::unique_lock<std::mutex> lock(compact_mtx_);
+        if (compact_cv_.wait_for(lock, kCompactInterval, [this] {
+              return !compact_thread_running_.load(std::memory_order_relaxed);
+            })) {
           break;
         }
+      }
+      if (!compact_thread_running_.load(std::memory_order_relaxed)) {
+        break;
+      }
+      try {
         size_t query_num_after = getExecutedQueryNum();
         if (query_num_before == query_num_after &&
-            (query_num_after > (last_compaction_at + 100000))) {
+            (query_num_after > (last_compaction_at + kCompactQueryThreshold))) {
           VLOG(10) << "Trigger auto compaction";
           last_compaction_at = query_num_after;
           auto session_guard = AcquireSession();
@@ -168,9 +193,13 @@ void NeugDBService::startCompactThreadIfNeeded() {
           txn.Commit();
           VLOG(10) << "Finish compaction";
         }
+      } catch (const std::exception& e) {
+        LOG(WARNING) << "Auto compaction failed: " << e.what();
+      } catch (...) {
+        LOG(WARNING) << "Auto compaction failed with unknown error";
       }
-    });
-  }
+    }
+  });
 }
 
 }  // namespace neug

--- a/src/server/neug_db_service.cc
+++ b/src/server/neug_db_service.cc
@@ -144,7 +144,7 @@ size_t NeugDBService::getExecutedQueryNum() const {
 }
 
 void NeugDBService::startCompactThreadIfNeeded() {
-  if (db_config_.enable_auto_compaction) {
+  if (service_config_.auto_compaction) {
     if (compact_thread_running_) {
       compact_thread_running_ = false;
       compact_thread_.join();

--- a/src/server/neug_db_service.cc
+++ b/src/server/neug_db_service.cc
@@ -99,7 +99,7 @@ void NeugDBService::run_and_wait_for_exit() {
   if (!hdl_mgr_) {
     THROW_RUNTIME_ERROR("Query handler has not been inited!");
   }
-  startCompactThreadIfNeeded();
+  startCompactThread();
   running_.store(true, std::memory_order_relaxed);
   try {
     hdl_mgr_->RunAndWaitForExit();
@@ -134,7 +134,7 @@ std::string NeugDBService::Start() {
     THROW_RUNTIME_ERROR("NeugDB service has already been started!");
   }
   if (hdl_mgr_) {
-    startCompactThreadIfNeeded();
+    startCompactThread();
     try {
       auto ret = hdl_mgr_->Start();
       running_.store(true, std::memory_order_relaxed);
@@ -161,7 +161,7 @@ void NeugDBService::stopCompactThread() {
   compact_thread_.join();
 }
 
-void NeugDBService::startCompactThreadIfNeeded() {
+void NeugDBService::startCompactThread() {
   if (!service_config_.auto_compaction) {
     return;
   }

--- a/src/server/neug_db_service.cc
+++ b/src/server/neug_db_service.cc
@@ -153,12 +153,11 @@ size_t NeugDBService::getExecutedQueryNum() const {
 }
 
 void NeugDBService::stopCompactThread() {
-  if (!compact_thread_.joinable()) {
-    return;
-  }
   compact_thread_running_.store(false, std::memory_order_relaxed);
   compact_cv_.notify_all();
-  compact_thread_.join();
+  if (compact_thread_.joinable()) {
+    compact_thread_.join();
+  }
 }
 
 void NeugDBService::startCompactThread() {
@@ -167,39 +166,45 @@ void NeugDBService::startCompactThread() {
   }
   stopCompactThread();
   compact_thread_running_.store(true, std::memory_order_relaxed);
-  compact_thread_ = std::thread([this]() {
-    size_t last_compaction_at = 0;
-    while (compact_thread_running_.load(std::memory_order_relaxed)) {
-      size_t query_num_before = getExecutedQueryNum();
-      {
-        std::unique_lock<std::mutex> lock(compact_mtx_);
-        if (compact_cv_.wait_for(lock, kCompactInterval, [this] {
-              return !compact_thread_running_.load(std::memory_order_relaxed);
-            })) {
+  try {
+    compact_thread_ = std::thread([this]() {
+      size_t last_compaction_at = 0;
+      while (compact_thread_running_.load(std::memory_order_relaxed)) {
+        size_t query_num_before = getExecutedQueryNum();
+        {
+          std::unique_lock<std::mutex> lock(compact_mtx_);
+          if (compact_cv_.wait_for(lock, kCompactInterval, [this] {
+                return !compact_thread_running_.load(std::memory_order_relaxed);
+              })) {
+            break;
+          }
+        }
+        if (!compact_thread_running_.load(std::memory_order_relaxed)) {
           break;
         }
-      }
-      if (!compact_thread_running_.load(std::memory_order_relaxed)) {
-        break;
-      }
-      try {
-        size_t query_num_after = getExecutedQueryNum();
-        if (query_num_before == query_num_after &&
-            (query_num_after > (last_compaction_at + kCompactQueryThreshold))) {
-          VLOG(10) << "Trigger auto compaction";
-          last_compaction_at = query_num_after;
-          auto session_guard = AcquireSession();
-          auto txn = session_guard->GetCompactTransaction();
-          txn.Commit();
-          VLOG(10) << "Finish compaction";
+        try {
+          size_t query_num_after = getExecutedQueryNum();
+          if (query_num_before == query_num_after &&
+              (query_num_after >
+               (last_compaction_at + kCompactQueryThreshold))) {
+            VLOG(10) << "Trigger auto compaction";
+            last_compaction_at = query_num_after;
+            auto session_guard = AcquireSession();
+            auto txn = session_guard->GetCompactTransaction();
+            txn.Commit();
+            VLOG(10) << "Finish compaction";
+          }
+        } catch (const std::exception& e) {
+          LOG(WARNING) << "Auto compaction failed: " << e.what();
+        } catch (...) {
+          LOG(WARNING) << "Auto compaction failed with unknown error";
         }
-      } catch (const std::exception& e) {
-        LOG(WARNING) << "Auto compaction failed: " << e.what();
-      } catch (...) {
-        LOG(WARNING) << "Auto compaction failed with unknown error";
       }
-    }
-  });
+    });
+  } catch (...) {
+    compact_thread_running_.store(false, std::memory_order_relaxed);
+    throw;
+  }
 }
 
 }  // namespace neug

--- a/tests/memory_leak/test_node_create.cc
+++ b/tests/memory_leak/test_node_create.cc
@@ -85,7 +85,6 @@ NeugDBConfig MakeConfig(const std::string& dir) {
   NeugDBConfig config;
   config.data_dir = dir;
   config.mode = DBMode::READ_WRITE;
-  config.enable_auto_compaction = false;
   config.checkpoint_on_close = true;
   return config;
 }

--- a/tests/memory_leak/test_temporary_tables.cc
+++ b/tests/memory_leak/test_temporary_tables.cc
@@ -100,7 +100,6 @@ NeugDBConfig MakeConfig(const std::string& dir) {
   NeugDBConfig config;
   config.data_dir = dir;
   config.mode = DBMode::READ_WRITE;
-  config.enable_auto_compaction = false;
   config.checkpoint_on_close = true;
   return config;
 }

--- a/tests/storage/test_checkpoint.cc
+++ b/tests/storage/test_checkpoint.cc
@@ -180,7 +180,6 @@ class CheckpointTestBase : public ::testing::Test {
     config.data_dir = data_dir;
     config.memory_level = kMemoryLevel;
     config.checkpoint_on_close = true;
-    config.enable_auto_compaction = false;
     return config;
   }
 

--- a/tests/storage/test_copy_temp.cc
+++ b/tests/storage/test_copy_temp.cc
@@ -74,7 +74,6 @@ class CopyTempTest : public ::testing::Test {
     NeugDBConfig config;
     config.data_dir = DB_DIR;
     config.checkpoint_on_close = true;
-    config.enable_auto_compaction = false;
     db_->Open(config);
   }
 
@@ -306,7 +305,6 @@ TEST_F(CopyTempTest, CleanupOnClose) {
     NeugDBConfig config;
     config.data_dir = DB_DIR;
     config.checkpoint_on_close = true;
-    config.enable_auto_compaction = false;
     db2->Open(config);
     auto conn2 = db2->Connect();
     auto q = conn2->Query("MATCH (n:TempEphemeral) RETURN n.id;");
@@ -372,7 +370,6 @@ TEST_F(CopyTempTest, PersistentSurvivesTempCleanup) {
     NeugDBConfig config;
     config.data_dir = DB_DIR;
     config.checkpoint_on_close = true;
-    config.enable_auto_compaction = false;
     db2->Open(config);
     auto conn2 = db2->Connect();
     auto q1 = conn2->Query("MATCH (n:Persistent) RETURN count(n);");

--- a/tests/storage/test_open_graph.cc
+++ b/tests/storage/test_open_graph.cc
@@ -204,7 +204,7 @@ TEST(DatabaseTest, TestPersist) {
       std::filesystem::remove_all(db_dir);
     }
     neug::NeugDB db;
-    db.Open(db_dir, 1, neug::DBMode::READ_WRITE, "gopt", false, true);
+    db.Open(db_dir, 1, neug::DBMode::READ_WRITE, "gopt", true);
     auto conn = db.Connect();
     std::string flex_data_dir = std::getenv("FLEX_DATA_DIR");
     EXPECT_FALSE(flex_data_dir.empty());
@@ -233,7 +233,7 @@ TEST(DatabaseTest, TestCompaction) {
       std::filesystem::remove_all(db_dir);
     }
     neug::NeugDB db;
-    db.Open(db_dir, 1, neug::DBMode::READ_WRITE, "gopt", false, true);
+    db.Open(db_dir, 1, neug::DBMode::READ_WRITE, "gopt", true);
     auto conn = db.Connect();
     std::string flex_data_dir = std::getenv("FLEX_DATA_DIR");
     EXPECT_FALSE(flex_data_dir.empty());
@@ -275,6 +275,6 @@ TEST(DatabaseTest, TestCompaction) {
 
   {
     neug::NeugDB db3;
-    db3.Open(db_dir, 1, neug::DBMode::READ_WRITE, "gopt", false, true);
+    db3.Open(db_dir, 1, neug::DBMode::READ_WRITE, "gopt", true);
   }
 }

--- a/tests/transaction/test_wal_replay.cc
+++ b/tests/transaction/test_wal_replay.cc
@@ -43,7 +43,6 @@ std::string make_test_dir() {
 neug::NeugDBConfig make_config(const std::string& db_dir) {
   neug::NeugDBConfig config(db_dir, 1);
   config.memory_level = neug::MemoryLevel::kInMemory;
-  config.enable_auto_compaction = false;
   config.checkpoint_on_close = false;
   config.checkpoint_on_recovery = false;
   return config;

--- a/tests/unittest/test_connection.cc
+++ b/tests/unittest/test_connection.cc
@@ -36,7 +36,6 @@ class ConnectionTest : public ::testing::Test {
     neug::NeugDBConfig config;
     config.data_dir = DB_DIR;
     config.checkpoint_on_close = true;
-    config.enable_auto_compaction = false;  // TODO(zhanglei): very slow
     db_->Open(config);
     auto conn = db_->Connect();
 

--- a/tests/unittest/test_db_svc.cc
+++ b/tests/unittest/test_db_svc.cc
@@ -104,8 +104,7 @@ TEST_F(NeugDBServiceTest, GetServiceConfig) {
   EXPECT_EQ(retrieved_config.query_port, config_.query_port);
   EXPECT_EQ(retrieved_config.host_str, config_.host_str);
   EXPECT_EQ(retrieved_config.thread_num, config_.thread_num);
-  EXPECT_EQ(retrieved_config.auto_compaction,
-            config_.auto_compaction);
+  EXPECT_EQ(retrieved_config.auto_compaction, config_.auto_compaction);
 }
 
 TEST_F(NeugDBServiceTest, DefaultServiceThreadsFollowDatabaseMaxThreadNum) {

--- a/tests/unittest/test_db_svc.cc
+++ b/tests/unittest/test_db_svc.cc
@@ -104,6 +104,8 @@ TEST_F(NeugDBServiceTest, GetServiceConfig) {
   EXPECT_EQ(retrieved_config.query_port, config_.query_port);
   EXPECT_EQ(retrieved_config.host_str, config_.host_str);
   EXPECT_EQ(retrieved_config.thread_num, config_.thread_num);
+  EXPECT_EQ(retrieved_config.auto_compaction,
+            config_.auto_compaction);
 }
 
 TEST_F(NeugDBServiceTest, DefaultServiceThreadsFollowDatabaseMaxThreadNum) {

--- a/tools/python_bind/README.md
+++ b/tools/python_bind/README.md
@@ -77,6 +77,7 @@ endpoint = db.serve(
     port=10000,
     blocking=False,
     thread_num=0,
+    auto_compaction=True,
 )
 ```
 
@@ -86,6 +87,9 @@ value. With the default database thread setting, `max_thread_num` is resolved
 from hardware concurrency and falls back to `1` if the runtime cannot detect it.
 This is separate from client-side `Session(..., num_threads=...)`, which
 configures the client's HTTP connection pool.
+
+`auto_compaction` controls whether a background auto-compaction thread
+runs while serving (default `True`).
 
 ### Multi-version wheels via cibuildwheel
 

--- a/tools/python_bind/neug/database.py
+++ b/tools/python_bind/neug/database.py
@@ -254,6 +254,7 @@ class Database(object):
         host: str = "localhost",
         blocking: bool = True,
         thread_num: int = 0,
+        auto_compaction: bool = True,
     ):
         """
         Start the database server for handling remote connections(TP mode).
@@ -276,6 +277,8 @@ class Database(object):
             Service thread count. Default is 0, which means auto-select from
             database max_thread_num. If set explicitly, it must be less than or
             equal to max_thread_num.
+        auto_compaction : bool
+            Enable background auto-compaction while serving. Default is True.
 
         Returns
         -------
@@ -331,7 +334,9 @@ class Database(object):
         self._serving = True
         logger.info(f"Starting database server on {host}:{port}.")
         try:
-            endpoint = self._database.serve(port, host, thread_num, blocking)
+            endpoint = self._database.serve(
+                port, host, thread_num, blocking, auto_compaction
+            )
         except KeyboardInterrupt:
             self.stop_serving()
         return endpoint

--- a/tools/python_bind/src/py_database.cc
+++ b/tools/python_bind/src/py_database.cc
@@ -62,6 +62,7 @@ void PyDatabase::initialize(pybind11::handle& m) {
       .def("serve", &PyDatabase::serve, pybind11::arg("port") = 10000,
            pybind11::arg("host") = "localhost", pybind11::arg("thread_num") = 0,
            pybind11::arg("blocking") = false,
+           pybind11::arg("auto_compaction") = true,
            "Start the database server.\n\n"
            "Args:\n"
            "    port (int): The port to listen on, default is 10000.\n"
@@ -70,6 +71,8 @@ void PyDatabase::initialize(pybind11::handle& m) {
            "which means auto-select from database max_thread_num.\n"
            "    blocking (bool): Whether to block the function until the "
            "server shuts down.\n"
+           "    auto_compaction (bool): Enable background "
+           "auto-compaction while serving, default is True.\n"
            "Returns:\n"
            "    uri (str): A string containing the URL of the server.\n")
       .def("stop_serving", &PyDatabase::stop_serving,
@@ -86,7 +89,8 @@ PyConnection PyDatabase::connect() {
 }
 
 std::string PyDatabase::serve(int port, const std::string& host,
-                              int32_t thread_num, bool blocking) {
+                              int32_t thread_num, bool blocking,
+                              bool auto_compaction) {
 #ifdef BUILD_HTTP_SERVER
   if (!database) {
     THROW_RUNTIME_ERROR("Database is not initialized.");
@@ -123,6 +127,7 @@ std::string PyDatabase::serve(int port, const std::string& host,
   config.query_port = port;
   config.host_str = host;
   config.thread_num = static_cast<uint32_t>(thread_num);
+  config.auto_compaction = auto_compaction;
 #ifdef __APPLE__
   if (host == "localhost") {
     config.host_str = "127.0.0.1";

--- a/tools/python_bind/src/py_database.h
+++ b/tools/python_bind/src/py_database.h
@@ -78,11 +78,14 @@ class PyDatabase : public std::enable_shared_from_this<PyDatabase> {
    * @param thread_num The service thread count. 0 means auto-select from
    * database max_thread_num.
    * @param blocking Whether to block the function until the server shuts down.
+   * @param auto_compaction Enable background auto-compaction while
+   * serving.
    * @return A string containing the URL of the server.
    * @note This method will block until the server is stopped.
    */
   std::string serve(int port = 10000, const std::string& host = "localhost",
-                    int32_t thread_num = 0, bool blocking = false);
+                    int32_t thread_num = 0, bool blocking = false,
+                    bool auto_compaction = true);
 
   /**
    * @brief Stop the database server.

--- a/tools/python_bind/src/py_database.h
+++ b/tools/python_bind/src/py_database.h
@@ -81,7 +81,8 @@ class PyDatabase : public std::enable_shared_from_this<PyDatabase> {
    * @param auto_compaction Enable background auto-compaction while
    * serving.
    * @return A string containing the URL of the server.
-   * @note This method will block until the server is stopped.
+   * @note When blocking is true, this method blocks until the server is
+   * stopped; otherwise it returns immediately after the server starts.
    */
   std::string serve(int port = 10000, const std::string& host = "localhost",
                     int32_t thread_num = 0, bool blocking = false,


### PR DESCRIPTION
This pull request refactors how background auto-compaction is configured in the database and service APIs. The main change is to remove the `enable_auto_compaction` option from the core database configuration (`NeugDBConfig` and `NeugDB::Open`) and move auto-compaction control to the service layer (`ServiceConfig` and `serve` API). Documentation and tests are updated to reflect this change, and the Python API and docs now expose `auto_compaction` as a parameter for serving.
