### PR TITLE
fix(core): preserve durable checkpoint publications when reopening fails

### DIFF
--- a/src/storages/graph/checkpoint_manager.cc
+++ b/src/storages/graph/checkpoint_manager.cc
@@ -224,9 +224,15 @@ std::shared_ptr<Checkpoint> create_staging_checkpoint(const std::string& db_dir,
         path.string() + ": " + ec.message());
   }
 
-  std::filesystem::create_directories(path);
-  CheckpointManifest::GenerateEmptyMeta((path / "meta").string());
-  return Checkpoint::Open(path.string(), generation);
+  try {
+    std::filesystem::create_directories(path);
+    CheckpointManifest::GenerateEmptyMeta((path / "meta").string());
+    return Checkpoint::Open(path.string(), generation);
+  } catch (...) {
+    remove_checkpoint_dir_best_effort(
+        path, "CheckpointManager::CreateStagingCheckpoint");
+    throw;
+  }
 }
 
 std::shared_ptr<Checkpoint> publish_staging_checkpoint(
@@ -288,8 +294,8 @@ std::shared_ptr<Checkpoint> publish_staging_checkpoint(
   try {
     final_checkpoint = Checkpoint::Open(final_path.string(), generation);
   } catch (...) {
-    remove_checkpoint_dir_best_effort(
-        final_path, "CheckpointManager::CommitStagingCheckpoint");
+    // rename is the durable commit point. Keep the published generation even
+    // if opening its handle fails; the next database Open will validate it.
     throw;
   }
 

--- a/tests/storage/test_checkpoint.cc
+++ b/tests/storage/test_checkpoint.cc
@@ -830,6 +830,29 @@ TEST(CheckpointGCTest, commit_staging_checkpoint_rejects_inactive_handle) {
   EXPECT_EQ(mgr.CurrentCheckpoint()->id(), 0);
 }
 
+TEST(CheckpointGCTest, commit_open_failure_preserves_published_generation) {
+  auto db_path = make_checkpoint_gc_test_dir("checkpoint_gc");
+  neug::CheckpointManager mgr;
+  mgr.Open(db_path);
+
+  auto staging = mgr.CreateStagingCheckpoint();
+  write_valid_empty_manifest(staging.checkpoint());
+  const auto staging_path = std::filesystem::path(staging.checkpoint()->path());
+  const auto published_path = std::filesystem::path(db_path) / "checkpoint-0";
+
+  // Keep the cached manifest valid so commit reaches the durable rename, but
+  // make reopening the renamed checkpoint fail.
+  std::ofstream(staging_path / "meta", std::ios::trunc)
+      << "invalid checkpoint manifest";
+
+  EXPECT_THROW(staging.Commit(), std::exception);
+  EXPECT_FALSE(std::filesystem::exists(staging_path));
+  EXPECT_TRUE(std::filesystem::exists(published_path));
+  EXPECT_EQ(mgr.CurrentCheckpoint(), nullptr);
+
+  staging.Discard();
+}
+
 TEST(CheckpointGCTest, staging_and_session_cleanup_cover_failure_edges) {
   auto db_path = make_checkpoint_gc_test_dir("checkpoint_gc");
   std::string closed_staging_path;


### PR DESCRIPTION
## Summary

- clean partial staging directories when checkpoint creation fails
- treat the staging rename as the durable publication point
- preserve the published checkpoint if reopening its handle fails
- add a regression test for the post-rename reopen failure

## Rationale

After `checkpoint-N.next` is renamed to `checkpoint-N`, removing the final directory on a subsequent in-memory reopen failure corrupts an already durable publication. The next database open should validate and recover that published generation instead.

Fixes #808

## Validation

- `cmake --build build --target storage_test -j14`
- `build/tests/storage/storage_test --gtest_filter=CheckpointGCTest.commit_open_failure_preserves_published_generation:CheckpointGCTest.staging_and_session_cleanup_cover_failure_edges`
- `clang-format --dry-run --Werror src/storages/graph/checkpoint_manager.cc tests/storage/test_checkpoint.cc`
- `git diff --check upstream/main...HEAD`
