### PR TITLE
fix: publish coherent read views

### DIFF
--- a/include/neug/storages/graph/graph_stats.h
+++ b/include/neug/storages/graph/graph_stats.h
@@ -25,7 +25,7 @@
 #include <string>
 #include <unordered_map>
 
-#include "neug/storages/graph/property_graph.h"
+#include "neug/storages/graph/graph_view.h"
 
 namespace neug {
 namespace main {
@@ -37,14 +37,14 @@ class CatalogEntry;
 }
 
 // Statistics access interface used by the compiler layer. It reads
-// cardinalities directly from a PropertyGraph when estimating table sizes.
+// cardinalities from a GraphView when estimating table sizes.
 class GraphStats {
  public:
   GraphStats() = default;
-  explicit GraphStats(const PropertyGraph& graph) : graph_(&graph) {}
+  explicit GraphStats(const GraphView& view) : view_(&view) {}
 
-  void UpdateGraph(const PropertyGraph& graph) { graph_ = &graph; }
-  const Schema& schema() const { return graph_->schema(); }
+  void UpdateView(const GraphView& view) { view_ = &view; }
+  const Schema& schema() const { return view_->schema(); }
 #ifdef NEUG_BUILD_TEST
   void LoadFromJson(const Schema& schema, const std::string& stats_json);
 #endif
@@ -64,7 +64,7 @@ class GraphStats {
   }
 
  private:
-  const PropertyGraph* graph_ = nullptr;
+  const GraphView* view_ = nullptr;
 #ifdef NEUG_BUILD_TEST
   std::unordered_map<uint64_t, uint64_t> table_cardinalities_;
 #endif

--- a/include/neug/storages/graph/graph_view.h
+++ b/include/neug/storages/graph/graph_view.h
@@ -60,6 +60,9 @@ class VertexTableView {
 
   bool get_lid(const Value& oid, vid_t& lid, timestamp_t ts) const;
   vid_t LidNum() const;
+  // Returns the latest storage cardinality for statistics/planning, not the
+  // number of vertices visible at a specific MVCC timestamp.
+  size_t VertexNum() const;
   bool IsValidLid(vid_t lid, timestamp_t ts) const;
   Value GetOid(vid_t lid, timestamp_t ts) const;
   VertexSet GetVertexSet(timestamp_t ts) const;
@@ -85,6 +88,9 @@ class EdgeTableView {
 
   CsrView GetOutgoingView(timestamp_t ts) const;
   CsrView GetIncomingView(timestamp_t ts) const;
+  // Returns the latest storage cardinality for statistics/planning, not a
+  // timestamp-scoped MVCC-visible count.
+  size_t EdgeNum() const;
   EdgeDataAccessor GetDataAccessor(int prop_id) const;
   EdgeDataAccessor GetDataAccessor(const std::string& prop_name) const;
 
@@ -124,6 +130,9 @@ class GraphView {
   inline vid_t LidNum(label_t label) const {
     return vertex_views_[label].LidNum();
   }
+  // Returns the latest storage cardinality for statistics/planning, not a
+  // timestamp-scoped MVCC-visible count.
+  vid_t VertexNum(label_t label) const;
   inline bool IsValidLid(label_t label, vid_t lid, timestamp_t ts) const {
     return vertex_views_[label].IsValidLid(lid, ts);
   }
@@ -143,6 +152,10 @@ class GraphView {
                                  label_t edge_label, timestamp_t ts) const;
   CsrView GetGenericIncomingView(label_t src_label, label_t dst_label,
                                  label_t edge_label, timestamp_t ts) const;
+  // Returns the latest storage cardinality for statistics/planning, not a
+  // timestamp-scoped MVCC-visible count.
+  size_t EdgeNum(label_t src_label, label_t dst_label,
+                 label_t edge_label) const;
   EdgeDataAccessor GetEdgeDataAccessor(label_t src_label, label_t dst_label,
                                        label_t edge_label, int prop_id) const;
   EdgeDataAccessor GetEdgeDataAccessor(label_t src_label, label_t dst_label,

--- a/include/neug/storages/graph_snapshot_store.h
+++ b/include/neug/storages/graph_snapshot_store.h
@@ -161,7 +161,7 @@ class GraphSnapshotStore {
   void returnFreeSlot(int slot_index);
   uint32_t reserveSnapshotGeneration();
   void publishPreparedSnapshot(int slot_index) noexcept;
-  void UnpinSnapshotByIndex(int slot_index) noexcept;
+  void unpinSnapshotByIndex(int slot_index) noexcept;
   void cleanupSlot(int slot_index);
 };
 

--- a/include/neug/storages/graph_snapshot_store.h
+++ b/include/neug/storages/graph_snapshot_store.h
@@ -110,7 +110,7 @@ class GraphSnapshotStore {
   /// -> release prep pin. Old slots are recycled lazily by UnpinSnapshot.
   /// Returns ERR_POOL_EXHAUSTED without touching @p new_pg on failure.
   Status PublishSnapshot(const std::shared_ptr<PropertyGraph>& new_pg,
-                         uint32_t view_generation = 0);
+                         uint32_t view_generation);
 
   /// Pool capacity.
   int SlotCount() const { return slot_num_; }

--- a/include/neug/storages/graph_snapshot_store.h
+++ b/include/neug/storages/graph_snapshot_store.h
@@ -121,8 +121,9 @@ class GraphSnapshotStore {
   ~GraphSnapshotStore();
 
   /// Pin the current slot via lock-free optimistic loop: load cur_slot_index_,
-  /// fetch_add reader_count, verify index unchanged. Retries on concurrent
-  /// publication or cleanup-in-progress. Caller must UnpinSnapshot().
+  /// increment a positive reader_count with CAS, then verify the index is
+  /// unchanged. Retries on concurrent publication or cleanup-in-progress.
+  /// Caller must UnpinSnapshot().
   SnapshotSlot& PinCurrentSnapshot() noexcept;
 
   /// Unpin a slot. Cleans up and recycles if last reader on a stale slot.

--- a/include/neug/storages/graph_snapshot_store.h
+++ b/include/neug/storages/graph_snapshot_store.h
@@ -38,14 +38,12 @@ namespace neug {
  * - Read/Insert: PinCurrentSnapshot() -> slot.view() -> UnpinSnapshot().
  *   InsertTransaction mutates the live slot in-place (timestamp-filtered).
  * - Update: CurrentSnapshot().Clone() -> mutate COW copy ->
- * PublishSnapshot().
+ * PrepareSnapshot() -> PreparedSnapshot::Publish().
  *
  * Concurrency:
  * - Lock-free PinCurrentSnapshot via optimistic pin + verify loop.
- * - Concurrent installs are NOT safe — VersionManager serializes
- *   updates via begin_update_commit (CAS 0→1), ensuring only one
- *   update/compact can be in progress at a time.
- * - PublishSnapshot publishes the new slot BEFORE VersionManager advances
+ * - Current-slot transfers use one atomic exchange.
+ * - Publish() installs the prepared slot BEFORE VersionManager advances
  *   read_ts_, so readers never see "new ts + old slot".
  */
 class GraphSnapshotStore {
@@ -72,28 +70,59 @@ class GraphSnapshotStore {
     /// Mutable PropertyGraph pointer (storage_.get() yields T* regardless
     /// of shared_ptr constness, so this works through const SnapshotSlot& too).
     PropertyGraph* mutable_graph() const { return storage_.get(); }
-    /// Identity of this slot incarnation in the published read-view protocol.
-    uint32_t view_generation() const { return view_generation_; }
+    /// Snapshot publication generation carried by this slot incarnation.
+    uint32_t snapshot_generation() const { return snapshot_generation_; }
 
    private:
     friend class GraphSnapshotStore;
     std::shared_ptr<PropertyGraph> storage_;
     GraphView view_;
-    uint32_t view_generation_{0};
+    uint32_t snapshot_generation_{0};
     std::atomic<int> reader_count_{0};
+  };
+
+  /**
+   * @brief RAII owner of a prepared snapshot slot.
+   *
+   * Preparation reserves a pool slot and snapshot generation and builds the
+   * GraphView. Publish() only switches the current slot and therefore cannot
+   * fail. Destruction without Publish() discards the prepared slot and returns
+   * it to the pool.
+   */
+  class PreparedSnapshot {
+   public:
+    ~PreparedSnapshot() noexcept;
+
+    PreparedSnapshot(const PreparedSnapshot&) = delete;
+    PreparedSnapshot& operator=(const PreparedSnapshot&) = delete;
+
+    PreparedSnapshot(PreparedSnapshot&& other) noexcept;
+    PreparedSnapshot& operator=(PreparedSnapshot&&) = delete;
+
+    /// Consumes this preparation, installs its slot, and returns its
+    /// generation.
+    uint32_t Publish() && noexcept;
+
+   private:
+    friend class GraphSnapshotStore;
+
+    PreparedSnapshot(GraphSnapshotStore& store, int slot_index) noexcept;
+
+    GraphSnapshotStore* store_;
+    int slot_index_;
   };
 
   /// @param slot_num  Pool capacity (default 128).
   /// @param initial_pg Published into slot 0.
   explicit GraphSnapshotStore(int slot_num,
                               std::shared_ptr<PropertyGraph> initial_pg,
-                              uint32_t initial_view_generation = 0);
+                              uint32_t initial_snapshot_generation = 0);
 
   ~GraphSnapshotStore();
 
   /// Pin the current slot via lock-free optimistic loop: load cur_slot_index_,
   /// fetch_add reader_count, verify index unchanged. Retries on concurrent
-  /// PublishSnapshot or cleanup-in-progress. Caller must UnpinSnapshot().
+  /// publication or cleanup-in-progress. Caller must UnpinSnapshot().
   SnapshotSlot& PinCurrentSnapshot() noexcept;
 
   /// Unpin a slot. Cleans up and recycles if last reader on a stale slot.
@@ -104,20 +133,16 @@ class GraphSnapshotStore {
   /// (admission_state_==kInsertsBlocked, all inserters drained).
   const PropertyGraph& CurrentSnapshot() const;
 
-  /// Publish a COW PropertyGraph into a free slot and switch cur_slot_index_.
-  /// Steps: reserve free slot -> prep-pin new slot -> write PG + build view
-  /// -> phantom-pin old slot -> switch (release store) -> release phantom pin
-  /// -> release prep pin. Old slots are recycled lazily by UnpinSnapshot.
+  /// Reserve a slot/generation and fully build a pending snapshot publication.
   /// Returns ERR_POOL_EXHAUSTED without touching @p new_pg on failure.
-  Status PublishSnapshot(const std::shared_ptr<PropertyGraph>& new_pg,
-                         uint32_t view_generation);
+  result<PreparedSnapshot> PrepareSnapshot(
+      const std::shared_ptr<PropertyGraph>& new_pg);
 
   /// Pool capacity.
   int SlotCount() const { return slot_num_; }
 
-  /// Best-effort check for a free slot. Used by Commit() to fail-fast
-  /// before writing WAL. Stable under serialized Updates; `false` may
-  /// become `true` asynchronously as readers unpin stale slots.
+  /// Best-effort diagnostic used by lifecycle and pool-reclamation tests.
+  /// `false` may become `true` asynchronously as readers unpin stale slots.
   bool HasFreeSlot() const {
     std::lock_guard<std::mutex> lock(free_list_mutex_);
     return !free_list_.empty();
@@ -127,12 +152,15 @@ class GraphSnapshotStore {
   int slot_num_;
   std::vector<SnapshotSlot> slots_;
   std::atomic<int> cur_slot_index_{0};
+  std::atomic<uint32_t> last_reserved_snapshot_generation_{0};
   std::vector<int> free_list_;
   mutable std::mutex free_list_mutex_;
 
   void initFreeList();
   int getFreeSlot();
   void returnFreeSlot(int slot_index);
+  uint32_t reserveSnapshotGeneration();
+  void publishPreparedSnapshot(int slot_index) noexcept;
   void UnpinSnapshotByIndex(int slot_index) noexcept;
   void cleanupSlot(int slot_index);
 };

--- a/include/neug/storages/graph_snapshot_store.h
+++ b/include/neug/storages/graph_snapshot_store.h
@@ -72,18 +72,22 @@ class GraphSnapshotStore {
     /// Mutable PropertyGraph pointer (storage_.get() yields T* regardless
     /// of shared_ptr constness, so this works through const SnapshotSlot& too).
     PropertyGraph* mutable_graph() const { return storage_.get(); }
+    /// Identity of this slot incarnation in the published read-view protocol.
+    uint32_t view_generation() const { return view_generation_; }
 
    private:
     friend class GraphSnapshotStore;
     std::shared_ptr<PropertyGraph> storage_;
     GraphView view_;
+    uint32_t view_generation_{0};
     std::atomic<int> reader_count_{0};
   };
 
   /// @param slot_num  Pool capacity (default 128).
   /// @param initial_pg Published into slot 0.
   explicit GraphSnapshotStore(int slot_num,
-                              std::shared_ptr<PropertyGraph> initial_pg);
+                              std::shared_ptr<PropertyGraph> initial_pg,
+                              uint32_t initial_view_generation = 0);
 
   ~GraphSnapshotStore();
 
@@ -105,7 +109,8 @@ class GraphSnapshotStore {
   /// -> phantom-pin old slot -> switch (release store) -> release phantom pin
   /// -> release prep pin. Old slots are recycled lazily by UnpinSnapshot.
   /// Returns ERR_POOL_EXHAUSTED without touching @p new_pg on failure.
-  Status PublishSnapshot(const std::shared_ptr<PropertyGraph>& new_pg);
+  Status PublishSnapshot(const std::shared_ptr<PropertyGraph>& new_pg,
+                         uint32_t view_generation = 0);
 
   /// Pool capacity.
   int SlotCount() const { return slot_num_; }

--- a/include/neug/storages/graph_snapshot_store.h
+++ b/include/neug/storages/graph_snapshot_store.h
@@ -67,8 +67,6 @@ class GraphSnapshotStore {
     const GraphView& view() const { return view_; }
     /// Mutable view accessor (for InsertTransaction / AP write path).
     GraphView& mutable_view() { return view_; }
-    /// Read-only PropertyGraph accessor.
-    const PropertyGraph* graph() const { return storage_.get(); }
     /// Mutable PropertyGraph accessor (for InsertTransaction / AP write path).
     PropertyGraph* mutable_graph() { return storage_.get(); }
     /// Snapshot publication generation carried by this slot incarnation.

--- a/include/neug/storages/graph_snapshot_store.h
+++ b/include/neug/storages/graph_snapshot_store.h
@@ -67,9 +67,10 @@ class GraphSnapshotStore {
     const GraphView& view() const { return view_; }
     /// Mutable view accessor (for InsertTransaction / AP write path).
     GraphView& mutable_view() { return view_; }
-    /// Mutable PropertyGraph pointer (storage_.get() yields T* regardless
-    /// of shared_ptr constness, so this works through const SnapshotSlot& too).
-    PropertyGraph* mutable_graph() const { return storage_.get(); }
+    /// Read-only PropertyGraph accessor.
+    const PropertyGraph* graph() const { return storage_.get(); }
+    /// Mutable PropertyGraph accessor (for InsertTransaction / AP write path).
+    PropertyGraph* mutable_graph() { return storage_.get(); }
     /// Snapshot publication generation carried by this slot incarnation.
     uint32_t snapshot_generation() const { return snapshot_generation_; }
 

--- a/include/neug/transaction/README.md
+++ b/include/neug/transaction/README.md
@@ -6,11 +6,21 @@
 
 ## Read Transaction
 
-With an `ReadTransaction`, a specific version of the graph can be read. The version is determined by the timestamp of the transaction.
+With a `ReadTransaction`, a specific version of the graph can be read. Its
+`ReadSnapshotLease` owns a visibility timestamp and a pinned graph snapshot as
+one coherent read view.
+
+Reader acquisition captures an atomically published
+`{visibility timestamp, view generation}` pair, pins the current snapshot, and
+validates that the slot generation matches. If an update publishes between the
+capture and the pin, the generation mismatch is detected and the complete
+acquisition is retried. A transaction therefore cannot observe an old
+timestamp with a newly published snapshot.
 
 `ReadTransaction` provides a set of APIs to read the graph, including schema, topology, and properties.
 
-After query with the `ReadTransaction` object, the transaction should be released by calling `ReadTransaction::Release()`.
+Commit, abort, and destruction all release the snapshot pin before unregistering
+the reader from `VersionManager`.
 
 ## Insert Transaction
 

--- a/include/neug/transaction/README.md
+++ b/include/neug/transaction/README.md
@@ -11,9 +11,9 @@ With a `ReadTransaction`, a specific version of the graph can be read. Its
 one coherent read view.
 
 Reader acquisition captures an atomically published
-`{visibility timestamp, view generation}` pair, pins the current snapshot, and
-validates that the slot generation matches. If an update publishes between the
-capture and the pin, the generation mismatch is detected and the complete
+`{visibility timestamp, snapshot generation}` pair, pins the current snapshot,
+and validates that the slot generation matches. If an update publishes between
+the capture and the pin, the generation mismatch is detected and the complete
 acquisition is retried. A transaction therefore cannot observe an old
 timestamp with a newly published snapshot.
 

--- a/include/neug/transaction/insert_transaction.h
+++ b/include/neug/transaction/insert_transaction.h
@@ -196,7 +196,7 @@ class InsertTransaction {
 
   const Schema& schema() const;
 
-  GraphStats statistic() const { return GraphStats(*guard_.get().graph()); }
+  GraphStats statistic() const { return GraphStats(guard_.get().view()); }
 
   bool GetVertexIndex(label_t label, const Value& oid, vid_t& lid) const;
 

--- a/include/neug/transaction/insert_transaction.h
+++ b/include/neug/transaction/insert_transaction.h
@@ -196,9 +196,7 @@ class InsertTransaction {
 
   const Schema& schema() const;
 
-  GraphStats statistic() const {
-    return GraphStats(*guard_.get().mutable_graph());
-  }
+  GraphStats statistic() const { return GraphStats(*guard_.get().graph()); }
 
   bool GetVertexIndex(label_t label, const Value& oid, vid_t& lid) const;
 

--- a/include/neug/transaction/read_snapshot_lease.h
+++ b/include/neug/transaction/read_snapshot_lease.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include <stdint.h>
-#include <utility>
 
 #include "neug/storages/graph_snapshot_store.h"
 #include "neug/transaction/version_manager.h"
@@ -36,41 +35,15 @@ class ReadSnapshotLease {
   static ReadSnapshotLease Acquire(IVersionManager& version_manager,
                                    GraphSnapshotStore& snapshot_store);
 
-  ReadSnapshotLease(ReadSnapshotLease&& other) noexcept
-      : version_manager_(other.version_manager_),
-        published_view_(other.published_view_),
-        active_(other.active_),
-        snapshot_(std::move(other.snapshot_)) {
-    other.version_manager_ = nullptr;
-    other.active_ = false;
-  }
-
-  ReadSnapshotLease& operator=(ReadSnapshotLease&& other) noexcept {
-    if (this != &other) {
-      release();
-      version_manager_ = other.version_manager_;
-      published_view_ = other.published_view_;
-      active_ = other.active_;
-      snapshot_ = std::move(other.snapshot_);
-      other.version_manager_ = nullptr;
-      other.active_ = false;
-    }
-    return *this;
-  }
+  ReadSnapshotLease(ReadSnapshotLease&& other) noexcept;
+  ReadSnapshotLease& operator=(ReadSnapshotLease&& other) noexcept;
 
   ReadSnapshotLease(const ReadSnapshotLease&) = delete;
   ReadSnapshotLease& operator=(const ReadSnapshotLease&) = delete;
 
-  ~ReadSnapshotLease() noexcept { release(); }
+  ~ReadSnapshotLease() noexcept;
 
-  void release() noexcept {
-    if (!active_) {
-      return;
-    }
-    active_ = false;
-    snapshot_.release();
-    version_manager_->release_read_view();
-  }
+  void release() noexcept;
 
   timestamp_t timestamp() const { return published_view_.visibility_ts; }
   uint32_t snapshot_generation() const {
@@ -82,11 +55,7 @@ class ReadSnapshotLease {
 
  private:
   ReadSnapshotLease(IVersionManager& version_manager, SnapshotGuard snapshot,
-                    PublishedReadView published_view) noexcept
-      : version_manager_(&version_manager),
-        published_view_(published_view),
-        active_(true),
-        snapshot_(std::move(snapshot)) {}
+                    PublishedReadView published_view) noexcept;
 
   IVersionManager* version_manager_;
   PublishedReadView published_view_;

--- a/include/neug/transaction/read_snapshot_lease.h
+++ b/include/neug/transaction/read_snapshot_lease.h
@@ -69,7 +69,7 @@ class ReadSnapshotLease {
     }
     active_ = false;
     snapshot_.release();
-    version_manager_->release_read_timestamp();
+    version_manager_->release_read_view();
   }
 
   timestamp_t timestamp() const { return published_view_.visibility_ts; }

--- a/include/neug/transaction/read_snapshot_lease.h
+++ b/include/neug/transaction/read_snapshot_lease.h
@@ -1,0 +1,96 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <stdint.h>
+#include <utility>
+
+#include "neug/storages/graph_snapshot_store.h"
+#include "neug/transaction/version_manager.h"
+#include "neug/utils/property/types.h"
+
+namespace neug {
+
+/**
+ * @brief Move-only owner of one coherent timestamp/snapshot pair.
+ *
+ * Acquisition registers a reader, captures the atomically published
+ * timestamp/generation pair, pins the current snapshot, and validates that
+ * the pinned slot belongs to that generation. A concurrent publication
+ * produces a detectable mismatch and is retried internally.
+ */
+class ReadSnapshotLease {
+ public:
+  static ReadSnapshotLease Acquire(IVersionManager& version_manager,
+                                   GraphSnapshotStore& snapshot_store);
+
+  ReadSnapshotLease(ReadSnapshotLease&& other) noexcept
+      : version_manager_(other.version_manager_),
+        published_view_(other.published_view_),
+        active_(other.active_),
+        snapshot_(std::move(other.snapshot_)) {
+    other.version_manager_ = nullptr;
+    other.active_ = false;
+  }
+
+  ReadSnapshotLease& operator=(ReadSnapshotLease&& other) noexcept {
+    if (this != &other) {
+      release();
+      version_manager_ = other.version_manager_;
+      published_view_ = other.published_view_;
+      active_ = other.active_;
+      snapshot_ = std::move(other.snapshot_);
+      other.version_manager_ = nullptr;
+      other.active_ = false;
+    }
+    return *this;
+  }
+
+  ReadSnapshotLease(const ReadSnapshotLease&) = delete;
+  ReadSnapshotLease& operator=(const ReadSnapshotLease&) = delete;
+
+  ~ReadSnapshotLease() noexcept { release(); }
+
+  void release() noexcept {
+    if (!active_) {
+      return;
+    }
+    active_ = false;
+    snapshot_.release();
+    version_manager_->release_read_timestamp();
+  }
+
+  timestamp_t timestamp() const { return published_view_.visibility_ts; }
+  uint32_t view_generation() const { return published_view_.view_generation; }
+  const GraphView& view() const { return snapshot_.get().view(); }
+  const PropertyGraph* graph() const { return snapshot_.get().mutable_graph(); }
+  bool valid() const { return active_; }
+
+ private:
+  ReadSnapshotLease(IVersionManager& version_manager, SnapshotGuard snapshot,
+                    PublishedReadView published_view) noexcept
+      : version_manager_(&version_manager),
+        published_view_(published_view),
+        active_(true),
+        snapshot_(std::move(snapshot)) {}
+
+  IVersionManager* version_manager_;
+  PublishedReadView published_view_;
+  bool active_;
+  // Declared last so fallback destruction also unpins before reader release.
+  SnapshotGuard snapshot_;
+};
+
+}  // namespace neug

--- a/include/neug/transaction/read_snapshot_lease.h
+++ b/include/neug/transaction/read_snapshot_lease.h
@@ -45,21 +45,17 @@ class ReadSnapshotLease {
 
   void release() noexcept;
 
-  timestamp_t timestamp() const { return published_view_.visibility_ts; }
-  uint32_t snapshot_generation() const {
-    return published_view_.snapshot_generation;
+  timestamp_t timestamp() const { return timestamp_; }
+  const GraphSnapshotStore::SnapshotSlot& snapshot() const {
+    return snapshot_.get();
   }
-  const GraphView& view() const { return snapshot_.get().view(); }
-  const PropertyGraph* graph() const { return snapshot_.get().mutable_graph(); }
-  bool valid() const { return active_; }
 
  private:
   ReadSnapshotLease(IVersionManager& version_manager, SnapshotGuard snapshot,
-                    PublishedReadView published_view) noexcept;
+                    timestamp_t timestamp) noexcept;
 
   IVersionManager* version_manager_;
-  PublishedReadView published_view_;
-  bool active_;
+  timestamp_t timestamp_;
   // Declared last so fallback destruction also unpins before reader release.
   SnapshotGuard snapshot_;
 };

--- a/include/neug/transaction/read_snapshot_lease.h
+++ b/include/neug/transaction/read_snapshot_lease.h
@@ -46,9 +46,8 @@ class ReadSnapshotLease {
   void release() noexcept;
 
   timestamp_t timestamp() const { return timestamp_; }
-  const GraphSnapshotStore::SnapshotSlot& snapshot() const {
-    return snapshot_.get();
-  }
+  /// The returned view remains valid until this lease is released or destroyed.
+  const GraphView& view() const { return snapshot_.get().view(); }
 
  private:
   ReadSnapshotLease(IVersionManager& version_manager, SnapshotGuard snapshot,

--- a/include/neug/transaction/read_snapshot_lease.h
+++ b/include/neug/transaction/read_snapshot_lease.h
@@ -73,7 +73,9 @@ class ReadSnapshotLease {
   }
 
   timestamp_t timestamp() const { return published_view_.visibility_ts; }
-  uint32_t view_generation() const { return published_view_.view_generation; }
+  uint32_t snapshot_generation() const {
+    return published_view_.snapshot_generation;
+  }
   const GraphView& view() const { return snapshot_.get().view(); }
   const PropertyGraph* graph() const { return snapshot_.get().mutable_graph(); }
   bool valid() const { return active_; }

--- a/include/neug/transaction/read_transaction.h
+++ b/include/neug/transaction/read_transaction.h
@@ -91,11 +91,9 @@ class ReadTransaction {
 
   void Abort();
 
-  const GraphView& view() const { return lease_.snapshot().view(); }
+  const GraphView& view() const { return lease_.view(); }
 
-  GraphStats statistic() const {
-    return GraphStats(*lease_.snapshot().graph());
-  }
+  GraphStats statistic() const { return GraphStats(view()); }
 
   const Schema& schema() const;
 

--- a/include/neug/transaction/read_transaction.h
+++ b/include/neug/transaction/read_transaction.h
@@ -91,9 +91,11 @@ class ReadTransaction {
 
   void Abort();
 
-  const GraphView& view() const { return lease_.view(); }
+  const GraphView& view() const { return lease_.snapshot().view(); }
 
-  GraphStats statistic() const { return GraphStats(*lease_.graph()); }
+  GraphStats statistic() const {
+    return GraphStats(*lease_.snapshot().graph());
+  }
 
   const Schema& schema() const;
 

--- a/include/neug/transaction/read_transaction.h
+++ b/include/neug/transaction/read_transaction.h
@@ -36,7 +36,7 @@
 #include "neug/storages/graph/graph_view.h"
 #include "neug/storages/graph/property_graph.h"
 #include "neug/storages/graph/schema.h"
-#include "neug/storages/graph_snapshot_store.h"
+#include "neug/transaction/read_snapshot_lease.h"
 #include "neug/transaction/transaction_utils.h"
 #include "neug/utils/property/column.h"
 #include "neug/utils/property/table.h"
@@ -45,7 +45,6 @@
 namespace neug {
 
 class PropertyGraph;
-class IVersionManager;
 template <typename EDATA_T>
 class TypedMutableCsrBase;
 
@@ -69,16 +68,13 @@ class TypedMutableCsrBase;
 class ReadTransaction {
  public:
   /**
-   * @brief Construct a ReadTransaction with a pinned SnapshotSlot.
+   * @brief Construct a ReadTransaction with one coherent read lease.
    *
-   * @param guard SnapshotGuard managing the pinned SnapshotSlot.
-   * @param vm Reference to version manager.
-   * @param timestamp Snapshot timestamp for this transaction.
+   * @param lease Timestamp, generation, and pinned snapshot owned together.
    *
    * @since v0.1.0
    */
-  ReadTransaction(SnapshotGuard guard, IVersionManager& vm,
-                  timestamp_t timestamp);
+  explicit ReadTransaction(ReadSnapshotLease lease);
 
   /**
    * @brief Destructor that calls release().
@@ -95,19 +91,15 @@ class ReadTransaction {
 
   void Abort();
 
-  const GraphView& view() const { return guard_.get().view(); }
+  const GraphView& view() const { return lease_.view(); }
 
-  GraphStats statistic() const {
-    return GraphStats(*guard_.get().mutable_graph());
-  }
+  GraphStats statistic() const { return GraphStats(*lease_.graph()); }
 
   const Schema& schema() const;
 
  private:
   void release();
-  SnapshotGuard guard_;
-  IVersionManager& vm_;
-  timestamp_t timestamp_;
+  ReadSnapshotLease lease_;
 };
 
 }  // namespace neug

--- a/include/neug/transaction/runtime_wait.h
+++ b/include/neug/transaction/runtime_wait.h
@@ -19,10 +19,10 @@
 namespace neug {
 
 /**
- * Runtime-specific scheduler operation used by AdaptiveBackoff.
+ * Runtime-specific scheduler operation used by RuntimeBackoff.
  *
  * CPU relaxation is runtime-independent and handled directly by
- * AdaptiveBackoff. The callback is invoked only for yield and sleep actions.
+ * RuntimeBackoff. The callback is invoked only for yield and sleep actions.
  */
 enum class RuntimeWaitAction { kYield, kSleep };
 
@@ -54,16 +54,16 @@ enum class RuntimeWaitPhase { kSpin, kYield, kSleep };
 void RuntimeCpuRelax() noexcept;
 
 /**
- * Per-wait adaptive backoff cursor. Each blocking condition gets its own
+ * Per-wait runtime backoff cursor. Each blocking condition gets its own
  * instance so a newly entered wait always starts with CPU relaxation.
  *
  * Callers must not enter a wait while holding a pthread-owned lock or
  * retaining a pointer into ordinary thread-local storage: a cooperative
  * runtime may resume the same logical task on another pthread worker.
  */
-class AdaptiveBackoff final {
+class RuntimeBackoff final {
  public:
-  explicit AdaptiveBackoff(RuntimeWaitFn runtime_wait) noexcept
+  explicit RuntimeBackoff(RuntimeWaitFn runtime_wait) noexcept
       : runtime_wait_(runtime_wait) {}
 
   void operator()() noexcept {

--- a/include/neug/transaction/timestamp_lease.h
+++ b/include/neug/transaction/timestamp_lease.h
@@ -31,12 +31,12 @@ class IVersionManager;
 class UpdateTimestampLease {
  public:
   explicit UpdateTimestampLease(IVersionManager& version_manager);
-  UpdateTimestampLease(IVersionManager& version_manager,
-                       uint32_t timestamp) noexcept;
+  UpdateTimestampLease(UpdateTimestampLease&& other) noexcept;
   ~UpdateTimestampLease() noexcept;
 
   UpdateTimestampLease(const UpdateTimestampLease&) = delete;
   UpdateTimestampLease& operator=(const UpdateTimestampLease&) = delete;
+  UpdateTimestampLease& operator=(UpdateTimestampLease&&) = delete;
 
   uint32_t Timestamp() const noexcept { return timestamp_; }
 

--- a/include/neug/transaction/timestamp_lease.h
+++ b/include/neug/transaction/timestamp_lease.h
@@ -1,0 +1,57 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <stdint.h>
+#include <optional>
+
+namespace neug {
+
+class IVersionManager;
+
+/**
+ * @brief RAII owner of an update timestamp and its admission-state lifecycle.
+ *
+ * An unfinished lease closes its timestamp gap without changing the installed
+ * snapshot generation. Snapshot commits finish with the generation installed
+ * by the prepared snapshot publication.
+ */
+class UpdateTimestampLease {
+ public:
+  explicit UpdateTimestampLease(IVersionManager& version_manager);
+  UpdateTimestampLease(IVersionManager& version_manager,
+                       uint32_t timestamp) noexcept;
+  ~UpdateTimestampLease() noexcept;
+
+  UpdateTimestampLease(const UpdateTimestampLease&) = delete;
+  UpdateTimestampLease& operator=(const UpdateTimestampLease&) = delete;
+
+  uint32_t Timestamp() const noexcept { return timestamp_; }
+
+  void BeginCommit();
+  void MakeUpdateExclusive();
+  void Finish(std::optional<uint32_t> installed_snapshot_generation) noexcept;
+
+ private:
+  void reset() noexcept;
+
+  static constexpr uint32_t kInactiveTimestamp = UINT32_MAX;
+
+  IVersionManager* version_manager_{nullptr};
+  uint32_t timestamp_{kInactiveTimestamp};
+  bool commit_started_{false};
+};
+
+}  // namespace neug

--- a/include/neug/transaction/update_transaction.h
+++ b/include/neug/transaction/update_transaction.h
@@ -115,7 +115,7 @@ class UpdateTransaction {
 
   const GraphView& view() const { return view_; }
 
-  GraphStats statistic() const { return GraphStats(*cow_graph_); }
+  GraphStats statistic() const { return GraphStats(view_); }
 
   // --- Read-only accessors (not graph modifications) ---
   const Schema& schema() const { return cow_graph_->schema(); }

--- a/include/neug/transaction/update_transaction.h
+++ b/include/neug/transaction/update_transaction.h
@@ -52,7 +52,7 @@ class Schema;
  * @brief Resource holder and lifecycle manager for update transactions.
  *
  * UpdateTransaction owns the COW-cloned PropertyGraph and all associated
- * resources (WAL buffer, allocator, version manager, snapshot store).
+ * resources (WAL buffer, allocator, timestamp lease, snapshot store).
  * Graph modification logic (DDL/DML) is implemented by StorageTPUpdateInterface
  * which accesses UpdateTransaction's private members via friend declaration.
  *
@@ -81,18 +81,18 @@ class UpdateTransaction {
    * @param cow_graph PropertyGraph COW clone
    * @param alloc Reference to memory allocator
    * @param logger Reference to WAL writer
-   * @param vm Reference to version manager
    * @param snapshot_store Reference to GraphSnapshotStore for commit
    * @param cache Reference to query cache
-   * @param timestamp Transaction timestamp
+   * @param timestamp_lease Owner of the transaction timestamp
    *
-   * @note NeugDB is responsible for creating the COW copy via Clone()
+   * @note The caller is responsible for acquiring the timestamp lease before
+   * creating the COW copy via Clone().
    * @since v0.1.0
    */
   UpdateTransaction(std::shared_ptr<PropertyGraph> cow_graph, Allocator& alloc,
-                    IWalWriter& logger, IVersionManager& vm,
-                    GraphSnapshotStore& snapshot_store,
-                    execution::LocalQueryCache& cache, timestamp_t timestamp);
+                    IWalWriter& logger, GraphSnapshotStore& snapshot_store,
+                    execution::LocalQueryCache& cache,
+                    UpdateTimestampLease timestamp_lease);
 
   /**
    * @brief Destructor that calls Abort().

--- a/include/neug/transaction/update_transaction.h
+++ b/include/neug/transaction/update_transaction.h
@@ -18,6 +18,7 @@
 #include <stdint.h>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -34,6 +35,7 @@
 #include "neug/storages/graph/property_graph.h"
 #include "neug/storages/graph/property_graph_cow_state.h"
 #include "neug/storages/graph_snapshot_store.h"
+#include "neug/transaction/timestamp_lease.h"
 #include "neug/transaction/transaction_utils.h"
 #include "neug/transaction/wal/wal_builder.h"
 #include "neug/utils/property/table.h"
@@ -57,8 +59,8 @@ class Schema;
  * **COW Design:**
  * - Holds a shared_ptr to a COW-cloned PropertyGraph
  * - StorageTPUpdateInterface performs all DDL/DML modifications on the COW copy
- * - Commit flushes WAL and publishes the COW copy via
- * GraphSnapshotStore::PublishSnapshot()
+ * - Commit prepares the COW snapshot before WAL, then performs a no-fail
+ *   publication after WAL succeeds.
  * - Abort discards the COW copy (no effect on original)
  *
  * **Concurrency contract** (VersionManager state machine):
@@ -102,7 +104,7 @@ class UpdateTransaction {
    * @brief Get the transaction timestamp.
    * @since v0.1.0
    */
-  timestamp_t timestamp() const;
+  timestamp_t timestamp() const { return timestamp_lease_.Timestamp(); }
 
   bool Commit();
 
@@ -132,13 +134,13 @@ class UpdateTransaction {
   CsrView GetGenericOutgoingGraphView(label_t v_label, label_t neighbor_label,
                                       label_t edge_label) const {
     return cow_graph_->GetGenericOutgoingGraphView(v_label, neighbor_label,
-                                                   edge_label, timestamp_);
+                                                   edge_label, timestamp());
   }
 
   CsrView GetGenericIncomingGraphView(label_t v_label, label_t neighbor_label,
                                       label_t edge_label) const {
     return cow_graph_->GetGenericIncomingGraphView(v_label, neighbor_label,
-                                                   edge_label, timestamp_);
+                                                   edge_label, timestamp());
   }
 
   EdgeDataAccessor GetEdgeDataAccessor(label_t src_label, label_t dst_label,
@@ -150,7 +152,7 @@ class UpdateTransaction {
   friend class StorageTPUpdateInterface;
 
  private:
-  void release();
+  void release(std::optional<uint32_t> installed_snapshot_generation);
 
   // COW storage - the cloned PropertyGraph
   std::shared_ptr<PropertyGraph> cow_graph_;
@@ -159,12 +161,9 @@ class UpdateTransaction {
 
   Allocator& alloc_;
   IWalWriter& logger_;
-  IVersionManager& vm_;
   GraphSnapshotStore& snapshot_store_;
   execution::LocalQueryCache& pipeline_cache_;
-  timestamp_t timestamp_;
-  uint32_t view_generation_{0};
-  bool snapshot_published_{false};
+  UpdateTimestampLease timestamp_lease_;
 
   std::shared_ptr<Checkpoint> ckp_;
   WalBuilder wal_builder_;

--- a/include/neug/transaction/update_transaction.h
+++ b/include/neug/transaction/update_transaction.h
@@ -163,6 +163,8 @@ class UpdateTransaction {
   GraphSnapshotStore& snapshot_store_;
   execution::LocalQueryCache& pipeline_cache_;
   timestamp_t timestamp_;
+  uint32_t view_generation_{0};
+  bool snapshot_published_{false};
 
   std::shared_ptr<Checkpoint> ckp_;
   WalBuilder wal_builder_;

--- a/include/neug/transaction/version_manager.h
+++ b/include/neug/transaction/version_manager.h
@@ -16,6 +16,7 @@
 
 #include <stdint.h>
 #include <atomic>
+#include <optional>
 
 #include "neug/transaction/runtime_wait.h"
 #include "neug/transaction/timestamp_window.h"
@@ -32,11 +33,11 @@ namespace neug {
  */
 struct PublishedReadView {
   uint32_t visibility_ts;
-  uint32_t view_generation;
+  uint32_t snapshot_generation;
 };
 
 inline uint64_t PackPublishedReadView(const PublishedReadView& view) {
-  return (static_cast<uint64_t>(view.view_generation) << 32) |
+  return (static_cast<uint64_t>(view.snapshot_generation) << 32) |
          view.visibility_ts;
 }
 
@@ -68,25 +69,33 @@ class IVersionManager {
   // attempts so no already-waiting caller retains the previous runtime wait.
   virtual bool try_set_runtime_wait_if_quiescent(
       RuntimeWaitFn runtime_wait) noexcept = 0;
+  // Create a per-wait cursor without exposing the runtime callback itself.
+  RuntimeBackoff make_runtime_backoff() const noexcept {
+    return RuntimeBackoff(runtime_wait_impl());
+  }
   virtual PublishedReadView acquire_read_view() = 0;
   virtual void release_read_view() = 0;
   virtual uint32_t acquire_insert_timestamp() = 0;
   virtual void release_insert_timestamp(uint32_t ts) = 0;
   virtual uint32_t acquire_update_timestamp() = 0;
-  virtual uint32_t reserve_view_generation() = 0;
   virtual void begin_update_commit(uint32_t ts) = 0;
   // May invoke the runtime waiter. Checkpoint callers must enter commit and
   // drain readers before acquiring checkpoint-manager or other
   // OS-thread-owned mutexes.
   virtual void drain_readers() = 0;
-  virtual void release_update_timestamp(uint32_t ts) = 0;
-  virtual void release_update_timestamp_with_view(uint32_t ts,
-                                                  uint32_t view_generation) = 0;
+  // A present generation has already been installed in GraphSnapshotStore.
+  // nullopt keeps the currently installed generation.
+  virtual void finish_update_timestamp(
+      uint32_t ts,
+      std::optional<uint32_t> installed_snapshot_generation) noexcept = 0;
   virtual uint32_t acquire_compact_timestamp() = 0;
   virtual void release_compact_timestamp(uint32_t ts) = 0;
   virtual void revert_compact_timestamp(uint32_t ts) = 0;
 
   virtual ~IVersionManager() {}
+
+ protected:
+  virtual RuntimeWaitFn runtime_wait_impl() const noexcept = 0;
 };
 
 /**
@@ -104,7 +113,7 @@ class IVersionManager {
  *   | Update-exec   | yes  |  no    |   no        |    -          |   no    |
  *   | Update-commit |  no* |  no    |   -         |   no          |   no    |
  *   | Compact       |  no  |  no    |   no        |   no          |   no    |
- *   *New reads wait with the configured adaptive backoff; already-acquired
+ *   *New reads wait with the configured runtime backoff; already-acquired
  *   reads continue.
  *
  * Mechanism:
@@ -140,12 +149,11 @@ class VersionManager : public IVersionManager {
   uint32_t acquire_insert_timestamp() override;
   void release_insert_timestamp(uint32_t ts) override;
   uint32_t acquire_update_timestamp() override;
-  uint32_t reserve_view_generation() override;
   void begin_update_commit(uint32_t ts) override;
   void drain_readers() override;
-  void release_update_timestamp(uint32_t ts) override;
-  void release_update_timestamp_with_view(uint32_t ts,
-                                          uint32_t view_generation) override;
+  void finish_update_timestamp(
+      uint32_t ts,
+      std::optional<uint32_t> installed_snapshot_generation) noexcept override;
   uint32_t acquire_compact_timestamp() override;
   void release_compact_timestamp(uint32_t ts) override;
   void revert_compact_timestamp(uint32_t ts) override;
@@ -162,14 +170,13 @@ class VersionManager : public IVersionManager {
   // OS-thread-owned lock or retain an ordinary TLS pointer across the call.
   void enter_exclusive_state(AdmissionState desired_state);
   void wait_until_zero(const std::atomic<int>& counter);
-  RuntimeWaitFn runtime_wait() const noexcept;
   void complete_write_timestamp(uint32_t ts);
   void advance_read_ts_locked();
+  RuntimeWaitFn runtime_wait_impl() const noexcept override;
 
   std::atomic<uint32_t> write_ts_{1};
   std::atomic<uint32_t> read_ts_{1};
-  std::atomic<uint32_t> next_view_generation_{0};
-  std::atomic<uint32_t> current_view_generation_{0};
+  std::atomic<uint32_t> installed_snapshot_generation_{0};
   std::atomic<uint64_t> published_read_view_{PackPublishedReadView({1, 0})};
 
   std::atomic<int> active_readers_{0};

--- a/include/neug/transaction/version_manager.h
+++ b/include/neug/transaction/version_manager.h
@@ -68,15 +68,12 @@ class IVersionManager {
   // attempts so no already-waiting caller retains the previous runtime wait.
   virtual bool try_set_runtime_wait_if_quiescent(
       RuntimeWaitFn runtime_wait) noexcept = 0;
-  virtual uint32_t acquire_read_timestamp() = 0;
-  virtual PublishedReadView acquire_read_view() {
-    return {acquire_read_timestamp(), 0};
-  }
-  virtual void release_read_timestamp() = 0;
+  virtual PublishedReadView acquire_read_view() = 0;
+  virtual void release_read_view() = 0;
   virtual uint32_t acquire_insert_timestamp() = 0;
   virtual void release_insert_timestamp(uint32_t ts) = 0;
   virtual uint32_t acquire_update_timestamp() = 0;
-  virtual uint32_t reserve_view_generation() { return 0; }
+  virtual uint32_t reserve_view_generation() = 0;
   virtual void begin_update_commit(uint32_t ts) = 0;
   // May invoke the runtime waiter. Checkpoint callers must enter commit and
   // drain readers before acquiring checkpoint-manager or other
@@ -84,10 +81,7 @@ class IVersionManager {
   virtual void drain_readers() = 0;
   virtual void release_update_timestamp(uint32_t ts) = 0;
   virtual void release_update_timestamp_with_view(uint32_t ts,
-                                                  uint32_t view_generation) {
-    (void) view_generation;
-    release_update_timestamp(ts);
-  }
+                                                  uint32_t view_generation) = 0;
   virtual uint32_t acquire_compact_timestamp() = 0;
   virtual void release_compact_timestamp(uint32_t ts) = 0;
   virtual void revert_compact_timestamp(uint32_t ts) = 0;
@@ -122,8 +116,8 @@ class IVersionManager {
  * - admission_state_: controls whether new readers and inserters may enter.
  *   Update execution blocks inserters; update commit and compaction block
  *   both readers and inserters.
- * - acquire_read_timestamp uses a double-check pattern (pre-check + increment
- *   + post-check) to prevent ABA races with begin_update_commit.
+ * - acquire_read_view uses a double-check pattern (pre-check + increment +
+ *   post-check) to prevent ABA races with begin_update_commit.
  * - begin_update_commit blocks new readers before snapshot publication.
  *   Readers already between the pre-check and post-check either roll back
  *   after observing the blocked state or complete as an existing reader.
@@ -141,9 +135,8 @@ class VersionManager : public IVersionManager {
   bool try_set_runtime_wait_if_quiescent(
       RuntimeWaitFn runtime_wait) noexcept override;
 
-  uint32_t acquire_read_timestamp() override;
   PublishedReadView acquire_read_view() override;
-  void release_read_timestamp() override;
+  void release_read_view() override;
   uint32_t acquire_insert_timestamp() override;
   void release_insert_timestamp(uint32_t ts) override;
   uint32_t acquire_update_timestamp() override;

--- a/include/neug/transaction/version_manager.h
+++ b/include/neug/transaction/version_manager.h
@@ -63,7 +63,8 @@ inline PublishedReadView UnpackPublishedReadView(uint64_t packed) {
  */
 class IVersionManager {
  public:
-  virtual void init_ts(uint32_t ts, int thread_num) = 0;
+  // Initialize the timestamp timeline and its coherently installed snapshot.
+  virtual void init_ts(PublishedReadView initial_read_view, int thread_num) = 0;
   // Lifecycle-only operation. The implementation closes admission while
   // checking quiescence, but the caller must still prevent new transaction
   // attempts so no already-waiting caller retains the previous runtime wait.
@@ -140,7 +141,7 @@ class VersionManager : public IVersionManager {
   VersionManager();
   ~VersionManager() override = default;
 
-  void init_ts(uint32_t ts, int thread_num) override;
+  void init_ts(PublishedReadView initial_read_view, int thread_num) override;
   bool try_set_runtime_wait_if_quiescent(
       RuntimeWaitFn runtime_wait) noexcept override;
 

--- a/include/neug/transaction/version_manager.h
+++ b/include/neug/transaction/version_manager.h
@@ -24,6 +24,27 @@
 namespace neug {
 
 /**
+ * @brief Atomically published reader-visible state.
+ *
+ * The visibility timestamp and snapshot generation form one logical value:
+ * readers must never combine either field with a snapshot from another
+ * publication generation.
+ */
+struct PublishedReadView {
+  uint32_t visibility_ts;
+  uint32_t view_generation;
+};
+
+inline uint64_t PackPublishedReadView(const PublishedReadView& view) {
+  return (static_cast<uint64_t>(view.view_generation) << 32) |
+         view.visibility_ts;
+}
+
+inline PublishedReadView UnpackPublishedReadView(uint64_t packed) {
+  return {static_cast<uint32_t>(packed), static_cast<uint32_t>(packed >> 32)};
+}
+
+/**
  * @brief Unified interface for transaction timestamp and concurrency control.
  *
  * IVersionManager defines the contract for managing timestamp acquisition,
@@ -48,16 +69,25 @@ class IVersionManager {
   virtual bool try_set_runtime_wait_if_quiescent(
       RuntimeWaitFn runtime_wait) noexcept = 0;
   virtual uint32_t acquire_read_timestamp() = 0;
+  virtual PublishedReadView acquire_read_view() {
+    return {acquire_read_timestamp(), 0};
+  }
   virtual void release_read_timestamp() = 0;
   virtual uint32_t acquire_insert_timestamp() = 0;
   virtual void release_insert_timestamp(uint32_t ts) = 0;
   virtual uint32_t acquire_update_timestamp() = 0;
+  virtual uint32_t reserve_view_generation() { return 0; }
   virtual void begin_update_commit(uint32_t ts) = 0;
   // May invoke the runtime waiter. Checkpoint callers must enter commit and
   // drain readers before acquiring checkpoint-manager or other
   // OS-thread-owned mutexes.
   virtual void drain_readers() = 0;
   virtual void release_update_timestamp(uint32_t ts) = 0;
+  virtual void release_update_timestamp_with_view(uint32_t ts,
+                                                  uint32_t view_generation) {
+    (void) view_generation;
+    release_update_timestamp(ts);
+  }
   virtual uint32_t acquire_compact_timestamp() = 0;
   virtual void release_compact_timestamp(uint32_t ts) = 0;
   virtual void revert_compact_timestamp(uint32_t ts) = 0;
@@ -112,13 +142,17 @@ class VersionManager : public IVersionManager {
       RuntimeWaitFn runtime_wait) noexcept override;
 
   uint32_t acquire_read_timestamp() override;
+  PublishedReadView acquire_read_view() override;
   void release_read_timestamp() override;
   uint32_t acquire_insert_timestamp() override;
   void release_insert_timestamp(uint32_t ts) override;
   uint32_t acquire_update_timestamp() override;
+  uint32_t reserve_view_generation() override;
   void begin_update_commit(uint32_t ts) override;
   void drain_readers() override;
   void release_update_timestamp(uint32_t ts) override;
+  void release_update_timestamp_with_view(uint32_t ts,
+                                          uint32_t view_generation) override;
   uint32_t acquire_compact_timestamp() override;
   void release_compact_timestamp(uint32_t ts) override;
   void revert_compact_timestamp(uint32_t ts) override;
@@ -129,7 +163,7 @@ class VersionManager : public IVersionManager {
   enum class AdmissionState { kOpen, kInsertsBlocked, kAllBlocked };
 
   int thread_num_;
-  uint32_t acquire_read_timestamp_slow();
+  PublishedReadView acquire_read_view_slow();
   uint32_t acquire_insert_timestamp_slow();
   // These helpers may suspend the logical task. Callers must not hold an
   // OS-thread-owned lock or retain an ordinary TLS pointer across the call.
@@ -141,6 +175,9 @@ class VersionManager : public IVersionManager {
 
   std::atomic<uint32_t> write_ts_{1};
   std::atomic<uint32_t> read_ts_{1};
+  std::atomic<uint32_t> next_view_generation_{0};
+  std::atomic<uint32_t> current_view_generation_{0};
+  std::atomic<uint64_t> published_read_view_{PackPublishedReadView({1, 0})};
 
   std::atomic<int> active_readers_{0};
   std::atomic<int> active_inserters_{0};

--- a/src/main/execution_slot.cc
+++ b/src/main/execution_slot.cc
@@ -187,9 +187,8 @@ Status executePreparedQuery(execution::CacheValue& prepared_query,
 }  // namespace
 
 ReadTransaction ExecutionSlot::GetReadTransaction() const {
-  uint32_t ts = version_manager_.acquire_read_timestamp();
-  SnapshotGuard guard(snapshot_store_);
-  return ReadTransaction(std::move(guard), version_manager_, ts);
+  return ReadTransaction(
+      ReadSnapshotLease::Acquire(version_manager_, snapshot_store_));
 }
 
 InsertTransaction ExecutionSlot::GetInsertTransaction() {

--- a/src/main/execution_slot.cc
+++ b/src/main/execution_slot.cc
@@ -275,9 +275,9 @@ Status ExecutionSlot::executeCore(const std::string& query,
     if (access_mode == AccessMode::kRead) {
       auto lease =
           ReadSnapshotLease::Acquire(version_manager_, snapshot_store_);
-      const auto& snapshot = lease.snapshot();
-      StorageReadInterface storage(snapshot.view(), lease.timestamp());
-      status = execute_on_storage(GraphStats(*snapshot.graph()), storage);
+      const auto& view = lease.view();
+      StorageReadInterface storage(view, lease.timestamp());
+      status = execute_on_storage(GraphStats(view), storage);
     } else if (access_mode == AccessMode::kInsert ||
                access_mode == AccessMode::kUpdate ||
                access_mode == AccessMode::kSchema) {
@@ -288,7 +288,7 @@ Status ExecutionSlot::executeCore(const std::string& query,
       StorageAPUpdateInterface storage(*slot.mutable_graph(),
                                        slot.mutable_view(), lease.Timestamp(),
                                        alloc_);
-      status = execute_on_storage(GraphStats(*slot.mutable_graph()), storage);
+      status = execute_on_storage(GraphStats(slot.view()), storage);
     } else {
       return Status(
           StatusCode::ERR_NOT_SUPPORTED,
@@ -366,7 +366,7 @@ result<std::string> ExecutionSlot::ExecuteTransactionalRequest(
 
 std::string ExecutionSlot::GetSchema() const {
   auto lease = ReadSnapshotLease::Acquire(version_manager_, snapshot_store_);
-  auto yaml = lease.snapshot().graph()->schema().to_yaml();
+  auto yaml = lease.view().schema().to_yaml();
   return get_json_string_from_yaml(yaml.value()).value();
 }
 
@@ -374,7 +374,7 @@ void ExecutionSlot::ClearTemporarySchema() {
   CHECK(execution_strategy_ == QueryExecutionStrategy::kDirect);
   {
     auto lease = ReadSnapshotLease::Acquire(version_manager_, snapshot_store_);
-    const auto& schema = lease.snapshot().graph()->schema();
+    const auto& schema = lease.view().schema();
     if (schema.get_temporary_edge_triplet_keys().empty() &&
         schema.get_temporary_vertex_labels().empty()) {
       return;

--- a/src/main/execution_slot.cc
+++ b/src/main/execution_slot.cc
@@ -90,7 +90,7 @@ class TimestampLease {
       : version_manager_(&version_manager), kind_(kind) {
     switch (kind_) {
     case LeaseKind::kRead:
-      timestamp_ = version_manager_->acquire_read_timestamp();
+      timestamp_ = version_manager_->acquire_read_view().visibility_ts;
       break;
     case LeaseKind::kUpdate:
       timestamp_ = version_manager_->acquire_update_timestamp();
@@ -118,7 +118,7 @@ class TimestampLease {
     }
     switch (kind_) {
     case LeaseKind::kRead:
-      version_manager_->release_read_timestamp();
+      version_manager_->release_read_view();
       break;
     case LeaseKind::kUpdate:
       version_manager_->release_update_timestamp(timestamp_);

--- a/src/main/execution_slot.cc
+++ b/src/main/execution_slot.cc
@@ -275,8 +275,9 @@ Status ExecutionSlot::executeCore(const std::string& query,
     if (access_mode == AccessMode::kRead) {
       auto lease =
           ReadSnapshotLease::Acquire(version_manager_, snapshot_store_);
-      StorageReadInterface storage(lease.view(), lease.timestamp());
-      status = execute_on_storage(GraphStats(*lease.graph()), storage);
+      const auto& snapshot = lease.snapshot();
+      StorageReadInterface storage(snapshot.view(), lease.timestamp());
+      status = execute_on_storage(GraphStats(*snapshot.graph()), storage);
     } else if (access_mode == AccessMode::kInsert ||
                access_mode == AccessMode::kUpdate ||
                access_mode == AccessMode::kSchema) {
@@ -365,7 +366,7 @@ result<std::string> ExecutionSlot::ExecuteTransactionalRequest(
 
 std::string ExecutionSlot::GetSchema() const {
   auto lease = ReadSnapshotLease::Acquire(version_manager_, snapshot_store_);
-  auto yaml = lease.graph()->schema().to_yaml();
+  auto yaml = lease.snapshot().graph()->schema().to_yaml();
   return get_json_string_from_yaml(yaml.value()).value();
 }
 
@@ -373,7 +374,7 @@ void ExecutionSlot::ClearTemporarySchema() {
   CHECK(execution_strategy_ == QueryExecutionStrategy::kDirect);
   {
     auto lease = ReadSnapshotLease::Acquire(version_manager_, snapshot_store_);
-    const auto& schema = lease.graph()->schema();
+    const auto& schema = lease.snapshot().graph()->schema();
     if (schema.get_temporary_edge_triplet_keys().empty() &&
         schema.get_temporary_vertex_labels().empty()) {
       return;

--- a/src/main/execution_slot.cc
+++ b/src/main/execution_slot.cc
@@ -146,11 +146,11 @@ InsertTransaction ExecutionSlot::GetInsertTransaction() {
 }
 
 UpdateTransaction ExecutionSlot::GetUpdateTransaction() {
-  uint32_t ts = version_manager_.acquire_update_timestamp();
+  UpdateTimestampLease timestamp_lease(version_manager_);
   auto cow_graph = snapshot_store_.CurrentSnapshot().Clone();
   return UpdateTransaction(std::move(cow_graph), alloc_, *wal_writer_,
-                           version_manager_, snapshot_store_, pipeline_cache_,
-                           ts);
+                           snapshot_store_, pipeline_cache_,
+                           std::move(timestamp_lease));
 }
 
 CompactTransaction ExecutionSlot::GetCompactTransaction() {

--- a/src/main/execution_slot.cc
+++ b/src/main/execution_slot.cc
@@ -33,6 +33,7 @@
 #include "neug/storages/graph/graph_stats.h"
 #include "neug/storages/graph/property_graph.h"
 #include "neug/storages/graph/schema.h"
+#include "neug/transaction/timestamp_lease.h"
 #include "neug/transaction/version_manager.h"
 #include "neug/transaction/wal/wal.h"
 #include "neug/utils/exception/exception.h"
@@ -78,60 +79,6 @@ void ExecutionSlotLease::reset() noexcept {
 }
 
 namespace {
-
-enum class LeaseKind {
-  kRead,
-  kUpdate,
-};
-
-class TimestampLease {
- public:
-  TimestampLease(IVersionManager& version_manager, LeaseKind kind)
-      : version_manager_(&version_manager), kind_(kind) {
-    switch (kind_) {
-    case LeaseKind::kRead:
-      timestamp_ = version_manager_->acquire_read_view().visibility_ts;
-      break;
-    case LeaseKind::kUpdate:
-      timestamp_ = version_manager_->acquire_update_timestamp();
-      break;
-    }
-  }
-
-  ~TimestampLease() { release(); }
-
-  TimestampLease(const TimestampLease&) = delete;
-  TimestampLease& operator=(const TimestampLease&) = delete;
-
-  timestamp_t timestamp() const { return timestamp_; }
-
-  void makeUpdateExclusive() {
-    CHECK(kind_ == LeaseKind::kUpdate);
-    version_manager_->begin_update_commit(timestamp_);
-    version_manager_->drain_readers();
-  }
-
- private:
-  void release() {
-    if (!active_) {
-      return;
-    }
-    switch (kind_) {
-    case LeaseKind::kRead:
-      version_manager_->release_read_view();
-      break;
-    case LeaseKind::kUpdate:
-      version_manager_->release_update_timestamp(timestamp_);
-      break;
-    }
-    active_ = false;
-  }
-
-  IVersionManager* version_manager_;
-  LeaseKind kind_;
-  timestamp_t timestamp_{INVALID_TIMESTAMP};
-  bool active_{true};
-};
 
 bool invalidatesQueryCache(const physical::ExecutionFlag& flags) {
   return flags.schema() || flags.create_temp_table() || flags.batch() ||
@@ -326,20 +273,19 @@ Status ExecutionSlot::executeCore(const std::string& query,
   Status status;
   if (execution_strategy_ == QueryExecutionStrategy::kDirect) {
     if (access_mode == AccessMode::kRead) {
-      TimestampLease lease(version_manager_, LeaseKind::kRead);
-      SnapshotGuard guard(snapshot_store_);
-      StorageReadInterface storage(guard.get().view(), lease.timestamp());
-      status =
-          execute_on_storage(GraphStats(*guard.get().mutable_graph()), storage);
+      auto lease =
+          ReadSnapshotLease::Acquire(version_manager_, snapshot_store_);
+      StorageReadInterface storage(lease.view(), lease.timestamp());
+      status = execute_on_storage(GraphStats(*lease.graph()), storage);
     } else if (access_mode == AccessMode::kInsert ||
                access_mode == AccessMode::kUpdate ||
                access_mode == AccessMode::kSchema) {
-      TimestampLease lease(version_manager_, LeaseKind::kUpdate);
-      lease.makeUpdateExclusive();
+      UpdateTimestampLease lease(version_manager_);
+      lease.MakeUpdateExclusive();
       SnapshotGuard guard(snapshot_store_);
       auto& slot = guard.get();
       StorageAPUpdateInterface storage(*slot.mutable_graph(),
-                                       slot.mutable_view(), lease.timestamp(),
+                                       slot.mutable_view(), lease.Timestamp(),
                                        alloc_);
       status = execute_on_storage(GraphStats(*slot.mutable_graph()), storage);
     } else {
@@ -418,26 +364,24 @@ result<std::string> ExecutionSlot::ExecuteTransactionalRequest(
 }
 
 std::string ExecutionSlot::GetSchema() const {
-  TimestampLease lease(version_manager_, LeaseKind::kRead);
-  SnapshotGuard guard(snapshot_store_);
-  auto yaml = guard.get().mutable_graph()->schema().to_yaml();
+  auto lease = ReadSnapshotLease::Acquire(version_manager_, snapshot_store_);
+  auto yaml = lease.graph()->schema().to_yaml();
   return get_json_string_from_yaml(yaml.value()).value();
 }
 
 void ExecutionSlot::ClearTemporarySchema() {
   CHECK(execution_strategy_ == QueryExecutionStrategy::kDirect);
   {
-    TimestampLease lease(version_manager_, LeaseKind::kRead);
-    SnapshotGuard guard(snapshot_store_);
-    const auto& schema = guard.get().mutable_graph()->schema();
+    auto lease = ReadSnapshotLease::Acquire(version_manager_, snapshot_store_);
+    const auto& schema = lease.graph()->schema();
     if (schema.get_temporary_edge_triplet_keys().empty() &&
         schema.get_temporary_vertex_labels().empty()) {
       return;
     }
   }
 
-  TimestampLease lease(version_manager_, LeaseKind::kUpdate);
-  lease.makeUpdateExclusive();
+  UpdateTimestampLease lease(version_manager_);
+  lease.MakeUpdateExclusive();
   SnapshotGuard guard(snapshot_store_);
   auto& slot = guard.get();
   auto* graph = slot.mutable_graph();

--- a/src/main/neug_db.cc
+++ b/src/main/neug_db.cc
@@ -470,7 +470,10 @@ void NeugDB::initPlanner() {
 
 void NeugDB::initVersionManager() {
   auto version_manager = std::make_unique<VersionManager>();
-  version_manager->init_ts(last_ts_, max_thread_num_);
+  SnapshotGuard snapshot(*snapshot_store_);
+  const PublishedReadView initial_read_view{
+      last_ts_, snapshot.get().snapshot_generation()};
+  version_manager->init_ts(initial_read_view, max_thread_num_);
   version_manager_ = std::move(version_manager);
 }
 

--- a/src/storages/graph/graph_snapshot_store.cc
+++ b/src/storages/graph/graph_snapshot_store.cc
@@ -25,7 +25,8 @@ namespace neug {
 static constexpr int kCleanupSentinel = -(1 << 20);
 
 GraphSnapshotStore::GraphSnapshotStore(
-    int slot_num, std::shared_ptr<PropertyGraph> initial_pg)
+    int slot_num, std::shared_ptr<PropertyGraph> initial_pg,
+    uint32_t initial_view_generation)
     : slot_num_(slot_num), slots_(slot_num) {
   // Publish initial PG into slot 0.
   //
@@ -37,6 +38,7 @@ GraphSnapshotStore::GraphSnapshotStore(
   // because a live cur slot always has count >= 1.
   slots_[0].storage_ = std::move(initial_pg);
   slots_[0].view_ = GraphView(*slots_[0].storage_);
+  slots_[0].view_generation_ = initial_view_generation;
   slots_[0].reader_count_.store(1, std::memory_order_relaxed);  // cur-pin
   cur_slot_index_.store(0, std::memory_order_release);
 
@@ -78,6 +80,7 @@ void GraphSnapshotStore::cleanupSlot(int slot_index) {
   }
   slots_[slot_index].storage_.reset();
   slots_[slot_index].view_ = GraphView();
+  slots_[slot_index].view_generation_ = 0;
   slots_[slot_index].reader_count_.fetch_add(-kCleanupSentinel,
                                              std::memory_order_release);
   returnFreeSlot(slot_index);
@@ -165,7 +168,7 @@ const PropertyGraph& GraphSnapshotStore::CurrentSnapshot() const {
 }
 
 Status GraphSnapshotStore::PublishSnapshot(
-    const std::shared_ptr<PropertyGraph>& new_pg) {
+    const std::shared_ptr<PropertyGraph>& new_pg, uint32_t view_generation) {
   int slot_index = getFreeSlot();
   if (slot_index < 0) {
     return Status(StatusCode::ERR_POOL_EXHAUSTED,
@@ -187,6 +190,7 @@ Status GraphSnapshotStore::PublishSnapshot(
 
   slots_[slot_index].storage_ = new_pg;
   slots_[slot_index].view_ = GraphView(*new_pg);
+  slots_[slot_index].view_generation_ = view_generation;
 
   // Release the write-guard: bump reader_count_ from kCleanupSentinel to 1
   // (the prep-pin) atomically with a release fence so that all prior writes

--- a/src/storages/graph/graph_snapshot_store.cc
+++ b/src/storages/graph/graph_snapshot_store.cc
@@ -16,29 +16,56 @@
 #include "neug/storages/graph_snapshot_store.h"
 
 #include <glog/logging.h>
+#include <limits>
 #include <utility>
 
 #include "neug/generated/proto/plan/error.pb.h"
+#include "neug/utils/exception/exception.h"
 
 namespace neug {
 
 static constexpr int kCleanupSentinel = -(1 << 20);
 
+GraphSnapshotStore::PreparedSnapshot::PreparedSnapshot(
+    GraphSnapshotStore& store, int slot_index) noexcept
+    : store_(&store), slot_index_(slot_index) {}
+
+GraphSnapshotStore::PreparedSnapshot::~PreparedSnapshot() noexcept {
+  if (store_ != nullptr) {
+    store_->UnpinSnapshotByIndex(slot_index_);
+  }
+}
+
+GraphSnapshotStore::PreparedSnapshot::PreparedSnapshot(
+    PreparedSnapshot&& other) noexcept
+    : store_(std::exchange(other.store_, nullptr)),
+      slot_index_(other.slot_index_) {}
+
+uint32_t GraphSnapshotStore::PreparedSnapshot::Publish() && noexcept {
+  CHECK(store_ != nullptr);
+  auto* store = std::exchange(store_, nullptr);
+  const uint32_t generation = store->slots_[slot_index_].snapshot_generation_;
+  store->publishPreparedSnapshot(slot_index_);
+  return generation;
+}
+
 GraphSnapshotStore::GraphSnapshotStore(
     int slot_num, std::shared_ptr<PropertyGraph> initial_pg,
-    uint32_t initial_view_generation)
-    : slot_num_(slot_num), slots_(slot_num) {
+    uint32_t initial_snapshot_generation)
+    : slot_num_(slot_num),
+      slots_(slot_num),
+      last_reserved_snapshot_generation_(initial_snapshot_generation) {
   // Publish initial PG into slot 0.
   //
   // Invariant: while a slot is current, reader_count_ >= 1 (held by the
-  // "cur-pin").  PublishSnapshot transfers the cur-pin from the old slot to
-  // the new slot atomically around the cur_slot_index_ switch.  This lets
+  // "cur-pin"). A prepared publication transfers the cur-pin from the old slot
+  // to the new slot atomically around the cur_slot_index_ switch. This lets
   // PinCurrentSnapshot safely roll back when old_count == 0 (slot is free or
   // being cleaned up) without mistaking a live cur slot for a dead one,
   // because a live cur slot always has count >= 1.
   slots_[0].storage_ = std::move(initial_pg);
   slots_[0].view_ = GraphView(*slots_[0].storage_);
-  slots_[0].view_generation_ = initial_view_generation;
+  slots_[0].snapshot_generation_ = initial_snapshot_generation;
   slots_[0].reader_count_.store(1, std::memory_order_relaxed);  // cur-pin
   cur_slot_index_.store(0, std::memory_order_release);
 
@@ -80,7 +107,7 @@ void GraphSnapshotStore::cleanupSlot(int slot_index) {
   }
   slots_[slot_index].storage_.reset();
   slots_[slot_index].view_ = GraphView();
-  slots_[slot_index].view_generation_ = 0;
+  slots_[slot_index].snapshot_generation_ = 0;
   slots_[slot_index].reader_count_.fetch_add(-kCleanupSentinel,
                                              std::memory_order_release);
   returnFreeSlot(slot_index);
@@ -93,7 +120,7 @@ GraphSnapshotStore::PinCurrentSnapshot() noexcept {
 
     // Invariant: while a slot is current, reader_count_ >= 1 (cur-pin).
     // Spin until the slot looks ready: count <= 0 means either the
-    // write-guard is active (count < 0, PublishSnapshot still writing) or
+    // write-guard is active (count < 0, snapshot preparation still writing) or
     // the slot is transitioning / being cleaned up (count == 0, not yet
     // pinned by a new cur-pin).  In both cases reloading cur and retrying
     // is correct.  We do NOT modify reader_count_ in this branch to avoid
@@ -105,7 +132,7 @@ GraphSnapshotStore::PinCurrentSnapshot() noexcept {
     }
 
     // Optimistically pin with acq_rel so we synchronise with the release
-    // fence in PublishSnapshot and see fully-written storage_/view_.
+    // fence in PrepareSnapshot and see fully-written storage_/view_.
     int old_count = slots_[slot_index].reader_count_.fetch_add(
         1, std::memory_order_acq_rel);
 
@@ -167,60 +194,77 @@ const PropertyGraph& GraphSnapshotStore::CurrentSnapshot() const {
   return *slots_[slot_index].storage_;
 }
 
-Status GraphSnapshotStore::PublishSnapshot(
-    const std::shared_ptr<PropertyGraph>& new_pg, uint32_t view_generation) {
-  int slot_index = getFreeSlot();
-  if (slot_index < 0) {
-    return Status(StatusCode::ERR_POOL_EXHAUSTED,
-                  "GraphSnapshotStore slot exhausted");
+uint32_t GraphSnapshotStore::reserveSnapshotGeneration() {
+  uint32_t current =
+      last_reserved_snapshot_generation_.load(std::memory_order_relaxed);
+  while (true) {
+    if (current == std::numeric_limits<uint32_t>::max()) {
+      THROW_RUNTIME_ERROR(
+          "Snapshot generation space exhausted; restart the database before "
+          "preparing another snapshot");
+    }
+    if (last_reserved_snapshot_generation_.compare_exchange_weak(
+            current, current + 1, std::memory_order_acq_rel,
+            std::memory_order_relaxed)) {
+      return current + 1;
+    }
+  }
+}
+
+result<GraphSnapshotStore::PreparedSnapshot>
+GraphSnapshotStore::PrepareSnapshot(
+    const std::shared_ptr<PropertyGraph>& new_pg) {
+  if (!new_pg) {
+    return tl::unexpected(
+        Status(StatusCode::ERR_INVALID_ARGUMENT,
+               "Cannot prepare a null PropertyGraph snapshot"));
   }
 
-  // Write-guard: set reader_count_ to a large negative sentinel so that any
-  // concurrent PinCurrentSnapshot that races onto this slot (via ABA reuse)
-  // observes old_count < 0 and spins away.  We must finish writing
-  // storage_ and view_ before making the slot visible to readers, so the
-  // sentinel acts as a write-in-progress flag.
-  //
-  // cleanupSlot() leaves reader_count_ at 0 after returning the slot to the
-  // free_list (fetch_add(-kCleanupSentinel) brings it from kCleanupSentinel
-  // back to 0). We use store(kCleanupSentinel) here rather than fetch_add to
-  // set an unambiguous negative value regardless of any residual count.
-  slots_[slot_index].reader_count_.store(kCleanupSentinel,
-                                         std::memory_order_relaxed);
+  int slot_index = getFreeSlot();
+  if (slot_index < 0) {
+    return tl::unexpected(Status(StatusCode::ERR_POOL_EXHAUSTED,
+                                 "GraphSnapshotStore slot exhausted"));
+  }
 
-  slots_[slot_index].storage_ = new_pg;
-  slots_[slot_index].view_ = GraphView(*new_pg);
-  slots_[slot_index].view_generation_ = view_generation;
+  uint32_t snapshot_generation = 0;
+  try {
+    snapshot_generation = reserveSnapshotGeneration();
 
-  // Release the write-guard: bump reader_count_ from kCleanupSentinel to 1
-  // (the prep-pin) atomically with a release fence so that all prior writes
-  // to storage_ and view_ are visible to any reader that subsequently observes
-  // old_count >= 0 via fetch_add(1) with acquire semantics.
-  slots_[slot_index].reader_count_.fetch_add(-kCleanupSentinel + 1,
-                                             std::memory_order_release);
+    // Keep the reserved slot invisible while its storage and view are built.
+    slots_[slot_index].reader_count_.store(kCleanupSentinel,
+                                           std::memory_order_relaxed);
+    slots_[slot_index].storage_ = new_pg;
+    slots_[slot_index].view_ = GraphView(*new_pg);
+    slots_[slot_index].snapshot_generation_ = snapshot_generation;
 
-  // Load the old cur slot index while holding the invariant that the old
-  // cur slot's count >= 1 (its cur-pin).  No need for a phantom-pin: the
-  // cur-pin itself protects the old slot from premature cleanup across the
-  // switch, because UnpinSnapshotByIndex only triggers cleanup when
-  // prev_count == 1, meaning count drops to 0, which cannot happen while
-  // the cur-pin is still held.
-  int old_slot_index = cur_slot_index_.load(std::memory_order_acquire);
+    // Convert the write guard into the token's prep-pin. The prep-pin becomes
+    // the cur-pin if Publish() succeeds, or drives cleanup if the token aborts.
+    slots_[slot_index].reader_count_.fetch_add(-kCleanupSentinel + 1,
+                                               std::memory_order_release);
+  } catch (...) {
+    slots_[slot_index].storage_.reset();
+    slots_[slot_index].view_ = GraphView();
+    slots_[slot_index].snapshot_generation_ = 0;
+    slots_[slot_index].reader_count_.store(0, std::memory_order_release);
+    returnFreeSlot(slot_index);
+    throw;
+  }
 
-  // Switch cur to the new slot.  The new slot already has its cur-pin (= 1)
-  // set by the fetch_add above, so readers that observe the new index will
-  // see old_count >= 1 and pin successfully.
-  cur_slot_index_.store(slot_index, std::memory_order_release);
+  return PreparedSnapshot(*this, slot_index);
+}
 
-  // Release the old slot's cur-pin now that the new slot is current.
-  // If no readers are holding the old slot, prev_count == 1, count drops to
-  // 0, and cleanup fires via the CAS inside UnpinSnapshotByIndex.
-  // If readers still hold it, cleanup is deferred to the last reader release.
+void GraphSnapshotStore::publishPreparedSnapshot(int slot_index) noexcept {
+  CHECK_GE(slot_index, 0);
+  CHECK_LT(slot_index, slot_num_);
+  CHECK_EQ(slots_[slot_index].reader_count_.load(std::memory_order_acquire), 1);
+
+  // The prepared slot's prep-pin becomes its cur-pin at this exchange. Atomic
+  // exchange also makes simultaneous slot transfers form a safe hand-off chain.
+  const int old_slot_index =
+      cur_slot_index_.exchange(slot_index, std::memory_order_acq_rel);
+
+  // Release the old cur-pin; cleanup is immediate only when no reader holds it.
   UnpinSnapshotByIndex(old_slot_index);
-
-  // The new slot's prep-pin becomes its cur-pin — do NOT release it here.
-
-  return Status::OK();
 }
 
 }  // namespace neug

--- a/src/storages/graph/graph_snapshot_store.cc
+++ b/src/storages/graph/graph_snapshot_store.cc
@@ -60,9 +60,8 @@ GraphSnapshotStore::GraphSnapshotStore(
   // Invariant: while a slot is current, reader_count_ >= 1 (held by the
   // "cur-pin"). A prepared publication transfers the cur-pin from the old slot
   // to the new slot atomically around the cur_slot_index_ switch. This lets
-  // PinCurrentSnapshot safely roll back when old_count == 0 (slot is free or
-  // being cleaned up) without mistaking a live cur slot for a dead one,
-  // because a live cur slot always has count >= 1.
+  // PinCurrentSnapshot distinguish live slots from free or cleanup states,
+  // because only a live slot has a positive count.
   slots_[0].storage_ = std::move(initial_pg);
   slots_[0].view_ = GraphView(*slots_[0].storage_);
   slots_[0].snapshot_generation_ = initial_snapshot_generation;
@@ -119,29 +118,16 @@ GraphSnapshotStore::PinCurrentSnapshot() noexcept {
     int slot_index = cur_slot_index_.load(std::memory_order_acquire);
 
     // Invariant: while a slot is current, reader_count_ >= 1 (cur-pin).
-    // Spin until the slot looks ready: count <= 0 means either the
-    // write-guard is active (count < 0, snapshot preparation still writing) or
-    // the slot is transitioning / being cleaned up (count == 0, not yet
-    // pinned by a new cur-pin).  In both cases reloading cur and retrying
-    // is correct.  We do NOT modify reader_count_ in this branch to avoid
-    // racing with the writer's release-bump.
+    // Increment only while the count remains positive. An unconditional
+    // fetch_add followed by rollback can cross a cleanup/reuse boundary and
+    // accidentally remove the next slot incarnation's prep-pin.
     int observed =
         slots_[slot_index].reader_count_.load(std::memory_order_acquire);
+    while (observed > 0 &&
+           !slots_[slot_index].reader_count_.compare_exchange_weak(
+               observed, observed + 1, std::memory_order_acq_rel,
+               std::memory_order_acquire)) {}
     if (observed <= 0) {
-      continue;
-    }
-
-    // Optimistically pin with acq_rel so we synchronise with the release
-    // fence in PrepareSnapshot and see fully-written storage_/view_.
-    int old_count = slots_[slot_index].reader_count_.fetch_add(
-        1, std::memory_order_acq_rel);
-
-    if (old_count <= 0) {
-      // Raced between the load and fetch_add — count dropped back to <= 0
-      // (write-guard re-entered or slot freed).  Roll back with a plain
-      // relaxed sub: count stays negative/zero throughout so no cleanup
-      // CAS (which requires count == 0 after transition from cur-pin) fires.
-      slots_[slot_index].reader_count_.fetch_sub(1, std::memory_order_relaxed);
       continue;
     }
 
@@ -164,6 +150,9 @@ void GraphSnapshotStore::unpinSnapshotByIndex(int slot_index) noexcept {
     return;
   }
 
+  // Every caller owns either a cur-pin, prep-pin, or a positive-count pin
+  // acquired by PinCurrentSnapshot. That ownership prevents cleanup/reuse
+  // until this decrement, so a single fetch_sub is sufficient here.
   int prev_count =
       slots_[slot_index].reader_count_.fetch_sub(1, std::memory_order_acq_rel);
   if (prev_count <= 0) {
@@ -172,10 +161,10 @@ void GraphSnapshotStore::unpinSnapshotByIndex(int slot_index) noexcept {
   }
 
   // If this was the last reader and slot is no longer current, clean it up.
-  // Use CAS on reader_count (0 → -1) as a cleanup lock to prevent a
-  // concurrent PinCurrentSnapshot (which does fetch_add(1)) from racing with
-  // cleanup. If CAS fails, another thread either pinned the slot (count > 0)
-  // or is already cleaning it up (count < 0); either way we skip cleanup.
+  // Use CAS on reader_count (0 → sentinel) as a cleanup lock to prevent a
+  // concurrent positive-count pin from racing with cleanup. If CAS fails,
+  // another thread either pinned the slot (count > 0) or is already cleaning
+  // it up (count < 0); either way we skip cleanup.
   if (prev_count == 1) {
     int current = cur_slot_index_.load(std::memory_order_acquire);
     if (slot_index != current && slots_[slot_index].storage_) {
@@ -256,7 +245,11 @@ GraphSnapshotStore::PrepareSnapshot(
 void GraphSnapshotStore::publishPreparedSnapshot(int slot_index) noexcept {
   CHECK_GE(slot_index, 0);
   CHECK_LT(slot_index, slot_num_);
-  CHECK_EQ(slots_[slot_index].reader_count_.load(std::memory_order_acquire), 1);
+  // The prep-pin must still exist. A reader that retained this slot index from
+  // an older incarnation may have speculatively pinned it after reuse. Such a
+  // pin either becomes valid after the exchange or observes another current
+  // slot and releases itself.
+  CHECK_GE(slots_[slot_index].reader_count_.load(std::memory_order_acquire), 1);
 
   // The prepared slot's prep-pin becomes its cur-pin at this exchange. Atomic
   // exchange also makes simultaneous slot transfers form a safe hand-off chain.

--- a/src/storages/graph/graph_snapshot_store.cc
+++ b/src/storages/graph/graph_snapshot_store.cc
@@ -32,7 +32,7 @@ GraphSnapshotStore::PreparedSnapshot::PreparedSnapshot(
 
 GraphSnapshotStore::PreparedSnapshot::~PreparedSnapshot() noexcept {
   if (store_ != nullptr) {
-    store_->UnpinSnapshotByIndex(slot_index_);
+    store_->unpinSnapshotByIndex(slot_index_);
   }
 }
 
@@ -149,16 +149,16 @@ GraphSnapshotStore::PinCurrentSnapshot() noexcept {
       return slots_[slot_index];
     }
 
-    UnpinSnapshotByIndex(slot_index);
+    unpinSnapshotByIndex(slot_index);
   }
 }
 
 void GraphSnapshotStore::UnpinSnapshot(const SnapshotSlot& slot) noexcept {
   int slot_index = static_cast<int>(&slot - slots_.data());
-  UnpinSnapshotByIndex(slot_index);
+  unpinSnapshotByIndex(slot_index);
 }
 
-void GraphSnapshotStore::UnpinSnapshotByIndex(int slot_index) noexcept {
+void GraphSnapshotStore::unpinSnapshotByIndex(int slot_index) noexcept {
   if (slot_index < 0 || slot_index >= slot_num_) {
     LOG(ERROR) << "Invalid slot index in UnpinSnapshot: " << slot_index;
     return;
@@ -264,7 +264,7 @@ void GraphSnapshotStore::publishPreparedSnapshot(int slot_index) noexcept {
       cur_slot_index_.exchange(slot_index, std::memory_order_acq_rel);
 
   // Release the old cur-pin; cleanup is immediate only when no reader holds it.
-  UnpinSnapshotByIndex(old_slot_index);
+  unpinSnapshotByIndex(old_slot_index);
 }
 
 }  // namespace neug

--- a/src/storages/graph/graph_stats.cc
+++ b/src/storages/graph/graph_stats.cc
@@ -111,10 +111,10 @@ uint64_t GraphStats::getTable(uint64_t tableID) const {
     return atLeastOne(it->second);
   }
 #endif
-  if (graph_ == nullptr) {
+  if (view_ == nullptr) {
     return 1;
   }
-  if (graph_->schema().is_vertex_label_valid(tableID)) {
+  if (view_->schema().is_vertex_label_valid(tableID)) {
     return getTable(tableID, SchemaEntryType::NODE);
   }
   return getTable(tableID, SchemaEntryType::REL);
@@ -128,27 +128,27 @@ uint64_t GraphStats::getTable(uint64_t tableID,
     return atLeastOne(it->second);
   }
 #endif
-  if (graph_ == nullptr) {
+  if (view_ == nullptr) {
     return 1;
   }
   if (tableType == SchemaEntryType::NODE) {
-    if (!graph_->schema().is_vertex_label_valid(tableID)) {
+    if (!view_->schema().is_vertex_label_valid(tableID)) {
       return 1;
     }
-    return atLeastOne(graph_->VertexNum(tableID, MAX_TIMESTAMP));
+    return atLeastOne(view_->VertexNum(tableID));
   }
 
-  for (auto edge_label : graph_->schema().get_edge_label_ids()) {
-    for (auto src_label : graph_->schema().get_vertex_label_ids()) {
-      for (auto dst_label : graph_->schema().get_vertex_label_ids()) {
-        if (!graph_->schema().is_edge_triplet_valid(src_label, dst_label,
-                                                    edge_label)) {
+  for (auto edge_label : view_->schema().get_edge_label_ids()) {
+    for (auto src_label : view_->schema().get_vertex_label_ids()) {
+      for (auto dst_label : view_->schema().get_vertex_label_ids()) {
+        if (!view_->schema().is_edge_triplet_valid(src_label, dst_label,
+                                                   edge_label)) {
           continue;
         }
         auto edgeSchema =
-            graph_->schema().get_edge_schema(src_label, dst_label, edge_label);
+            view_->schema().get_edge_schema(src_label, dst_label, edge_label);
         if (edgeSchema && edgeSchema->get_entry_id() == tableID) {
-          return atLeastOne(graph_->EdgeNum(src_label, edge_label, dst_label));
+          return atLeastOne(view_->EdgeNum(src_label, dst_label, edge_label));
         }
       }
     }
@@ -166,7 +166,7 @@ uint64_t GraphStats::getTable(SchemaEntry* tableEntry) const {
     return atLeastOne(it->second);
   }
 #endif
-  if (graph_ == nullptr) {
+  if (view_ == nullptr) {
     return 1;
   }
   if (tableEntry->get_entry_type() == SchemaEntryType::NODE) {
@@ -177,14 +177,14 @@ uint64_t GraphStats::getTable(SchemaEntry* tableEntry) const {
   if (edgeSchema == nullptr) {
     THROW_EXCEPTION_WITH_FILE_LINE("Expected EdgeSchema for REL statistics");
   }
-  if (!graph_->schema().is_edge_triplet_valid(edgeSchema->getSrcTableID(),
-                                              edgeSchema->getDstTableID(),
-                                              edgeSchema->getLabelId())) {
+  if (!view_->schema().is_edge_triplet_valid(edgeSchema->getSrcTableID(),
+                                             edgeSchema->getDstTableID(),
+                                             edgeSchema->getLabelId())) {
     return 1;
   }
-  return atLeastOne(graph_->EdgeNum(edgeSchema->getSrcTableID(),
-                                    edgeSchema->getLabelId(),
-                                    edgeSchema->getDstTableID()));
+  return atLeastOne(view_->EdgeNum(edgeSchema->getSrcTableID(),
+                                   edgeSchema->getDstTableID(),
+                                   edgeSchema->getLabelId()));
 }
 
 }  // namespace neug

--- a/src/storages/graph/graph_view.cc
+++ b/src/storages/graph/graph_view.cc
@@ -84,6 +84,10 @@ bool VertexTableView::get_lid(const Value& oid, vid_t& lid,
 
 vid_t VertexTableView::LidNum() const { return indexer_->size(); }
 
+size_t VertexTableView::VertexNum() const {
+  return v_ts_->ValidVertexNum(MAX_TIMESTAMP, indexer_->size());
+}
+
 bool VertexTableView::IsValidLid(vid_t lid, timestamp_t ts) const {
   return lid < indexer_->size() && v_ts_->IsVertexValid(lid, ts);
 }
@@ -145,6 +149,16 @@ CsrView EdgeTableView::GetOutgoingView(timestamp_t ts) const {
 
 CsrView EdgeTableView::GetIncomingView(timestamp_t ts) const {
   return in_csr_->get_generic_view(ts);
+}
+
+size_t EdgeTableView::EdgeNum() const {
+  if (out_csr_) {
+    return out_csr_->edge_num();
+  }
+  if (in_csr_) {
+    return in_csr_->edge_num();
+  }
+  return 0;
 }
 
 EdgeDataAccessor EdgeTableView::GetDataAccessor(int prop_id) const {
@@ -224,6 +238,11 @@ VertexSet GraphView::GetVertexSet(label_t label, timestamp_t ts) const {
   return vertex_views_[label].GetVertexSet(ts);
 }
 
+vid_t GraphView::VertexNum(label_t label) const {
+  schema_->ensure_vertex_label_valid(label);
+  return vertex_views_[label].VertexNum();
+}
+
 Value GraphView::GetOid(label_t label, vid_t lid, timestamp_t ts) const {
   return vertex_views_[label].GetOid(lid, ts);
 }
@@ -252,6 +271,14 @@ CsrView GraphView::GetGenericIncomingView(label_t src_label, label_t dst_label,
         "Edge table for edge label triplet not found");
   }
   return it->second.GetIncomingView(ts);
+}
+
+size_t GraphView::EdgeNum(label_t src_label, label_t dst_label,
+                          label_t edge_label) const {
+  uint32_t index =
+      schema_->generate_edge_label(src_label, dst_label, edge_label);
+  auto it = edge_views_.find(index);
+  return it == edge_views_.end() ? 0 : it->second.EdgeNum();
 }
 
 EdgeDataAccessor GraphView::GetEdgeDataAccessor(label_t src_label,

--- a/src/transaction/read_snapshot_lease.cc
+++ b/src/transaction/read_snapshot_lease.cc
@@ -1,0 +1,36 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "neug/transaction/read_snapshot_lease.h"
+
+namespace neug {
+
+ReadSnapshotLease ReadSnapshotLease::Acquire(
+    IVersionManager& version_manager, GraphSnapshotStore& snapshot_store) {
+  for (;;) {
+    const PublishedReadView published = version_manager.acquire_read_view();
+    SnapshotGuard snapshot(snapshot_store);
+    if (snapshot.get().view_generation() == published.view_generation) {
+      return ReadSnapshotLease(version_manager, std::move(snapshot), published);
+    }
+
+    // A snapshot was published between the read-view capture and the pin.
+    // Release in protocol order, then reacquire a complete view.
+    snapshot.release();
+    version_manager.release_read_timestamp();
+  }
+}
+
+}  // namespace neug

--- a/src/transaction/read_snapshot_lease.cc
+++ b/src/transaction/read_snapshot_lease.cc
@@ -29,7 +29,7 @@ ReadSnapshotLease ReadSnapshotLease::Acquire(
     // A snapshot was published between the read-view capture and the pin.
     // Release in protocol order, then reacquire a complete view.
     snapshot.release();
-    version_manager.release_read_timestamp();
+    version_manager.release_read_view();
   }
 }
 

--- a/src/transaction/read_snapshot_lease.cc
+++ b/src/transaction/read_snapshot_lease.cc
@@ -15,14 +15,17 @@
 
 #include "neug/transaction/read_snapshot_lease.h"
 
+#include <optional>
+
 namespace neug {
 
 ReadSnapshotLease ReadSnapshotLease::Acquire(
     IVersionManager& version_manager, GraphSnapshotStore& snapshot_store) {
+  std::optional<RuntimeBackoff> wait;
   for (;;) {
     const PublishedReadView published = version_manager.acquire_read_view();
     SnapshotGuard snapshot(snapshot_store);
-    if (snapshot.get().view_generation() == published.view_generation) {
+    if (snapshot.get().snapshot_generation() == published.snapshot_generation) {
       return ReadSnapshotLease(version_manager, std::move(snapshot), published);
     }
 
@@ -30,6 +33,10 @@ ReadSnapshotLease ReadSnapshotLease::Acquire(
     // Release in protocol order, then reacquire a complete view.
     snapshot.release();
     version_manager.release_read_view();
+    if (!wait) {
+      wait.emplace(version_manager.make_runtime_backoff());
+    }
+    (*wait)();
   }
 }
 

--- a/src/transaction/read_snapshot_lease.cc
+++ b/src/transaction/read_snapshot_lease.cc
@@ -16,8 +16,42 @@
 #include "neug/transaction/read_snapshot_lease.h"
 
 #include <optional>
+#include <utility>
 
 namespace neug {
+
+ReadSnapshotLease::ReadSnapshotLease(IVersionManager& version_manager,
+                                     SnapshotGuard snapshot,
+                                     PublishedReadView published_view) noexcept
+    : version_manager_(&version_manager),
+      published_view_(published_view),
+      active_(true),
+      snapshot_(std::move(snapshot)) {}
+
+ReadSnapshotLease::ReadSnapshotLease(ReadSnapshotLease&& other) noexcept
+    : version_manager_(other.version_manager_),
+      published_view_(other.published_view_),
+      active_(other.active_),
+      snapshot_(std::move(other.snapshot_)) {
+  other.version_manager_ = nullptr;
+  other.active_ = false;
+}
+
+ReadSnapshotLease& ReadSnapshotLease::operator=(
+    ReadSnapshotLease&& other) noexcept {
+  if (this != &other) {
+    release();
+    version_manager_ = other.version_manager_;
+    published_view_ = other.published_view_;
+    active_ = other.active_;
+    snapshot_ = std::move(other.snapshot_);
+    other.version_manager_ = nullptr;
+    other.active_ = false;
+  }
+  return *this;
+}
+
+ReadSnapshotLease::~ReadSnapshotLease() noexcept { release(); }
 
 ReadSnapshotLease ReadSnapshotLease::Acquire(
     IVersionManager& version_manager, GraphSnapshotStore& snapshot_store) {
@@ -38,6 +72,15 @@ ReadSnapshotLease ReadSnapshotLease::Acquire(
     }
     (*wait)();
   }
+}
+
+void ReadSnapshotLease::release() noexcept {
+  if (!active_) {
+    return;
+  }
+  active_ = false;
+  snapshot_.release();
+  version_manager_->release_read_view();
 }
 
 }  // namespace neug

--- a/src/transaction/read_snapshot_lease.cc
+++ b/src/transaction/read_snapshot_lease.cc
@@ -22,31 +22,23 @@ namespace neug {
 
 ReadSnapshotLease::ReadSnapshotLease(IVersionManager& version_manager,
                                      SnapshotGuard snapshot,
-                                     PublishedReadView published_view) noexcept
+                                     timestamp_t timestamp) noexcept
     : version_manager_(&version_manager),
-      published_view_(published_view),
-      active_(true),
+      timestamp_(timestamp),
       snapshot_(std::move(snapshot)) {}
 
 ReadSnapshotLease::ReadSnapshotLease(ReadSnapshotLease&& other) noexcept
-    : version_manager_(other.version_manager_),
-      published_view_(other.published_view_),
-      active_(other.active_),
-      snapshot_(std::move(other.snapshot_)) {
-  other.version_manager_ = nullptr;
-  other.active_ = false;
-}
+    : version_manager_(std::exchange(other.version_manager_, nullptr)),
+      timestamp_(other.timestamp_),
+      snapshot_(std::move(other.snapshot_)) {}
 
 ReadSnapshotLease& ReadSnapshotLease::operator=(
     ReadSnapshotLease&& other) noexcept {
   if (this != &other) {
     release();
-    version_manager_ = other.version_manager_;
-    published_view_ = other.published_view_;
-    active_ = other.active_;
+    version_manager_ = std::exchange(other.version_manager_, nullptr);
+    timestamp_ = other.timestamp_;
     snapshot_ = std::move(other.snapshot_);
-    other.version_manager_ = nullptr;
-    other.active_ = false;
   }
   return *this;
 }
@@ -60,7 +52,8 @@ ReadSnapshotLease ReadSnapshotLease::Acquire(
     const PublishedReadView published = version_manager.acquire_read_view();
     SnapshotGuard snapshot(snapshot_store);
     if (snapshot.get().snapshot_generation() == published.snapshot_generation) {
-      return ReadSnapshotLease(version_manager, std::move(snapshot), published);
+      return ReadSnapshotLease(version_manager, std::move(snapshot),
+                               published.visibility_ts);
     }
 
     // A snapshot was published between the read-view capture and the pin.
@@ -75,12 +68,12 @@ ReadSnapshotLease ReadSnapshotLease::Acquire(
 }
 
 void ReadSnapshotLease::release() noexcept {
-  if (!active_) {
+  auto* version_manager = std::exchange(version_manager_, nullptr);
+  if (!version_manager) {
     return;
   }
-  active_ = false;
   snapshot_.release();
-  version_manager_->release_read_view();
+  version_manager->release_read_view();
 }
 
 }  // namespace neug

--- a/src/transaction/read_transaction.cc
+++ b/src/transaction/read_transaction.cc
@@ -38,9 +38,7 @@ bool ReadTransaction::Commit() {
 
 void ReadTransaction::Abort() { release(); }
 
-const Schema& ReadTransaction::schema() const {
-  return lease_.snapshot().graph()->schema();
-}
+const Schema& ReadTransaction::schema() const { return lease_.view().schema(); }
 
 void ReadTransaction::release() { lease_.release(); }
 

--- a/src/transaction/read_transaction.cc
+++ b/src/transaction/read_transaction.cc
@@ -20,18 +20,16 @@
 #include "neug/storages/csr/csr_base.h"
 #include "neug/storages/graph/graph_view.h"
 #include "neug/storages/graph/property_graph.h"
-#include "neug/transaction/version_manager.h"
 #include "neug/utils/likely.h"
 
 namespace neug {
 
-ReadTransaction::ReadTransaction(SnapshotGuard guard, IVersionManager& vm,
-                                 timestamp_t timestamp)
-    : guard_(std::move(guard)), vm_(vm), timestamp_(timestamp) {}
+ReadTransaction::ReadTransaction(ReadSnapshotLease lease)
+    : lease_(std::move(lease)) {}
 
 ReadTransaction::~ReadTransaction() { release(); }
 
-timestamp_t ReadTransaction::timestamp() const { return timestamp_; }
+timestamp_t ReadTransaction::timestamp() const { return lease_.timestamp(); }
 
 bool ReadTransaction::Commit() {
   release();
@@ -41,15 +39,9 @@ bool ReadTransaction::Commit() {
 void ReadTransaction::Abort() { release(); }
 
 const Schema& ReadTransaction::schema() const {
-  return guard_.get().mutable_graph()->schema();
+  return lease_.graph()->schema();
 }
 
-void ReadTransaction::release() {
-  if (timestamp_ != INVALID_TIMESTAMP) {
-    guard_.release();
-    vm_.release_read_timestamp();
-    timestamp_ = INVALID_TIMESTAMP;
-  }
-}
+void ReadTransaction::release() { lease_.release(); }
 
 }  // namespace neug

--- a/src/transaction/read_transaction.cc
+++ b/src/transaction/read_transaction.cc
@@ -39,7 +39,7 @@ bool ReadTransaction::Commit() {
 void ReadTransaction::Abort() { release(); }
 
 const Schema& ReadTransaction::schema() const {
-  return lease_.graph()->schema();
+  return lease_.snapshot().graph()->schema();
 }
 
 void ReadTransaction::release() { lease_.release(); }

--- a/src/transaction/timestamp_lease.cc
+++ b/src/transaction/timestamp_lease.cc
@@ -1,0 +1,69 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "neug/transaction/timestamp_lease.h"
+
+#include <glog/logging.h>
+
+#include "neug/transaction/version_manager.h"
+
+namespace neug {
+
+UpdateTimestampLease::UpdateTimestampLease(IVersionManager& version_manager)
+    : version_manager_(&version_manager),
+      timestamp_(version_manager.acquire_update_timestamp()) {
+  CHECK_NE(timestamp_, kInactiveTimestamp);
+}
+
+UpdateTimestampLease::UpdateTimestampLease(IVersionManager& version_manager,
+                                           uint32_t timestamp) noexcept
+    : version_manager_(&version_manager), timestamp_(timestamp) {
+  CHECK_NE(timestamp_, kInactiveTimestamp);
+}
+
+UpdateTimestampLease::~UpdateTimestampLease() noexcept { reset(); }
+
+void UpdateTimestampLease::BeginCommit() {
+  CHECK_NE(timestamp_, kInactiveTimestamp);
+  CHECK(!commit_started_);
+  version_manager_->begin_update_commit(timestamp_);
+  commit_started_ = true;
+}
+
+void UpdateTimestampLease::MakeUpdateExclusive() {
+  BeginCommit();
+  version_manager_->drain_readers();
+}
+
+void UpdateTimestampLease::Finish(
+    std::optional<uint32_t> installed_snapshot_generation) noexcept {
+  CHECK_NE(timestamp_, kInactiveTimestamp);
+  CHECK(!installed_snapshot_generation || commit_started_);
+  version_manager_->finish_update_timestamp(timestamp_,
+                                            installed_snapshot_generation);
+  timestamp_ = kInactiveTimestamp;
+  commit_started_ = false;
+}
+
+void UpdateTimestampLease::reset() noexcept {
+  if (timestamp_ == kInactiveTimestamp) {
+    return;
+  }
+  version_manager_->finish_update_timestamp(timestamp_, std::nullopt);
+  timestamp_ = kInactiveTimestamp;
+  commit_started_ = false;
+}
+
+}  // namespace neug

--- a/src/transaction/timestamp_lease.cc
+++ b/src/transaction/timestamp_lease.cc
@@ -15,6 +15,8 @@
 
 #include "neug/transaction/timestamp_lease.h"
 
+#include <utility>
+
 #include <glog/logging.h>
 
 #include "neug/transaction/version_manager.h"
@@ -27,11 +29,11 @@ UpdateTimestampLease::UpdateTimestampLease(IVersionManager& version_manager)
   CHECK_NE(timestamp_, kInactiveTimestamp);
 }
 
-UpdateTimestampLease::UpdateTimestampLease(IVersionManager& version_manager,
-                                           uint32_t timestamp) noexcept
-    : version_manager_(&version_manager), timestamp_(timestamp) {
-  CHECK_NE(timestamp_, kInactiveTimestamp);
-}
+UpdateTimestampLease::UpdateTimestampLease(
+    UpdateTimestampLease&& other) noexcept
+    : version_manager_(std::exchange(other.version_manager_, nullptr)),
+      timestamp_(std::exchange(other.timestamp_, kInactiveTimestamp)),
+      commit_started_(std::exchange(other.commit_started_, false)) {}
 
 UpdateTimestampLease::~UpdateTimestampLease() noexcept { reset(); }
 

--- a/src/transaction/update_transaction.cc
+++ b/src/transaction/update_transaction.cc
@@ -354,6 +354,11 @@ bool UpdateTransaction::Commit() {
     return false;
   }
 
+  // Reserve the snapshot identity before WAL append so generation exhaustion
+  // cannot turn into a post-WAL failure. Aborted transactions may leave a
+  // harmless gap in the generation sequence.
+  view_generation_ = vm_.reserve_view_generation();
+
   wal_builder_.finalize(timestamp_);
   if (!logger_.append(wal_builder_.data(), wal_builder_.size())) {
     LOG(ERROR) << "Failed to append wal log";
@@ -371,7 +376,7 @@ bool UpdateTransaction::Commit() {
   // release_update_timestamp (advancing read_ts_). This ordering guarantees
   // that any new reader observing the advanced read_ts will also see the new
   // slot.
-  auto status = snapshot_store_.PublishSnapshot(cow_graph_);
+  auto status = snapshot_store_.PublishSnapshot(cow_graph_, view_generation_);
   if (!status.ok()) {
     // We should never fail to publish the snapshot.
     LOG(FATAL) << "Failed to publish snapshot: " << status.ToString();
@@ -380,6 +385,7 @@ bool UpdateTransaction::Commit() {
   // The COW PG is now owned by the new slot. Drop our reference so this
   // transaction does not appear to still hold the snapshot. view_ wraps
   // cow_graph_, so reset it too to keep pg_ from dangling.
+  snapshot_published_ = true;
   view_ = GraphView();
   release();
   return true;
@@ -390,8 +396,14 @@ void UpdateTransaction::Abort() { release(); }
 void UpdateTransaction::release() {
   if (timestamp_ != INVALID_TIMESTAMP) {
     wal_builder_.clear();
-    vm_.release_update_timestamp(timestamp_);
+    if (snapshot_published_) {
+      vm_.release_update_timestamp_with_view(timestamp_, view_generation_);
+    } else {
+      vm_.release_update_timestamp(timestamp_);
+    }
     timestamp_ = INVALID_TIMESTAMP;
+    view_generation_ = 0;
+    snapshot_published_ = false;
   }
   cow_graph_.reset();
 }

--- a/src/transaction/update_transaction.cc
+++ b/src/transaction/update_transaction.cc
@@ -321,10 +321,9 @@ static Status deleteVertexIndexData(
 
 UpdateTransaction::UpdateTransaction(std::shared_ptr<PropertyGraph> cow_graph,
                                      Allocator& alloc, IWalWriter& logger,
-                                     IVersionManager& vm,
                                      GraphSnapshotStore& snapshot_store,
                                      execution::LocalQueryCache& cache,
-                                     timestamp_t timestamp)
+                                     UpdateTimestampLease timestamp_lease)
     : cow_graph_(std::move(cow_graph)),
       cow_state_(PropertyGraphCowState::FromSchema(cow_graph_->schema())),
       view_(*cow_graph_),
@@ -332,7 +331,7 @@ UpdateTransaction::UpdateTransaction(std::shared_ptr<PropertyGraph> cow_graph,
       logger_(logger),
       snapshot_store_(snapshot_store),
       pipeline_cache_(cache),
-      timestamp_lease_(vm, timestamp),
+      timestamp_lease_(std::move(timestamp_lease)),
       ckp_(cow_graph_->checkpoint_ptr()) {}
 
 UpdateTransaction::~UpdateTransaction() { Abort(); }

--- a/src/transaction/update_transaction.cc
+++ b/src/transaction/update_transaction.cc
@@ -22,6 +22,7 @@
 #include <filesystem>
 #include <functional>
 #include <limits>
+#include <optional>
 #include <ostream>
 #include <string_view>
 
@@ -329,82 +330,65 @@ UpdateTransaction::UpdateTransaction(std::shared_ptr<PropertyGraph> cow_graph,
       view_(*cow_graph_),
       alloc_(alloc),
       logger_(logger),
-      vm_(vm),
       snapshot_store_(snapshot_store),
       pipeline_cache_(cache),
-      timestamp_(timestamp),
+      timestamp_lease_(vm, timestamp),
       ckp_(cow_graph_->checkpoint_ptr()) {}
 
 UpdateTransaction::~UpdateTransaction() { Abort(); }
 
-timestamp_t UpdateTransaction::timestamp() const { return timestamp_; }
-
 bool UpdateTransaction::Commit() {
-  if (timestamp_ == INVALID_TIMESTAMP) {
+  if (timestamp() == INVALID_TIMESTAMP) {
     return true;
   }
   if (wal_builder_.op_num() == 0 && wal_builder_.content_size() == 0) {
-    release();
+    release(std::nullopt);
     return true;
   }
 
-  if (!snapshot_store_.HasFreeSlot()) {
-    LOG(ERROR) << "GraphSnapshotStore slot exhausted; refusing to commit";
+  auto prepared_result = snapshot_store_.PrepareSnapshot(cow_graph_);
+  if (!prepared_result) {
+    LOG(ERROR) << "Failed to prepare graph snapshot: "
+               << prepared_result.error().ToString();
     Abort();
     return false;
   }
+  auto prepared = std::move(prepared_result).value();
 
-  // Reserve the snapshot identity before WAL append so generation exhaustion
-  // cannot turn into a post-WAL failure. Aborted transactions may leave a
-  // harmless gap in the generation sequence.
-  view_generation_ = vm_.reserve_view_generation();
-
-  wal_builder_.finalize(timestamp_);
+  wal_builder_.finalize(timestamp());
   if (!logger_.append(wal_builder_.data(), wal_builder_.size())) {
     LOG(ERROR) << "Failed to append wal log";
     Abort();
     return false;
   }
 
-  vm_.begin_update_commit(timestamp_);
+  timestamp_lease_.BeginCommit();
 
   if (wal_builder_.schema_changed()) {
     pipeline_cache_.clearGlobalCache();
   }
 
-  // PublishSnapshot MUST happen BEFORE release() which calls
-  // release_update_timestamp (advancing read_ts_). This ordering guarantees
-  // that any new reader observing the advanced read_ts will also see the new
-  // slot.
-  auto status = snapshot_store_.PublishSnapshot(cow_graph_, view_generation_);
-  if (!status.ok()) {
-    // We should never fail to publish the snapshot.
-    LOG(FATAL) << "Failed to publish snapshot: " << status.ToString();
-  }
-
-  // The COW PG is now owned by the new slot. Drop our reference so this
-  // transaction does not appear to still hold the snapshot. view_ wraps
-  // cow_graph_, so reset it too to keep pg_ from dangling.
-  snapshot_published_ = true;
-  view_ = GraphView();
-  release();
+  // Preparation completed before WAL append, so publication is a bounded,
+  // no-fail current-slot switch. Finish publishes the matching read view
+  // before admission reopens.
+  const uint32_t snapshot_generation = std::move(prepared).Publish();
+  release(snapshot_generation);
   return true;
 }
 
-void UpdateTransaction::Abort() { release(); }
-
-void UpdateTransaction::release() {
-  if (timestamp_ != INVALID_TIMESTAMP) {
-    wal_builder_.clear();
-    if (snapshot_published_) {
-      vm_.release_update_timestamp_with_view(timestamp_, view_generation_);
-    } else {
-      vm_.release_update_timestamp(timestamp_);
-    }
-    timestamp_ = INVALID_TIMESTAMP;
-    view_generation_ = 0;
-    snapshot_published_ = false;
+void UpdateTransaction::Abort() {
+  if (timestamp() != INVALID_TIMESTAMP) {
+    release(std::nullopt);
   }
+}
+
+void UpdateTransaction::release(
+    std::optional<uint32_t> installed_snapshot_generation) {
+  if (timestamp() != INVALID_TIMESTAMP) {
+    wal_builder_.clear();
+    timestamp_lease_.Finish(installed_snapshot_generation);
+  }
+  view_ = GraphView();
   cow_graph_.reset();
 }
 
@@ -935,7 +919,7 @@ Status StorageTPUpdateInterface::DeleteEdgeImpl(
 Value UpdateTransaction::GetVertexProperty(label_t label, vid_t lid,
                                            int col_id) const {
   auto col = cow_graph_->GetVertexPropertyColumn(label, col_id);
-  if (!cow_graph_->IsValidLid(label, lid, timestamp_)) {
+  if (!cow_graph_->IsValidLid(label, lid, timestamp())) {
     THROW_INVALID_ARGUMENT_EXCEPTION(
         "Vertex lid is not valid in this transaction");
   }
@@ -946,12 +930,12 @@ Value UpdateTransaction::GetVertexProperty(label_t label, vid_t lid,
 }
 
 Value UpdateTransaction::GetVertexId(label_t label, vid_t lid) const {
-  return cow_graph_->GetOid(label, lid, timestamp_);
+  return cow_graph_->GetOid(label, lid, timestamp());
 }
 
 bool UpdateTransaction::GetVertexIndex(label_t label, const Value& id,
                                        vid_t& index) const {
-  return cow_graph_->get_lid(label, id, index, timestamp_);
+  return cow_graph_->get_lid(label, id, index, timestamp());
 }
 
 Status StorageTPUpdateInterface::UpdateVertexPropertyImpl(label_t label,

--- a/src/transaction/version_manager.cc
+++ b/src/transaction/version_manager.cc
@@ -27,7 +27,9 @@ namespace neug {
 
 VersionManager::VersionManager() : runtime_wait_(&NativeRuntimeWait) {}
 
-void VersionManager::init_ts(uint32_t ts, int thread_num) {
+void VersionManager::init_ts(PublishedReadView initial_read_view,
+                             int thread_num) {
+  const uint32_t ts = initial_read_view.visibility_ts;
   if (ts == std::numeric_limits<uint32_t>::max()) {
     THROW_RUNTIME_ERROR(
         "Transaction timestamp space exhausted; checkpoint/reset the timeline "
@@ -35,8 +37,9 @@ void VersionManager::init_ts(uint32_t ts, int thread_num) {
   }
   write_ts_.store(ts + 1, std::memory_order_relaxed);
   read_ts_.store(ts, std::memory_order_relaxed);
-  installed_snapshot_generation_.store(0, std::memory_order_relaxed);
-  published_read_view_.store(PackPublishedReadView({ts, 0}),
+  installed_snapshot_generation_.store(initial_read_view.snapshot_generation,
+                                       std::memory_order_relaxed);
+  published_read_view_.store(PackPublishedReadView(initial_read_view),
                              std::memory_order_relaxed);
   active_readers_.store(0, std::memory_order_relaxed);
   active_inserters_.store(0, std::memory_order_relaxed);

--- a/src/transaction/version_manager.cc
+++ b/src/transaction/version_manager.cc
@@ -77,10 +77,6 @@ bool VersionManager::try_set_runtime_wait_if_quiescent(
   return quiescent;
 }
 
-uint32_t VersionManager::acquire_read_timestamp() {
-  return acquire_read_view().visibility_ts;
-}
-
 PublishedReadView VersionManager::acquire_read_view() {
   // Pre-check: avoid incrementing if in commit phase
   auto state = admission_state_.load(std::memory_order_acquire);
@@ -118,7 +114,7 @@ PublishedReadView VersionManager::acquire_read_view_slow() {
   return acquire_read_view();
 }
 
-void VersionManager::release_read_timestamp() {
+void VersionManager::release_read_view() {
   active_readers_.fetch_sub(1, std::memory_order_acq_rel);
 }
 

--- a/src/transaction/version_manager.cc
+++ b/src/transaction/version_manager.cc
@@ -35,8 +35,7 @@ void VersionManager::init_ts(uint32_t ts, int thread_num) {
   }
   write_ts_.store(ts + 1, std::memory_order_relaxed);
   read_ts_.store(ts, std::memory_order_relaxed);
-  next_view_generation_.store(0, std::memory_order_relaxed);
-  current_view_generation_.store(0, std::memory_order_relaxed);
+  installed_snapshot_generation_.store(0, std::memory_order_relaxed);
   published_read_view_.store(PackPublishedReadView({ts, 0}),
                              std::memory_order_relaxed);
   active_readers_.store(0, std::memory_order_relaxed);
@@ -104,7 +103,7 @@ PublishedReadView VersionManager::acquire_read_view() {
 }
 
 PublishedReadView VersionManager::acquire_read_view_slow() {
-  AdaptiveBackoff wait(runtime_wait());
+  RuntimeBackoff wait = make_runtime_backoff();
   while (admission_state_.load(std::memory_order_acquire) ==
          AdmissionState::kAllBlocked) {
     wait();
@@ -140,7 +139,7 @@ uint32_t VersionManager::acquire_insert_timestamp() {
 }
 
 uint32_t VersionManager::acquire_insert_timestamp_slow() {
-  AdaptiveBackoff wait(runtime_wait());
+  RuntimeBackoff wait = make_runtime_backoff();
   while (admission_state_.load(std::memory_order_acquire) !=
          AdmissionState::kOpen) {
     wait();
@@ -164,7 +163,7 @@ void VersionManager::complete_write_timestamp(uint32_t ts) {
   // Check under lock: only advance if ts == read_ts + 1
   std::unique_lock lock(lock_, std::defer_lock);
   if (!lock.try_lock()) {
-    AdaptiveBackoff wait(runtime_wait());
+    RuntimeBackoff wait = make_runtime_backoff();
     do {
       wait();
     } while (!lock.try_lock());
@@ -196,8 +195,8 @@ void VersionManager::advance_read_ts_locked() {
   // Sliding window maintenance
   ts_window_.slide_window(current);
   published_read_view_.store(
-      PackPublishedReadView(
-          {current, current_view_generation_.load(std::memory_order_relaxed)}),
+      PackPublishedReadView({current, installed_snapshot_generation_.load(
+                                          std::memory_order_relaxed)}),
       std::memory_order_release);
 }
 
@@ -209,7 +208,7 @@ void VersionManager::enter_exclusive_state(AdmissionState desired_state) {
     return;
   }
 
-  AdaptiveBackoff wait(runtime_wait());
+  RuntimeBackoff wait = make_runtime_backoff();
   do {
     wait();
     expected = AdmissionState::kOpen;
@@ -223,13 +222,13 @@ void VersionManager::wait_until_zero(const std::atomic<int>& counter) {
     return;
   }
 
-  AdaptiveBackoff wait(runtime_wait());
+  RuntimeBackoff wait = make_runtime_backoff();
   do {
     wait();
   } while (counter.load(std::memory_order_seq_cst) > 0);
 }
 
-RuntimeWaitFn VersionManager::runtime_wait() const noexcept {
+RuntimeWaitFn VersionManager::runtime_wait_impl() const noexcept {
   return runtime_wait_.load(std::memory_order_acquire);
 }
 
@@ -238,22 +237,6 @@ uint32_t VersionManager::acquire_update_timestamp() {
   wait_until_zero(active_inserters_);
 
   return write_ts_.fetch_add(1, std::memory_order_acq_rel);
-}
-
-uint32_t VersionManager::reserve_view_generation() {
-  uint32_t current = next_view_generation_.load(std::memory_order_relaxed);
-  while (true) {
-    if (current == std::numeric_limits<uint32_t>::max()) {
-      THROW_RUNTIME_ERROR(
-          "Snapshot generation space exhausted; restart the database before "
-          "publishing another snapshot");
-    }
-    if (next_view_generation_.compare_exchange_weak(
-            current, current + 1, std::memory_order_acq_rel,
-            std::memory_order_relaxed)) {
-      return current + 1;
-    }
-  }
 }
 
 void VersionManager::begin_update_commit(uint32_t ts) {
@@ -276,19 +259,17 @@ void VersionManager::drain_readers() {
   wait_until_zero(active_readers_);
 }
 
-void VersionManager::release_update_timestamp(uint32_t ts) {
+void VersionManager::finish_update_timestamp(
+    uint32_t ts,
+    std::optional<uint32_t> installed_snapshot_generation) noexcept {
+  if (installed_snapshot_generation) {
+    installed_snapshot_generation_.store(*installed_snapshot_generation,
+                                         std::memory_order_relaxed);
+  }
   complete_write_timestamp(ts);
 
-  // Restore normal operation.
-  admission_state_.store(AdmissionState::kOpen, std::memory_order_release);
-}
-
-void VersionManager::release_update_timestamp_with_view(
-    uint32_t ts, uint32_t view_generation) {
-  current_view_generation_.store(view_generation, std::memory_order_relaxed);
-  complete_write_timestamp(ts);
-
-  // Snapshot installation and the matching read view are now visible.
+  // Timestamp completion and any matching snapshot generation are visible
+  // before new readers and inserters are admitted.
   admission_state_.store(AdmissionState::kOpen, std::memory_order_release);
 }
 

--- a/src/transaction/version_manager.cc
+++ b/src/transaction/version_manager.cc
@@ -15,6 +15,7 @@
 
 #include "neug/transaction/version_manager.h"
 
+#include <limits>
 #include <mutex>
 
 #include "neug/utils/exception/exception.h"
@@ -27,8 +28,17 @@ namespace neug {
 VersionManager::VersionManager() : runtime_wait_(&NativeRuntimeWait) {}
 
 void VersionManager::init_ts(uint32_t ts, int thread_num) {
+  if (ts == std::numeric_limits<uint32_t>::max()) {
+    THROW_RUNTIME_ERROR(
+        "Transaction timestamp space exhausted; checkpoint/reset the timeline "
+        "before reopening the database");
+  }
   write_ts_.store(ts + 1, std::memory_order_relaxed);
   read_ts_.store(ts, std::memory_order_relaxed);
+  next_view_generation_.store(0, std::memory_order_relaxed);
+  current_view_generation_.store(0, std::memory_order_relaxed);
+  published_read_view_.store(PackPublishedReadView({ts, 0}),
+                             std::memory_order_relaxed);
   active_readers_.store(0, std::memory_order_relaxed);
   active_inserters_.store(0, std::memory_order_relaxed);
   admission_state_.store(AdmissionState::kOpen, std::memory_order_relaxed);
@@ -68,10 +78,14 @@ bool VersionManager::try_set_runtime_wait_if_quiescent(
 }
 
 uint32_t VersionManager::acquire_read_timestamp() {
+  return acquire_read_view().visibility_ts;
+}
+
+PublishedReadView VersionManager::acquire_read_view() {
   // Pre-check: avoid incrementing if in commit phase
   auto state = admission_state_.load(std::memory_order_acquire);
   if (NEUG_UNLIKELY(state == AdmissionState::kAllBlocked)) {
-    return acquire_read_timestamp_slow();
+    return acquire_read_view_slow();
   }
 
   // Optimistically increment counter
@@ -82,17 +96,18 @@ uint32_t VersionManager::acquire_read_timestamp() {
   // but misses a concurrent transition to all-blocked.
   state = admission_state_.load(std::memory_order_seq_cst);
   if (NEUG_LIKELY(state != AdmissionState::kAllBlocked)) {
-    return read_ts_.load(std::memory_order_acquire);
+    return UnpackPublishedReadView(
+        published_read_view_.load(std::memory_order_acquire));
   }
 
   // Rollback: commit started while we were incrementing
   active_readers_.fetch_sub(1, std::memory_order_acq_rel);
 
   // Slow path
-  return acquire_read_timestamp_slow();
+  return acquire_read_view_slow();
 }
 
-uint32_t VersionManager::acquire_read_timestamp_slow() {
+PublishedReadView VersionManager::acquire_read_view_slow() {
   AdaptiveBackoff wait(runtime_wait());
   while (admission_state_.load(std::memory_order_acquire) ==
          AdmissionState::kAllBlocked) {
@@ -100,7 +115,7 @@ uint32_t VersionManager::acquire_read_timestamp_slow() {
   }
 
   // Retry
-  return acquire_read_timestamp();
+  return acquire_read_view();
 }
 
 void VersionManager::release_read_timestamp() {
@@ -184,6 +199,10 @@ void VersionManager::advance_read_ts_locked() {
 
   // Sliding window maintenance
   ts_window_.slide_window(current);
+  published_read_view_.store(
+      PackPublishedReadView(
+          {current, current_view_generation_.load(std::memory_order_relaxed)}),
+      std::memory_order_release);
 }
 
 void VersionManager::enter_exclusive_state(AdmissionState desired_state) {
@@ -225,6 +244,22 @@ uint32_t VersionManager::acquire_update_timestamp() {
   return write_ts_.fetch_add(1, std::memory_order_acq_rel);
 }
 
+uint32_t VersionManager::reserve_view_generation() {
+  uint32_t current = next_view_generation_.load(std::memory_order_relaxed);
+  while (true) {
+    if (current == std::numeric_limits<uint32_t>::max()) {
+      THROW_RUNTIME_ERROR(
+          "Snapshot generation space exhausted; restart the database before "
+          "publishing another snapshot");
+    }
+    if (next_view_generation_.compare_exchange_weak(
+            current, current + 1, std::memory_order_acq_rel,
+            std::memory_order_relaxed)) {
+      return current + 1;
+    }
+  }
+}
+
 void VersionManager::begin_update_commit(uint32_t ts) {
   (void) ts;
 
@@ -249,6 +284,15 @@ void VersionManager::release_update_timestamp(uint32_t ts) {
   complete_write_timestamp(ts);
 
   // Restore normal operation.
+  admission_state_.store(AdmissionState::kOpen, std::memory_order_release);
+}
+
+void VersionManager::release_update_timestamp_with_view(
+    uint32_t ts, uint32_t view_generation) {
+  current_view_generation_.store(view_generation, std::memory_order_relaxed);
+  complete_write_timestamp(ts);
+
+  // Snapshot installation and the matching read view are now visible.
   admission_state_.store(AdmissionState::kOpen, std::memory_order_release);
 }
 

--- a/tests/storage/test_graph_snapshot_store_concurrency.cc
+++ b/tests/storage/test_graph_snapshot_store_concurrency.cc
@@ -297,17 +297,16 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, PublishExclusivityVsPinShared) {
   EXPECT_GT(reads_done.load(), 0);
 }
 
-// 6. PinCurrentSnapshot keeps the pinned PG alive across a concurrent
+// 6. PinCurrentSnapshot keeps the pinned snapshot alive across a concurrent
 // prepared publication that installs a new cur slot.
 TEST_F(GraphSnapshotStoreConcurrencyTest, PinnedSnapshotSurvivesPublish) {
   auto& slot = store_->PinCurrentSnapshot();
-  ASSERT_NE(slot.graph(), nullptr);
 
   ASSERT_TRUE(PrepareAndPublishSnapshot(*store_, make_new_pg()).ok());
 
-  // graph pointer is still safely dereferenceable: storage held alive by our
-  // pin.
-  EXPECT_GE(slot.graph()->schema().vertex_label_num(), 1u);
+  // The view remains safely dereferenceable because its storage is held alive
+  // by our pin.
+  EXPECT_GE(slot.view().schema().vertex_label_num(), 1u);
 
   store_->UnpinSnapshot(slot);
 }
@@ -331,9 +330,9 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, CowPublishIsVisibleToNewReaders) {
 
   // A new reader must observe the "company" vertex type.
   auto& slot = store_->PinCurrentSnapshot();
-  EXPECT_TRUE(slot.graph()->schema().is_vertex_label_valid("company"));
-  EXPECT_TRUE(slot.graph()->schema().is_vertex_label_valid("person"));
-  EXPECT_EQ(slot.graph()->schema().vertex_label_num(), 2u);
+  EXPECT_TRUE(slot.view().schema().is_vertex_label_valid("company"));
+  EXPECT_TRUE(slot.view().schema().is_vertex_label_valid("person"));
+  EXPECT_EQ(slot.view().schema().vertex_label_num(), 2u);
   store_->UnpinSnapshot(slot);
 }
 
@@ -415,7 +414,7 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, CowIsolationAfterCloneMutatePublish) {
   // Publish cow2 and verify a reader sees all three.
   ASSERT_TRUE(PrepareAndPublishSnapshot(*store_, cow2).ok());
   auto& slot = store_->PinCurrentSnapshot();
-  EXPECT_EQ(slot.graph()->VertexNum(0, MAX_TIMESTAMP), 3u);
+  EXPECT_EQ(slot.view().VertexNum(0), 3u);
   store_->UnpinSnapshot(slot);
 }
 

--- a/tests/storage/test_graph_snapshot_store_concurrency.cc
+++ b/tests/storage/test_graph_snapshot_store_concurrency.cc
@@ -125,7 +125,7 @@ TEST_F(GraphSnapshotStoreConcurrencyTest,
         // PublishSnapshot is NOT safe for concurrent calls — caller must
         // serialize externally (see GraphSnapshotStore class doc).
         std::lock_guard<std::mutex> lock(publish_mutex);
-        auto status = store_->PublishSnapshot(pg);
+        auto status = store_->PublishSnapshot(pg, 0);
         if (status.ok()) {
           publishes_done.fetch_add(1, std::memory_order_relaxed);
         }
@@ -161,7 +161,7 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, PhantomPinPreventsCleanupLeak) {
 
   // Publish kReaders new snapshots while readers continue holding slot 0.
   for (int i = 0; i < kReaders; ++i) {
-    auto status = store_->PublishSnapshot(make_new_pg());
+    auto status = store_->PublishSnapshot(make_new_pg(), 0);
     ASSERT_TRUE(status.ok()) << "publish " << i << " failed";
   }
 
@@ -175,7 +175,7 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, PhantomPinPreventsCleanupLeak) {
   // publishes back-to-back without exhausting the pool. (1 slot is the live
   // cur; all others must have been recycled.)
   for (int i = 0; i < kSlotNum - 2; ++i) {
-    auto status = store_->PublishSnapshot(make_new_pg());
+    auto status = store_->PublishSnapshot(make_new_pg(), 0);
     ASSERT_TRUE(status.ok())
         << "publish " << i << " failed — pool leak suspected";
   }
@@ -191,7 +191,7 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, LastReaderCleansRule) {
 
   // Publish slot B → phantom-pin on slot 0, then release. Slot 0 still has 3
   // real reader pins, so it survives.
-  ASSERT_TRUE(store_->PublishSnapshot(make_new_pg()).ok());
+  ASSERT_TRUE(store_->PublishSnapshot(make_new_pg(), 0).ok());
 
   std::mt19937 gen(12345);
   std::shuffle(pins.begin(), pins.end(), gen);
@@ -201,7 +201,7 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, LastReaderCleansRule) {
 
   // Slot 0 must now be in the free pool. Verify by exhausting publishes.
   for (int i = 0; i < kSlotNum - 2; ++i) {
-    auto status = store_->PublishSnapshot(make_new_pg());
+    auto status = store_->PublishSnapshot(make_new_pg(), 0);
     ASSERT_TRUE(status.ok())
         << "publish " << i << " failed — slot 0 leak suspected";
   }
@@ -215,7 +215,7 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, PoolExhaustionDoesNotConsumeNewPg) {
   std::vector<GraphSnapshotStore::SnapshotSlot*> pinned;
   pinned.push_back(&store_->PinCurrentSnapshot());
   for (int i = 0; i < kSlotNum - 1; ++i) {
-    ASSERT_TRUE(store_->PublishSnapshot(make_new_pg()).ok())
+    ASSERT_TRUE(store_->PublishSnapshot(make_new_pg(), 0).ok())
         << "setup publish " << i << " failed";
     pinned.push_back(&store_->PinCurrentSnapshot());
   }
@@ -223,7 +223,7 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, PoolExhaustionDoesNotConsumeNewPg) {
   // All slots pinned; one more publish must fail with ERR_POOL_EXHAUSTED.
   auto extra_pg = make_new_pg();
   long use_count_before = extra_pg.use_count();
-  auto status = store_->PublishSnapshot(extra_pg);
+  auto status = store_->PublishSnapshot(extra_pg, 0);
   EXPECT_FALSE(status.ok());
   EXPECT_EQ(status.error_code(), StatusCode::ERR_POOL_EXHAUSTED);
   EXPECT_EQ(extra_pg.use_count(), use_count_before)
@@ -256,7 +256,7 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, PublishExclusivityVsPinShared) {
   }
   std::thread writer([&] {
     for (int i = 0; i < kPublishes; ++i) {
-      (void) store_->PublishSnapshot(make_new_pg());
+      (void) store_->PublishSnapshot(make_new_pg(), 0);
     }
   });
 
@@ -275,7 +275,7 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, PinnedSnapshotSurvivesPublish) {
   auto& slot = store_->PinCurrentSnapshot();
   ASSERT_NE(slot.mutable_graph(), nullptr);
 
-  ASSERT_TRUE(store_->PublishSnapshot(make_new_pg()).ok());
+  ASSERT_TRUE(store_->PublishSnapshot(make_new_pg(), 0).ok());
 
   // graph pointer is still safely dereferenceable: storage held alive by our
   // pin.
@@ -299,7 +299,7 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, CowPublishIsVisibleToNewReaders) {
   ASSERT_TRUE(status.ok());
 
   // Publish the mutated snapshot.
-  ASSERT_TRUE(store_->PublishSnapshot(cow_pg).ok());
+  ASSERT_TRUE(store_->PublishSnapshot(cow_pg, 0).ok());
 
   // A new reader must observe the "company" vertex type.
   auto& slot = store_->PinCurrentSnapshot();
@@ -317,7 +317,7 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, AbortReleasesSlotWithoutLeak) {
   auto& old_slot = store_->PinCurrentSnapshot();
 
   // Publish a new snapshot (simulates successful COW commit path).
-  ASSERT_TRUE(store_->PublishSnapshot(make_new_pg()).ok());
+  ASSERT_TRUE(store_->PublishSnapshot(make_new_pg(), 0).ok());
 
   // Release the old pin (simulates Abort/release_pin).
   store_->UnpinSnapshot(old_slot);
@@ -325,7 +325,7 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, AbortReleasesSlotWithoutLeak) {
   // Verify no slot leak: we should still be able to exhaust (kSlotNum - 2)
   // publishes without hitting pool exhaustion.
   for (int i = 0; i < kSlotNum - 2; ++i) {
-    auto status = store_->PublishSnapshot(make_new_pg());
+    auto status = store_->PublishSnapshot(make_new_pg(), 0);
     ASSERT_TRUE(status.ok())
         << "publish " << i << " failed — abort slot leak suspected";
   }
@@ -360,7 +360,7 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, CowIsolationAfterCloneMutatePublish) {
   ASSERT_EQ(cow1->VertexNum(0, MAX_TIMESTAMP), 2u);
 
   // Publish the mutated COW clone as the new snapshot.
-  ASSERT_TRUE(store_->PublishSnapshot(cow1).ok());
+  ASSERT_TRUE(store_->PublishSnapshot(cow1, 0).ok());
 
   // Phase 3: clone again from the published snapshot. Explicitly detach
   // shared modules so cow2's mutations don't leak back to cow1.
@@ -385,7 +385,7 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, CowIsolationAfterCloneMutatePublish) {
   EXPECT_EQ(initial_pg_->VertexNum(0, MAX_TIMESTAMP), 1u);
 
   // Publish cow2 and verify a reader sees all three.
-  ASSERT_TRUE(store_->PublishSnapshot(cow2).ok());
+  ASSERT_TRUE(store_->PublishSnapshot(cow2, 0).ok());
   auto& slot = store_->PinCurrentSnapshot();
   EXPECT_EQ(slot.mutable_graph()->VertexNum(0, MAX_TIMESTAMP), 3u);
   store_->UnpinSnapshot(slot);

--- a/tests/storage/test_graph_snapshot_store_concurrency.cc
+++ b/tests/storage/test_graph_snapshot_store_concurrency.cc
@@ -16,8 +16,8 @@
 // Concurrency tests for GraphSnapshotStore at the unit level (no NeugDB
 // execution-slot layer). Validates the lock-window invariants documented in
 // graph_snapshot_store.h: phantom-pin, last-reader-cleans rule, pool exhaustion
-// safety, and the shared/exclusive interlock between PinCurrentSnapshot and
-// PublishSnapshot.
+// safety, and the interlock between PinCurrentSnapshot and prepared
+// publication.
 //
 // Run under thread sanitizer to surface data races:
 //   cmake -DENABLE_THREAD_SANITIZER=ON -DBUILD_TEST=ON ..
@@ -31,6 +31,7 @@
 #include <filesystem>
 #include <random>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "neug/generated/proto/plan/error.pb.h"
@@ -84,13 +85,24 @@ class GraphSnapshotStoreConcurrencyTest : public ::testing::Test {
     }
   }
 
-  // Build a fresh PG suitable for PublishSnapshot. Clones from initial_pg_
+  // Build a fresh PG suitable for publication. Clones from initial_pg_
   // (held alive by the fixture) rather than from store_->CurrentSnapshot()
   // to avoid racing on a slot that may be freed under concurrent publishes.
   std::shared_ptr<PropertyGraph> make_new_pg() const {
     return initial_pg_->Clone();
   }
 };
+
+Status PrepareAndPublishSnapshot(
+    GraphSnapshotStore& store, const std::shared_ptr<PropertyGraph>& snapshot) {
+  auto prepared_result = store.PrepareSnapshot(snapshot);
+  if (!prepared_result) {
+    return prepared_result.error();
+  }
+  auto prepared = std::move(prepared_result).value();
+  std::move(prepared).Publish();
+  return Status::OK();
+}
 
 // 1. Heavy concurrent pin/unpin vs publish. Verifies PinCurrentSnapshot
 // always returns a handle whose view points to a live PG with the seeded
@@ -106,7 +118,6 @@ TEST_F(GraphSnapshotStoreConcurrencyTest,
   std::atomic<int64_t> pins_done{0};
   std::atomic<int64_t> publishes_done{0};
 
-  std::mutex publish_mutex;
   std::vector<std::thread> threads;
   for (int i = 0; i < kReaders; ++i) {
     threads.emplace_back([&] {
@@ -122,10 +133,7 @@ TEST_F(GraphSnapshotStoreConcurrencyTest,
     threads.emplace_back([&] {
       while (!stop.load(std::memory_order_relaxed)) {
         auto pg = make_new_pg();
-        // PublishSnapshot is NOT safe for concurrent calls — caller must
-        // serialize externally (see GraphSnapshotStore class doc).
-        std::lock_guard<std::mutex> lock(publish_mutex);
-        auto status = store_->PublishSnapshot(pg, 0);
+        auto status = PrepareAndPublishSnapshot(*store_, pg);
         if (status.ok()) {
           publishes_done.fetch_add(1, std::memory_order_relaxed);
         }
@@ -161,7 +169,7 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, PhantomPinPreventsCleanupLeak) {
 
   // Publish kReaders new snapshots while readers continue holding slot 0.
   for (int i = 0; i < kReaders; ++i) {
-    auto status = store_->PublishSnapshot(make_new_pg(), 0);
+    auto status = PrepareAndPublishSnapshot(*store_, make_new_pg());
     ASSERT_TRUE(status.ok()) << "publish " << i << " failed";
   }
 
@@ -175,7 +183,7 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, PhantomPinPreventsCleanupLeak) {
   // publishes back-to-back without exhausting the pool. (1 slot is the live
   // cur; all others must have been recycled.)
   for (int i = 0; i < kSlotNum - 2; ++i) {
-    auto status = store_->PublishSnapshot(make_new_pg(), 0);
+    auto status = PrepareAndPublishSnapshot(*store_, make_new_pg());
     ASSERT_TRUE(status.ok())
         << "publish " << i << " failed — pool leak suspected";
   }
@@ -191,7 +199,7 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, LastReaderCleansRule) {
 
   // Publish slot B → phantom-pin on slot 0, then release. Slot 0 still has 3
   // real reader pins, so it survives.
-  ASSERT_TRUE(store_->PublishSnapshot(make_new_pg(), 0).ok());
+  ASSERT_TRUE(PrepareAndPublishSnapshot(*store_, make_new_pg()).ok());
 
   std::mt19937 gen(12345);
   std::shuffle(pins.begin(), pins.end(), gen);
@@ -201,7 +209,7 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, LastReaderCleansRule) {
 
   // Slot 0 must now be in the free pool. Verify by exhausting publishes.
   for (int i = 0; i < kSlotNum - 2; ++i) {
-    auto status = store_->PublishSnapshot(make_new_pg(), 0);
+    auto status = PrepareAndPublishSnapshot(*store_, make_new_pg());
     ASSERT_TRUE(status.ok())
         << "publish " << i << " failed — slot 0 leak suspected";
   }
@@ -215,7 +223,7 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, PoolExhaustionDoesNotConsumeNewPg) {
   std::vector<GraphSnapshotStore::SnapshotSlot*> pinned;
   pinned.push_back(&store_->PinCurrentSnapshot());
   for (int i = 0; i < kSlotNum - 1; ++i) {
-    ASSERT_TRUE(store_->PublishSnapshot(make_new_pg(), 0).ok())
+    ASSERT_TRUE(PrepareAndPublishSnapshot(*store_, make_new_pg()).ok())
         << "setup publish " << i << " failed";
     pinned.push_back(&store_->PinCurrentSnapshot());
   }
@@ -223,16 +231,36 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, PoolExhaustionDoesNotConsumeNewPg) {
   // All slots pinned; one more publish must fail with ERR_POOL_EXHAUSTED.
   auto extra_pg = make_new_pg();
   long use_count_before = extra_pg.use_count();
-  auto status = store_->PublishSnapshot(extra_pg, 0);
+  auto prepared_result = store_->PrepareSnapshot(extra_pg);
+  Status status = prepared_result ? Status::OK() : prepared_result.error();
   EXPECT_FALSE(status.ok());
   EXPECT_EQ(status.error_code(), StatusCode::ERR_POOL_EXHAUSTED);
   EXPECT_EQ(extra_pg.use_count(), use_count_before)
-      << "PublishSnapshot must not consume new_pg on failure";
+      << "PrepareSnapshot must not consume new_pg on failure";
 
   // Release all pins so TearDown can run cleanly.
   for (auto* slot : pinned) {
     store_->UnpinSnapshot(*slot);
   }
+}
+
+TEST_F(GraphSnapshotStoreConcurrencyTest,
+       PreparedSnapshotAbortReturnsReservedSlot) {
+  GraphSnapshotStore store(2, initial_pg_);
+
+  {
+    auto first_result = store.PrepareSnapshot(make_new_pg());
+    ASSERT_TRUE(first_result.has_value());
+    auto first = std::move(first_result).value();
+    EXPECT_FALSE(store.HasFreeSlot());
+  }
+  EXPECT_TRUE(store.HasFreeSlot());
+
+  auto second_result = store.PrepareSnapshot(make_new_pg());
+  ASSERT_TRUE(second_result.has_value());
+  auto second = std::move(second_result).value();
+  EXPECT_EQ(std::move(second).Publish(), 2u)
+      << "Aborted prepared generations must not be reused";
 }
 
 // 5. Reader throughput stays positive under heavy concurrent publish
@@ -256,7 +284,7 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, PublishExclusivityVsPinShared) {
   }
   std::thread writer([&] {
     for (int i = 0; i < kPublishes; ++i) {
-      (void) store_->PublishSnapshot(make_new_pg(), 0);
+      (void) PrepareAndPublishSnapshot(*store_, make_new_pg());
     }
   });
 
@@ -270,12 +298,12 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, PublishExclusivityVsPinShared) {
 }
 
 // 6. PinCurrentSnapshot keeps the pinned PG alive across a concurrent
-// PublishSnapshot that publishes a new cur slot.
+// prepared publication that installs a new cur slot.
 TEST_F(GraphSnapshotStoreConcurrencyTest, PinnedSnapshotSurvivesPublish) {
   auto& slot = store_->PinCurrentSnapshot();
   ASSERT_NE(slot.mutable_graph(), nullptr);
 
-  ASSERT_TRUE(store_->PublishSnapshot(make_new_pg(), 0).ok());
+  ASSERT_TRUE(PrepareAndPublishSnapshot(*store_, make_new_pg()).ok());
 
   // graph pointer is still safely dereferenceable: storage held alive by our
   // pin.
@@ -299,7 +327,7 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, CowPublishIsVisibleToNewReaders) {
   ASSERT_TRUE(status.ok());
 
   // Publish the mutated snapshot.
-  ASSERT_TRUE(store_->PublishSnapshot(cow_pg, 0).ok());
+  ASSERT_TRUE(PrepareAndPublishSnapshot(*store_, cow_pg).ok());
 
   // A new reader must observe the "company" vertex type.
   auto& slot = store_->PinCurrentSnapshot();
@@ -317,7 +345,7 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, AbortReleasesSlotWithoutLeak) {
   auto& old_slot = store_->PinCurrentSnapshot();
 
   // Publish a new snapshot (simulates successful COW commit path).
-  ASSERT_TRUE(store_->PublishSnapshot(make_new_pg(), 0).ok());
+  ASSERT_TRUE(PrepareAndPublishSnapshot(*store_, make_new_pg()).ok());
 
   // Release the old pin (simulates Abort/release_pin).
   store_->UnpinSnapshot(old_slot);
@@ -325,7 +353,7 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, AbortReleasesSlotWithoutLeak) {
   // Verify no slot leak: we should still be able to exhaust (kSlotNum - 2)
   // publishes without hitting pool exhaustion.
   for (int i = 0; i < kSlotNum - 2; ++i) {
-    auto status = store_->PublishSnapshot(make_new_pg(), 0);
+    auto status = PrepareAndPublishSnapshot(*store_, make_new_pg());
     ASSERT_TRUE(status.ok())
         << "publish " << i << " failed — abort slot leak suspected";
   }
@@ -360,7 +388,7 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, CowIsolationAfterCloneMutatePublish) {
   ASSERT_EQ(cow1->VertexNum(0, MAX_TIMESTAMP), 2u);
 
   // Publish the mutated COW clone as the new snapshot.
-  ASSERT_TRUE(store_->PublishSnapshot(cow1, 0).ok());
+  ASSERT_TRUE(PrepareAndPublishSnapshot(*store_, cow1).ok());
 
   // Phase 3: clone again from the published snapshot. Explicitly detach
   // shared modules so cow2's mutations don't leak back to cow1.
@@ -385,7 +413,7 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, CowIsolationAfterCloneMutatePublish) {
   EXPECT_EQ(initial_pg_->VertexNum(0, MAX_TIMESTAMP), 1u);
 
   // Publish cow2 and verify a reader sees all three.
-  ASSERT_TRUE(store_->PublishSnapshot(cow2, 0).ok());
+  ASSERT_TRUE(PrepareAndPublishSnapshot(*store_, cow2).ok());
   auto& slot = store_->PinCurrentSnapshot();
   EXPECT_EQ(slot.mutable_graph()->VertexNum(0, MAX_TIMESTAMP), 3u);
   store_->UnpinSnapshot(slot);

--- a/tests/storage/test_graph_snapshot_store_concurrency.cc
+++ b/tests/storage/test_graph_snapshot_store_concurrency.cc
@@ -301,13 +301,13 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, PublishExclusivityVsPinShared) {
 // prepared publication that installs a new cur slot.
 TEST_F(GraphSnapshotStoreConcurrencyTest, PinnedSnapshotSurvivesPublish) {
   auto& slot = store_->PinCurrentSnapshot();
-  ASSERT_NE(slot.mutable_graph(), nullptr);
+  ASSERT_NE(slot.graph(), nullptr);
 
   ASSERT_TRUE(PrepareAndPublishSnapshot(*store_, make_new_pg()).ok());
 
   // graph pointer is still safely dereferenceable: storage held alive by our
   // pin.
-  EXPECT_GE(slot.mutable_graph()->schema().vertex_label_num(), 1u);
+  EXPECT_GE(slot.graph()->schema().vertex_label_num(), 1u);
 
   store_->UnpinSnapshot(slot);
 }
@@ -331,9 +331,9 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, CowPublishIsVisibleToNewReaders) {
 
   // A new reader must observe the "company" vertex type.
   auto& slot = store_->PinCurrentSnapshot();
-  EXPECT_TRUE(slot.mutable_graph()->schema().is_vertex_label_valid("company"));
-  EXPECT_TRUE(slot.mutable_graph()->schema().is_vertex_label_valid("person"));
-  EXPECT_EQ(slot.mutable_graph()->schema().vertex_label_num(), 2u);
+  EXPECT_TRUE(slot.graph()->schema().is_vertex_label_valid("company"));
+  EXPECT_TRUE(slot.graph()->schema().is_vertex_label_valid("person"));
+  EXPECT_EQ(slot.graph()->schema().vertex_label_num(), 2u);
   store_->UnpinSnapshot(slot);
 }
 
@@ -415,7 +415,7 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, CowIsolationAfterCloneMutatePublish) {
   // Publish cow2 and verify a reader sees all three.
   ASSERT_TRUE(PrepareAndPublishSnapshot(*store_, cow2).ok());
   auto& slot = store_->PinCurrentSnapshot();
-  EXPECT_EQ(slot.mutable_graph()->VertexNum(0, MAX_TIMESTAMP), 3u);
+  EXPECT_EQ(slot.graph()->VertexNum(0, MAX_TIMESTAMP), 3u);
   store_->UnpinSnapshot(slot);
 }
 

--- a/tests/storage/test_graph_view.cc
+++ b/tests/storage/test_graph_view.cc
@@ -22,6 +22,7 @@
 
 #include "neug/storages/allocators.h"
 #include "neug/storages/checkpoint_manager.h"
+#include "neug/storages/graph/graph_stats.h"
 #include "neug/storages/graph/graph_view.h"
 #include "neug/storages/graph/operation_params.h"
 #include "neug/storages/graph/property_graph.h"
@@ -150,6 +151,28 @@ TEST_F(GraphViewTest, SchemaAccess) {
 
   EXPECT_EQ(view.schema().vertex_label_num(), 1);
   EXPECT_EQ(view.schema().edge_label_num(), 1);
+}
+
+TEST_F(GraphViewTest, CardinalityAccess) {
+  GraphView view(*graph_);
+  label_t person_label = view.schema().get_vertex_label_id("person");
+  label_t knows_label = view.schema().get_edge_label_id("knows");
+
+  EXPECT_EQ(view.VertexNum(person_label), 3u);
+  EXPECT_EQ(view.EdgeNum(person_label, person_label, knows_label), 2u);
+
+  GraphStats stats(view);
+  auto vertex_schema = view.schema().get_vertex_schema(person_label);
+  auto edge_schema =
+      view.schema().get_edge_schema(person_label, person_label, knows_label);
+  ASSERT_NE(vertex_schema, nullptr);
+  ASSERT_NE(edge_schema, nullptr);
+  EXPECT_EQ(stats.getTableCardinality(vertex_schema->get_entry_id(),
+                                      SchemaEntryType::NODE),
+            3u);
+  EXPECT_EQ(stats.getTableCardinality(edge_schema->get_entry_id(),
+                                      SchemaEntryType::REL),
+            2u);
 }
 
 TEST_F(GraphViewTest, IsValidLid) {

--- a/tests/storage/test_tp_index.cc
+++ b/tests/storage/test_tp_index.cc
@@ -133,9 +133,8 @@ class TPIndexTest : public ::testing::Test {
   }
 
   ReadTransaction NewReadTransaction() {
-    auto ts = version_manager_.acquire_read_timestamp();
-    SnapshotGuard guard(*snapshot_store_);
-    return ReadTransaction(std::move(guard), version_manager_, ts);
+    return ReadTransaction(
+        ReadSnapshotLease::Acquire(version_manager_, *snapshot_store_));
   }
 
   void Commit(UpdateTransaction& txn) { ASSERT_TRUE(txn.Commit()); }

--- a/tests/storage/test_tp_index.cc
+++ b/tests/storage/test_tp_index.cc
@@ -111,7 +111,7 @@ class TPIndexTest : public ::testing::Test {
     view_ = std::make_unique<GraphView>(*graph_);
     ap_ = std::make_unique<StorageAPUpdateInterface>(*graph_, *view_, 0,
                                                      allocator_);
-    version_manager_.init_ts(0, 1);
+    version_manager_.init_ts({0, 0}, 1);
     wal_writer_.records.clear();
     auto global_cache = std::make_shared<execution::GlobalQueryCache>(
         std::make_shared<StubPlanner>());

--- a/tests/storage/test_tp_index.cc
+++ b/tests/storage/test_tp_index.cc
@@ -125,11 +125,11 @@ class TPIndexTest : public ::testing::Test {
   }
 
   UpdateTransaction NewUpdateTransaction() {
-    auto ts = version_manager_.acquire_update_timestamp();
+    UpdateTimestampLease timestamp_lease(version_manager_);
     auto cow_graph = snapshot_store_->CurrentSnapshot().Clone();
     return UpdateTransaction(std::move(cow_graph), allocator_, wal_writer_,
-                             version_manager_, *snapshot_store_, *local_cache_,
-                             ts);
+                             *snapshot_store_, *local_cache_,
+                             std::move(timestamp_lease));
   }
 
   ReadTransaction NewReadTransaction() {

--- a/tests/transaction/CMakeLists.txt
+++ b/tests/transaction/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_neug_test(runtime_wait_test test_runtime_wait.cc)
+add_neug_test(read_view_publication_test test_read_view_publication.cc)
 
 if (BUILD_HTTP_SERVER)
 	add_neug_test(

--- a/tests/transaction/test_acid.cc
+++ b/tests/transaction/test_acid.cc
@@ -2971,9 +2971,9 @@ TEST_F(NeugDBACIDTest, CommitVisibilitySemantics) {
 //
 // Empirically the reader nearly always wins, because the writer's path from
 // barrier release to release_update_timestamp includes WAL append +
-// PublishSnapshot, while the reader's path is just acquire_read_timestamp
-// (an atomic load). The pre-domination is a property of the path lengths,
-// not a bug. Both outcomes are CORRECT; we only assert no garbage.
+// PublishSnapshot, while the reader's path enters through
+// ReadSnapshotLease::Acquire. The pre-domination is a property of the path
+// lengths, not a bug. Both outcomes are CORRECT; we only assert no garbage.
 TEST_F(NeugDBACIDTest, ConcurrentReadsAndCommitsObserveConsistentValues) {
   std::string dir = work_dir_ + "/CommitWindowRace";
   NeugDB db;

--- a/tests/transaction/test_acid.cc
+++ b/tests/transaction/test_acid.cc
@@ -1729,7 +1729,7 @@ size_t cc_count_persons(NeugDBService& svc) {
 // Each "*_via" helper reads through a held ReadTransaction's frozen GraphView
 // (`txn.view()`), so the observation reflects the snapshot pinned in the
 // GraphSnapshotStore slot — not the live PropertyGraph (which a concurrent
-// writer may have replaced via PublishSnapshot).
+// writer may have replaced through prepared snapshot publication).
 
 // Count visible vertices for a label via a held read snapshot.
 size_t cc_count_vertices_via(const ReadTransaction& txn, label_t label) {
@@ -2967,11 +2967,11 @@ TEST_F(NeugDBACIDTest, CommitVisibilitySemantics) {
 // the per-row timestamp filter: a reader's observation depends on whether
 // its read_ts (allocated at GetReadTransaction time) is < or >= the writer's
 // write_ts (allocated at GetUpdateTransaction time, published at
-// release_update_timestamp time).
+// UpdateTimestampLease::finish time).
 //
 // Empirically the reader nearly always wins, because the writer's path from
-// barrier release to release_update_timestamp includes WAL append +
-// PublishSnapshot, while the reader's path enters through
+// barrier release to UpdateTimestampLease::finish includes WAL append +
+// prepared-snapshot publication, while the reader's path enters through
 // ReadSnapshotLease::Acquire. The pre-domination is a property of the path
 // lengths, not a bug. Both outcomes are CORRECT; we only assert no garbage.
 TEST_F(NeugDBACIDTest, ConcurrentReadsAndCommitsObserveConsistentValues) {

--- a/tests/transaction/test_compact_transaction.cc
+++ b/tests/transaction/test_compact_transaction.cc
@@ -345,8 +345,11 @@ TEST_F(CompactTransactionTest, CompactBlocksRead) {
   vm.init_ts(0, 1);
 
   AssertCompactBlocksAcquire(
-      vm, [](neug::VersionManager& v) { v.acquire_read_timestamp(); },
-      [](neug::VersionManager& v, uint32_t) { v.release_read_timestamp(); });
+      vm,
+      [](neug::VersionManager& v) {
+        return v.acquire_read_view().visibility_ts;
+      },
+      [](neug::VersionManager& v, uint32_t) { v.release_read_view(); });
 }
 
 TEST_F(CompactTransactionTest, CompactBlocksInsert) {

--- a/tests/transaction/test_compact_transaction.cc
+++ b/tests/transaction/test_compact_transaction.cc
@@ -368,7 +368,7 @@ TEST_F(CompactTransactionTest, CompactBlocksUpdate) {
   AssertCompactBlocksAcquire(
       vm, [](neug::VersionManager& v) { v.acquire_update_timestamp(); },
       [](neug::VersionManager& v, uint32_t ts) {
-        v.release_update_timestamp(ts);
+        v.finish_update_timestamp(ts, std::nullopt);
       });
 }
 

--- a/tests/transaction/test_compact_transaction.cc
+++ b/tests/transaction/test_compact_transaction.cc
@@ -342,7 +342,7 @@ static void AssertCompactBlocksAcquire(
 
 TEST_F(CompactTransactionTest, CompactBlocksRead) {
   neug::VersionManager vm;
-  vm.init_ts(0, 1);
+  vm.init_ts({0, 0}, 1);
 
   AssertCompactBlocksAcquire(
       vm,
@@ -354,7 +354,7 @@ TEST_F(CompactTransactionTest, CompactBlocksRead) {
 
 TEST_F(CompactTransactionTest, CompactBlocksInsert) {
   neug::VersionManager vm;
-  vm.init_ts(0, 1);
+  vm.init_ts({0, 0}, 1);
   AssertCompactBlocksAcquire(
       vm, [](neug::VersionManager& v) { v.acquire_insert_timestamp(); },
       [](neug::VersionManager& v, uint32_t ts) {
@@ -364,7 +364,7 @@ TEST_F(CompactTransactionTest, CompactBlocksInsert) {
 
 TEST_F(CompactTransactionTest, CompactBlocksUpdate) {
   neug::VersionManager vm;
-  vm.init_ts(0, 1);
+  vm.init_ts({0, 0}, 1);
   AssertCompactBlocksAcquire(
       vm, [](neug::VersionManager& v) { v.acquire_update_timestamp(); },
       [](neug::VersionManager& v, uint32_t ts) {
@@ -374,7 +374,7 @@ TEST_F(CompactTransactionTest, CompactBlocksUpdate) {
 
 TEST_F(CompactTransactionTest, CompactBlocksCompact) {
   neug::VersionManager vm;
-  vm.init_ts(0, 1);
+  vm.init_ts({0, 0}, 1);
   AssertCompactBlocksAcquire(
       vm, [](neug::VersionManager& v) { v.acquire_compact_timestamp(); },
       [](neug::VersionManager& v, uint32_t ts) {

--- a/tests/transaction/test_read_view_publication.cc
+++ b/tests/transaction/test_read_view_publication.cc
@@ -140,17 +140,31 @@ class ReadViewPublicationTest : public ::testing::Test {
     std::filesystem::remove_all(work_dir_);
   }
 
-  std::pair<std::shared_ptr<PropertyGraph>, uint32_t> PublishReplacement(
-      VersionManager& version_manager) {
-    const uint32_t timestamp = version_manager.acquire_update_timestamp();
+  std::shared_ptr<PropertyGraph> MakeReplacement() {
     auto replacement = initial_graph_->Clone();
+    CreateVertexTypeParamBuilder company;
+    auto status =
+        replacement->CreateVertexType(company.VertexLabel("company")
+                                          .AddProperty("id", Value::INT64(0))
+                                          .AddPrimaryKeyName("id")
+                                          .Build());
+    if (!status.ok()) {
+      ADD_FAILURE() << "Failed to create replacement marker schema: "
+                    << status.error_message();
+    }
+    return replacement;
+  }
+
+  uint32_t PublishReplacement(VersionManager& version_manager) {
+    const uint32_t timestamp = version_manager.acquire_update_timestamp();
+    auto replacement = MakeReplacement();
     auto prepared_result = store_->PrepareSnapshot(replacement);
     EXPECT_TRUE(prepared_result.has_value());
     auto prepared = std::move(prepared_result).value();
     version_manager.begin_update_commit(timestamp);
     const uint32_t snapshot_generation = std::move(prepared).Publish();
     version_manager.finish_update_timestamp(timestamp, snapshot_generation);
-    return {std::move(replacement), timestamp};
+    return timestamp;
   }
 
   std::string work_dir_;
@@ -164,13 +178,12 @@ TEST_F(ReadViewPublicationTest, SplitAcquisitionExposesGenerationMismatch) {
   version_manager.init_ts({1, 0}, 2);
 
   const PublishedReadView old_view = version_manager.acquire_read_view();
-  const auto publication = PublishReplacement(version_manager);
-  const auto& replacement = publication.first;
+  PublishReplacement(version_manager);
 
   SnapshotGuard current(*store_);
   EXPECT_EQ(old_view.visibility_ts, 1u);
   EXPECT_EQ(old_view.snapshot_generation, 0u);
-  EXPECT_EQ(current.get().graph(), replacement.get());
+  EXPECT_TRUE(current.get().view().schema().is_vertex_label_valid("company"));
   EXPECT_NE(current.get().snapshot_generation(), old_view.snapshot_generation);
 
   current.release();
@@ -182,18 +195,15 @@ TEST_F(ReadViewPublicationTest, ValidatedReaderKeepsPinnedOldSnapshot) {
   version_manager.init_ts({1, 0}, 2);
 
   auto lease = ReadSnapshotLease::Acquire(version_manager, *store_);
-  const auto [replacement, timestamp] = PublishReplacement(version_manager);
+  const auto timestamp = PublishReplacement(version_manager);
 
   EXPECT_EQ(lease.timestamp(), 1u);
-  EXPECT_EQ(lease.snapshot().snapshot_generation(), 0u);
-  EXPECT_EQ(lease.snapshot().graph(), initial_graph_.get());
-  EXPECT_NE(lease.snapshot().graph(), replacement.get());
+  EXPECT_FALSE(lease.view().schema().is_vertex_label_valid("company"));
 
   lease.release();
   auto next = ReadSnapshotLease::Acquire(version_manager, *store_);
   EXPECT_EQ(next.timestamp(), timestamp);
-  EXPECT_EQ(next.snapshot().snapshot_generation(), 1u);
-  EXPECT_EQ(next.snapshot().graph(), replacement.get());
+  EXPECT_TRUE(next.view().schema().is_vertex_label_valid("company"));
 }
 
 TEST_F(ReadViewPublicationTest,
@@ -213,13 +223,12 @@ TEST_F(ReadViewPublicationTest,
 
   auto lease = ReadSnapshotLease::Acquire(version_manager, *store_);
   EXPECT_EQ(lease.timestamp(), kInitialTimestamp);
-  EXPECT_EQ(lease.snapshot().snapshot_generation(), kInitialSnapshotGeneration);
-  EXPECT_EQ(lease.snapshot().graph(), initial_graph_.get());
+  EXPECT_FALSE(lease.view().schema().is_vertex_label_valid("company"));
 }
 
 TEST_F(ReadViewPublicationTest, LeaseRetriesAfterBlockedOpenCycle) {
   ScriptedVersionManager version_manager({1, 0});
-  auto replacement = initial_graph_->Clone();
+  auto replacement = MakeReplacement();
   bool publish_succeeded = false;
   version_manager.set_acquire_hook([&](int acquire_count) {
     if (acquire_count == 1) {
@@ -237,8 +246,7 @@ TEST_F(ReadViewPublicationTest, LeaseRetriesAfterBlockedOpenCycle) {
   EXPECT_EQ(version_manager.acquire_count(), 2);
   EXPECT_EQ(version_manager.release_count(), 1);
   EXPECT_EQ(lease.timestamp(), 2u);
-  EXPECT_EQ(lease.snapshot().snapshot_generation(), 1u);
-  EXPECT_EQ(lease.snapshot().graph(), replacement.get());
+  EXPECT_TRUE(lease.view().schema().is_vertex_label_valid("company"));
 
   lease.release();
   EXPECT_EQ(version_manager.release_count(), 2);
@@ -249,7 +257,7 @@ TEST_F(ReadViewPublicationTest, LeaseRetryUsesConfiguredRuntimeWait) {
   version_manager.set_runtime_wait(&CountRuntimeWait);
   runtime_wait_calls.store(0, std::memory_order_relaxed);
 
-  auto replacement = initial_graph_->Clone();
+  auto replacement = MakeReplacement();
   bool publish_succeeded = true;
   constexpr int mismatch_count = kRuntimeWaitSpinIterations + 1;
   version_manager.set_acquire_hook([&](int acquire_count) {
@@ -270,9 +278,7 @@ TEST_F(ReadViewPublicationTest, LeaseRetryUsesConfiguredRuntimeWait) {
   EXPECT_EQ(version_manager.release_count(), mismatch_count);
   EXPECT_EQ(runtime_wait_calls.load(std::memory_order_relaxed), 1);
   EXPECT_EQ(lease.timestamp(), static_cast<uint32_t>(mismatch_count + 1));
-  EXPECT_EQ(lease.snapshot().snapshot_generation(),
-            static_cast<uint32_t>(mismatch_count));
-  EXPECT_EQ(lease.snapshot().graph(), replacement.get());
+  EXPECT_TRUE(lease.view().schema().is_vertex_label_valid("company"));
 }
 
 }  // namespace

--- a/tests/transaction/test_read_view_publication.cc
+++ b/tests/transaction/test_read_view_publication.cc
@@ -69,7 +69,7 @@ class ScriptedVersionManager : public IVersionManager {
   int acquire_count() const { return acquire_count_.load(); }
   int release_count() const { return release_count_.load(); }
 
-  void init_ts(uint32_t, int) override {}
+  void init_ts(PublishedReadView, int) override {}
   bool try_set_runtime_wait_if_quiescent(RuntimeWaitFn) noexcept override {
     return true;
   }
@@ -161,7 +161,7 @@ class ReadViewPublicationTest : public ::testing::Test {
 
 TEST_F(ReadViewPublicationTest, SplitAcquisitionExposesGenerationMismatch) {
   VersionManager version_manager;
-  version_manager.init_ts(1, 2);
+  version_manager.init_ts({1, 0}, 2);
 
   const PublishedReadView old_view = version_manager.acquire_read_view();
   const auto publication = PublishReplacement(version_manager);
@@ -179,7 +179,7 @@ TEST_F(ReadViewPublicationTest, SplitAcquisitionExposesGenerationMismatch) {
 
 TEST_F(ReadViewPublicationTest, ValidatedReaderKeepsPinnedOldSnapshot) {
   VersionManager version_manager;
-  version_manager.init_ts(1, 2);
+  version_manager.init_ts({1, 0}, 2);
 
   auto lease = ReadSnapshotLease::Acquire(version_manager, *store_);
   const auto [replacement, timestamp] = PublishReplacement(version_manager);
@@ -194,6 +194,27 @@ TEST_F(ReadViewPublicationTest, ValidatedReaderKeepsPinnedOldSnapshot) {
   EXPECT_EQ(next.timestamp(), timestamp);
   EXPECT_EQ(next.snapshot_generation(), 1u);
   EXPECT_EQ(next.graph(), replacement.get());
+}
+
+TEST_F(ReadViewPublicationTest,
+       InitialReadViewMatchesNonzeroSnapshotGeneration) {
+  constexpr uint32_t kInitialTimestamp = 7;
+  constexpr uint32_t kInitialSnapshotGeneration = 19;
+  store_ = std::make_unique<GraphSnapshotStore>(4, initial_graph_,
+                                                kInitialSnapshotGeneration);
+
+  VersionManager version_manager;
+  version_manager.init_ts({kInitialTimestamp, kInitialSnapshotGeneration}, 2);
+
+  const PublishedReadView initialized = version_manager.acquire_read_view();
+  version_manager.release_read_view();
+  ASSERT_EQ(initialized.visibility_ts, kInitialTimestamp);
+  ASSERT_EQ(initialized.snapshot_generation, kInitialSnapshotGeneration);
+
+  auto lease = ReadSnapshotLease::Acquire(version_manager, *store_);
+  EXPECT_EQ(lease.timestamp(), kInitialTimestamp);
+  EXPECT_EQ(lease.snapshot_generation(), kInitialSnapshotGeneration);
+  EXPECT_EQ(lease.graph(), initial_graph_.get());
 }
 
 TEST_F(ReadViewPublicationTest, LeaseRetriesAfterBlockedOpenCycle) {

--- a/tests/transaction/test_read_view_publication.cc
+++ b/tests/transaction/test_read_view_publication.cc
@@ -170,7 +170,7 @@ TEST_F(ReadViewPublicationTest, SplitAcquisitionExposesGenerationMismatch) {
   SnapshotGuard current(*store_);
   EXPECT_EQ(old_view.visibility_ts, 1u);
   EXPECT_EQ(old_view.snapshot_generation, 0u);
-  EXPECT_EQ(current.get().mutable_graph(), replacement.get());
+  EXPECT_EQ(current.get().graph(), replacement.get());
   EXPECT_NE(current.get().snapshot_generation(), old_view.snapshot_generation);
 
   current.release();
@@ -185,15 +185,15 @@ TEST_F(ReadViewPublicationTest, ValidatedReaderKeepsPinnedOldSnapshot) {
   const auto [replacement, timestamp] = PublishReplacement(version_manager);
 
   EXPECT_EQ(lease.timestamp(), 1u);
-  EXPECT_EQ(lease.snapshot_generation(), 0u);
-  EXPECT_EQ(lease.graph(), initial_graph_.get());
-  EXPECT_NE(lease.graph(), replacement.get());
+  EXPECT_EQ(lease.snapshot().snapshot_generation(), 0u);
+  EXPECT_EQ(lease.snapshot().graph(), initial_graph_.get());
+  EXPECT_NE(lease.snapshot().graph(), replacement.get());
 
   lease.release();
   auto next = ReadSnapshotLease::Acquire(version_manager, *store_);
   EXPECT_EQ(next.timestamp(), timestamp);
-  EXPECT_EQ(next.snapshot_generation(), 1u);
-  EXPECT_EQ(next.graph(), replacement.get());
+  EXPECT_EQ(next.snapshot().snapshot_generation(), 1u);
+  EXPECT_EQ(next.snapshot().graph(), replacement.get());
 }
 
 TEST_F(ReadViewPublicationTest,
@@ -213,8 +213,8 @@ TEST_F(ReadViewPublicationTest,
 
   auto lease = ReadSnapshotLease::Acquire(version_manager, *store_);
   EXPECT_EQ(lease.timestamp(), kInitialTimestamp);
-  EXPECT_EQ(lease.snapshot_generation(), kInitialSnapshotGeneration);
-  EXPECT_EQ(lease.graph(), initial_graph_.get());
+  EXPECT_EQ(lease.snapshot().snapshot_generation(), kInitialSnapshotGeneration);
+  EXPECT_EQ(lease.snapshot().graph(), initial_graph_.get());
 }
 
 TEST_F(ReadViewPublicationTest, LeaseRetriesAfterBlockedOpenCycle) {
@@ -237,8 +237,8 @@ TEST_F(ReadViewPublicationTest, LeaseRetriesAfterBlockedOpenCycle) {
   EXPECT_EQ(version_manager.acquire_count(), 2);
   EXPECT_EQ(version_manager.release_count(), 1);
   EXPECT_EQ(lease.timestamp(), 2u);
-  EXPECT_EQ(lease.snapshot_generation(), 1u);
-  EXPECT_EQ(lease.graph(), replacement.get());
+  EXPECT_EQ(lease.snapshot().snapshot_generation(), 1u);
+  EXPECT_EQ(lease.snapshot().graph(), replacement.get());
 
   lease.release();
   EXPECT_EQ(version_manager.release_count(), 2);
@@ -270,8 +270,9 @@ TEST_F(ReadViewPublicationTest, LeaseRetryUsesConfiguredRuntimeWait) {
   EXPECT_EQ(version_manager.release_count(), mismatch_count);
   EXPECT_EQ(runtime_wait_calls.load(std::memory_order_relaxed), 1);
   EXPECT_EQ(lease.timestamp(), static_cast<uint32_t>(mismatch_count + 1));
-  EXPECT_EQ(lease.snapshot_generation(), static_cast<uint32_t>(mismatch_count));
-  EXPECT_EQ(lease.graph(), replacement.get());
+  EXPECT_EQ(lease.snapshot().snapshot_generation(),
+            static_cast<uint32_t>(mismatch_count));
+  EXPECT_EQ(lease.snapshot().graph(), replacement.get());
 }
 
 }  // namespace

--- a/tests/transaction/test_read_view_publication.cc
+++ b/tests/transaction/test_read_view_publication.cc
@@ -63,17 +63,15 @@ class ScriptedVersionManager : public IVersionManager {
     return captured;
   }
 
-  uint32_t acquire_read_timestamp() override {
-    return acquire_read_view().visibility_ts;
-  }
-
-  void release_read_timestamp() override { release_count_.fetch_add(1); }
+  void release_read_view() override { release_count_.fetch_add(1); }
   uint32_t acquire_insert_timestamp() override { return 1; }
   void release_insert_timestamp(uint32_t) override {}
   uint32_t acquire_update_timestamp() override { return 1; }
+  uint32_t reserve_view_generation() override { return 0; }
   void begin_update_commit(uint32_t) override {}
   void drain_readers() override {}
   void release_update_timestamp(uint32_t) override {}
+  void release_update_timestamp_with_view(uint32_t, uint32_t) override {}
   uint32_t acquire_compact_timestamp() override { return 1; }
   void release_compact_timestamp(uint32_t) override {}
   void revert_compact_timestamp(uint32_t) override {}
@@ -149,7 +147,7 @@ TEST_F(ReadViewPublicationTest, SplitAcquisitionExposesGenerationMismatch) {
   EXPECT_NE(current.get().view_generation(), old_view.view_generation);
 
   current.release();
-  version_manager.release_read_timestamp();
+  version_manager.release_read_view();
 }
 
 TEST_F(ReadViewPublicationTest, ValidatedReaderKeepsPinnedOldSnapshot) {

--- a/tests/transaction/test_read_view_publication.cc
+++ b/tests/transaction/test_read_view_publication.cc
@@ -33,13 +33,33 @@
 namespace neug {
 namespace {
 
+result<uint32_t> PrepareAndPublishSnapshot(
+    GraphSnapshotStore& store, const std::shared_ptr<PropertyGraph>& snapshot) {
+  auto prepared_result = store.PrepareSnapshot(snapshot);
+  if (!prepared_result) {
+    return tl::unexpected(prepared_result.error());
+  }
+  auto prepared = std::move(prepared_result).value();
+  return std::move(prepared).Publish();
+}
+
+std::atomic<int> runtime_wait_calls{0};
+
+void CountRuntimeWait(RuntimeWaitAction) noexcept {
+  runtime_wait_calls.fetch_add(1, std::memory_order_relaxed);
+}
+
 class ScriptedVersionManager : public IVersionManager {
  public:
   explicit ScriptedVersionManager(PublishedReadView initial)
       : published_(PackPublishedReadView(initial)) {}
 
-  void set_first_acquire_hook(std::function<void()> hook) {
-    first_acquire_hook_ = std::move(hook);
+  void set_acquire_hook(std::function<void(int)> hook) {
+    acquire_hook_ = std::move(hook);
+  }
+
+  void set_runtime_wait(RuntimeWaitFn runtime_wait) {
+    runtime_wait_ = runtime_wait;
   }
 
   void publish(PublishedReadView view) {
@@ -57,8 +77,9 @@ class ScriptedVersionManager : public IVersionManager {
   PublishedReadView acquire_read_view() override {
     const auto captured =
         UnpackPublishedReadView(published_.load(std::memory_order_acquire));
-    if (acquire_count_.fetch_add(1) == 0 && first_acquire_hook_) {
-      first_acquire_hook_();
+    const int acquire_count = acquire_count_.fetch_add(1) + 1;
+    if (acquire_hook_) {
+      acquire_hook_(acquire_count);
     }
     return captured;
   }
@@ -67,20 +88,24 @@ class ScriptedVersionManager : public IVersionManager {
   uint32_t acquire_insert_timestamp() override { return 1; }
   void release_insert_timestamp(uint32_t) override {}
   uint32_t acquire_update_timestamp() override { return 1; }
-  uint32_t reserve_view_generation() override { return 0; }
   void begin_update_commit(uint32_t) override {}
   void drain_readers() override {}
-  void release_update_timestamp(uint32_t) override {}
-  void release_update_timestamp_with_view(uint32_t, uint32_t) override {}
+  void finish_update_timestamp(uint32_t,
+                               std::optional<uint32_t>) noexcept override {}
   uint32_t acquire_compact_timestamp() override { return 1; }
   void release_compact_timestamp(uint32_t) override {}
   void revert_compact_timestamp(uint32_t) override {}
 
  private:
+  RuntimeWaitFn runtime_wait_impl() const noexcept override {
+    return runtime_wait_;
+  }
+
   std::atomic<uint64_t> published_;
   std::atomic<int> acquire_count_{0};
   std::atomic<int> release_count_{0};
-  std::function<void()> first_acquire_hook_;
+  std::function<void(int)> acquire_hook_;
+  RuntimeWaitFn runtime_wait_{&NativeRuntimeWait};
 };
 
 class ReadViewPublicationTest : public ::testing::Test {
@@ -118,11 +143,13 @@ class ReadViewPublicationTest : public ::testing::Test {
   std::pair<std::shared_ptr<PropertyGraph>, uint32_t> PublishReplacement(
       VersionManager& version_manager) {
     const uint32_t timestamp = version_manager.acquire_update_timestamp();
-    const uint32_t generation = version_manager.reserve_view_generation();
-    version_manager.begin_update_commit(timestamp);
     auto replacement = initial_graph_->Clone();
-    EXPECT_TRUE(store_->PublishSnapshot(replacement, generation).ok());
-    version_manager.release_update_timestamp_with_view(timestamp, generation);
+    auto prepared_result = store_->PrepareSnapshot(replacement);
+    EXPECT_TRUE(prepared_result.has_value());
+    auto prepared = std::move(prepared_result).value();
+    version_manager.begin_update_commit(timestamp);
+    const uint32_t snapshot_generation = std::move(prepared).Publish();
+    version_manager.finish_update_timestamp(timestamp, snapshot_generation);
     return {std::move(replacement), timestamp};
   }
 
@@ -142,9 +169,9 @@ TEST_F(ReadViewPublicationTest, SplitAcquisitionExposesGenerationMismatch) {
 
   SnapshotGuard current(*store_);
   EXPECT_EQ(old_view.visibility_ts, 1u);
-  EXPECT_EQ(old_view.view_generation, 0u);
+  EXPECT_EQ(old_view.snapshot_generation, 0u);
   EXPECT_EQ(current.get().mutable_graph(), replacement.get());
-  EXPECT_NE(current.get().view_generation(), old_view.view_generation);
+  EXPECT_NE(current.get().snapshot_generation(), old_view.snapshot_generation);
 
   current.release();
   version_manager.release_read_view();
@@ -158,14 +185,14 @@ TEST_F(ReadViewPublicationTest, ValidatedReaderKeepsPinnedOldSnapshot) {
   const auto [replacement, timestamp] = PublishReplacement(version_manager);
 
   EXPECT_EQ(lease.timestamp(), 1u);
-  EXPECT_EQ(lease.view_generation(), 0u);
+  EXPECT_EQ(lease.snapshot_generation(), 0u);
   EXPECT_EQ(lease.graph(), initial_graph_.get());
   EXPECT_NE(lease.graph(), replacement.get());
 
   lease.release();
   auto next = ReadSnapshotLease::Acquire(version_manager, *store_);
   EXPECT_EQ(next.timestamp(), timestamp);
-  EXPECT_EQ(next.view_generation(), 1u);
+  EXPECT_EQ(next.snapshot_generation(), 1u);
   EXPECT_EQ(next.graph(), replacement.get());
 }
 
@@ -173,9 +200,14 @@ TEST_F(ReadViewPublicationTest, LeaseRetriesAfterBlockedOpenCycle) {
   ScriptedVersionManager version_manager({1, 0});
   auto replacement = initial_graph_->Clone();
   bool publish_succeeded = false;
-  version_manager.set_first_acquire_hook([&] {
-    publish_succeeded = store_->PublishSnapshot(replacement, 1).ok();
-    version_manager.publish({2, 1});
+  version_manager.set_acquire_hook([&](int acquire_count) {
+    if (acquire_count == 1) {
+      auto published = PrepareAndPublishSnapshot(*store_, replacement);
+      publish_succeeded = published.has_value();
+      if (published) {
+        version_manager.publish({2, published.value()});
+      }
+    }
   });
 
   auto lease = ReadSnapshotLease::Acquire(version_manager, *store_);
@@ -184,11 +216,41 @@ TEST_F(ReadViewPublicationTest, LeaseRetriesAfterBlockedOpenCycle) {
   EXPECT_EQ(version_manager.acquire_count(), 2);
   EXPECT_EQ(version_manager.release_count(), 1);
   EXPECT_EQ(lease.timestamp(), 2u);
-  EXPECT_EQ(lease.view_generation(), 1u);
+  EXPECT_EQ(lease.snapshot_generation(), 1u);
   EXPECT_EQ(lease.graph(), replacement.get());
 
   lease.release();
   EXPECT_EQ(version_manager.release_count(), 2);
+}
+
+TEST_F(ReadViewPublicationTest, LeaseRetryUsesConfiguredRuntimeWait) {
+  ScriptedVersionManager version_manager({1, 0});
+  version_manager.set_runtime_wait(&CountRuntimeWait);
+  runtime_wait_calls.store(0, std::memory_order_relaxed);
+
+  auto replacement = initial_graph_->Clone();
+  bool publish_succeeded = true;
+  constexpr int mismatch_count = kRuntimeWaitSpinIterations + 1;
+  version_manager.set_acquire_hook([&](int acquire_count) {
+    if (acquire_count <= mismatch_count) {
+      auto published = PrepareAndPublishSnapshot(*store_, replacement);
+      publish_succeeded &= published.has_value();
+      if (published) {
+        version_manager.publish(
+            {static_cast<uint32_t>(acquire_count + 1), published.value()});
+      }
+    }
+  });
+
+  auto lease = ReadSnapshotLease::Acquire(version_manager, *store_);
+
+  EXPECT_TRUE(publish_succeeded);
+  EXPECT_EQ(version_manager.acquire_count(), mismatch_count + 1);
+  EXPECT_EQ(version_manager.release_count(), mismatch_count);
+  EXPECT_EQ(runtime_wait_calls.load(std::memory_order_relaxed), 1);
+  EXPECT_EQ(lease.timestamp(), static_cast<uint32_t>(mismatch_count + 1));
+  EXPECT_EQ(lease.snapshot_generation(), static_cast<uint32_t>(mismatch_count));
+  EXPECT_EQ(lease.graph(), replacement.get());
 }
 
 }  // namespace

--- a/tests/transaction/test_read_view_publication.cc
+++ b/tests/transaction/test_read_view_publication.cc
@@ -1,0 +1,197 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <filesystem>
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "neug/storages/checkpoint_manager.h"
+#include "neug/storages/graph/operation_params.h"
+#include "neug/storages/graph/property_graph.h"
+#include "neug/storages/graph_snapshot_store.h"
+#include "neug/transaction/read_snapshot_lease.h"
+#include "neug/transaction/version_manager.h"
+#include "unittest/utils.h"
+
+namespace neug {
+namespace {
+
+class ScriptedVersionManager : public IVersionManager {
+ public:
+  explicit ScriptedVersionManager(PublishedReadView initial)
+      : published_(PackPublishedReadView(initial)) {}
+
+  void set_first_acquire_hook(std::function<void()> hook) {
+    first_acquire_hook_ = std::move(hook);
+  }
+
+  void publish(PublishedReadView view) {
+    published_.store(PackPublishedReadView(view), std::memory_order_release);
+  }
+
+  int acquire_count() const { return acquire_count_.load(); }
+  int release_count() const { return release_count_.load(); }
+
+  void init_ts(uint32_t, int) override {}
+  bool try_set_runtime_wait_if_quiescent(RuntimeWaitFn) noexcept override {
+    return true;
+  }
+
+  PublishedReadView acquire_read_view() override {
+    const auto captured =
+        UnpackPublishedReadView(published_.load(std::memory_order_acquire));
+    if (acquire_count_.fetch_add(1) == 0 && first_acquire_hook_) {
+      first_acquire_hook_();
+    }
+    return captured;
+  }
+
+  uint32_t acquire_read_timestamp() override {
+    return acquire_read_view().visibility_ts;
+  }
+
+  void release_read_timestamp() override { release_count_.fetch_add(1); }
+  uint32_t acquire_insert_timestamp() override { return 1; }
+  void release_insert_timestamp(uint32_t) override {}
+  uint32_t acquire_update_timestamp() override { return 1; }
+  void begin_update_commit(uint32_t) override {}
+  void drain_readers() override {}
+  void release_update_timestamp(uint32_t) override {}
+  uint32_t acquire_compact_timestamp() override { return 1; }
+  void release_compact_timestamp(uint32_t) override {}
+  void revert_compact_timestamp(uint32_t) override {}
+
+ private:
+  std::atomic<uint64_t> published_;
+  std::atomic<int> acquire_count_{0};
+  std::atomic<int> release_count_{0};
+  std::function<void()> first_acquire_hook_;
+};
+
+class ReadViewPublicationTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    work_dir_ =
+        (std::filesystem::temp_directory_path() /
+         ("test_read_view_publication_" +
+          std::string(
+              ::testing::UnitTest::GetInstance()->current_test_info()->name())))
+            .string();
+    std::filesystem::remove_all(work_dir_);
+    std::filesystem::create_directories(work_dir_);
+
+    checkpoint_manager_.Open(work_dir_);
+    initial_graph_ = std::make_shared<PropertyGraph>();
+    initial_graph_->Open(make_checkpoint(checkpoint_manager_),
+                         MemoryLevel::kInMemory);
+    CreateVertexTypeParamBuilder person;
+    ASSERT_TRUE(initial_graph_
+                    ->CreateVertexType(person.VertexLabel("person")
+                                           .AddProperty("id", Value::INT64(0))
+                                           .AddPrimaryKeyName("id")
+                                           .Build())
+                    .ok());
+    store_ = std::make_unique<GraphSnapshotStore>(4, initial_graph_);
+  }
+
+  void TearDown() override {
+    store_.reset();
+    initial_graph_.reset();
+    std::filesystem::remove_all(work_dir_);
+  }
+
+  std::pair<std::shared_ptr<PropertyGraph>, uint32_t> PublishReplacement(
+      VersionManager& version_manager) {
+    const uint32_t timestamp = version_manager.acquire_update_timestamp();
+    const uint32_t generation = version_manager.reserve_view_generation();
+    version_manager.begin_update_commit(timestamp);
+    auto replacement = initial_graph_->Clone();
+    EXPECT_TRUE(store_->PublishSnapshot(replacement, generation).ok());
+    version_manager.release_update_timestamp_with_view(timestamp, generation);
+    return {std::move(replacement), timestamp};
+  }
+
+  std::string work_dir_;
+  CheckpointManager checkpoint_manager_;
+  std::shared_ptr<PropertyGraph> initial_graph_;
+  std::unique_ptr<GraphSnapshotStore> store_;
+};
+
+TEST_F(ReadViewPublicationTest, SplitAcquisitionExposesGenerationMismatch) {
+  VersionManager version_manager;
+  version_manager.init_ts(1, 2);
+
+  const PublishedReadView old_view = version_manager.acquire_read_view();
+  const auto publication = PublishReplacement(version_manager);
+  const auto& replacement = publication.first;
+
+  SnapshotGuard current(*store_);
+  EXPECT_EQ(old_view.visibility_ts, 1u);
+  EXPECT_EQ(old_view.view_generation, 0u);
+  EXPECT_EQ(current.get().mutable_graph(), replacement.get());
+  EXPECT_NE(current.get().view_generation(), old_view.view_generation);
+
+  current.release();
+  version_manager.release_read_timestamp();
+}
+
+TEST_F(ReadViewPublicationTest, ValidatedReaderKeepsPinnedOldSnapshot) {
+  VersionManager version_manager;
+  version_manager.init_ts(1, 2);
+
+  auto lease = ReadSnapshotLease::Acquire(version_manager, *store_);
+  const auto [replacement, timestamp] = PublishReplacement(version_manager);
+
+  EXPECT_EQ(lease.timestamp(), 1u);
+  EXPECT_EQ(lease.view_generation(), 0u);
+  EXPECT_EQ(lease.graph(), initial_graph_.get());
+  EXPECT_NE(lease.graph(), replacement.get());
+
+  lease.release();
+  auto next = ReadSnapshotLease::Acquire(version_manager, *store_);
+  EXPECT_EQ(next.timestamp(), timestamp);
+  EXPECT_EQ(next.view_generation(), 1u);
+  EXPECT_EQ(next.graph(), replacement.get());
+}
+
+TEST_F(ReadViewPublicationTest, LeaseRetriesAfterBlockedOpenCycle) {
+  ScriptedVersionManager version_manager({1, 0});
+  auto replacement = initial_graph_->Clone();
+  bool publish_succeeded = false;
+  version_manager.set_first_acquire_hook([&] {
+    publish_succeeded = store_->PublishSnapshot(replacement, 1).ok();
+    version_manager.publish({2, 1});
+  });
+
+  auto lease = ReadSnapshotLease::Acquire(version_manager, *store_);
+
+  EXPECT_TRUE(publish_succeeded);
+  EXPECT_EQ(version_manager.acquire_count(), 2);
+  EXPECT_EQ(version_manager.release_count(), 1);
+  EXPECT_EQ(lease.timestamp(), 2u);
+  EXPECT_EQ(lease.view_generation(), 1u);
+  EXPECT_EQ(lease.graph(), replacement.get());
+
+  lease.release();
+  EXPECT_EQ(version_manager.release_count(), 2);
+}
+
+}  // namespace
+}  // namespace neug

--- a/tests/transaction/test_runtime_wait.cc
+++ b/tests/transaction/test_runtime_wait.cc
@@ -69,7 +69,7 @@ void CountingNativeRuntimeWait(RuntimeWaitAction action) noexcept {
 }
 
 void InitManager(VersionManager& manager) {
-  manager.init_ts(1, 4);
+  manager.init_ts({1, 0}, 4);
   EXPECT_TRUE(manager.try_set_runtime_wait_if_quiescent(&CountingRuntimeWait));
 }
 
@@ -321,7 +321,7 @@ TEST(RuntimeWaitPhaseTest, UsesSpecifiedBoundaries) {
 
 TEST(VersionManagerWaitTest, RuntimeWaitSwitchRequiresQuiescence) {
   VersionManager manager;
-  manager.init_ts(1, 4);
+  manager.init_ts({1, 0}, 4);
 
   EXPECT_FALSE(manager.try_set_runtime_wait_if_quiescent(nullptr));
   EXPECT_TRUE(manager.try_set_runtime_wait_if_quiescent(&CountingRuntimeWait));
@@ -353,7 +353,7 @@ TEST(NativeRuntimeWaitTest, SleepPhaseCompletesContendedWait) {
   ResetRuntimeWaitCalls();
 
   VersionManager manager;
-  manager.init_ts(1, 4);
+  manager.init_ts({1, 0}, 4);
   ASSERT_TRUE(
       manager.try_set_runtime_wait_if_quiescent(&CountingNativeRuntimeWait));
   const auto update_ts = manager.acquire_update_timestamp();
@@ -403,7 +403,7 @@ TEST(BthreadRuntimeWaitTest, SleepPhaseLeavesWorkerAvailableForNewBthread) {
   ResetRuntimeWaitCalls();
 
   VersionManager manager;
-  manager.init_ts(1, 4);
+  manager.init_ts({1, 0}, 4);
   ASSERT_TRUE(
       manager.try_set_runtime_wait_if_quiescent(&CountingBthreadRuntimeWait));
   const auto update_ts = manager.acquire_update_timestamp();

--- a/tests/transaction/test_runtime_wait.cc
+++ b/tests/transaction/test_runtime_wait.cc
@@ -73,6 +73,10 @@ void InitManager(VersionManager& manager) {
   EXPECT_TRUE(manager.try_set_runtime_wait_if_quiescent(&CountingRuntimeWait));
 }
 
+void FinishUpdate(VersionManager& manager, uint32_t timestamp) {
+  manager.finish_update_timestamp(timestamp, std::nullopt);
+}
+
 template <typename Predicate>
 bool WaitUntil(Predicate predicate) {
   const auto deadline = std::chrono::steady_clock::now() + kWaitTimeout;
@@ -123,7 +127,7 @@ TEST(VersionManagerWaitTest, UncontendedPathsDoNotInvokeBackoff) {
   const auto update_ts = manager.acquire_update_timestamp();
   manager.begin_update_commit(update_ts);
   manager.drain_readers();
-  manager.release_update_timestamp(update_ts);
+  FinishUpdate(manager, update_ts);
 
   const auto compact_ts = manager.acquire_compact_timestamp();
   manager.release_compact_timestamp(compact_ts);
@@ -143,7 +147,7 @@ TEST(VersionManagerWaitTest, AllContendedPathsUseBackoff) {
           manager.acquire_read_view();
           manager.release_read_view();
         },
-        [&]() { manager.release_update_timestamp(update_ts); });
+        [&]() { FinishUpdate(manager, update_ts); });
   }
   {
     SCOPED_TRACE("insert slow path");
@@ -151,7 +155,7 @@ TEST(VersionManagerWaitTest, AllContendedPathsUseBackoff) {
     uint32_t insert_ts = 0;
     ExpectRuntimeWaitWhile(
         [&]() { insert_ts = manager.acquire_insert_timestamp(); },
-        [&]() { manager.release_update_timestamp(update_ts); });
+        [&]() { FinishUpdate(manager, update_ts); });
     manager.release_insert_timestamp(insert_ts);
   }
   {
@@ -164,8 +168,8 @@ TEST(VersionManagerWaitTest, AllContendedPathsUseBackoff) {
     uint32_t next_update_ts = 0;
     ExpectRuntimeWaitWhile(
         [&]() { next_update_ts = manager.acquire_update_timestamp(); },
-        [&]() { manager.release_update_timestamp(update_ts); });
-    manager.release_update_timestamp(next_update_ts);
+        [&]() { FinishUpdate(manager, update_ts); });
+    FinishUpdate(manager, next_update_ts);
   }
   {
     SCOPED_TRACE("explicit reader drain");
@@ -174,7 +178,7 @@ TEST(VersionManagerWaitTest, AllContendedPathsUseBackoff) {
     manager.begin_update_commit(update_ts);
     ExpectRuntimeWaitWhile([&]() { manager.drain_readers(); },
                            [&]() { manager.release_read_view(); });
-    manager.release_update_timestamp(update_ts);
+    FinishUpdate(manager, update_ts);
     EXPECT_ANY_THROW(manager.drain_readers());
   }
   {
@@ -183,7 +187,7 @@ TEST(VersionManagerWaitTest, AllContendedPathsUseBackoff) {
     uint32_t compact_ts = 0;
     ExpectRuntimeWaitWhile(
         [&]() { compact_ts = manager.acquire_compact_timestamp(); },
-        [&]() { manager.release_update_timestamp(update_ts); });
+        [&]() { FinishUpdate(manager, update_ts); });
     manager.release_compact_timestamp(compact_ts);
   }
   {
@@ -278,9 +282,9 @@ TEST(VersionManagerAdmissionTest,
   EXPECT_EQ(violations.load(std::memory_order_relaxed), 0);
 }
 
-TEST(AdaptiveBackoffTest, KeepsSpinLocalAndDispatchesRuntimeWaits) {
+TEST(RuntimeBackoffTest, KeepsSpinLocalAndDispatchesRuntimeWaits) {
   ResetRuntimeWaitCalls();
-  AdaptiveBackoff wait(&CountingRuntimeWait);
+  RuntimeBackoff wait(&CountingRuntimeWait);
 
   for (uint32_t i = 0; i < kRuntimeWaitSpinIterations; ++i) {
     wait();
@@ -332,7 +336,7 @@ TEST(VersionManagerWaitTest, RuntimeWaitSwitchRequiresQuiescence) {
 
   const auto update_ts = manager.acquire_update_timestamp();
   EXPECT_FALSE(manager.try_set_runtime_wait_if_quiescent(&NativeRuntimeWait));
-  manager.release_update_timestamp(update_ts);
+  FinishUpdate(manager, update_ts);
 
   const auto compact_ts = manager.acquire_compact_timestamp();
   EXPECT_FALSE(manager.try_set_runtime_wait_if_quiescent(&NativeRuntimeWait));
@@ -363,7 +367,7 @@ TEST(NativeRuntimeWaitTest, SleepPhaseCompletesContendedWait) {
   });
 
   const bool sleep_phase_observed = WaitForSleep();
-  manager.release_update_timestamp(update_ts);
+  FinishUpdate(manager, update_ts);
   waiter.join();
 
   EXPECT_TRUE(sleep_phase_observed);
@@ -419,7 +423,7 @@ TEST(BthreadRuntimeWaitTest, SleepPhaseLeavesWorkerAvailableForNewBthread) {
     }
   }
   if (started_waiters != waiter_count) {
-    manager.release_update_timestamp(update_ts);
+    FinishUpdate(manager, update_ts);
     for (int i = 0; i < started_waiters; ++i) {
       EXPECT_EQ(bthread_join(waiters[i], nullptr), 0);
     }
@@ -443,7 +447,7 @@ TEST(BthreadRuntimeWaitTest, SleepPhaseLeavesWorkerAvailableForNewBthread) {
         return probe_scheduled.load(std::memory_order_acquire);
       });
 
-  manager.release_update_timestamp(update_ts);
+  FinishUpdate(manager, update_ts);
   if (probe_start_result == 0) {
     EXPECT_EQ(bthread_join(probe, nullptr), 0);
   }

--- a/tests/transaction/test_runtime_wait.cc
+++ b/tests/transaction/test_runtime_wait.cc
@@ -113,9 +113,9 @@ TEST(VersionManagerWaitTest, UncontendedPathsDoNotInvokeBackoff) {
   InitManager(manager);
   ResetRuntimeWaitCalls();
 
-  const auto read_ts = manager.acquire_read_timestamp();
+  const auto read_ts = manager.acquire_read_view().visibility_ts;
   EXPECT_EQ(read_ts, 1U);
-  manager.release_read_timestamp();
+  manager.release_read_view();
 
   const auto insert_ts = manager.acquire_insert_timestamp();
   manager.release_insert_timestamp(insert_ts);
@@ -140,8 +140,8 @@ TEST(VersionManagerWaitTest, AllContendedPathsUseBackoff) {
     manager.begin_update_commit(update_ts);
     ExpectRuntimeWaitWhile(
         [&]() {
-          manager.acquire_read_timestamp();
-          manager.release_read_timestamp();
+          manager.acquire_read_view();
+          manager.release_read_view();
         },
         [&]() { manager.release_update_timestamp(update_ts); });
   }
@@ -169,11 +169,11 @@ TEST(VersionManagerWaitTest, AllContendedPathsUseBackoff) {
   }
   {
     SCOPED_TRACE("explicit reader drain");
-    manager.acquire_read_timestamp();
+    manager.acquire_read_view();
     const auto update_ts = manager.acquire_update_timestamp();
     manager.begin_update_commit(update_ts);
     ExpectRuntimeWaitWhile([&]() { manager.drain_readers(); },
-                           [&]() { manager.release_read_timestamp(); });
+                           [&]() { manager.release_read_view(); });
     manager.release_update_timestamp(update_ts);
     EXPECT_ANY_THROW(manager.drain_readers());
   }
@@ -197,11 +197,11 @@ TEST(VersionManagerWaitTest, AllContendedPathsUseBackoff) {
   }
   {
     SCOPED_TRACE("compact reader drain");
-    manager.acquire_read_timestamp();
+    manager.acquire_read_view();
     uint32_t compact_ts = 0;
     ExpectRuntimeWaitWhile(
         [&]() { compact_ts = manager.acquire_compact_timestamp(); },
-        [&]() { manager.release_read_timestamp(); });
+        [&]() { manager.release_read_view(); });
     manager.release_compact_timestamp(compact_ts);
   }
 }
@@ -229,7 +229,7 @@ TEST(VersionManagerAdmissionTest,
 
   auto reader = [&]() {
     while (!stop.load(std::memory_order_acquire)) {
-      manager.acquire_read_timestamp();
+      manager.acquire_read_view();
       observed_readers.fetch_add(1, std::memory_order_seq_cst);
       if (compact_active.load(std::memory_order_seq_cst)) {
         violations.fetch_add(1, std::memory_order_relaxed);
@@ -239,7 +239,7 @@ TEST(VersionManagerAdmissionTest,
         violations.fetch_add(1, std::memory_order_relaxed);
       }
       observed_readers.fetch_sub(1, std::memory_order_seq_cst);
-      manager.release_read_timestamp();
+      manager.release_read_view();
     }
   };
   auto inserter = [&]() {
@@ -322,9 +322,9 @@ TEST(VersionManagerWaitTest, RuntimeWaitSwitchRequiresQuiescence) {
   EXPECT_FALSE(manager.try_set_runtime_wait_if_quiescent(nullptr));
   EXPECT_TRUE(manager.try_set_runtime_wait_if_quiescent(&CountingRuntimeWait));
 
-  manager.acquire_read_timestamp();
+  manager.acquire_read_view();
   EXPECT_FALSE(manager.try_set_runtime_wait_if_quiescent(&NativeRuntimeWait));
-  manager.release_read_timestamp();
+  manager.release_read_view();
 
   const auto insert_ts = manager.acquire_insert_timestamp();
   EXPECT_FALSE(manager.try_set_runtime_wait_if_quiescent(&NativeRuntimeWait));
@@ -357,8 +357,8 @@ TEST(NativeRuntimeWaitTest, SleepPhaseCompletesContendedWait) {
 
   std::atomic<bool> completed{false};
   std::thread waiter([&]() {
-    manager.acquire_read_timestamp();
-    manager.release_read_timestamp();
+    manager.acquire_read_view();
+    manager.release_read_view();
     completed.store(true, std::memory_order_release);
   });
 
@@ -385,8 +385,8 @@ struct ReaderState {
 void* WaitForReadTimestamp(void* arg) {
   auto& state = *static_cast<ReaderState*>(arg);
   state.started->fetch_add(1, std::memory_order_relaxed);
-  state.manager->acquire_read_timestamp();
-  state.manager->release_read_timestamp();
+  state.manager->acquire_read_view();
+  state.manager->release_read_view();
   return nullptr;
 }
 

--- a/tests/transaction/test_transaction_release_order.cc
+++ b/tests/transaction/test_transaction_release_order.cc
@@ -32,6 +32,7 @@
 #include "neug/transaction/compact_transaction.h"
 #include "neug/transaction/insert_transaction.h"
 #include "neug/transaction/read_transaction.h"
+#include "neug/transaction/timestamp_lease.h"
 #include "neug/transaction/version_manager.h"
 #include "neug/transaction/wal/dummy_wal_writer.h"
 #include "unittest/utils.h"
@@ -187,6 +188,23 @@ TEST_P(TransactionReleaseOrderTest, ReleasesSnapshotBeforeTimestamp) {
   EXPECT_EQ(version_manager.release_count(), 1);
   EXPECT_TRUE(version_manager.snapshot_was_released_first())
       << "The snapshot pin must be released before the timestamp lease";
+}
+
+TEST(UpdateTimestampLeaseTest, MoveTransfersTimestampOwnership) {
+  VersionManager version_manager;
+  version_manager.init_ts({0, 0}, 2);
+
+  {
+    UpdateTimestampLease source(version_manager);
+    EXPECT_EQ(source.Timestamp(), 1);
+
+    UpdateTimestampLease target(std::move(source));
+    EXPECT_EQ(target.Timestamp(), 1);
+  }
+
+  const auto next_timestamp = version_manager.acquire_update_timestamp();
+  EXPECT_EQ(next_timestamp, 2);
+  version_manager.finish_update_timestamp(next_timestamp, std::nullopt);
 }
 
 TEST(APInPlaceConcurrencyTest, ExistingReaderBlocksWriterMutationPhase) {

--- a/tests/transaction/test_transaction_release_order.cc
+++ b/tests/transaction/test_transaction_release_order.cc
@@ -60,11 +60,10 @@ class ReleaseOrderVersionManager : public IVersionManager {
   PublishedReadView acquire_read_view() override { return {1, 0}; }
   uint32_t acquire_insert_timestamp() override { return 1; }
   uint32_t acquire_update_timestamp() override { return 1; }
-  uint32_t reserve_view_generation() override { return 0; }
   void begin_update_commit(uint32_t) override {}
   void drain_readers() override {}
-  void release_update_timestamp(uint32_t) override {}
-  void release_update_timestamp_with_view(uint32_t, uint32_t) override {}
+  void finish_update_timestamp(uint32_t,
+                               std::optional<uint32_t>) noexcept override {}
   uint32_t acquire_compact_timestamp() override { return 1; }
 
   void release_read_view() override { record_release(); }
@@ -79,6 +78,10 @@ class ReleaseOrderVersionManager : public IVersionManager {
   int release_count() const { return release_count_; }
 
  private:
+  RuntimeWaitFn runtime_wait_impl() const noexcept override {
+    return &NativeRuntimeWait;
+  }
+
   void record_release() {
     ++release_count_;
     if (release_count_ == 1) {
@@ -125,7 +128,10 @@ class TransactionReleaseOrderTest
   }
 
   void publish_replacement_snapshot() {
-    ASSERT_TRUE(store_->PublishSnapshot(initial_graph_->Clone(), 0).ok());
+    auto prepared_result = store_->PrepareSnapshot(initial_graph_->Clone());
+    ASSERT_TRUE(prepared_result.has_value());
+    auto prepared = std::move(prepared_result).value();
+    std::move(prepared).Publish();
     ASSERT_FALSE(store_->HasFreeSlot())
         << "The transaction-owned pin must keep the stale slot occupied";
   }
@@ -199,7 +205,7 @@ TEST(APInPlaceConcurrencyTest, ExistingReaderBlocksWriterMutationPhase) {
     entered_commit.set_value();
     version_manager.drain_readers();
     drained.set_value();
-    version_manager.release_update_timestamp(timestamp);
+    version_manager.finish_update_timestamp(timestamp, std::nullopt);
   });
 
   entered_commit_future.wait();
@@ -234,7 +240,7 @@ TEST(APInPlaceConcurrencyTest, WriterBlocksNewReadersUntilReleased) {
   EXPECT_EQ(acquired_read_future.wait_for(std::chrono::milliseconds(20)),
             std::future_status::timeout);
 
-  version_manager.release_update_timestamp(writer_timestamp);
+  version_manager.finish_update_timestamp(writer_timestamp, std::nullopt);
   EXPECT_EQ(acquired_read_future.wait_for(std::chrono::seconds(1)),
             std::future_status::ready);
   reader.join();
@@ -254,14 +260,14 @@ TEST(APInPlaceConcurrencyTest, WritersAreSerialized) {
     attempting_update.set_value();
     const auto timestamp = version_manager.acquire_update_timestamp();
     acquired_update.set_value(timestamp);
-    version_manager.release_update_timestamp(timestamp);
+    version_manager.finish_update_timestamp(timestamp, std::nullopt);
   });
 
   attempting_update_future.wait();
   EXPECT_EQ(acquired_update_future.wait_for(std::chrono::milliseconds(20)),
             std::future_status::timeout);
 
-  version_manager.release_update_timestamp(first_timestamp);
+  version_manager.finish_update_timestamp(first_timestamp, std::nullopt);
   EXPECT_EQ(acquired_update_future.wait_for(std::chrono::seconds(1)),
             std::future_status::ready);
   second_writer.join();

--- a/tests/transaction/test_transaction_release_order.cc
+++ b/tests/transaction/test_transaction_release_order.cc
@@ -141,8 +141,8 @@ TEST_P(TransactionReleaseOrderTest, ReleasesSnapshotBeforeTimestamp) {
   const auto& path = GetParam();
   switch (path.transaction_kind) {
   case TransactionKind::kRead: {
-    SnapshotGuard guard(*store_);
-    ReadTransaction transaction(std::move(guard), version_manager, 1);
+    ReadTransaction transaction(
+        ReadSnapshotLease::Acquire(version_manager, *store_));
     publish_replacement_snapshot();
     ASSERT_TRUE(transaction.Commit());
     break;

--- a/tests/transaction/test_transaction_release_order.cc
+++ b/tests/transaction/test_transaction_release_order.cc
@@ -53,7 +53,7 @@ class ReleaseOrderVersionManager : public IVersionManager {
   explicit ReleaseOrderVersionManager(GraphSnapshotStore& store)
       : store_(store) {}
 
-  void init_ts(uint32_t, int) override {}
+  void init_ts(PublishedReadView, int) override {}
   bool try_set_runtime_wait_if_quiescent(RuntimeWaitFn) noexcept override {
     return true;
   }
@@ -191,7 +191,7 @@ TEST_P(TransactionReleaseOrderTest, ReleasesSnapshotBeforeTimestamp) {
 
 TEST(APInPlaceConcurrencyTest, ExistingReaderBlocksWriterMutationPhase) {
   VersionManager version_manager;
-  version_manager.init_ts(0, 2);
+  version_manager.init_ts({0, 0}, 2);
 
   version_manager.acquire_read_view();
 
@@ -220,7 +220,7 @@ TEST(APInPlaceConcurrencyTest, ExistingReaderBlocksWriterMutationPhase) {
 
 TEST(APInPlaceConcurrencyTest, WriterBlocksNewReadersUntilReleased) {
   VersionManager version_manager;
-  version_manager.init_ts(0, 2);
+  version_manager.init_ts({0, 0}, 2);
 
   const auto writer_timestamp = version_manager.acquire_update_timestamp();
   version_manager.begin_update_commit(writer_timestamp);
@@ -248,7 +248,7 @@ TEST(APInPlaceConcurrencyTest, WriterBlocksNewReadersUntilReleased) {
 
 TEST(APInPlaceConcurrencyTest, WritersAreSerialized) {
   VersionManager version_manager;
-  version_manager.init_ts(0, 2);
+  version_manager.init_ts({0, 0}, 2);
 
   const auto first_timestamp = version_manager.acquire_update_timestamp();
 

--- a/tests/transaction/test_transaction_release_order.cc
+++ b/tests/transaction/test_transaction_release_order.cc
@@ -57,15 +57,17 @@ class ReleaseOrderVersionManager : public IVersionManager {
   bool try_set_runtime_wait_if_quiescent(RuntimeWaitFn) noexcept override {
     return true;
   }
-  uint32_t acquire_read_timestamp() override { return 1; }
+  PublishedReadView acquire_read_view() override { return {1, 0}; }
   uint32_t acquire_insert_timestamp() override { return 1; }
   uint32_t acquire_update_timestamp() override { return 1; }
+  uint32_t reserve_view_generation() override { return 0; }
   void begin_update_commit(uint32_t) override {}
   void drain_readers() override {}
   void release_update_timestamp(uint32_t) override {}
+  void release_update_timestamp_with_view(uint32_t, uint32_t) override {}
   uint32_t acquire_compact_timestamp() override { return 1; }
 
-  void release_read_timestamp() override { record_release(); }
+  void release_read_view() override { record_release(); }
   void release_insert_timestamp(uint32_t) override { record_release(); }
   void release_compact_timestamp(uint32_t) override { record_release(); }
   void revert_compact_timestamp(uint32_t) override { record_release(); }
@@ -123,7 +125,7 @@ class TransactionReleaseOrderTest
   }
 
   void publish_replacement_snapshot() {
-    ASSERT_TRUE(store_->PublishSnapshot(initial_graph_->Clone()).ok());
+    ASSERT_TRUE(store_->PublishSnapshot(initial_graph_->Clone(), 0).ok());
     ASSERT_FALSE(store_->HasFreeSlot())
         << "The transaction-owned pin must keep the stale slot occupied";
   }
@@ -185,7 +187,7 @@ TEST(APInPlaceConcurrencyTest, ExistingReaderBlocksWriterMutationPhase) {
   VersionManager version_manager;
   version_manager.init_ts(0, 2);
 
-  version_manager.acquire_read_timestamp();
+  version_manager.acquire_read_view();
 
   std::promise<void> entered_commit;
   std::promise<void> drained;
@@ -204,7 +206,7 @@ TEST(APInPlaceConcurrencyTest, ExistingReaderBlocksWriterMutationPhase) {
   EXPECT_EQ(drained_future.wait_for(std::chrono::milliseconds(20)),
             std::future_status::timeout);
 
-  version_manager.release_read_timestamp();
+  version_manager.release_read_view();
   EXPECT_EQ(drained_future.wait_for(std::chrono::seconds(1)),
             std::future_status::ready);
   writer.join();
@@ -223,9 +225,9 @@ TEST(APInPlaceConcurrencyTest, WriterBlocksNewReadersUntilReleased) {
   auto acquired_read_future = acquired_read.get_future();
   std::thread reader([&]() {
     attempting_read.set_value();
-    const auto timestamp = version_manager.acquire_read_timestamp();
-    acquired_read.set_value(timestamp);
-    version_manager.release_read_timestamp();
+    const auto published = version_manager.acquire_read_view();
+    acquired_read.set_value(published.visibility_ts);
+    version_manager.release_read_view();
   });
 
   attempting_read_future.wait();

--- a/tests/transaction/test_wal_replay.cc
+++ b/tests/transaction/test_wal_replay.cc
@@ -288,7 +288,7 @@ class WalReplayTest : public ::testing::Test {
 static void expect_compact_completes_timestamp_and_preserves_next_insert(
     bool commit) {
   neug::VersionManager version_manager;
-  version_manager.init_ts(0, 1);
+  version_manager.init_ts({0, 0}, 1);
 
   const auto insert_ts = version_manager.acquire_insert_timestamp();
   version_manager.release_insert_timestamp(insert_ts);

--- a/tests/transaction/test_wal_replay.cc
+++ b/tests/transaction/test_wal_replay.cc
@@ -259,10 +259,11 @@ static void expect_compact_completes_timestamp_and_preserves_next_insert(
     version_manager.revert_compact_timestamp(compact_ts);
   }
 
-  const auto read_after_compact_ts = version_manager.acquire_read_timestamp();
+  const auto read_after_compact_ts =
+      version_manager.acquire_read_view().visibility_ts;
   EXPECT_EQ(read_after_compact_ts, compact_ts)
       << "compaction timestamps must be marked complete so readers can advance";
-  version_manager.release_read_timestamp();
+  version_manager.release_read_view();
 
   const auto next_insert_ts = version_manager.acquire_insert_timestamp();
   EXPECT_GT(next_insert_ts, compact_ts)
@@ -270,10 +271,11 @@ static void expect_compact_completes_timestamp_and_preserves_next_insert(
          "replay cannot collide with pre-compaction insert records";
   version_manager.release_insert_timestamp(next_insert_ts);
 
-  const auto read_after_insert_ts = version_manager.acquire_read_timestamp();
+  const auto read_after_insert_ts =
+      version_manager.acquire_read_view().visibility_ts;
   EXPECT_EQ(read_after_insert_ts, next_insert_ts)
       << "a compact timestamp gap must not block later insert visibility";
-  version_manager.release_read_timestamp();
+  version_manager.release_read_view();
 }
 
 TEST(WalReplayVersionManagerTest,


### PR DESCRIPTION
## Summary

- Publish the visibility timestamp and snapshot generation as one coherent read-view value.
- Acquire the pair through a move-only `ReadSnapshotLease` that retries if the pinned snapshot slot does not match the published generation.
- Tag copy-on-write snapshots with their reserved generation and preserve snapshot-before-admission release order.
- Add deterministic regressions for generation mismatch, retry, pinned old snapshots, and release ordering.

## Root cause

A reader could previously acquire an old visibility timestamp and then pin a newly published graph snapshot. Each operation was individually valid, but together they did not form one linearizable read view.

## Scope

This PR is intentionally limited to coherent read-view publication. Admission-gate hardening (#794), snapshot/WAL lifecycle hardening, and schema-aware query-cache invalidation (#775) are split into follow-up PRs.


Fixes #793