### PR TITLE
refactor: Revert"refactor: Avoid unnecessary compact for csr before dump (#738)"

### DIFF
--- a/include/neug/storages/csr/csr_base.h
+++ b/include/neug/storages/csr/csr_base.h
@@ -29,8 +29,6 @@
 
 namespace neug {
 
-class EdgeTable;
-
 // CsrType is defined in csr_view.h to avoid a csr_base <-> csr_view
 // include cycle (CsrView may need to know about CsrType in future).
 
@@ -95,13 +93,6 @@ class CsrBase : public Module {
   /// (e.g. PropertyGraphCowState) is responsible for tracking which
   /// adjlists have been detached.
   virtual void DetachVertex(vid_t vid, Allocator& alloc) = 0;
-
- private:
-  friend class EdgeTable;
-
-  // Called after a timestamped edge update so compact() cannot take the
-  // "nothing to do" fast path.
-  virtual void mark_compaction_required() = 0;
 };
 
 template <typename EDATA_T>

--- a/include/neug/storages/csr/immutable_csr.h
+++ b/include/neug/storages/csr/immutable_csr.h
@@ -116,9 +116,6 @@ class ImmutableCsr : public TypedCsrBase<EDATA_T> {
     cow_clone->nbr_list_buffer_ = nbr_list_buffer_;
     cow_clone->unsorted_since_ = unsorted_since_;
     cow_clone->edge_num_ = edge_num_.load();
-    cow_clone->needs_compact_.store(
-        needs_compact_.load(std::memory_order_relaxed),
-        std::memory_order_relaxed);
     return cow_clone;
   }
 
@@ -134,16 +131,11 @@ class ImmutableCsr : public TypedCsrBase<EDATA_T> {
   }
 
  private:
-  void mark_compaction_required() override {
-    needs_compact_.store(true, std::memory_order_relaxed);
-  }
-
   std::shared_ptr<IDataContainer> adj_list_buffer_;
   std::shared_ptr<IDataContainer> degree_list_buffer_;
   std::shared_ptr<IDataContainer> nbr_list_buffer_;
   timestamp_t unsorted_since_;
   std::atomic<uint64_t> edge_num_{0};
-  std::atomic<bool> needs_compact_{false};
   CsrPrefetchPolicy prefetch_policy_;
 
   void refresh_prefetch_policy();
@@ -247,8 +239,6 @@ class SingleImmutableCsr : public TypedCsrBase<EDATA_T> {
   }
 
  private:
-  void mark_compaction_required() override {}
-
   void refresh_prefetch_policy();
   CsrPrefetchPolicy prefetch_policy_;
   std::shared_ptr<IDataContainer> nbr_list_buffer_;

--- a/include/neug/storages/csr/mutable_csr.h
+++ b/include/neug/storages/csr/mutable_csr.h
@@ -142,9 +142,6 @@ class MutableCsr : public TypedCsrBase<EDATA_T> {
     nbr.data = data;
     nbr.timestamp.store(ts);
     edge_num_.fetch_add(1);
-    if (ts != 0) {
-      needs_compact_.store(true, std::memory_order_relaxed);
-    }
     // invalidate sort flag
     if (ts < unsorted_since_) {
       unsorted_since_ = 0;
@@ -220,9 +217,6 @@ class MutableCsr : public TypedCsrBase<EDATA_T> {
     cow_clone->nbr_list_ = nbr_list_;
     cow_clone->unsorted_since_ = unsorted_since_;
     cow_clone->edge_num_ = edge_num_.load();
-    cow_clone->needs_compact_.store(
-        needs_compact_.load(std::memory_order_relaxed),
-        std::memory_order_relaxed);
     return cow_clone;
   }
 
@@ -241,10 +235,6 @@ class MutableCsr : public TypedCsrBase<EDATA_T> {
   }
 
  private:
-  void mark_compaction_required() override {
-    needs_compact_.store(true, std::memory_order_relaxed);
-  }
-
   std::unique_ptr<SpinLock[]> locks_;
   std::shared_ptr<IDataContainer> adj_list_buffer_;
   std::shared_ptr<IDataContainer> degree_list_;
@@ -252,7 +242,6 @@ class MutableCsr : public TypedCsrBase<EDATA_T> {
   std::shared_ptr<IDataContainer> nbr_list_;
   timestamp_t unsorted_since_;
   std::atomic<uint64_t> edge_num_{0};
-  std::atomic<bool> needs_compact_{false};
   CsrPrefetchPolicy prefetch_policy_;
 
   void refresh_prefetch_policy();
@@ -342,9 +331,6 @@ class SingleMutableCsr : public TypedCsrBase<EDATA_T> {
     CHECK_EQ(nbrs[src].timestamp, std::numeric_limits<timestamp_t>::max());
     nbrs[src].timestamp.store(ts);
     edge_num_.fetch_add(1, std::memory_order_relaxed);
-    if (ts != 0) {
-      needs_compact_.store(true, std::memory_order_relaxed);
-    }
     return {0, static_cast<const void*>(&nbrs[src].data)};
   }
 
@@ -381,9 +367,6 @@ class SingleMutableCsr : public TypedCsrBase<EDATA_T> {
     auto cow_clone = std::make_unique<SingleMutableCsr<EDATA_T>>();
     cow_clone->nbr_list_ = nbr_list_;
     cow_clone->edge_num_ = edge_num_.load();
-    cow_clone->needs_compact_.store(
-        needs_compact_.load(std::memory_order_relaxed),
-        std::memory_order_relaxed);
     return cow_clone;
   }
 
@@ -399,13 +382,8 @@ class SingleMutableCsr : public TypedCsrBase<EDATA_T> {
   }
 
  private:
-  void mark_compaction_required() override {
-    needs_compact_.store(true, std::memory_order_relaxed);
-  }
-
   std::shared_ptr<IDataContainer> nbr_list_;
   std::atomic<uint64_t> edge_num_{0};
-  std::atomic<bool> needs_compact_{false};
   CsrPrefetchPolicy prefetch_policy_;
 
   void refresh_prefetch_policy();
@@ -500,9 +478,6 @@ class EmptyCsr : public TypedCsrBase<EDATA_T> {
   static std::string type_name() {
     return "empty_csr<" + type_name_string<EDATA_T>() + ">";
   }
-
- private:
-  void mark_compaction_required() override {}
 };
 
 }  // namespace neug

--- a/src/storages/csr/immutable_csr.cc
+++ b/src/storages/csr/immutable_csr.cc
@@ -42,7 +42,6 @@ void ImmutableCsr<EDATA_T>::Open(Checkpoint& ckp, const ModuleDescriptor& desc,
                                  MemoryLevel memory_level) {
   unsorted_since_ = std::stoull(desc.get("unsorted_since").value_or("0"));
   edge_num_.store(std::stoull(desc.get("edge_num").value_or("0")));
-  needs_compact_.store(false, std::memory_order_relaxed);
   degree_list_buffer_ = ckp.OpenFile(
       desc.get_path(ModuleDescriptor::kDegreeListPath).value_or(""),
       memory_level);
@@ -90,9 +89,6 @@ void ImmutableCsr<EDATA_T>::Dump(Checkpoint& ckp, CheckpointManifest& meta,
 
 template <typename EDATA_T>
 void ImmutableCsr<EDATA_T>::compact() {
-  if (!needs_compact_.load(std::memory_order_relaxed)) {
-    return;
-  }
   // For current adj_list where the dst vertex is invalid, swap it to the end.
   vid_t vnum = size();
   if (vnum <= 0) {
@@ -129,7 +125,6 @@ void ImmutableCsr<EDATA_T>::compact() {
     adj_arr[i] = ptr;
     ptr += deg_arr[i];
   }
-  needs_compact_.store(false, std::memory_order_relaxed);
 }
 
 template <typename EDATA_T>
@@ -187,9 +182,6 @@ void ImmutableCsr<EDATA_T>::batch_sort_by_edge_data(timestamp_t ts) {
 template <typename EDATA_T>
 void ImmutableCsr<EDATA_T>::batch_delete_vertices(
     const std::set<vid_t>& src_set, const std::set<vid_t>& dst_set) {
-  if (!src_set.empty() || !dst_set.empty()) {
-    needs_compact_.store(true, std::memory_order_relaxed);
-  }
   vid_t vnum = size();
   auto** adj_arr = reinterpret_cast<nbr_t**>(adj_list_buffer_->GetData());
   auto* deg_arr = reinterpret_cast<int*>(degree_list_buffer_->GetData());
@@ -240,9 +232,6 @@ void ImmutableCsr<EDATA_T>::batch_delete_vertices(
 template <typename EDATA_T>
 void ImmutableCsr<EDATA_T>::batch_delete_edges(
     const std::vector<vid_t>& src_list, const std::vector<vid_t>& dst_list) {
-  if (!src_list.empty()) {
-    needs_compact_.store(true, std::memory_order_relaxed);
-  }
   std::map<vid_t, std::set<vid_t>> src_dst_map;
   vid_t vnum = size();
   for (size_t i = 0; i < src_list.size(); ++i) {
@@ -281,9 +270,6 @@ void ImmutableCsr<EDATA_T>::batch_delete_edges(
 template <typename EDATA_T>
 void ImmutableCsr<EDATA_T>::batch_delete_edges(
     const std::vector<std::pair<vid_t, int32_t>>& edges) {
-  if (!edges.empty()) {
-    needs_compact_.store(true, std::memory_order_relaxed);
-  }
   std::map<vid_t, std::set<int32_t>> src_offset_map;
   vid_t vnum = size();
   auto** adj_arr = reinterpret_cast<nbr_t**>(adj_list_buffer_->GetData());
@@ -328,7 +314,6 @@ void ImmutableCsr<EDATA_T>::delete_edge(vid_t src, int32_t offset,
   }
   nbrs[offset].neighbor = std::numeric_limits<vid_t>::max();
   edge_num_.fetch_sub(1, std::memory_order_relaxed);
-  needs_compact_.store(true, std::memory_order_relaxed);
   unsorted_since_ = 0;
 }
 

--- a/src/storages/csr/mutable_csr.cc
+++ b/src/storages/csr/mutable_csr.cc
@@ -85,7 +85,6 @@ void MutableCsr<EDATA_T>::Open(Checkpoint& ckp,
         " but degree list implies " + std::to_string(edge_count) +
         ", desc: " + descriptor.ToJsonString());
   }
-  needs_compact_.store(false, std::memory_order_relaxed);
   refresh_prefetch_policy();
 }
 
@@ -172,9 +171,6 @@ void MutableCsr<EDATA_T>::Dump(Checkpoint& ckp, CheckpointManifest& meta,
 
 template <typename EDATA_T>
 void MutableCsr<EDATA_T>::compact() {
-  if (!needs_compact_.load(std::memory_order_relaxed)) {
-    return;
-  }
   // Remove deleted edges and reset timestamps on surviving edges.
   size_t vnum = vertex_capacity();
   auto** buf_arr = reinterpret_cast<nbr_t**>(adj_list_buffer_->GetData());
@@ -213,7 +209,6 @@ void MutableCsr<EDATA_T>::compact() {
         std::to_string(edge_num_.load()) + ", actual " +
         std::to_string(total_edge_num));
   }
-  needs_compact_.store(false, std::memory_order_relaxed);
 }
 
 template <typename EDATA_T>
@@ -283,9 +278,6 @@ void MutableCsr<EDATA_T>::batch_sort_by_edge_data(timestamp_t ts) {
 template <typename EDATA_T>
 void MutableCsr<EDATA_T>::batch_delete_vertices(
     const std::set<vid_t>& src_set, const std::set<vid_t>& dst_set) {
-  if (!src_set.empty() || !dst_set.empty()) {
-    needs_compact_.store(true, std::memory_order_relaxed);
-  }
   vid_t vnum = static_cast<vid_t>(vertex_capacity());
   auto** buf_arr = reinterpret_cast<nbr_t**>(adj_list_buffer_->GetData());
   auto* sz_arr = reinterpret_cast<std::atomic<int>*>(degree_list_->GetData());
@@ -341,9 +333,6 @@ void MutableCsr<EDATA_T>::batch_delete_vertices(
 template <typename EDATA_T>
 void MutableCsr<EDATA_T>::batch_delete_edges(
     const std::vector<vid_t>& src_list, const std::vector<vid_t>& dst_list) {
-  if (!src_list.empty()) {
-    needs_compact_.store(true, std::memory_order_relaxed);
-  }
   std::map<vid_t, std::set<vid_t>> src_dst_map;
   vid_t vnum = static_cast<vid_t>(vertex_capacity());
   for (size_t i = 0; i < src_list.size(); ++i) {
@@ -378,9 +367,6 @@ void MutableCsr<EDATA_T>::batch_delete_edges(
 template <typename EDATA_T>
 void MutableCsr<EDATA_T>::batch_delete_edges(
     const std::vector<std::pair<vid_t, int32_t>>& edges) {
-  if (!edges.empty()) {
-    needs_compact_.store(true, std::memory_order_relaxed);
-  }
   std::map<vid_t, std::set<int32_t>> src_offset_map;
   vid_t vnum = static_cast<vid_t>(vertex_capacity());
   auto* sz_arr = reinterpret_cast<std::atomic<int>*>(degree_list_->GetData());
@@ -427,7 +413,6 @@ void MutableCsr<EDATA_T>::delete_edge(vid_t src, int32_t offset,
   if (old_ts <= ts) {
     nbrs[offset].timestamp.store(std::numeric_limits<timestamp_t>::max());
     edge_num_.fetch_sub(1, std::memory_order_relaxed);
-    needs_compact_.store(true, std::memory_order_relaxed);
     unsorted_since_ = 0;
   } else if (old_ts == std::numeric_limits<timestamp_t>::max()) {
     LOG(ERROR) << "Attempting to delete already deleted edge.";
@@ -457,9 +442,6 @@ void MutableCsr<EDATA_T>::revert_delete_edge(vid_t src, vid_t nbr,
     assert(nbrs[offset].neighbor == nbr);
     nbrs[offset].timestamp.store(ts);
     edge_num_.fetch_add(1, std::memory_order_relaxed);
-    if (ts != 0) {
-      needs_compact_.store(true, std::memory_order_relaxed);
-    }
   } else {
     THROW_INVALID_ARGUMENT_EXCEPTION(
         "Attempting to revert delete on edge that is not deleted.");
@@ -537,9 +519,6 @@ void MutableCsr<EDATA_T>::batch_put_edges(const std::vector<vid_t>& src_list,
     added_edge_num++;
   }
   edge_num_.fetch_add(added_edge_num, std::memory_order_relaxed);
-  if (ts != 0 && added_edge_num > 0) {
-    needs_compact_.store(true, std::memory_order_relaxed);
-  }
   // invalidate sort flag
   if (ts < unsorted_since_) {
     unsorted_since_ = 0;
@@ -556,7 +535,6 @@ void SingleMutableCsr<EDATA_T>::Open(Checkpoint& ckp,
   nbr_list_ = ckp.OpenFile(
       descriptor.get_path(ModuleDescriptor::kNbrListPath).value_or(""), level);
   edge_num_.store(std::stoull(descriptor.get("edge_num").value_or("0")));
-  needs_compact_.store(false, std::memory_order_relaxed);
   refresh_prefetch_policy();
 }
 
@@ -580,9 +558,6 @@ void SingleMutableCsr<EDATA_T>::Dump(Checkpoint& ckp, CheckpointManifest& meta,
 
 template <typename EDATA_T>
 void SingleMutableCsr<EDATA_T>::compact() {
-  if (!needs_compact_.load(std::memory_order_relaxed)) {
-    return;
-  }
   if (!nbr_list_) {
     return;
   }
@@ -593,7 +568,6 @@ void SingleMutableCsr<EDATA_T>::compact() {
       data[i].timestamp.store(0, std::memory_order_relaxed);
     }
   }
-  needs_compact_.store(false, std::memory_order_relaxed);
 }
 
 template <typename EDATA_T>
@@ -627,9 +601,6 @@ void SingleMutableCsr<EDATA_T>::batch_delete_vertices(
   if (!nbr_list_) {
     return;
   }
-  if (!src_set.empty() || !dst_set.empty()) {
-    needs_compact_.store(true, std::memory_order_relaxed);
-  }
   nbr_t* data = reinterpret_cast<nbr_t*>(nbr_list_->GetData());
   vid_t vnum = static_cast<vid_t>(vertex_capacity());
   for (auto src : src_set) {
@@ -658,9 +629,6 @@ void SingleMutableCsr<EDATA_T>::batch_delete_edges(
   if (!nbr_list_) {
     return;
   }
-  if (!src_list.empty()) {
-    needs_compact_.store(true, std::memory_order_relaxed);
-  }
   nbr_t* data = reinterpret_cast<nbr_t*>(nbr_list_->GetData());
   vid_t vnum = static_cast<vid_t>(vertex_capacity());
   for (size_t i = 0; i != src_list.size(); ++i) {
@@ -684,9 +652,6 @@ void SingleMutableCsr<EDATA_T>::batch_delete_edges(
     const std::vector<std::pair<vid_t, int32_t>>& edge_list) {
   if (!nbr_list_) {
     return;
-  }
-  if (!edge_list.empty()) {
-    needs_compact_.store(true, std::memory_order_relaxed);
   }
   nbr_t* data = reinterpret_cast<nbr_t*>(nbr_list_->GetData());
   vid_t vnum = static_cast<vid_t>(vertex_capacity());
@@ -720,7 +685,6 @@ void SingleMutableCsr<EDATA_T>::delete_edge(vid_t src, int32_t offset,
   if (nbr.timestamp.load() <= ts) {
     nbr.timestamp.store(std::numeric_limits<timestamp_t>::max());
     edge_num_.fetch_sub(1, std::memory_order_relaxed);
-    needs_compact_.store(true, std::memory_order_relaxed);
   } else if (nbr.timestamp.load() == std::numeric_limits<timestamp_t>::max()) {
     LOG(ERROR) << "Fail to delete edge, already deleted.";
   } else {
@@ -747,9 +711,6 @@ void SingleMutableCsr<EDATA_T>::revert_delete_edge(vid_t src, vid_t nbr_vid,
   if (nbr.timestamp.load() == std::numeric_limits<timestamp_t>::max()) {
     nbr.timestamp.store(ts);
     edge_num_.fetch_add(1, std::memory_order_relaxed);
-    if (ts != 0) {
-      needs_compact_.store(true, std::memory_order_relaxed);
-    }
   } else {
     THROW_INVALID_ARGUMENT_EXCEPTION(
         "Attempting to revert delete on edge that is not deleted.");
@@ -775,9 +736,6 @@ void SingleMutableCsr<EDATA_T>::batch_put_edges(
     nbr.data = data_list[i];
     nbr.timestamp.store(ts);
     edge_num_.fetch_add(1, std::memory_order_relaxed);
-    if (ts != 0) {
-      needs_compact_.store(true, std::memory_order_relaxed);
-    }
   }
 }
 

--- a/src/storages/graph/edge_table.cc
+++ b/src/storages/graph/edge_table.cc
@@ -603,9 +603,6 @@ void EdgeTable::UpdateEdgeProperty(vid_t src_lid, vid_t dst_lid,
   if (oe_iter == oe_edges.end()) {
     THROW_INVALID_ARGUMENT_EXCEPTION("invalid oe offset ");
   }
-  if (ts != 0) {
-    out_csr_->mark_compaction_required();
-  }
   accessor.set_data(oe_iter, prop, ts);
   if (meta_->is_bundled()) {
     auto ie_edges = in_csr_->get_generic_view(ts).get_edges(dst_lid);
@@ -613,9 +610,6 @@ void EdgeTable::UpdateEdgeProperty(vid_t src_lid, vid_t dst_lid,
     ie_iter += ie_offset;
     if (ie_iter == ie_edges.end()) {
       THROW_INVALID_ARGUMENT_EXCEPTION("invalid ie offset ");
-    }
-    if (ts != 0) {
-      in_csr_->mark_compaction_required();
     }
     accessor.set_data(ie_iter, prop, ts);
   }

--- a/tests/storage/test_edge_table.cc
+++ b/tests/storage/test_edge_table.cc
@@ -1103,39 +1103,6 @@ TEST_F(EdgeTableTest, TestUpdateEdgeData) {
   }
 }
 
-TEST_F(EdgeTableTest, TestUpdateEdgePropertyMarksCompactNeeded) {
-  auto ckp = make_checkpoint(workspace());
-  this->InitIndexers(*ckp, 2, 2);
-  this->ConstructEdgeTable(src_label_, dst_label_, edge_label_int_);
-  this->OpenEdgeTableInMemory(ckp, neug::CheckpointManifest(), 2, 2);
-  this->edge_table->EnsureCapacity(2, 2);
-
-  neug::Allocator allocator(neug::MemoryLevel::kInMemory, allocator_dir_);
-  this->edge_table->AddEdge(0, 1, {neug::Value::INT32(1)}, 0, allocator, false);
-
-  this->edge_table->UpdateEdgeProperty(0, 1, 0, 0, 0, neug::Value::INT32(9), 5);
-  {
-    auto edges =
-        this->edge_table->get_outgoing_view(neug::MAX_TIMESTAMP).get_edges(0);
-    auto it = edges.begin();
-    ASSERT_NE(it, edges.end());
-    EXPECT_EQ(it.get_timestamp(), 5);
-    auto accessor = this->edge_table->get_edge_data_accessor(0);
-    EXPECT_EQ(accessor.get_data(it).GetValue<int32_t>(), 9);
-  }
-
-  this->edge_table->Compact(std::nullopt, neug::MAX_TIMESTAMP);
-  {
-    auto edges =
-        this->edge_table->get_outgoing_view(neug::MAX_TIMESTAMP).get_edges(0);
-    auto it = edges.begin();
-    ASSERT_NE(it, edges.end());
-    EXPECT_EQ(it.get_timestamp(), 0);
-    auto accessor = this->edge_table->get_edge_data_accessor(0);
-    EXPECT_EQ(accessor.get_data(it).GetValue<int32_t>(), 9);
-  }
-}
-
 TEST_F(EdgeTableTest, TestAddPropertiesTransitionFromEmptyToBundledUnbundled) {
   auto ckp = make_checkpoint(workspace());
   this->InitIndexers(*ckp, 4, 4);

--- a/tests/storage/test_open_graph.cc
+++ b/tests/storage/test_open_graph.cc
@@ -14,6 +14,9 @@
  */
 
 #include <gtest/gtest.h>
+#include <unistd.h>
+#include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <string>
 #include "column_assertions.h"
@@ -25,6 +28,15 @@
 #include "unittest/utils.h"
 
 #include <glog/logging.h>
+
+namespace {
+
+std::filesystem::path unique_test_dir(const std::string& test_name) {
+  return std::filesystem::temp_directory_path() /
+         (test_name + "_" + std::to_string(::getpid()));
+}
+
+}  // namespace
 
 TEST(DatabaseTest, OpenClose) {
   std::string dir = "/tmp/test_open_close";

--- a/tests/storage/test_open_graph.cc
+++ b/tests/storage/test_open_graph.cc
@@ -14,9 +14,6 @@
  */
 
 #include <gtest/gtest.h>
-#include <unistd.h>
-#include <filesystem>
-#include <fstream>
 #include <iostream>
 #include <string>
 #include "column_assertions.h"
@@ -28,15 +25,6 @@
 #include "unittest/utils.h"
 
 #include <glog/logging.h>
-
-namespace {
-
-std::filesystem::path unique_test_dir(const std::string& test_name) {
-  return std::filesystem::temp_directory_path() /
-         (test_name + "_" + std::to_string(::getpid()));
-}
-
-}  // namespace
 
 TEST(DatabaseTest, OpenClose) {
   std::string dir = "/tmp/test_open_close";
@@ -259,69 +247,6 @@ TEST(DatabaseTest, TestPersist) {
     conn->Close();
     db2.Close();
   }
-}
-
-TEST(DatabaseTest, TestCopyInitialLoadCheckpointReopen) {
-  auto test_dir = unique_test_dir("test_copy_initial_load_checkpoint_reopen");
-  auto db_dir = (test_dir / "db").string();
-  auto csv_dir = (test_dir / "csv").string();
-  if (std::filesystem::exists(test_dir)) {
-    std::filesystem::remove_all(test_dir);
-  }
-  std::filesystem::create_directories(csv_dir);
-  auto person_csv_path =
-      (std::filesystem::path(csv_dir) / "person.csv").string();
-  auto knows_csv_path =
-      (std::filesystem::path(csv_dir) / "person_knows_person.csv").string();
-  {
-    std::ofstream person_csv(person_csv_path);
-    ASSERT_TRUE(person_csv.good());
-    person_csv << "id|name|age\n";
-    person_csv << "1|Alice|30\n";
-    person_csv << "2|Bob|31\n";
-    person_csv << "3|Cora|32\n";
-    person_csv << "4|Dan|33\n";
-  }
-  {
-    std::ofstream knows_csv(knows_csv_path);
-    ASSERT_TRUE(knows_csv.good());
-    knows_csv << "from|to|weight\n";
-    knows_csv << "1|2|0.5\n";
-    knows_csv << "2|3|1.5\n";
-  }
-
-  {
-    neug::NeugDB db;
-    db.Open(db_dir, 1, neug::DBMode::READ_WRITE, "gopt", false);
-    auto conn = db.Connect();
-    EXPECT_TRUE(conn->Query(
-        "CREATE NODE TABLE person(id INT64, name STRING, age INT64, "
-        "PRIMARY KEY(id));"));
-    EXPECT_TRUE(conn->Query(
-        "CREATE REL TABLE knows(FROM person TO person, weight DOUBLE);"));
-    EXPECT_TRUE(conn->Query("COPY person from \"" + person_csv_path + "\";"));
-    EXPECT_TRUE(conn->Query("COPY knows from \"" + knows_csv_path +
-                            "\" (from=\"person\", to=\"person\");"));
-    EXPECT_TRUE(conn->Query("CHECKPOINT;"));
-    conn->Close();
-    db.Close();
-  }
-
-  {
-    neug::NeugDB db;
-    db.Open(db_dir, 1, neug::DBMode::READ_ONLY);
-    auto conn = db.Connect();
-    auto vertex_count = conn->Query("MATCH (n: person) return COUNT(n);");
-    EXPECT_TRUE(vertex_count);
-    neug::test::AssertInt64Column(vertex_count.value().response(), 0, {4});
-    auto edge_count = conn->Query(
-        "MATCH (a: person)-[r: knows]->(b: person) return COUNT(r);");
-    EXPECT_TRUE(edge_count);
-    neug::test::AssertInt64Column(edge_count.value().response(), 0, {2});
-    conn->Close();
-    db.Close();
-  }
-  std::filesystem::remove_all(test_dir);
 }
 
 TEST(DatabaseTest, TestCompaction) {

--- a/tests/transaction/test_acid.cc
+++ b/tests/transaction/test_acid.cc
@@ -421,8 +421,8 @@ void G0(neug::NeugDBSession& db, int64_t person1_id, int64_t person2_id,
       break;
     }
   }
-  auto ed_accessor = gui.GetEdgeDataAccessor(person_label_id, knows_label_id,
-                                             person_label_id, 0);
+  auto ed_accessor = gui.GetEdgeDataAccessor(person_label_id, person_label_id,
+                                             knows_label_id, 0);
   CHECK(oeit != oeit_end);
 
   auto cur = ed_accessor.get_data(oeit);

--- a/tests/transaction/test_acid.cc
+++ b/tests/transaction/test_acid.cc
@@ -421,8 +421,8 @@ void G0(neug::NeugDBSession& db, int64_t person1_id, int64_t person2_id,
       break;
     }
   }
-  auto ed_accessor = gui.GetEdgeDataAccessor(person_label_id, person_label_id,
-                                             knows_label_id, 0);
+  auto ed_accessor = gui.GetEdgeDataAccessor(person_label_id, knows_label_id,
+                                             person_label_id, 0);
   CHECK(oeit != oeit_end);
 
   auto cur = ed_accessor.get_data(oeit);


### PR DESCRIPTION
This reverts commit 3cb9e59f501ab28acf4209de0e92e499afa1cdf2.

The latest timestamp will be maintained in the CSR and used to determine whether a compaction or dump should be performed.



