### PR TITLE
fix: preserve empty grouped aggregate semantics

### DIFF
--- a/src/execution/common/operators/retrieve/group_by.cc
+++ b/src/execution/common/operators/retrieve/group_by.cc
@@ -31,6 +31,12 @@ neug::result<ContextChunk> GroupBy::group_by(ContextChunk&& chunk,
   for (auto& aggr : aggrs) {
     aggr.reduce(ret, groups);
   }
+  // A grouped aggregate over an empty input has no groups, hence no rows.
+  // Reducers may produce scalar empty-input values (for example COUNT = 0),
+  // but those values only belong to ungrouped aggregates.
+  if (groups.empty() && !tag_alias.empty()) {
+    ret.reshuffle({});
+  }
   ret.head().reset();
   return ret;
 }

--- a/tools/python_bind/tests/test_query.py
+++ b/tools/python_bind/tests/test_query.py
@@ -56,6 +56,29 @@ def test_query_on_empty_graph(empty_db):
     assert res is not None and len(res) == 0
 
 
+def test_empty_grouped_aggregate(empty_db):
+    _, conn = empty_db
+    conn.execute("CREATE NODE TABLE person(id INT64, PRIMARY KEY(id));")
+
+    result = conn.execute(
+        "MATCH (person:person) "
+        "RETURN person.id AS person_id, count(person) AS person_count;"
+    )
+
+    assert len(result) == 0
+    assert list(result) == []
+    assert result.column_names() == ["person_id", "person_count"]
+
+
+def test_empty_ungrouped_count(empty_db):
+    _, conn = empty_db
+    conn.execute("CREATE NODE TABLE person(id INT64, PRIMARY KEY(id));")
+
+    result = conn.execute("MATCH (person:person) RETURN count(person);")
+
+    assert list(result) == [[0]]
+
+
 def test_result_getitem(modern_graph):
     conn = modern_graph
     res = conn.execute("MATCH (n) RETURN count(n);")


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/neug/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

修复在空表情况下，分组聚合操作返回结果中，列长度不一致问题：对空表聚合或者聚合结果为空时，分组聚合应返回 0 行、所有列均为空。保留无分组 COUNT 在空输入时返回一行 0 的语义。

## Related issue number
None

测试：编译并运行 test_group_by，两个测试通过：空分组聚合没有输出值；
空输入的无分组 COUNT 返回 0。