### PR TITLE
fix: persist sort_key_for_nbr in schema dump

### DIFF
--- a/src/storages/graph/schema.cc
+++ b/src/storages/graph/schema.cc
@@ -1288,6 +1288,18 @@ bool Schema::Equals(const Schema& other) const {
               return false;
             }
           }
+          {
+            if (outgoing_edge_mutable(src_label_name, dst_label_name,
+                                      edge_label_name) !=
+                    other.outgoing_edge_mutable(src_label_name, dst_label_name,
+                                                edge_label_name) ||
+                incoming_edge_mutable(src_label_name, dst_label_name,
+                                      edge_label_name) !=
+                    other.incoming_edge_mutable(src_label_name, dst_label_name,
+                                                edge_label_name)) {
+              return false;
+            }
+          }
         }
       }
     }
@@ -1938,18 +1950,16 @@ bool dump_edges_schema(const Schema& schema, YAML::Node& node) {
               schema.get_vertex_label_name(dst_v);
           vertex_type_pair_node["relation"] =
               schema.get_edge_strategy(src_v, dst_v, e_label);
-          // Persist CSR params that LoadFromYaml reads back from x_csr_params.
-          // Omitting them drops sort_key_for_nbr / mutability across checkpoint
-          // dump -> reopen (schema lives in meta JSON via DumpToYaml/ToJson).
+          // Persist the subset of x_csr_params needed after checkpoint
+          // DumpToYaml/ToJson reopen: sort_key_for_nbr and non-default
+          // oe/ie mutability. (edge_storage_strategy is already covered by
+          // "relation"; other LoadFromYaml CSR fields are not dumped here.)
           {
-            const auto& src_name = schema.get_vertex_label_name(src_v);
-            const auto& dst_name = schema.get_vertex_label_name(dst_v);
-            const auto& e_name = schema.get_edge_label_name(e_label);
-            auto sort_key = schema.get_sort_key_for_nbr(src_v, dst_v, e_label);
-            const bool oe_mutable =
-                schema.outgoing_edge_mutable(src_name, dst_name, e_name);
-            const bool ie_mutable =
-                schema.incoming_edge_mutable(src_name, dst_name, e_name);
+            const auto edge_schema =
+                schema.get_edge_schema(src_v, dst_v, e_label);
+            const auto& sort_key = edge_schema->sort_key_for_nbr;
+            const bool oe_mutable = edge_schema->oe_mutable;
+            const bool ie_mutable = edge_schema->ie_mutable;
             if (sort_key.has_value() || !oe_mutable || !ie_mutable) {
               YAML::Node csr_node;
               if (sort_key.has_value()) {

--- a/src/storages/graph/schema.cc
+++ b/src/storages/graph/schema.cc
@@ -1279,6 +1279,15 @@ bool Schema::Equals(const Schema& other) const {
               return false;
             }
           }
+          {
+            auto lhs = get_sort_key_for_nbr(src_label_name, dst_label_name,
+                                           edge_label_name);
+            auto rhs = other.get_sort_key_for_nbr(
+                src_label_name, dst_label_name, edge_label_name);
+            if (lhs != rhs) {
+              return false;
+            }
+          }
         }
       }
     }
@@ -1929,6 +1938,33 @@ bool dump_edges_schema(const Schema& schema, YAML::Node& node) {
               schema.get_vertex_label_name(dst_v);
           vertex_type_pair_node["relation"] =
               schema.get_edge_strategy(src_v, dst_v, e_label);
+          // Persist CSR params that LoadFromYaml reads back from x_csr_params.
+          // Omitting them drops sort_key_for_nbr / mutability across checkpoint
+          // dump -> reopen (schema lives in meta JSON via DumpToYaml/ToJson).
+          {
+            const auto& src_name = schema.get_vertex_label_name(src_v);
+            const auto& dst_name = schema.get_vertex_label_name(dst_v);
+            const auto& e_name = schema.get_edge_label_name(e_label);
+            auto sort_key =
+                schema.get_sort_key_for_nbr(src_v, dst_v, e_label);
+            const bool oe_mutable =
+                schema.outgoing_edge_mutable(src_name, dst_name, e_name);
+            const bool ie_mutable =
+                schema.incoming_edge_mutable(src_name, dst_name, e_name);
+            if (sort_key.has_value() || !oe_mutable || !ie_mutable) {
+              YAML::Node csr_node;
+              if (sort_key.has_value()) {
+                csr_node["sort_key_for_nbr"] = sort_key.value();
+              }
+              if (!oe_mutable) {
+                csr_node["oe_mutability"] = "IMMUTABLE";
+              }
+              if (!ie_mutable) {
+                csr_node["ie_mutability"] = "IMMUTABLE";
+              }
+              vertex_type_pair_node["x_csr_params"] = csr_node;
+            }
+          }
           cur_node["vertex_type_pair_relations"].push_back(
               vertex_type_pair_node);
         }

--- a/src/storages/graph/schema.cc
+++ b/src/storages/graph/schema.cc
@@ -1281,7 +1281,7 @@ bool Schema::Equals(const Schema& other) const {
           }
           {
             auto lhs = get_sort_key_for_nbr(src_label_name, dst_label_name,
-                                           edge_label_name);
+                                            edge_label_name);
             auto rhs = other.get_sort_key_for_nbr(
                 src_label_name, dst_label_name, edge_label_name);
             if (lhs != rhs) {
@@ -1945,8 +1945,7 @@ bool dump_edges_schema(const Schema& schema, YAML::Node& node) {
             const auto& src_name = schema.get_vertex_label_name(src_v);
             const auto& dst_name = schema.get_vertex_label_name(dst_v);
             const auto& e_name = schema.get_edge_label_name(e_label);
-            auto sort_key =
-                schema.get_sort_key_for_nbr(src_v, dst_v, e_label);
+            auto sort_key = schema.get_sort_key_for_nbr(src_v, dst_v, e_label);
             const bool oe_mutable =
                 schema.outgoing_edge_mutable(src_name, dst_name, e_name);
             const bool ie_mutable =

--- a/tests/unittest/schema_test.cc
+++ b/tests/unittest/schema_test.cc
@@ -629,7 +629,7 @@ neug::Schema BuildComplexSchema() {
   schema.AddEdgeLabel("Person", "Person", "KNOWS",
                       {DataTypeId::kInt64, DataTypeId::kFloat},
                       {"since", "weight"}, EdgeStrategy::kMultiple,
-                      EdgeStrategy::kSingle, true, true, std::nullopt, "knows");
+                      EdgeStrategy::kSingle, true, true, "since", "knows");
 
   schema.AddEdgeLabel("Person", "Company", "WORKS_AT", {}, {},
                       EdgeStrategy::kMultiple, EdgeStrategy::kMultiple, true,

--- a/tests/unittest/schema_test.cc
+++ b/tests/unittest/schema_test.cc
@@ -676,10 +676,67 @@ TEST(SchemaJsonRoundTrip, ComplexSchemaRoundTripIsStable) {
   EXPECT_EQ(
       reconstituted.get_edge_properties("Person", "Company", "WORKS_AT").size(),
       0u);
+  ASSERT_TRUE(reconstituted.get_sort_key_for_nbr("Person", "Person", "KNOWS")
+                  .has_value());
+  EXPECT_EQ(
+      reconstituted.get_sort_key_for_nbr("Person", "Person", "KNOWS").value(),
+      "since");
 
   auto json_result2 = reconstituted.ToJson();
   ASSERT_TRUE(json_result2);
   EXPECT_EQ(DocToString(json_result2.value()), json_str);
+}
+
+// Checkpoint meta persists schema via DumpToYaml/ToJson. Regression for #780:
+// sort_key_for_nbr and non-default mutability must survive dump -> load.
+TEST(SchemaYamlRoundTrip, PreservesSortKeyForNbrAndMutability) {
+  neug::Schema original;
+  auto t = VProps({DataType::VARCHAR});
+  auto n = VNames({"name"});
+  auto pk = VPk(DataType::INT64, "id", 0);
+  original.AddVertexLabel("Person", t, {n.begin(), n.end()}, pk, 1024, "");
+  original.AddVertexLabel("Company", t, {n.begin(), n.end()}, pk, 1024, "");
+  original.AddEdgeLabel("Person", "Company", "WorksAt", {DataType::INT32},
+                        {"since"}, /*oe*/ EdgeStrategy::kMultiple,
+                        /*ie*/ EdgeStrategy::kSingle,
+                        /*oe_mutable*/ true, /*ie_mutable*/ false,
+                        /*sort_key_for_nbr*/ "since", /*desc*/ "employment");
+
+  auto yaml = neug::Schema::DumpToYaml(original);
+  ASSERT_TRUE(yaml);
+
+  // Dumped YAML should carry x_csr_params for the edge triplet.
+  const auto& edge_types = yaml.value()["schema"]["edge_types"];
+  ASSERT_GE(edge_types.size(), 1);
+  bool found_csr_params = false;
+  for (const auto& et : edge_types) {
+    if (et["type_name"].as<std::string>() != "WorksAt") {
+      continue;
+    }
+    for (const auto& pair : et["vertex_type_pair_relations"]) {
+      ASSERT_TRUE(pair["x_csr_params"]);
+      EXPECT_EQ(pair["x_csr_params"]["sort_key_for_nbr"].as<std::string>(),
+                "since");
+      EXPECT_EQ(pair["x_csr_params"]["ie_mutability"].as<std::string>(),
+                "IMMUTABLE");
+      found_csr_params = true;
+    }
+  }
+  EXPECT_TRUE(found_csr_params);
+
+  auto loaded = neug::Schema::LoadFromYamlNode(yaml.value());
+  ASSERT_TRUE(loaded);
+  const auto& reconstituted = loaded.value();
+  ASSERT_TRUE(reconstituted.get_sort_key_for_nbr("Person", "Company", "WorksAt")
+                  .has_value());
+  EXPECT_EQ(reconstituted.get_sort_key_for_nbr("Person", "Company", "WorksAt")
+                .value(),
+            "since");
+  EXPECT_TRUE(
+      reconstituted.outgoing_edge_mutable("Person", "Company", "WorksAt"));
+  EXPECT_FALSE(
+      reconstituted.incoming_edge_mutable("Person", "Company", "WorksAt"));
+  EXPECT_TRUE(original.Equals(reconstituted));
 }
 
 TEST(SchemaCloneTest, CloneIsDeepCopyAndIndependent) {

--- a/tests/unittest/schema_test.cc
+++ b/tests/unittest/schema_test.cc
@@ -694,8 +694,10 @@ TEST(SchemaYamlRoundTrip, PreservesSortKeyForNbrAndMutability) {
   auto t = VProps({DataType::VARCHAR});
   auto n = VNames({"name"});
   auto pk = VPk(DataType::INT64, "id", 0);
-  original.AddVertexLabel("Person", t, {n.begin(), n.end()}, pk, 1024, "");
-  original.AddVertexLabel("Company", t, {n.begin(), n.end()}, pk, 1024, "");
+  // Use the YAML-load default max_vnum; dump_vertices_schema does not persist
+  // a custom max_vertex_num, so Equals would fail after round-trip otherwise.
+  original.AddVertexLabel("Person", t, {n.begin(), n.end()}, pk, kMaxVNum, "");
+  original.AddVertexLabel("Company", t, {n.begin(), n.end()}, pk, kMaxVNum, "");
   original.AddEdgeLabel("Person", "Company", "WorksAt", {DataType::INT32},
                         {"since"}, /*oe*/ EdgeStrategy::kMultiple,
                         /*ie*/ EdgeStrategy::kSingle,

--- a/tools/python_bind/tests/test_ddl.py
+++ b/tools/python_bind/tests/test_ddl.py
@@ -615,8 +615,8 @@ def test_create_rel_table_edge_multiplicity(tmp_path):
 
 def test_create_rel_table_with_options(tmp_path):
     """
-    `CREATE REL TABLE` may include a trailing ``WITH (k=v, ...)`` clause; only
-    checks that the DDL runs without error (no return-value assertions).
+    `CREATE REL TABLE ... WITH (sort_key_for_nbr=...)` must persist across
+    close/reopen (checkpoint meta DumpToYaml/ToJson path; see #780).
     """
     db_dir = str(tmp_path / "test_rel_table_options")
     shutil.rmtree(db_dir, ignore_errors=True)
@@ -627,6 +627,21 @@ def test_create_rel_table_with_options(tmp_path):
     conn.execute(
         "CREATE REL TABLE LivesIn (FROM User TO City, creationDate INT64) WITH (sort_key_for_nbr='creationDate');"
     )
-    # todo: check options in graph schema
+
+    def _assert_sort_key(schema_text: str):
+        by_edge = _get_edge_pair_relations_by_type_name(schema_text)
+        pairs = by_edge.get("LivesIn", [])
+        assert len(pairs) == 1, pairs
+        csr = pairs[0].get("x_csr_params") or {}
+        assert csr.get("sort_key_for_nbr") == "creationDate", pairs[0]
+
+    _assert_sort_key(conn.get_schema())
     conn.close()
     db.close()
+
+    # Reopen from checkpoint; sort_key must still be present in schema meta.
+    db2 = Database(db_dir, "r")
+    conn2 = db2.connect()
+    _assert_sort_key(conn2.get_schema())
+    conn2.close()
+    db2.close()


### PR DESCRIPTION
## Summary
- Emit `x_csr_params` (`sort_key_for_nbr`, non-default oe/ie mutability) from `dump_edges_schema` so checkpoint meta dump/reopen no longer drops neighbor sort keys.
- Include `sort_key_for_nbr` in `Schema::Equals`, and exercise it in the JSON round-trip fixture.

Fixes #780


