### PR TITLE
fix(core): safely reopen WAL writers on a new URI

### DIFF
--- a/include/neug/server/tp_execution_slot_pool.h
+++ b/include/neug/server/tp_execution_slot_pool.h
@@ -64,7 +64,7 @@ class TpExecutionSlotPool {
           std::shared_ptr<execution::GlobalQueryCache> global_query_cache,
           std::shared_ptr<Allocator> alloc, IVersionManager& version_manager,
           int slot_id, std::unique_ptr<IWalWriter> in_logger,
-          const NeugDBConfig& config)
+          const std::string& wal_uri, const NeugDBConfig& config)
         : allocator(std::move(alloc)),
           logger(std::move(in_logger)),
           slot(snapshot_store, std::move(planner),
@@ -72,7 +72,7 @@ class TpExecutionSlotPool {
                QueryExecutionStrategy::kTransactional, logger.get(), config,
                slot_id) {
       CHECK(logger != nullptr);
-      logger->open();
+      logger->open(wal_uri);
     }
 
     std::shared_ptr<Allocator> allocator;
@@ -114,7 +114,7 @@ class TpExecutionSlotPool {
         new (&entries_[constructed_entries])
             Entry(snapshot_store, planner, global_query_cache,
                   allocators.at(constructed_entries), version_manager, slot_id,
-                  std::move(logger), config);
+                  std::move(logger), wal_uri, config);
       }
     } catch (...) {
       while (constructed_entries > 0) {

--- a/include/neug/transaction/wal/dummy_wal_writer.h
+++ b/include/neug/transaction/wal/dummy_wal_writer.h
@@ -31,7 +31,7 @@ class DummyWalWriter : public IWalWriter {
 
   std::string type() const override;
 
-  void open() override;
+  void open(const std::string& wal_uri) override;
 
   void close() override;
   bool append(const char* data, size_t length) override;

--- a/include/neug/transaction/wal/local_wal_writer.h
+++ b/include/neug/transaction/wal/local_wal_writer.h
@@ -36,7 +36,7 @@ class LocalWalWriter : public IWalWriter {
         file_used_(0) {}
   ~LocalWalWriter() noexcept override;
 
-  void open() override;
+  void open(const std::string& wal_uri) override;
   void close() override;
   bool append(const char* data, size_t length) override;
   std::string type() const override { return "file"; }

--- a/include/neug/transaction/wal/wal.h
+++ b/include/neug/transaction/wal/wal.h
@@ -68,7 +68,7 @@ class IWalWriter {
    * writer for the full transaction.
    * The uri could be a file_path or a remote connection string.
    */
-  virtual void open() = 0;
+  virtual void open(const std::string& wal_uri) = 0;
 
   /**
    * Close the wal writer. If a remote connection is hold by the wal writer,

--- a/src/transaction/wal/dummy_wal_writer.cc
+++ b/src/transaction/wal/dummy_wal_writer.cc
@@ -17,7 +17,7 @@
 
 namespace neug {
 std::string DummyWalWriter::type() const { return "dummy"; }
-void DummyWalWriter::open() {}
+void DummyWalWriter::open(const std::string&) {}
 void DummyWalWriter::close() {}
 bool DummyWalWriter::append(const char* data, size_t length) { return true; }
 }  // namespace neug

--- a/src/transaction/wal/local_wal_writer.cc
+++ b/src/transaction/wal/local_wal_writer.cc
@@ -40,11 +40,14 @@ LocalWalWriter::~LocalWalWriter() noexcept {
   try {
     close();
   } catch (const std::exception& e) {
-    LOG(WARNING) << "Failed to close WAL writer: " << e.what();
-  } catch (...) { LOG(WARNING) << "Failed to close WAL writer"; }
+    LOG(ERROR) << "Failed to close WAL writer during destruction: " << e.what();
+  } catch (...) {
+    LOG(ERROR) << "Failed to close WAL writer during destruction.";
+  }
 }
 
-void LocalWalWriter::open() {
+void LocalWalWriter::open(const std::string& wal_uri) {
+  wal_uri_ = wal_uri;
   auto prefix = get_wal_uri_path(wal_uri_);
   if (!std::filesystem::exists(prefix)) {
     std::filesystem::create_directories(prefix);
@@ -76,12 +79,16 @@ void LocalWalWriter::open() {
 
 void LocalWalWriter::close() {
   if (fd_ != -1) {
-    if (::close(fd_) != 0) {
-      THROW_IO_EXCEPTION("Failed to close file" + std::string(strerror(errno)));
-    }
+    // Retire the descriptor before calling close(). Retrying close() after an
+    // error is unsafe because the descriptor may already have been released
+    // and reused by another thread.
+    const int fd = fd_;
     fd_ = -1;
     file_size_ = 0;
     file_used_ = 0;
+    if (::close(fd) != 0) {
+      THROW_IO_EXCEPTION("Failed to close file" + std::string(strerror(errno)));
+    }
   }
 }
 

--- a/src/transaction/wal/local_wal_writer.cc
+++ b/src/transaction/wal/local_wal_writer.cc
@@ -47,6 +47,7 @@ LocalWalWriter::~LocalWalWriter() noexcept {
 }
 
 void LocalWalWriter::open(const std::string& wal_uri) {
+  close();
   wal_uri_ = wal_uri;
   auto prefix = get_wal_uri_path(wal_uri_);
   if (!std::filesystem::exists(prefix)) {

--- a/tests/storage/test_tp_index.cc
+++ b/tests/storage/test_tp_index.cc
@@ -49,7 +49,7 @@ namespace {
 class CapturingWalWriter : public IWalWriter {
  public:
   std::string type() const override { return "capturing"; }
-  void open() override {}
+  void open(const std::string&) override {}
   void close() override {}
 
   bool append(const char* data, size_t length) override {

--- a/tests/transaction/test_wal_replay.cc
+++ b/tests/transaction/test_wal_replay.cc
@@ -58,7 +58,6 @@ TEST(WalWriterTest, ReopensSameInstanceOnNewTimeline) {
     writer->open(old_wal_dir);
     ASSERT_TRUE(writer->append(reinterpret_cast<const char*>(&old_marker),
                                sizeof(old_marker)));
-    writer->close();
 
     writer->open(new_wal_dir);
     EXPECT_EQ(writer.get(), identity);

--- a/tests/transaction/test_wal_replay.cc
+++ b/tests/transaction/test_wal_replay.cc
@@ -21,12 +21,15 @@
 #include "neug/transaction/version_manager.h"
 
 #include <unistd.h>
+#include <cstdint>
 #include <cstdlib>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <string>
 
 #include "gtest/gtest.h"
+#include "neug/transaction/wal/wal.h"
 
 namespace {
 
@@ -38,6 +41,45 @@ std::string make_test_dir() {
                         std::to_string(::getpid()) + "_" +
                         info->test_suite_name() + "_" + info->name();
   return (std::filesystem::temp_directory_path() / dir_name).string();
+}
+
+TEST(WalWriterTest, ReopensSameInstanceOnNewTimeline) {
+  const auto test_dir = make_test_dir();
+  const auto old_wal_dir =
+      (std::filesystem::path(test_dir) / "checkpoint-0" / "wal").string();
+  const auto new_wal_dir =
+      (std::filesystem::path(test_dir) / "checkpoint-1" / "wal").string();
+  constexpr uint32_t old_marker = 17;
+  constexpr uint32_t new_marker = 29;
+
+  {
+    auto writer = neug::WalWriterFactory::CreateWalWriter(old_wal_dir, 0);
+    auto* const identity = writer.get();
+    writer->open(old_wal_dir);
+    ASSERT_TRUE(writer->append(reinterpret_cast<const char*>(&old_marker),
+                               sizeof(old_marker)));
+    writer->close();
+
+    writer->open(new_wal_dir);
+    EXPECT_EQ(writer.get(), identity);
+    ASSERT_TRUE(writer->append(reinterpret_cast<const char*>(&new_marker),
+                               sizeof(new_marker)));
+    writer->close();
+  }
+
+  const auto read_marker = [](const std::string& wal_dir) {
+    const auto begin = std::filesystem::directory_iterator(wal_dir);
+    const auto end = std::filesystem::directory_iterator();
+    EXPECT_NE(begin, end);
+    std::ifstream wal_file(begin->path(), std::ios::binary);
+    uint32_t marker = 0;
+    wal_file.read(reinterpret_cast<char*>(&marker), sizeof(marker));
+    return marker;
+  };
+  EXPECT_EQ(read_marker(old_wal_dir), old_marker);
+  EXPECT_EQ(read_marker(new_wal_dir), new_marker);
+
+  std::filesystem::remove_all(test_dir);
 }
 
 neug::NeugDBConfig make_config(const std::string& db_dir) {


### PR DESCRIPTION
## Summary

- add an explicit `IWalWriter::open(wal_uri)` lifecycle operation
- allow the same local WAL writer instance to reopen on a new URI
- retire the file descriptor state before invoking `close(2)`
- keep destructor cleanup non-throwing and log failures
- add a focused reopen regression test

## Rationale

TP execution slots retain the writer object's identity across checkpoint timeline changes. Reopening that writer explicitly keeps the lifecycle visible and avoids retaining the previous WAL URI or stale descriptor state.

Fixes #809

## Validation

- `cmake --build build --target transaction_test tp_index_test -j14`
- `build/tests/transaction/transaction_test --gtest_filter=WalWriterTest.ReopensSameInstanceOnNewTimeline`
- `build/tests/storage/tp_index_test` (13 tests passed)
- `clang-format --dry-run --Werror` on all eight changed files
- `git diff --check upstream/main...HEAD`
