### PR TITLE
fix: support aggregate initialization with clang 15

### DIFF
--- a/src/storages/index/storage_index.cc
+++ b/src/storages/index/storage_index.cc
@@ -57,7 +57,7 @@ result<std::vector<SearchResult>> StorageIndex::Search(
   for (const auto& candidate : candidates.value()) {
     auto vid = index_id_accessor_->GetVIDByIndexID(candidate.index_id);
     if (vid != INVALID_VID) {
-      results.emplace_back(vid, candidate.score);
+      results.push_back(SearchResult{vid, candidate.score});
     }
   }
   return results;


### PR DESCRIPTION
## Summary

- replace parenthesized emplacement with explicit aggregate initialization
- retain the existing behavior while supporting Apple Clang 15

## Testing

- `cmake --build build --target neug_storages_index -j4`

Fixes #791