### PR TITLE
refactor: remove unused timestamp parameter from Compact

### DIFF
--- a/include/neug/storages/graph/edge_table.h
+++ b/include/neug/storages/graph/edge_table.h
@@ -177,8 +177,7 @@ class EdgeTable {
                           int32_t ie_offset, int32_t col_id,
                           const Value& new_prop, timestamp_t ts);
 
-  void Compact(const std::optional<std::string>& sort_key_for_nbr,
-               timestamp_t ts);
+  void Compact(const std::optional<std::string>& sort_key_for_nbr);
 
   size_t PropTableSize() const;
 

--- a/include/neug/storages/graph/property_graph.h
+++ b/include/neug/storages/graph/property_graph.h
@@ -125,7 +125,7 @@ class PropertyGraph {
    */
   void Open(std::shared_ptr<Checkpoint> ckp, MemoryLevel memory_level);
 
-  void Compact(timestamp_t ts);
+  void Compact();
 
   /// Dump this graph into @p ckp and clear all in-memory storage afterwards.
   /// Callers that need a usable graph after dumping must explicitly Open() a

--- a/include/neug/storages/graph/vertex_table.h
+++ b/include/neug/storages/graph/vertex_table.h
@@ -260,7 +260,7 @@ class VertexTable {
   void RenameProperties(const std::vector<std::string>& old_names,
                         const std::vector<std::string>& new_names);
 
-  void Compact(timestamp_t ts = MAX_TIMESTAMP);
+  void Compact();
 
   void insert_vertices(std::shared_ptr<IDataChunkSupplier> suppliers);
 

--- a/src/main/neug_db.cc
+++ b/src/main/neug_db.cc
@@ -330,7 +330,7 @@ void NeugDB::ingestWals(IWalParser& parser, PropertyGraph& graph) {
       IngestWalRange(graph, allocators_, parser, from_ts, to_ts);
     }
     if (update_wal.size == 0) {
-      graph.Compact(update_wal.timestamp);
+      graph.Compact();
       last_compaction_ts_ = update_wal.timestamp;
     } else {
       UpdateTransaction::IngestWal(graph, to_ts, update_wal.ptr,
@@ -380,7 +380,7 @@ std::shared_ptr<Checkpoint> NeugDB::consumeLiveGraphAndCommitCheckpoint(
   auto* live_graph = guard.get().mutable_graph();
   // Compact rewrites only already-dirty tables (does not mark); dump then
   // publishes. ClearAllDirty runs only after a successful Commit.
-  live_graph->Compact(MAX_TIMESTAMP);
+  live_graph->Compact();
   live_graph->DumpAndClear(checkpoint_session.staging_checkpoint());
   auto published_checkpoint = checkpoint_session.Commit();
   // Consumed graph is about to be dropped; ClearAllDirty is for the contract

--- a/src/storages/graph/edge_table.cc
+++ b/src/storages/graph/edge_table.cc
@@ -871,8 +871,7 @@ void EdgeTable::BatchAddEdges(
   }
 }
 
-void EdgeTable::Compact(const std::optional<std::string>& sort_key_for_nbr,
-                        timestamp_t ts) {
+void EdgeTable::Compact(const std::optional<std::string>& sort_key_for_nbr) {
   out_csr_->compact();
   in_csr_->compact();
   if (sort_key_for_nbr.has_value()) {

--- a/src/storages/graph/property_graph.cc
+++ b/src/storages/graph/property_graph.cc
@@ -855,7 +855,7 @@ void PropertyGraph::compact_schema() {
   v_mutex_.resize(new_schema.vertex_label_frontier());
 }
 
-void PropertyGraph::Compact(timestamp_t ts) {
+void PropertyGraph::Compact() {
   /**
    * The compaction process includes two parts:
    * 1. Schema: remove the deleted properties and labels from
@@ -874,7 +874,7 @@ void PropertyGraph::Compact(timestamp_t ts) {
     }
     // Compact only dirty tables; bits stay set until ClearAll after dump.
     if (IsVertexTableDirty(src_label_i)) {
-      vertex_tables_[src_label_i].Compact(ts);
+      vertex_tables_[src_label_i].Compact();
     }
     for (size_t dst_label_i = 0; dst_label_i != vertex_label_total_count_;
          ++dst_label_i) {
@@ -900,7 +900,7 @@ void PropertyGraph::Compact(timestamp_t ts) {
         }
         const auto& sort_key_for_nbr =
             schema_.get_sort_key_for_nbr(src_label_i, dst_label_i, e_label_i);
-        edge_tables_.at(index).Compact(sort_key_for_nbr, ts);
+        edge_tables_.at(index).Compact(sort_key_for_nbr);
       }
     }
   }

--- a/src/storages/graph/vertex_table.cc
+++ b/src/storages/graph/vertex_table.cc
@@ -294,7 +294,7 @@ void VertexTable::RenameProperties(const std::vector<std::string>& old_names,
   }
 }
 
-void VertexTable::Compact(timestamp_t ts) {
+void VertexTable::Compact() {
   v_ts_->Compact();
   // TODO(zhanglei): Support compact unused lid in indexer_ and table
 }

--- a/src/storages/loader/abstract_property_graph_loader.cc
+++ b/src/storages/loader/abstract_property_graph_loader.cc
@@ -181,7 +181,7 @@ result<bool> AbstractPropertyGraphLoader::LoadFragment() {
   try {
     loadVertices();
     loadEdges();
-    graph_.Compact(1);
+    graph_.Compact();
     graph_.DumpAndClear(staging_checkpoint_->checkpoint());
     staging_checkpoint_->Commit();
 

--- a/src/transaction/compact_transaction.cc
+++ b/src/transaction/compact_transaction.cc
@@ -56,7 +56,7 @@ bool CompactTransaction::Commit() {
       // In-place compact. Keep borrowed snapshot references scoped before the
       // timestamp lease is released.
       auto& slot = guard_.get();
-      slot.mutable_graph()->Compact(timestamp_);
+      slot.mutable_graph()->Compact();
       slot.mutable_view().Rebuild(*slot.mutable_graph());
     }
     LOG(INFO) << "after compact - " << timestamp_;

--- a/tests/storage/test_edge_table.cc
+++ b/tests/storage/test_edge_table.cc
@@ -1015,7 +1015,7 @@ TEST_F(EdgeTableTest, TestEdgeTableCompaction) {
     }
   }
   this->ExpectBundledStats(edge_num - delete_count);
-  this->edge_table->Compact(std::nullopt, neug::MAX_TIMESTAMP);
+  this->edge_table->Compact(std::nullopt);
   this->ExpectBundledStats(edge_num - delete_count);
   size_t edge_count = 0;
   for (size_t i = 0; i < dst_lids.size(); ++i) {

--- a/tests/storage/test_vertex_table.cc
+++ b/tests/storage/test_vertex_table.cc
@@ -691,7 +691,7 @@ TEST_F(VertexTableTest, VertexTableResizeTest) {
 
   EXPECT_EQ(table.VertexNum(), 10000);
   EXPECT_EQ(table.LidNum(), 10000);
-  table.Compact(true);
+  table.Compact();
   EXPECT_EQ(table.get_vertex_timestamp().InitVertexNum(), 10000);
 
   auto desc = DumpVertexTableLegacy(table, *ckp);


### PR DESCRIPTION
## Related Issues
fix #770

## What does this PR do?
Removes the unused `timestamp` parameter from the `Compact` interface across the storage layer, since the parameter was never actually used inside the implementation.

## What changes in this PR?
- `PropertyGraph::Compact()`: removed the `timestamp_t ts` parameter.
- `VertexTable::Compact()`: removed the `timestamp_t ts` parameter.
- `EdgeTable::Compact(sort_key_for_nbr)`: removed the `timestamp_t ts` parameter, keeping `sort_key_for_nbr`.
- Updated all call sites accordingly:
  - `src/transaction/compact_transaction.cc`
  - `src/storages/loader/abstract_property_graph_loader.cc`
  - `src/main/neug_db.cc`
  - `tests/storage/test_vertex_table.cc`
  - `tests/storage/test_edge_table.cc`
- Verified with a full `make -j10` build; compiles successfully with no errors.