### PR TITLE
fix: linearize transaction admission

### DIFF
--- a/include/neug/transaction/insert_transaction.h
+++ b/include/neug/transaction/insert_transaction.h
@@ -60,9 +60,9 @@ class Schema;
  * is a correctness bug, not a performance optimization.
  *
  * **Concurrency contract** (VersionManager state machine):
- * - Insert requires admission_state_==kOpen; multiple concurrent inserts are
- *   allowed (active_inserters_ counter). Update/compact transitions the state
- *   away from kOpen, blocking new inserts.
+ * - Insert requires the packed operation gate phase to be kOpen; multiple
+ *   concurrent inserts are tracked by its active-inserter field.
+ *   Update/compact transitions the phase away from kOpen, blocking new inserts.
  * - Insert does NOT block readers, and readers do NOT block insert.
  * - The pinned slot's PropertyGraph is shared with all readers on that slot.
  *

--- a/include/neug/transaction/update_transaction.h
+++ b/include/neug/transaction/update_transaction.h
@@ -83,7 +83,7 @@ class UpdateTransaction {
    * @param logger Reference to WAL writer
    * @param snapshot_store Reference to GraphSnapshotStore for commit
    * @param cache Reference to query cache
-   * @param timestamp_lease Owner of the transaction timestamp
+   * @param timestamp_lease Owned update timestamp and admission lifecycle
    *
    * @note The caller is responsible for acquiring the timestamp lease before
    * creating the COW copy via Clone().

--- a/include/neug/transaction/version_manager.h
+++ b/include/neug/transaction/version_manager.h
@@ -98,6 +98,82 @@ class IVersionManager {
   virtual RuntimeWaitFn runtime_wait_impl() const noexcept = 0;
 };
 
+namespace detail {
+
+enum class AdmissionState : uint8_t { kOpen, kInsertsBlocked, kAllBlocked };
+
+// Layout: [63:62] phase | [61:31] active readers | [30:0] active inserters.
+struct OperationGateWord {
+  static constexpr uint32_t kMaxCount = 0x7fffffffu;
+  static constexpr uint64_t kInserterMask = kMaxCount;
+  static constexpr uint64_t kReaderMask = uint64_t{kMaxCount} << 31;
+  static constexpr uint64_t kPhaseMask = uint64_t{3} << 62;
+  static constexpr uint64_t kInserterUnit = 1;
+  static constexpr uint64_t kReaderUnit = uint64_t{1} << 31;
+
+  [[nodiscard]] static constexpr uint64_t empty(AdmissionState phase) noexcept {
+    return static_cast<uint64_t>(phase) << 62;
+  }
+
+  [[nodiscard]] static constexpr AdmissionState phase(uint64_t word) noexcept {
+    return static_cast<AdmissionState>(word >> 62);
+  }
+
+  [[nodiscard]] static constexpr uint32_t readers(uint64_t word) noexcept {
+    return static_cast<uint32_t>((word >> 31) & kMaxCount);
+  }
+
+  [[nodiscard]] static constexpr uint32_t inserters(uint64_t word) noexcept {
+    return static_cast<uint32_t>(word & kInserterMask);
+  }
+
+  [[nodiscard]] static constexpr uint64_t with_phase(
+      uint64_t word, AdmissionState desired_phase) noexcept {
+    return (word & ~kPhaseMask) | (static_cast<uint64_t>(desired_phase) << 62);
+  }
+
+  // Callers validate the corresponding counter before changing it.
+  [[nodiscard]] static constexpr uint64_t increment_reader(
+      uint64_t word) noexcept {
+    return word + kReaderUnit;
+  }
+
+  [[nodiscard]] static constexpr uint64_t decrement_reader(
+      uint64_t word) noexcept {
+    return word - kReaderUnit;
+  }
+
+  [[nodiscard]] static constexpr uint64_t increment_inserter(
+      uint64_t word) noexcept {
+    return word + kInserterUnit;
+  }
+
+  [[nodiscard]] static constexpr uint64_t decrement_inserter(
+      uint64_t word) noexcept {
+    return word - kInserterUnit;
+  }
+
+  [[nodiscard]] static bool try_change_phase(
+      std::atomic<uint64_t>& gate, uint64_t& observed,
+      AdmissionState desired_phase) noexcept {
+    const uint64_t desired = with_phase(observed, desired_phase);
+    return gate.compare_exchange_weak(observed, desired,
+                                      std::memory_order_acq_rel,
+                                      std::memory_order_acquire);
+  }
+};
+
+static_assert((OperationGateWord::kPhaseMask &
+               OperationGateWord::kReaderMask) == 0);
+static_assert((OperationGateWord::kPhaseMask &
+               OperationGateWord::kInserterMask) == 0);
+static_assert((OperationGateWord::kReaderMask &
+               OperationGateWord::kInserterMask) == 0);
+static_assert((OperationGateWord::kPhaseMask | OperationGateWord::kReaderMask |
+               OperationGateWord::kInserterMask) == ~uint64_t{0});
+
+}  // namespace detail
+
 /**
  * @brief VersionManager — concurrency control via atomic state machine.
  *
@@ -163,72 +239,8 @@ class VersionManager : public IVersionManager {
   void revert_compact_timestamp(uint32_t ts) override;
 
  private:
-  enum class AdmissionState : uint8_t { kOpen, kInsertsBlocked, kAllBlocked };
-
-  // Layout: [63:62] phase | [61:31] active readers | [30:0] active inserters.
-  struct OperationGateWord {
-    static constexpr uint32_t kMaxCount = 0x7fffffffu;
-    static constexpr uint64_t kInserterMask = kMaxCount;
-    static constexpr uint64_t kReaderMask = uint64_t{kMaxCount} << 31;
-    static constexpr uint64_t kPhaseMask = uint64_t{3} << 62;
-    static constexpr uint64_t kInserterUnit = 1;
-    static constexpr uint64_t kReaderUnit = uint64_t{1} << 31;
-
-    [[nodiscard]] static constexpr uint64_t empty(
-        AdmissionState phase) noexcept {
-      return static_cast<uint64_t>(phase) << 62;
-    }
-
-    [[nodiscard]] static constexpr AdmissionState phase(
-        uint64_t word) noexcept {
-      return static_cast<AdmissionState>(word >> 62);
-    }
-
-    [[nodiscard]] static constexpr uint32_t readers(uint64_t word) noexcept {
-      return static_cast<uint32_t>((word >> 31) & kMaxCount);
-    }
-
-    [[nodiscard]] static constexpr uint32_t inserters(uint64_t word) noexcept {
-      return static_cast<uint32_t>(word & kInserterMask);
-    }
-
-    [[nodiscard]] static constexpr uint64_t with_phase(
-        uint64_t word, AdmissionState desired_phase) noexcept {
-      return (word & ~kPhaseMask) |
-             (static_cast<uint64_t>(desired_phase) << 62);
-    }
-
-    // Callers validate the corresponding counter before changing it.
-    [[nodiscard]] static constexpr uint64_t increment_reader(
-        uint64_t word) noexcept {
-      return word + kReaderUnit;
-    }
-
-    [[nodiscard]] static constexpr uint64_t decrement_reader(
-        uint64_t word) noexcept {
-      return word - kReaderUnit;
-    }
-
-    [[nodiscard]] static constexpr uint64_t increment_inserter(
-        uint64_t word) noexcept {
-      return word + kInserterUnit;
-    }
-
-    [[nodiscard]] static constexpr uint64_t decrement_inserter(
-        uint64_t word) noexcept {
-      return word - kInserterUnit;
-    }
-  };
-
-  static_assert((OperationGateWord::kPhaseMask &
-                 OperationGateWord::kReaderMask) == 0);
-  static_assert((OperationGateWord::kPhaseMask &
-                 OperationGateWord::kInserterMask) == 0);
-  static_assert((OperationGateWord::kReaderMask &
-                 OperationGateWord::kInserterMask) == 0);
-  static_assert((OperationGateWord::kPhaseMask |
-                 OperationGateWord::kReaderMask |
-                 OperationGateWord::kInserterMask) == ~uint64_t{0});
+  using AdmissionState = detail::AdmissionState;
+  using OperationGateWord = detail::OperationGateWord;
 
   int thread_num_;
   // These helpers may suspend the logical task. Callers must not hold an
@@ -236,9 +248,9 @@ class VersionManager : public IVersionManager {
   void enter_admission_phase(AdmissionState desired_phase);
   void transition_admission_phase(AdmissionState expected_phase,
                                   AdmissionState desired_phase);
-  void reopen_admission_after_update();
   void wait_for_gate_state_change(uint64_t observed) const;
-  void wait_until_operations_drained(bool readers, bool inserters);
+  void wait_for_readers_to_drain();
+  void wait_for_inserters_to_drain();
   void complete_write_timestamp(uint32_t ts);
   void advance_read_ts_locked();
   RuntimeWaitFn runtime_wait_impl() const noexcept override;

--- a/include/neug/transaction/version_manager.h
+++ b/include/neug/transaction/version_manager.h
@@ -54,9 +54,8 @@ inline PublishedReadView UnpackPublishedReadView(uint64_t packed) {
  * a timestamp and to coordinate exclusive/shared access with other
  * transaction types.
  *
- * The current implementation is VersionManager, which uses an atomic
- * admission state machine plus atomic counters for concurrency
- * control, replacing the earlier rw_mutex_-based design.
+ * The current implementation is VersionManager, which uses one packed atomic
+ * for the admission phase and active-operation counters.
  *
  * @see VersionManager for the concrete implementation and its
  *      concurrency matrix.
@@ -102,9 +101,14 @@ class IVersionManager {
 /**
  * @brief VersionManager — concurrency control via atomic state machine.
  *
- * admission_state_ transitions:
+ * The packed operation gate transitions:
  * - Update: open → inserts-blocked → all-blocked → open.
  * - Compact: open → all-blocked → open.
+ *
+ * Layout: phase: 2 bits | active readers: 31 bits | active inserters: 31 bits.
+ * Admissions and phase changes use CAS on this one word, so an operation is
+ * unambiguously counted before a blocking transition or rejected after it.
+ * Admission counters are checked before increment and cannot exceed 2^31 - 1.
  *
  * Concurrency (new acquisitions; in-flight ops are not interrupted):
  *
@@ -122,15 +126,14 @@ class IVersionManager {
  *   Storage compaction may reset per-record visibility timestamps to zero, but
  *   transaction/WAL timestamps must never be reset within a WAL timeline.
  * - read_ts_: highest timestamp fully committed and visible to all readers.
- * - active_readers_/active_inserters_: atomic counters for in-flight ops.
- * - admission_state_: controls whether new readers and inserters may enter.
+ * - operation_gate_state_: atomically combines admission phase and counters.
  *   Update execution blocks inserters; update commit and compaction block
  *   both readers and inserters.
- * - acquire_read_view uses a double-check pattern (pre-check + increment +
- *   post-check) to prevent ABA races with begin_update_commit.
- * - begin_update_commit blocks new readers before snapshot publication.
- *   Readers already between the pre-check and post-check either roll back
- *   after observing the blocked state or complete as an existing reader.
+ * - acquire_read_view admits the reader and increments its counter with one
+ *   CAS, then captures the atomically published timestamp/generation pair.
+ * - begin_update_commit blocks new readers through the same control word.
+ *   A reader is therefore either counted before the transition or rejected
+ *   after it and retried.
  * - SpinLock lock_: serializes read_ts advancement (check-and-advance
  *   in complete_write_timestamp).
  * - TimestampWindow ts_window_: tracks completed timestamps for read_ts
@@ -160,17 +163,29 @@ class VersionManager : public IVersionManager {
   void revert_compact_timestamp(uint32_t ts) override;
 
  private:
-  friend struct VersionManagerTestPeer;
-
   enum class AdmissionState { kOpen, kInsertsBlocked, kAllBlocked };
+  enum class AdmissionAttempt { kAdmitted, kBlocked, kRetry };
+
+  struct OperationGateState {
+    AdmissionState phase;
+    uint32_t readers;
+    uint32_t inserters;
+  };
+
+  static constexpr uint32_t kMaxAdmissionCount = 0x7fffffffu;
+  static uint64_t PackOperationGateState(OperationGateState state);
+  static OperationGateState UnpackOperationGateState(uint64_t packed);
 
   int thread_num_;
-  PublishedReadView acquire_read_view_slow();
-  uint32_t acquire_insert_timestamp_slow();
   // These helpers may suspend the logical task. Callers must not hold an
   // OS-thread-owned lock or retain an ordinary TLS pointer across the call.
   void enter_exclusive_state(AdmissionState desired_state);
-  void wait_until_zero(const std::atomic<int>& counter);
+  void set_admission_state(AdmissionState expected, AdmissionState desired);
+  void restore_open_after_update();
+  void wait_for_gate_change(uint64_t observed) const;
+  void wait_until_drained(bool readers, bool inserters);
+  AdmissionAttempt try_admit_reader(uint64_t& observed);
+  AdmissionAttempt try_admit_inserter(uint64_t& observed);
   void complete_write_timestamp(uint32_t ts);
   void advance_read_ts_locked();
   RuntimeWaitFn runtime_wait_impl() const noexcept override;
@@ -180,10 +195,7 @@ class VersionManager : public IVersionManager {
   std::atomic<uint32_t> installed_snapshot_generation_{0};
   std::atomic<uint64_t> published_read_view_{PackPublishedReadView({1, 0})};
 
-  std::atomic<int> active_readers_{0};
-  std::atomic<int> active_inserters_{0};
-
-  std::atomic<AdmissionState> admission_state_{AdmissionState::kOpen};
+  std::atomic<uint64_t> operation_gate_state_{0};
 
   TimestampWindow ts_window_;
 

--- a/include/neug/transaction/version_manager.h
+++ b/include/neug/transaction/version_manager.h
@@ -102,14 +102,18 @@ namespace detail {
 
 enum class AdmissionState : uint8_t { kOpen, kInsertsBlocked, kAllBlocked };
 
-// Layout: [63:62] phase | [61:31] active readers | [30:0] active inserters.
+// [63:62] phase | [61:31] inserters | [30] reader guard | [29:0] readers.
 struct OperationGateWord {
-  static constexpr uint32_t kMaxCount = 0x7fffffffu;
-  static constexpr uint64_t kInserterMask = kMaxCount;
-  static constexpr uint64_t kReaderMask = uint64_t{kMaxCount} << 31;
+  static constexpr uint32_t kMaxReaderCount = 0x3fffffffu;
+  static constexpr uint32_t kMaxInserterCount = 0x7fffffffu;
+  static constexpr uint64_t kReaderMask = kMaxReaderCount;
+  static constexpr uint64_t kReaderOverflowMask = uint64_t{1} << 30;
+  static constexpr uint64_t kReaderFieldMask =
+      kReaderMask | kReaderOverflowMask;
+  static constexpr uint64_t kInserterMask = uint64_t{kMaxInserterCount} << 31;
   static constexpr uint64_t kPhaseMask = uint64_t{3} << 62;
-  static constexpr uint64_t kInserterUnit = 1;
-  static constexpr uint64_t kReaderUnit = uint64_t{1} << 31;
+  static constexpr uint64_t kReaderUnit = 1;
+  static constexpr uint64_t kInserterUnit = uint64_t{1} << 31;
 
   [[nodiscard]] static constexpr uint64_t empty(AdmissionState phase) noexcept {
     return static_cast<uint64_t>(phase) << 62;
@@ -120,11 +124,17 @@ struct OperationGateWord {
   }
 
   [[nodiscard]] static constexpr uint32_t readers(uint64_t word) noexcept {
-    return static_cast<uint32_t>((word >> 31) & kMaxCount);
+    return static_cast<uint32_t>(word & kReaderMask);
+  }
+
+  // Includes the overflow guard so drain checks cannot mistake a pending
+  // overflow rollback for zero active readers.
+  [[nodiscard]] static constexpr uint32_t reader_field(uint64_t word) noexcept {
+    return static_cast<uint32_t>(word & kReaderFieldMask);
   }
 
   [[nodiscard]] static constexpr uint32_t inserters(uint64_t word) noexcept {
-    return static_cast<uint32_t>(word & kInserterMask);
+    return static_cast<uint32_t>((word >> 31) & kMaxInserterCount);
   }
 
   [[nodiscard]] static constexpr uint64_t with_phase(
@@ -132,25 +142,10 @@ struct OperationGateWord {
     return (word & ~kPhaseMask) | (static_cast<uint64_t>(desired_phase) << 62);
   }
 
-  // Callers validate the corresponding counter before changing it.
-  [[nodiscard]] static constexpr uint64_t increment_reader(
-      uint64_t word) noexcept {
-    return word + kReaderUnit;
-  }
-
-  [[nodiscard]] static constexpr uint64_t decrement_reader(
-      uint64_t word) noexcept {
-    return word - kReaderUnit;
-  }
-
+  // Callers validate the inserter counter before changing it.
   [[nodiscard]] static constexpr uint64_t increment_inserter(
       uint64_t word) noexcept {
     return word + kInserterUnit;
-  }
-
-  [[nodiscard]] static constexpr uint64_t decrement_inserter(
-      uint64_t word) noexcept {
-    return word - kInserterUnit;
   }
 
   [[nodiscard]] static bool try_change_phase(
@@ -159,17 +154,22 @@ struct OperationGateWord {
     const uint64_t desired = with_phase(observed, desired_phase);
     return gate.compare_exchange_weak(observed, desired,
                                       std::memory_order_acq_rel,
-                                      std::memory_order_acquire);
+                                      std::memory_order_relaxed);
   }
 };
 
 static_assert((OperationGateWord::kPhaseMask &
                OperationGateWord::kReaderMask) == 0);
 static_assert((OperationGateWord::kPhaseMask &
+               OperationGateWord::kReaderOverflowMask) == 0);
+static_assert((OperationGateWord::kPhaseMask &
                OperationGateWord::kInserterMask) == 0);
 static_assert((OperationGateWord::kReaderMask &
+               OperationGateWord::kReaderOverflowMask) == 0);
+static_assert((OperationGateWord::kReaderFieldMask &
                OperationGateWord::kInserterMask) == 0);
-static_assert((OperationGateWord::kPhaseMask | OperationGateWord::kReaderMask |
+static_assert((OperationGateWord::kPhaseMask |
+               OperationGateWord::kReaderFieldMask |
                OperationGateWord::kInserterMask) == ~uint64_t{0});
 
 }  // namespace detail
@@ -181,10 +181,11 @@ static_assert((OperationGateWord::kPhaseMask | OperationGateWord::kReaderMask |
  * - Update: open → inserts-blocked → all-blocked → open.
  * - Compact: open → all-blocked → open.
  *
- * Layout: phase: 2 bits | active readers: 31 bits | active inserters: 31 bits.
- * Admissions and phase changes use CAS on this one word, so an operation is
+ * Layout: phase: 2 bits | active inserters: 31 bits | reader guard: 1 bit |
+ * active readers: 30 bits. Reader admission uses fetch_add; inserter admission
+ * and phase changes use CAS on the same word. An operation is therefore
  * unambiguously counted before a blocking transition or rejected after it.
- * Admission counters are checked before increment and cannot exceed 2^31 - 1.
+ * Reader and inserter counts cannot exceed 2^30 - 1 and 2^31 - 1 respectively.
  *
  * Concurrency (new acquisitions; in-flight ops are not interrupted):
  *
@@ -205,8 +206,9 @@ static_assert((OperationGateWord::kPhaseMask | OperationGateWord::kReaderMask |
  * - operation_gate_state_: atomically combines admission phase and counters.
  *   Update execution blocks inserters; update commit and compaction block
  *   both readers and inserters.
- * - acquire_read_view admits the reader and increments its counter with one
- *   CAS, then captures the atomically published timestamp/generation pair.
+ * - acquire_read_view increments the reader count with fetch_add, validates the
+ *   phase and overflow state from the returned old word, then captures the
+ *   atomically published timestamp/generation pair.
  * - begin_update_commit blocks new readers through the same control word.
  *   A reader is therefore either counted before the transition or rejected
  *   after it and retried.
@@ -248,7 +250,6 @@ class VersionManager : public IVersionManager {
   void enter_admission_phase(AdmissionState desired_phase);
   void transition_admission_phase(AdmissionState expected_phase,
                                   AdmissionState desired_phase);
-  void wait_for_gate_state_change(uint64_t observed) const;
   void wait_for_readers_to_drain();
   void wait_for_inserters_to_drain();
   void complete_write_timestamp(uint32_t ts);

--- a/include/neug/transaction/version_manager.h
+++ b/include/neug/transaction/version_manager.h
@@ -163,29 +163,82 @@ class VersionManager : public IVersionManager {
   void revert_compact_timestamp(uint32_t ts) override;
 
  private:
-  enum class AdmissionState { kOpen, kInsertsBlocked, kAllBlocked };
-  enum class AdmissionAttempt { kAdmitted, kBlocked, kRetry };
+  enum class AdmissionState : uint8_t { kOpen, kInsertsBlocked, kAllBlocked };
 
-  struct OperationGateState {
-    AdmissionState phase;
-    uint32_t readers;
-    uint32_t inserters;
+  // Layout: [63:62] phase | [61:31] active readers | [30:0] active inserters.
+  struct OperationGateWord {
+    static constexpr uint32_t kMaxCount = 0x7fffffffu;
+    static constexpr uint64_t kInserterMask = kMaxCount;
+    static constexpr uint64_t kReaderMask = uint64_t{kMaxCount} << 31;
+    static constexpr uint64_t kPhaseMask = uint64_t{3} << 62;
+    static constexpr uint64_t kInserterUnit = 1;
+    static constexpr uint64_t kReaderUnit = uint64_t{1} << 31;
+
+    [[nodiscard]] static constexpr uint64_t empty(
+        AdmissionState phase) noexcept {
+      return static_cast<uint64_t>(phase) << 62;
+    }
+
+    [[nodiscard]] static constexpr AdmissionState phase(
+        uint64_t word) noexcept {
+      return static_cast<AdmissionState>(word >> 62);
+    }
+
+    [[nodiscard]] static constexpr uint32_t readers(uint64_t word) noexcept {
+      return static_cast<uint32_t>((word >> 31) & kMaxCount);
+    }
+
+    [[nodiscard]] static constexpr uint32_t inserters(uint64_t word) noexcept {
+      return static_cast<uint32_t>(word & kInserterMask);
+    }
+
+    [[nodiscard]] static constexpr uint64_t with_phase(
+        uint64_t word, AdmissionState desired_phase) noexcept {
+      return (word & ~kPhaseMask) |
+             (static_cast<uint64_t>(desired_phase) << 62);
+    }
+
+    // Callers validate the corresponding counter before changing it.
+    [[nodiscard]] static constexpr uint64_t increment_reader(
+        uint64_t word) noexcept {
+      return word + kReaderUnit;
+    }
+
+    [[nodiscard]] static constexpr uint64_t decrement_reader(
+        uint64_t word) noexcept {
+      return word - kReaderUnit;
+    }
+
+    [[nodiscard]] static constexpr uint64_t increment_inserter(
+        uint64_t word) noexcept {
+      return word + kInserterUnit;
+    }
+
+    [[nodiscard]] static constexpr uint64_t decrement_inserter(
+        uint64_t word) noexcept {
+      return word - kInserterUnit;
+    }
   };
 
-  static constexpr uint32_t kMaxAdmissionCount = 0x7fffffffu;
-  static uint64_t PackOperationGateState(OperationGateState state);
-  static OperationGateState UnpackOperationGateState(uint64_t packed);
+  static_assert((OperationGateWord::kPhaseMask &
+                 OperationGateWord::kReaderMask) == 0);
+  static_assert((OperationGateWord::kPhaseMask &
+                 OperationGateWord::kInserterMask) == 0);
+  static_assert((OperationGateWord::kReaderMask &
+                 OperationGateWord::kInserterMask) == 0);
+  static_assert((OperationGateWord::kPhaseMask |
+                 OperationGateWord::kReaderMask |
+                 OperationGateWord::kInserterMask) == ~uint64_t{0});
 
   int thread_num_;
   // These helpers may suspend the logical task. Callers must not hold an
   // OS-thread-owned lock or retain an ordinary TLS pointer across the call.
-  void enter_exclusive_state(AdmissionState desired_state);
-  void set_admission_state(AdmissionState expected, AdmissionState desired);
-  void restore_open_after_update();
-  void wait_for_gate_change(uint64_t observed) const;
-  void wait_until_drained(bool readers, bool inserters);
-  AdmissionAttempt try_admit_reader(uint64_t& observed);
-  AdmissionAttempt try_admit_inserter(uint64_t& observed);
+  void enter_admission_phase(AdmissionState desired_phase);
+  void transition_admission_phase(AdmissionState expected_phase,
+                                  AdmissionState desired_phase);
+  void reopen_admission_after_update();
+  void wait_for_gate_state_change(uint64_t observed) const;
+  void wait_until_operations_drained(bool readers, bool inserters);
   void complete_write_timestamp(uint32_t ts);
   void advance_read_ts_locked();
   RuntimeWaitFn runtime_wait_impl() const noexcept override;

--- a/include/neug/transaction/version_manager.h
+++ b/include/neug/transaction/version_manager.h
@@ -102,14 +102,11 @@ namespace detail {
 
 enum class AdmissionState : uint8_t { kOpen, kInsertsBlocked, kAllBlocked };
 
-// [63:62] phase | [61:31] inserters | [30] reader guard | [29:0] readers.
+// [63:62] phase | [61:31] inserters | [30:0] readers.
 struct OperationGateWord {
-  static constexpr uint32_t kMaxReaderCount = 0x3fffffffu;
+  static constexpr uint32_t kMaxReaderCount = 0x7fffffffu;
   static constexpr uint32_t kMaxInserterCount = 0x7fffffffu;
   static constexpr uint64_t kReaderMask = kMaxReaderCount;
-  static constexpr uint64_t kReaderOverflowMask = uint64_t{1} << 30;
-  static constexpr uint64_t kReaderFieldMask =
-      kReaderMask | kReaderOverflowMask;
   static constexpr uint64_t kInserterMask = uint64_t{kMaxInserterCount} << 31;
   static constexpr uint64_t kPhaseMask = uint64_t{3} << 62;
   static constexpr uint64_t kReaderUnit = 1;
@@ -125,12 +122,6 @@ struct OperationGateWord {
 
   [[nodiscard]] static constexpr uint32_t readers(uint64_t word) noexcept {
     return static_cast<uint32_t>(word & kReaderMask);
-  }
-
-  // Includes the overflow guard so drain checks cannot mistake a pending
-  // overflow rollback for zero active readers.
-  [[nodiscard]] static constexpr uint32_t reader_field(uint64_t word) noexcept {
-    return static_cast<uint32_t>(word & kReaderFieldMask);
   }
 
   [[nodiscard]] static constexpr uint32_t inserters(uint64_t word) noexcept {
@@ -161,15 +152,10 @@ struct OperationGateWord {
 static_assert((OperationGateWord::kPhaseMask &
                OperationGateWord::kReaderMask) == 0);
 static_assert((OperationGateWord::kPhaseMask &
-               OperationGateWord::kReaderOverflowMask) == 0);
-static_assert((OperationGateWord::kPhaseMask &
                OperationGateWord::kInserterMask) == 0);
 static_assert((OperationGateWord::kReaderMask &
-               OperationGateWord::kReaderOverflowMask) == 0);
-static_assert((OperationGateWord::kReaderFieldMask &
                OperationGateWord::kInserterMask) == 0);
-static_assert((OperationGateWord::kPhaseMask |
-               OperationGateWord::kReaderFieldMask |
+static_assert((OperationGateWord::kPhaseMask | OperationGateWord::kReaderMask |
                OperationGateWord::kInserterMask) == ~uint64_t{0});
 
 }  // namespace detail
@@ -181,11 +167,11 @@ static_assert((OperationGateWord::kPhaseMask |
  * - Update: open → inserts-blocked → all-blocked → open.
  * - Compact: open → all-blocked → open.
  *
- * Layout: phase: 2 bits | active inserters: 31 bits | reader guard: 1 bit |
- * active readers: 30 bits. Reader admission uses fetch_add; inserter admission
- * and phase changes use CAS on the same word. An operation is therefore
- * unambiguously counted before a blocking transition or rejected after it.
- * Reader and inserter counts cannot exceed 2^30 - 1 and 2^31 - 1 respectively.
+ * Layout: phase: 2 bits | active inserters: 31 bits | active readers: 31 bits.
+ * Reader admission uses fetch_add; inserter admission and phase changes use
+ * CAS on the same word. An operation is therefore unambiguously counted before
+ * a blocking transition or rejected after it. Reader and inserter counts
+ * cannot exceed 2^31 - 1.
  *
  * Concurrency (new acquisitions; in-flight ops are not interrupted):
  *

--- a/src/transaction/version_manager.cc
+++ b/src/transaction/version_manager.cc
@@ -20,6 +20,7 @@
 #include <mutex>
 
 #include "neug/utils/exception/exception.h"
+#include "neug/utils/likely.h"
 
 namespace neug {
 
@@ -27,63 +28,11 @@ namespace neug {
 
 VersionManager::VersionManager() : runtime_wait_(&NativeRuntimeWait) {}
 
-uint64_t VersionManager::PackOperationGateState(OperationGateState state) {
-  CHECK_LE(state.readers, kMaxAdmissionCount);
-  CHECK_LE(state.inserters, kMaxAdmissionCount);
-  return (static_cast<uint64_t>(state.phase) << 62) |
-         (static_cast<uint64_t>(state.readers) << 31) | state.inserters;
-}
-
-VersionManager::OperationGateState VersionManager::UnpackOperationGateState(
-    uint64_t packed) {
-  return {static_cast<AdmissionState>(packed >> 62),
-          static_cast<uint32_t>((packed >> 31) & kMaxAdmissionCount),
-          static_cast<uint32_t>(packed & kMaxAdmissionCount)};
-}
-
-void VersionManager::wait_for_gate_change(uint64_t observed) const {
+void VersionManager::wait_for_gate_state_change(uint64_t observed) const {
   RuntimeBackoff wait = make_runtime_backoff();
   while (operation_gate_state_.load(std::memory_order_acquire) == observed) {
     wait();
   }
-}
-
-VersionManager::AdmissionAttempt VersionManager::try_admit_reader(
-    uint64_t& observed) {
-  const OperationGateState state = UnpackOperationGateState(observed);
-  if (state.phase == AdmissionState::kAllBlocked) {
-    return AdmissionAttempt::kBlocked;
-  }
-  if (state.readers == kMaxAdmissionCount) {
-    THROW_RUNTIME_ERROR("Reader admission counter exhausted");
-  }
-  OperationGateState desired = state;
-  ++desired.readers;
-  if (operation_gate_state_.compare_exchange_weak(
-          observed, PackOperationGateState(desired), std::memory_order_acq_rel,
-          std::memory_order_acquire)) {
-    return AdmissionAttempt::kAdmitted;
-  }
-  return AdmissionAttempt::kRetry;
-}
-
-VersionManager::AdmissionAttempt VersionManager::try_admit_inserter(
-    uint64_t& observed) {
-  const OperationGateState state = UnpackOperationGateState(observed);
-  if (state.phase != AdmissionState::kOpen) {
-    return AdmissionAttempt::kBlocked;
-  }
-  if (state.inserters == kMaxAdmissionCount) {
-    THROW_RUNTIME_ERROR("Inserter admission counter exhausted");
-  }
-  OperationGateState desired = state;
-  ++desired.inserters;
-  if (operation_gate_state_.compare_exchange_weak(
-          observed, PackOperationGateState(desired), std::memory_order_acq_rel,
-          std::memory_order_acquire)) {
-    return AdmissionAttempt::kAdmitted;
-  }
-  return AdmissionAttempt::kRetry;
 }
 
 void VersionManager::init_ts(PublishedReadView initial_read_view,
@@ -100,9 +49,8 @@ void VersionManager::init_ts(PublishedReadView initial_read_view,
                                        std::memory_order_relaxed);
   published_read_view_.store(PackPublishedReadView(initial_read_view),
                              std::memory_order_relaxed);
-  operation_gate_state_.store(
-      PackOperationGateState({AdmissionState::kOpen, 0, 0}),
-      std::memory_order_relaxed);
+  operation_gate_state_.store(OperationGateWord::empty(AdmissionState::kOpen),
+                              std::memory_order_relaxed);
 
   ts_window_.init();
   thread_num_ = thread_num;
@@ -118,9 +66,9 @@ bool VersionManager::try_set_runtime_wait_if_quiescent(
     return false;
   }
 
-  uint64_t expected = PackOperationGateState({AdmissionState::kOpen, 0, 0});
+  uint64_t expected = OperationGateWord::empty(AdmissionState::kOpen);
   const uint64_t blocked =
-      PackOperationGateState({AdmissionState::kAllBlocked, 0, 0});
+      OperationGateWord::empty(AdmissionState::kAllBlocked);
   if (!operation_gate_state_.compare_exchange_strong(
           expected, blocked, std::memory_order_acq_rel,
           std::memory_order_acquire)) {
@@ -128,25 +76,31 @@ bool VersionManager::try_set_runtime_wait_if_quiescent(
   }
 
   runtime_wait_.store(runtime_wait, std::memory_order_release);
-  operation_gate_state_.store(
-      PackOperationGateState({AdmissionState::kOpen, 0, 0}),
-      std::memory_order_release);
+  operation_gate_state_.store(OperationGateWord::empty(AdmissionState::kOpen),
+                              std::memory_order_release);
   return true;
 }
 
 PublishedReadView VersionManager::acquire_read_view() {
   uint64_t observed = operation_gate_state_.load(std::memory_order_acquire);
   while (true) {
-    switch (try_admit_reader(observed)) {
-    case AdmissionAttempt::kAdmitted:
+    if (NEUG_UNLIKELY(OperationGateWord::phase(observed) ==
+                      AdmissionState::kAllBlocked)) {
+      wait_for_gate_state_change(observed);
+      observed = operation_gate_state_.load(std::memory_order_acquire);
+      continue;
+    }
+    if (NEUG_UNLIKELY(OperationGateWord::readers(observed) ==
+                      OperationGateWord::kMaxCount)) {
+      THROW_RUNTIME_ERROR("Reader admission counter exhausted");
+    }
+
+    const uint64_t desired = OperationGateWord::increment_reader(observed);
+    if (operation_gate_state_.compare_exchange_weak(
+            observed, desired, std::memory_order_acq_rel,
+            std::memory_order_acquire)) {
       return UnpackPublishedReadView(
           published_read_view_.load(std::memory_order_acquire));
-    case AdmissionAttempt::kBlocked:
-      wait_for_gate_change(observed);
-      observed = operation_gate_state_.load(std::memory_order_acquire);
-      break;
-    case AdmissionAttempt::kRetry:
-      break;
     }
   }
 }
@@ -154,15 +108,13 @@ PublishedReadView VersionManager::acquire_read_view() {
 void VersionManager::release_read_view() {
   uint64_t observed = operation_gate_state_.load(std::memory_order_acquire);
   while (true) {
-    const OperationGateState state = UnpackOperationGateState(observed);
-    if (state.readers == 0) {
+    if (NEUG_UNLIKELY(OperationGateWord::readers(observed) == 0)) {
       THROW_INTERNAL_EXCEPTION("release_read_view without admission");
     }
-    OperationGateState desired = state;
-    --desired.readers;
+    const uint64_t desired = OperationGateWord::decrement_reader(observed);
     if (operation_gate_state_.compare_exchange_weak(
-            observed, PackOperationGateState(desired),
-            std::memory_order_acq_rel, std::memory_order_acquire)) {
+            observed, desired, std::memory_order_acq_rel,
+            std::memory_order_acquire)) {
       return;
     }
   }
@@ -171,15 +123,22 @@ void VersionManager::release_read_view() {
 uint32_t VersionManager::acquire_insert_timestamp() {
   uint64_t observed = operation_gate_state_.load(std::memory_order_acquire);
   while (true) {
-    switch (try_admit_inserter(observed)) {
-    case AdmissionAttempt::kAdmitted:
-      return write_ts_.fetch_add(1, std::memory_order_acq_rel);
-    case AdmissionAttempt::kBlocked:
-      wait_for_gate_change(observed);
+    if (NEUG_UNLIKELY(OperationGateWord::phase(observed) !=
+                      AdmissionState::kOpen)) {
+      wait_for_gate_state_change(observed);
       observed = operation_gate_state_.load(std::memory_order_acquire);
-      break;
-    case AdmissionAttempt::kRetry:
-      break;
+      continue;
+    }
+    if (NEUG_UNLIKELY(OperationGateWord::inserters(observed) ==
+                      OperationGateWord::kMaxCount)) {
+      THROW_RUNTIME_ERROR("Inserter admission counter exhausted");
+    }
+
+    const uint64_t desired = OperationGateWord::increment_inserter(observed);
+    if (operation_gate_state_.compare_exchange_weak(
+            observed, desired, std::memory_order_acq_rel,
+            std::memory_order_acquire)) {
+      return write_ts_.fetch_add(1, std::memory_order_acq_rel);
     }
   }
 }
@@ -189,15 +148,13 @@ void VersionManager::release_insert_timestamp(uint32_t ts) {
 
   uint64_t observed = operation_gate_state_.load(std::memory_order_acquire);
   while (true) {
-    const OperationGateState state = UnpackOperationGateState(observed);
-    if (state.inserters == 0) {
+    if (NEUG_UNLIKELY(OperationGateWord::inserters(observed) == 0)) {
       THROW_INTERNAL_EXCEPTION("release_insert_timestamp without admission");
     }
-    OperationGateState desired = state;
-    --desired.inserters;
+    const uint64_t desired = OperationGateWord::decrement_inserter(observed);
     if (operation_gate_state_.compare_exchange_weak(
-            observed, PackOperationGateState(desired),
-            std::memory_order_acq_rel, std::memory_order_acquire)) {
+            observed, desired, std::memory_order_acq_rel,
+            std::memory_order_acquire)) {
       return;
     }
   }
@@ -247,71 +204,69 @@ void VersionManager::advance_read_ts_locked() {
       std::memory_order_release);
 }
 
-void VersionManager::enter_exclusive_state(AdmissionState desired_state) {
+void VersionManager::enter_admission_phase(AdmissionState desired_phase) {
   uint64_t observed = operation_gate_state_.load(std::memory_order_acquire);
   while (true) {
-    const OperationGateState state = UnpackOperationGateState(observed);
-    if (state.phase != AdmissionState::kOpen) {
-      wait_for_gate_change(observed);
+    if (OperationGateWord::phase(observed) != AdmissionState::kOpen) {
+      wait_for_gate_state_change(observed);
       observed = operation_gate_state_.load(std::memory_order_acquire);
       continue;
     }
-    OperationGateState desired = state;
-    desired.phase = desired_state;
+    const uint64_t desired =
+        OperationGateWord::with_phase(observed, desired_phase);
     if (operation_gate_state_.compare_exchange_weak(
-            observed, PackOperationGateState(desired),
-            std::memory_order_acq_rel, std::memory_order_acquire)) {
+            observed, desired, std::memory_order_acq_rel,
+            std::memory_order_acquire)) {
       return;
     }
   }
 }
 
-void VersionManager::set_admission_state(AdmissionState expected,
-                                         AdmissionState desired_phase) {
+void VersionManager::transition_admission_phase(AdmissionState expected_phase,
+                                                AdmissionState desired_phase) {
   uint64_t observed = operation_gate_state_.load(std::memory_order_acquire);
   while (true) {
-    const OperationGateState state = UnpackOperationGateState(observed);
-    if (state.phase != expected) {
+    if (OperationGateWord::phase(observed) != expected_phase) {
       THROW_INTERNAL_EXCEPTION("Invalid transaction admission transition");
     }
-    OperationGateState desired = state;
-    desired.phase = desired_phase;
+    const uint64_t desired =
+        OperationGateWord::with_phase(observed, desired_phase);
     if (operation_gate_state_.compare_exchange_weak(
-            observed, PackOperationGateState(desired),
-            std::memory_order_acq_rel, std::memory_order_acquire)) {
+            observed, desired, std::memory_order_acq_rel,
+            std::memory_order_acquire)) {
       return;
     }
   }
 }
 
-void VersionManager::restore_open_after_update() {
+void VersionManager::reopen_admission_after_update() {
   uint64_t observed = operation_gate_state_.load(std::memory_order_acquire);
   while (true) {
-    const OperationGateState state = UnpackOperationGateState(observed);
-    if (state.phase != AdmissionState::kInsertsBlocked &&
-        state.phase != AdmissionState::kAllBlocked) {
+    const AdmissionState phase = OperationGateWord::phase(observed);
+    if (phase != AdmissionState::kInsertsBlocked &&
+        phase != AdmissionState::kAllBlocked) {
       THROW_INTERNAL_EXCEPTION("Update released outside update state");
     }
-    OperationGateState desired = state;
-    desired.phase = AdmissionState::kOpen;
+    const uint64_t desired =
+        OperationGateWord::with_phase(observed, AdmissionState::kOpen);
     if (operation_gate_state_.compare_exchange_weak(
-            observed, PackOperationGateState(desired),
-            std::memory_order_acq_rel, std::memory_order_acquire)) {
+            observed, desired, std::memory_order_acq_rel,
+            std::memory_order_acquire)) {
       return;
     }
   }
 }
 
-void VersionManager::wait_until_drained(bool readers, bool inserters) {
+void VersionManager::wait_until_operations_drained(bool readers,
+                                                   bool inserters) {
   while (true) {
     const uint64_t observed =
         operation_gate_state_.load(std::memory_order_acquire);
-    const OperationGateState state = UnpackOperationGateState(observed);
-    if ((!readers || state.readers == 0) &&
-        (!inserters || state.inserters == 0)) {
+    if ((!readers || OperationGateWord::readers(observed) == 0) &&
+        (!inserters || OperationGateWord::inserters(observed) == 0)) {
       return;
     }
-    wait_for_gate_change(observed);
+    wait_for_gate_state_change(observed);
   }
 }
 
@@ -320,8 +275,8 @@ RuntimeWaitFn VersionManager::runtime_wait_impl() const noexcept {
 }
 
 uint32_t VersionManager::acquire_update_timestamp() {
-  enter_exclusive_state(AdmissionState::kInsertsBlocked);
-  wait_until_drained(false, true);
+  enter_admission_phase(AdmissionState::kInsertsBlocked);
+  wait_until_operations_drained(false, true);
 
   return write_ts_.fetch_add(1, std::memory_order_acq_rel);
 }
@@ -332,18 +287,17 @@ void VersionManager::begin_update_commit(uint32_t ts) {
   // Block new readers before publishing the new snapshot. Existing readers
   // keep using their pinned snapshots; a racing reader is either counted
   // before this transition or rejected after it.
-  set_admission_state(AdmissionState::kInsertsBlocked,
-                      AdmissionState::kAllBlocked);
+  transition_admission_phase(AdmissionState::kInsertsBlocked,
+                             AdmissionState::kAllBlocked);
 }
 
 void VersionManager::drain_readers() {
-  if (UnpackOperationGateState(
-          operation_gate_state_.load(std::memory_order_acquire))
-          .phase != AdmissionState::kAllBlocked) {
+  if (OperationGateWord::phase(operation_gate_state_.load(
+          std::memory_order_acquire)) != AdmissionState::kAllBlocked) {
     THROW_INTERNAL_EXCEPTION(
         "drain_readers called while readers are not blocked");
   }
-  wait_until_drained(true, false);
+  wait_until_operations_drained(true, false);
 }
 
 void VersionManager::finish_update_timestamp(
@@ -357,21 +311,20 @@ void VersionManager::finish_update_timestamp(
 
   // Timestamp completion and any matching snapshot generation are visible
   // through published_read_view_ before the packed gate admits new work.
-  restore_open_after_update();
+  reopen_admission_after_update();
 }
 
 uint32_t VersionManager::acquire_compact_timestamp() {
-  enter_exclusive_state(AdmissionState::kAllBlocked);
-  wait_until_drained(true, true);
+  enter_admission_phase(AdmissionState::kAllBlocked);
+  wait_until_operations_drained(true, true);
 
   return write_ts_.fetch_add(1, std::memory_order_acq_rel);
 }
 
 void VersionManager::release_compact_timestamp(uint32_t ts) {
   // Compact must have blocked new readers.
-  if (UnpackOperationGateState(
-          operation_gate_state_.load(std::memory_order_acquire))
-          .phase != AdmissionState::kAllBlocked) {
+  if (OperationGateWord::phase(operation_gate_state_.load(
+          std::memory_order_acquire)) != AdmissionState::kAllBlocked) {
     THROW_INTERNAL_EXCEPTION(
         "release_compact_timestamp called while not in compact state");
   }
@@ -379,14 +332,14 @@ void VersionManager::release_compact_timestamp(uint32_t ts) {
   complete_write_timestamp(ts);
 
   // Restore normal operation.
-  set_admission_state(AdmissionState::kAllBlocked, AdmissionState::kOpen);
+  transition_admission_phase(AdmissionState::kAllBlocked,
+                             AdmissionState::kOpen);
 }
 
 void VersionManager::revert_compact_timestamp(uint32_t ts) {
   // Compact must have blocked new readers.
-  if (UnpackOperationGateState(
-          operation_gate_state_.load(std::memory_order_acquire))
-          .phase != AdmissionState::kAllBlocked) {
+  if (OperationGateWord::phase(operation_gate_state_.load(
+          std::memory_order_acquire)) != AdmissionState::kAllBlocked) {
     THROW_INTERNAL_EXCEPTION(
         "revert_compact_timestamp called while not in compact state");
   }
@@ -395,7 +348,8 @@ void VersionManager::revert_compact_timestamp(uint32_t ts) {
   complete_write_timestamp(ts);
 
   // Restore normal operation.
-  set_admission_state(AdmissionState::kAllBlocked, AdmissionState::kOpen);
+  transition_admission_phase(AdmissionState::kAllBlocked,
+                             AdmissionState::kOpen);
 }
 
 }  // namespace neug

--- a/src/transaction/version_manager.cc
+++ b/src/transaction/version_manager.cc
@@ -28,13 +28,6 @@ namespace neug {
 
 VersionManager::VersionManager() : runtime_wait_(&NativeRuntimeWait) {}
 
-void VersionManager::wait_for_gate_state_change(uint64_t observed) const {
-  RuntimeBackoff wait = make_runtime_backoff();
-  while (operation_gate_state_.load(std::memory_order_acquire) == observed) {
-    wait();
-  }
-}
-
 void VersionManager::init_ts(PublishedReadView initial_read_view,
                              int thread_num) {
   const uint32_t ts = initial_read_view.visibility_ts;
@@ -82,60 +75,84 @@ bool VersionManager::try_set_runtime_wait_if_quiescent(
 }
 
 PublishedReadView VersionManager::acquire_read_view() {
-  uint64_t observed = operation_gate_state_.load(std::memory_order_acquire);
+  std::optional<RuntimeBackoff> wait;
+  uint64_t observed = operation_gate_state_.load(std::memory_order_relaxed);
   while (true) {
     if (NEUG_UNLIKELY(OperationGateWord::phase(observed) ==
                       AdmissionState::kAllBlocked)) {
-      wait_for_gate_state_change(observed);
-      observed = operation_gate_state_.load(std::memory_order_acquire);
+      if (!wait) {
+        wait.emplace(make_runtime_backoff());
+      }
+      (*wait)();
+      observed = operation_gate_state_.load(std::memory_order_relaxed);
       continue;
     }
-    if (NEUG_UNLIKELY(OperationGateWord::readers(observed) ==
-                      OperationGateWord::kMaxCount)) {
-      THROW_RUNTIME_ERROR("Reader admission counter exhausted");
-    }
-    const uint64_t desired = OperationGateWord::increment_reader(observed);
-    if (operation_gate_state_.compare_exchange_weak(
-            observed, desired, std::memory_order_acq_rel,
-            std::memory_order_acquire)) {
+
+    // The returned word linearizes admission with phase changes. The relaxed
+    // check above avoids unnecessary RMWs while readers are already blocked;
+    // this old-word check closes the race with a concurrent phase transition.
+    const uint64_t previous = operation_gate_state_.fetch_add(
+        OperationGateWord::kReaderUnit, std::memory_order_acquire);
+    const bool counter_exhausted = OperationGateWord::reader_field(previous) >=
+                                   OperationGateWord::kMaxReaderCount;
+    if (NEUG_LIKELY(OperationGateWord::phase(previous) !=
+                        AdmissionState::kAllBlocked &&
+                    !counter_exhausted)) {
       return UnpackPublishedReadView(
           published_read_view_.load(std::memory_order_acquire));
     }
+
+    // The guard bit keeps this rollback inside the reader field even when the
+    // count was already at its maximum.
+    operation_gate_state_.fetch_sub(OperationGateWord::kReaderUnit,
+                                    std::memory_order_release);
+    if (NEUG_UNLIKELY(counter_exhausted)) {
+      THROW_RUNTIME_ERROR("Reader admission counter exhausted");
+    }
+    if (!wait) {
+      wait.emplace(make_runtime_backoff());
+    }
+    (*wait)();
+    observed = operation_gate_state_.load(std::memory_order_relaxed);
   }
 }
 
 void VersionManager::release_read_view() {
-  uint64_t observed = operation_gate_state_.load(std::memory_order_acquire);
-  while (true) {
-    if (NEUG_UNLIKELY(OperationGateWord::readers(observed) == 0)) {
-      THROW_INTERNAL_EXCEPTION("release_read_view without admission");
-    }
-    const uint64_t desired = OperationGateWord::decrement_reader(observed);
-    if (operation_gate_state_.compare_exchange_weak(
-            observed, desired, std::memory_order_acq_rel,
-            std::memory_order_acquire)) {
-      return;
-    }
+  const uint64_t observed =
+      operation_gate_state_.load(std::memory_order_relaxed);
+  if (NEUG_UNLIKELY(OperationGateWord::reader_field(observed) == 0)) {
+    THROW_INTERNAL_EXCEPTION("release_read_view without admission");
   }
+  // A valid caller owns one count. The overflow guard keeps both releases and
+  // overflow rollbacks inside the reader field.
+  const uint64_t previous = operation_gate_state_.fetch_sub(
+      OperationGateWord::kReaderUnit, std::memory_order_release);
+  DCHECK_GT(OperationGateWord::reader_field(previous), 0U);
 }
 
 uint32_t VersionManager::acquire_insert_timestamp() {
-  uint64_t observed = operation_gate_state_.load(std::memory_order_acquire);
+  std::optional<RuntimeBackoff> wait;
+  uint64_t observed = operation_gate_state_.load(std::memory_order_relaxed);
   while (true) {
     if (NEUG_UNLIKELY(OperationGateWord::phase(observed) !=
                       AdmissionState::kOpen)) {
-      wait_for_gate_state_change(observed);
-      observed = operation_gate_state_.load(std::memory_order_acquire);
+      if (!wait) {
+        wait.emplace(make_runtime_backoff());
+      }
+      (*wait)();
+      observed = operation_gate_state_.load(std::memory_order_relaxed);
       continue;
     }
     if (NEUG_UNLIKELY(OperationGateWord::inserters(observed) ==
-                      OperationGateWord::kMaxCount)) {
+                      OperationGateWord::kMaxInserterCount)) {
       THROW_RUNTIME_ERROR("Inserter admission counter exhausted");
     }
     const uint64_t desired = OperationGateWord::increment_inserter(observed);
+    // Atomic modification order linearizes admission with phase changes.
+    // Acquire is only needed after this RMW succeeds.
     if (operation_gate_state_.compare_exchange_weak(
-            observed, desired, std::memory_order_acq_rel,
-            std::memory_order_acquire)) {
+            observed, desired, std::memory_order_acquire,
+            std::memory_order_relaxed)) {
       return write_ts_.fetch_add(1, std::memory_order_acq_rel);
     }
   }
@@ -144,18 +161,16 @@ uint32_t VersionManager::acquire_insert_timestamp() {
 void VersionManager::release_insert_timestamp(uint32_t ts) {
   complete_write_timestamp(ts);
 
-  uint64_t observed = operation_gate_state_.load(std::memory_order_acquire);
-  while (true) {
-    if (NEUG_UNLIKELY(OperationGateWord::inserters(observed) == 0)) {
-      THROW_INTERNAL_EXCEPTION("release_insert_timestamp without admission");
-    }
-    const uint64_t desired = OperationGateWord::decrement_inserter(observed);
-    if (operation_gate_state_.compare_exchange_weak(
-            observed, desired, std::memory_order_acq_rel,
-            std::memory_order_acquire)) {
-      return;
-    }
+  const uint64_t observed =
+      operation_gate_state_.load(std::memory_order_relaxed);
+  if (NEUG_UNLIKELY(OperationGateWord::inserters(observed) == 0)) {
+    THROW_INTERNAL_EXCEPTION("release_insert_timestamp without admission");
   }
+  // A valid caller owns one count, so valid concurrent releases cannot borrow
+  // from an adjacent field.
+  const uint64_t previous = operation_gate_state_.fetch_sub(
+      OperationGateWord::kInserterUnit, std::memory_order_release);
+  DCHECK_GT(OperationGateWord::inserters(previous), 0U);
 }
 
 void VersionManager::complete_write_timestamp(uint32_t ts) {
@@ -203,11 +218,15 @@ void VersionManager::advance_read_ts_locked() {
 }
 
 void VersionManager::enter_admission_phase(AdmissionState desired_phase) {
-  uint64_t observed = operation_gate_state_.load(std::memory_order_acquire);
+  std::optional<RuntimeBackoff> wait;
+  uint64_t observed = operation_gate_state_.load(std::memory_order_relaxed);
   while (true) {
     if (OperationGateWord::phase(observed) != AdmissionState::kOpen) {
-      wait_for_gate_state_change(observed);
-      observed = operation_gate_state_.load(std::memory_order_acquire);
+      if (!wait) {
+        wait.emplace(make_runtime_backoff());
+      }
+      (*wait)();
+      observed = operation_gate_state_.load(std::memory_order_relaxed);
       continue;
     }
     if (OperationGateWord::try_change_phase(operation_gate_state_, observed,
@@ -219,7 +238,7 @@ void VersionManager::enter_admission_phase(AdmissionState desired_phase) {
 
 void VersionManager::transition_admission_phase(AdmissionState expected_phase,
                                                 AdmissionState desired_phase) {
-  uint64_t observed = operation_gate_state_.load(std::memory_order_acquire);
+  uint64_t observed = operation_gate_state_.load(std::memory_order_relaxed);
   while (true) {
     if (OperationGateWord::phase(observed) != expected_phase) {
       THROW_INTERNAL_EXCEPTION("Invalid transaction admission transition");
@@ -232,25 +251,29 @@ void VersionManager::transition_admission_phase(AdmissionState expected_phase,
 }
 
 void VersionManager::wait_for_readers_to_drain() {
-  while (true) {
-    const uint64_t observed =
-        operation_gate_state_.load(std::memory_order_acquire);
-    if (OperationGateWord::readers(observed) == 0) {
-      return;
-    }
-    wait_for_gate_state_change(observed);
+  uint64_t observed = operation_gate_state_.load(std::memory_order_acquire);
+  if (OperationGateWord::reader_field(observed) == 0) {
+    return;
   }
+
+  RuntimeBackoff wait = make_runtime_backoff();
+  do {
+    wait();
+    observed = operation_gate_state_.load(std::memory_order_acquire);
+  } while (OperationGateWord::reader_field(observed) != 0);
 }
 
 void VersionManager::wait_for_inserters_to_drain() {
-  while (true) {
-    const uint64_t observed =
-        operation_gate_state_.load(std::memory_order_acquire);
-    if (OperationGateWord::inserters(observed) == 0) {
-      return;
-    }
-    wait_for_gate_state_change(observed);
+  uint64_t observed = operation_gate_state_.load(std::memory_order_acquire);
+  if (OperationGateWord::inserters(observed) == 0) {
+    return;
   }
+
+  RuntimeBackoff wait = make_runtime_backoff();
+  do {
+    wait();
+    observed = operation_gate_state_.load(std::memory_order_acquire);
+  } while (OperationGateWord::inserters(observed) != 0);
 }
 
 RuntimeWaitFn VersionManager::runtime_wait_impl() const noexcept {

--- a/src/transaction/version_manager.cc
+++ b/src/transaction/version_manager.cc
@@ -15,17 +15,76 @@
 
 #include "neug/transaction/version_manager.h"
 
+#include <glog/logging.h>
 #include <limits>
 #include <mutex>
 
 #include "neug/utils/exception/exception.h"
-#include "neug/utils/likely.h"
 
 namespace neug {
 
 // VersionManager implementation
 
 VersionManager::VersionManager() : runtime_wait_(&NativeRuntimeWait) {}
+
+uint64_t VersionManager::PackOperationGateState(OperationGateState state) {
+  CHECK_LE(state.readers, kMaxAdmissionCount);
+  CHECK_LE(state.inserters, kMaxAdmissionCount);
+  return (static_cast<uint64_t>(state.phase) << 62) |
+         (static_cast<uint64_t>(state.readers) << 31) | state.inserters;
+}
+
+VersionManager::OperationGateState VersionManager::UnpackOperationGateState(
+    uint64_t packed) {
+  return {static_cast<AdmissionState>(packed >> 62),
+          static_cast<uint32_t>((packed >> 31) & kMaxAdmissionCount),
+          static_cast<uint32_t>(packed & kMaxAdmissionCount)};
+}
+
+void VersionManager::wait_for_gate_change(uint64_t observed) const {
+  RuntimeBackoff wait = make_runtime_backoff();
+  while (operation_gate_state_.load(std::memory_order_acquire) == observed) {
+    wait();
+  }
+}
+
+VersionManager::AdmissionAttempt VersionManager::try_admit_reader(
+    uint64_t& observed) {
+  const OperationGateState state = UnpackOperationGateState(observed);
+  if (state.phase == AdmissionState::kAllBlocked) {
+    return AdmissionAttempt::kBlocked;
+  }
+  if (state.readers == kMaxAdmissionCount) {
+    THROW_RUNTIME_ERROR("Reader admission counter exhausted");
+  }
+  OperationGateState desired = state;
+  ++desired.readers;
+  if (operation_gate_state_.compare_exchange_weak(
+          observed, PackOperationGateState(desired), std::memory_order_acq_rel,
+          std::memory_order_acquire)) {
+    return AdmissionAttempt::kAdmitted;
+  }
+  return AdmissionAttempt::kRetry;
+}
+
+VersionManager::AdmissionAttempt VersionManager::try_admit_inserter(
+    uint64_t& observed) {
+  const OperationGateState state = UnpackOperationGateState(observed);
+  if (state.phase != AdmissionState::kOpen) {
+    return AdmissionAttempt::kBlocked;
+  }
+  if (state.inserters == kMaxAdmissionCount) {
+    THROW_RUNTIME_ERROR("Inserter admission counter exhausted");
+  }
+  OperationGateState desired = state;
+  ++desired.inserters;
+  if (operation_gate_state_.compare_exchange_weak(
+          observed, PackOperationGateState(desired), std::memory_order_acq_rel,
+          std::memory_order_acquire)) {
+    return AdmissionAttempt::kAdmitted;
+  }
+  return AdmissionAttempt::kRetry;
+}
 
 void VersionManager::init_ts(PublishedReadView initial_read_view,
                              int thread_num) {
@@ -41,9 +100,9 @@ void VersionManager::init_ts(PublishedReadView initial_read_view,
                                        std::memory_order_relaxed);
   published_read_view_.store(PackPublishedReadView(initial_read_view),
                              std::memory_order_relaxed);
-  active_readers_.store(0, std::memory_order_relaxed);
-  active_inserters_.store(0, std::memory_order_relaxed);
-  admission_state_.store(AdmissionState::kOpen, std::memory_order_relaxed);
+  operation_gate_state_.store(
+      PackOperationGateState({AdmissionState::kOpen, 0, 0}),
+      std::memory_order_relaxed);
 
   ts_window_.init();
   thread_num_ = thread_num;
@@ -59,104 +118,89 @@ bool VersionManager::try_set_runtime_wait_if_quiescent(
     return false;
   }
 
-  AdmissionState expected = AdmissionState::kOpen;
-  if (!admission_state_.compare_exchange_strong(
-          expected, AdmissionState::kAllBlocked, std::memory_order_seq_cst,
+  uint64_t expected = PackOperationGateState({AdmissionState::kOpen, 0, 0});
+  const uint64_t blocked =
+      PackOperationGateState({AdmissionState::kAllBlocked, 0, 0});
+  if (!operation_gate_state_.compare_exchange_strong(
+          expected, blocked, std::memory_order_acq_rel,
           std::memory_order_acquire)) {
     return false;
   }
 
-  // The seq_cst admission transition participates in the same total order as
-  // transaction counter increments and their post-admission checks. Therefore
-  // either an entrant observes kAllBlocked and rolls back, or this check
-  // observes its increment.
-  const bool quiescent = active_readers_.load(std::memory_order_seq_cst) == 0 &&
-                         active_inserters_.load(std::memory_order_seq_cst) == 0;
-  if (quiescent) {
-    runtime_wait_.store(runtime_wait, std::memory_order_release);
-  }
-  admission_state_.store(AdmissionState::kOpen, std::memory_order_release);
-  return quiescent;
+  runtime_wait_.store(runtime_wait, std::memory_order_release);
+  operation_gate_state_.store(
+      PackOperationGateState({AdmissionState::kOpen, 0, 0}),
+      std::memory_order_release);
+  return true;
 }
 
 PublishedReadView VersionManager::acquire_read_view() {
-  // Pre-check: avoid incrementing if in commit phase
-  auto state = admission_state_.load(std::memory_order_acquire);
-  if (NEUG_UNLIKELY(state == AdmissionState::kAllBlocked)) {
-    return acquire_read_view_slow();
+  uint64_t observed = operation_gate_state_.load(std::memory_order_acquire);
+  while (true) {
+    switch (try_admit_reader(observed)) {
+    case AdmissionAttempt::kAdmitted:
+      return UnpackPublishedReadView(
+          published_read_view_.load(std::memory_order_acquire));
+    case AdmissionAttempt::kBlocked:
+      wait_for_gate_change(observed);
+      observed = operation_gate_state_.load(std::memory_order_acquire);
+      break;
+    case AdmissionAttempt::kRetry:
+      break;
+    }
   }
-
-  // Optimistically increment counter
-  active_readers_.fetch_add(1, std::memory_order_seq_cst);
-
-  // Double-check: ensure commit didn't start between pre-check and increment.
-  // This eliminates the ABA race where a reader increments active_readers_
-  // but misses a concurrent transition to all-blocked.
-  state = admission_state_.load(std::memory_order_seq_cst);
-  if (NEUG_LIKELY(state != AdmissionState::kAllBlocked)) {
-    return UnpackPublishedReadView(
-        published_read_view_.load(std::memory_order_acquire));
-  }
-
-  // Rollback: commit started while we were incrementing
-  active_readers_.fetch_sub(1, std::memory_order_acq_rel);
-
-  // Slow path
-  return acquire_read_view_slow();
-}
-
-PublishedReadView VersionManager::acquire_read_view_slow() {
-  RuntimeBackoff wait = make_runtime_backoff();
-  while (admission_state_.load(std::memory_order_acquire) ==
-         AdmissionState::kAllBlocked) {
-    wait();
-  }
-
-  // Retry
-  return acquire_read_view();
 }
 
 void VersionManager::release_read_view() {
-  active_readers_.fetch_sub(1, std::memory_order_acq_rel);
+  uint64_t observed = operation_gate_state_.load(std::memory_order_acquire);
+  while (true) {
+    const OperationGateState state = UnpackOperationGateState(observed);
+    if (state.readers == 0) {
+      THROW_INTERNAL_EXCEPTION("release_read_view without admission");
+    }
+    OperationGateState desired = state;
+    --desired.readers;
+    if (operation_gate_state_.compare_exchange_weak(
+            observed, PackOperationGateState(desired),
+            std::memory_order_acq_rel, std::memory_order_acquire)) {
+      return;
+    }
+  }
 }
 
 uint32_t VersionManager::acquire_insert_timestamp() {
-  // Check state first (fast path)
-  auto state = admission_state_.load(std::memory_order_acquire);
-  if (NEUG_UNLIKELY(state != AdmissionState::kOpen)) {
-    return acquire_insert_timestamp_slow();
+  uint64_t observed = operation_gate_state_.load(std::memory_order_acquire);
+  while (true) {
+    switch (try_admit_inserter(observed)) {
+    case AdmissionAttempt::kAdmitted:
+      return write_ts_.fetch_add(1, std::memory_order_acq_rel);
+    case AdmissionAttempt::kBlocked:
+      wait_for_gate_change(observed);
+      observed = operation_gate_state_.load(std::memory_order_acquire);
+      break;
+    case AdmissionAttempt::kRetry:
+      break;
+    }
   }
-
-  // Increment counter
-  active_inserters_.fetch_add(1, std::memory_order_seq_cst);
-
-  // Double check: ensure update didn't start between checks
-  state = admission_state_.load(std::memory_order_seq_cst);
-  if (NEUG_LIKELY(state == AdmissionState::kOpen)) {
-    return write_ts_.fetch_add(1, std::memory_order_acq_rel);
-  }
-
-  // Slow path: update just started
-  active_inserters_.fetch_sub(1, std::memory_order_acq_rel);
-  return acquire_insert_timestamp_slow();
-}
-
-uint32_t VersionManager::acquire_insert_timestamp_slow() {
-  RuntimeBackoff wait = make_runtime_backoff();
-  while (admission_state_.load(std::memory_order_acquire) !=
-         AdmissionState::kOpen) {
-    wait();
-  }
-
-  // Retry
-  return acquire_insert_timestamp();
 }
 
 void VersionManager::release_insert_timestamp(uint32_t ts) {
   complete_write_timestamp(ts);
 
-  // Decrement active inserter count
-  active_inserters_.fetch_sub(1, std::memory_order_acq_rel);
+  uint64_t observed = operation_gate_state_.load(std::memory_order_acquire);
+  while (true) {
+    const OperationGateState state = UnpackOperationGateState(observed);
+    if (state.inserters == 0) {
+      THROW_INTERNAL_EXCEPTION("release_insert_timestamp without admission");
+    }
+    OperationGateState desired = state;
+    --desired.inserters;
+    if (operation_gate_state_.compare_exchange_weak(
+            observed, PackOperationGateState(desired),
+            std::memory_order_acq_rel, std::memory_order_acquire)) {
+      return;
+    }
+  }
 }
 
 void VersionManager::complete_write_timestamp(uint32_t ts) {
@@ -204,31 +248,71 @@ void VersionManager::advance_read_ts_locked() {
 }
 
 void VersionManager::enter_exclusive_state(AdmissionState desired_state) {
-  AdmissionState expected = AdmissionState::kOpen;
-  if (admission_state_.compare_exchange_strong(expected, desired_state,
-                                               std::memory_order_seq_cst,
-                                               std::memory_order_acquire)) {
-    return;
+  uint64_t observed = operation_gate_state_.load(std::memory_order_acquire);
+  while (true) {
+    const OperationGateState state = UnpackOperationGateState(observed);
+    if (state.phase != AdmissionState::kOpen) {
+      wait_for_gate_change(observed);
+      observed = operation_gate_state_.load(std::memory_order_acquire);
+      continue;
+    }
+    OperationGateState desired = state;
+    desired.phase = desired_state;
+    if (operation_gate_state_.compare_exchange_weak(
+            observed, PackOperationGateState(desired),
+            std::memory_order_acq_rel, std::memory_order_acquire)) {
+      return;
+    }
   }
-
-  RuntimeBackoff wait = make_runtime_backoff();
-  do {
-    wait();
-    expected = AdmissionState::kOpen;
-  } while (!admission_state_.compare_exchange_strong(
-      expected, desired_state, std::memory_order_seq_cst,
-      std::memory_order_acquire));
 }
 
-void VersionManager::wait_until_zero(const std::atomic<int>& counter) {
-  if (counter.load(std::memory_order_seq_cst) <= 0) {
-    return;
+void VersionManager::set_admission_state(AdmissionState expected,
+                                         AdmissionState desired_phase) {
+  uint64_t observed = operation_gate_state_.load(std::memory_order_acquire);
+  while (true) {
+    const OperationGateState state = UnpackOperationGateState(observed);
+    if (state.phase != expected) {
+      THROW_INTERNAL_EXCEPTION("Invalid transaction admission transition");
+    }
+    OperationGateState desired = state;
+    desired.phase = desired_phase;
+    if (operation_gate_state_.compare_exchange_weak(
+            observed, PackOperationGateState(desired),
+            std::memory_order_acq_rel, std::memory_order_acquire)) {
+      return;
+    }
   }
+}
 
-  RuntimeBackoff wait = make_runtime_backoff();
-  do {
-    wait();
-  } while (counter.load(std::memory_order_seq_cst) > 0);
+void VersionManager::restore_open_after_update() {
+  uint64_t observed = operation_gate_state_.load(std::memory_order_acquire);
+  while (true) {
+    const OperationGateState state = UnpackOperationGateState(observed);
+    if (state.phase != AdmissionState::kInsertsBlocked &&
+        state.phase != AdmissionState::kAllBlocked) {
+      THROW_INTERNAL_EXCEPTION("Update released outside update state");
+    }
+    OperationGateState desired = state;
+    desired.phase = AdmissionState::kOpen;
+    if (operation_gate_state_.compare_exchange_weak(
+            observed, PackOperationGateState(desired),
+            std::memory_order_acq_rel, std::memory_order_acquire)) {
+      return;
+    }
+  }
+}
+
+void VersionManager::wait_until_drained(bool readers, bool inserters) {
+  while (true) {
+    const uint64_t observed =
+        operation_gate_state_.load(std::memory_order_acquire);
+    const OperationGateState state = UnpackOperationGateState(observed);
+    if ((!readers || state.readers == 0) &&
+        (!inserters || state.inserters == 0)) {
+      return;
+    }
+    wait_for_gate_change(observed);
+  }
 }
 
 RuntimeWaitFn VersionManager::runtime_wait_impl() const noexcept {
@@ -237,7 +321,7 @@ RuntimeWaitFn VersionManager::runtime_wait_impl() const noexcept {
 
 uint32_t VersionManager::acquire_update_timestamp() {
   enter_exclusive_state(AdmissionState::kInsertsBlocked);
-  wait_until_zero(active_inserters_);
+  wait_until_drained(false, true);
 
   return write_ts_.fetch_add(1, std::memory_order_acq_rel);
 }
@@ -246,20 +330,20 @@ void VersionManager::begin_update_commit(uint32_t ts) {
   (void) ts;
 
   // Block new readers before publishing the new snapshot. Existing readers
-  // keep using their pinned snapshots; readers in the acquisition window
-  // either roll back after observing this state or complete as existing
-  // readers.
-  admission_state_.store(AdmissionState::kAllBlocked,
-                         std::memory_order_seq_cst);
+  // keep using their pinned snapshots; a racing reader is either counted
+  // before this transition or rejected after it.
+  set_admission_state(AdmissionState::kInsertsBlocked,
+                      AdmissionState::kAllBlocked);
 }
 
 void VersionManager::drain_readers() {
-  if (admission_state_.load(std::memory_order_acquire) !=
-      AdmissionState::kAllBlocked) {
+  if (UnpackOperationGateState(
+          operation_gate_state_.load(std::memory_order_acquire))
+          .phase != AdmissionState::kAllBlocked) {
     THROW_INTERNAL_EXCEPTION(
         "drain_readers called while readers are not blocked");
   }
-  wait_until_zero(active_readers_);
+  wait_until_drained(true, false);
 }
 
 void VersionManager::finish_update_timestamp(
@@ -272,23 +356,22 @@ void VersionManager::finish_update_timestamp(
   complete_write_timestamp(ts);
 
   // Timestamp completion and any matching snapshot generation are visible
-  // before new readers and inserters are admitted.
-  admission_state_.store(AdmissionState::kOpen, std::memory_order_release);
+  // through published_read_view_ before the packed gate admits new work.
+  restore_open_after_update();
 }
 
 uint32_t VersionManager::acquire_compact_timestamp() {
   enter_exclusive_state(AdmissionState::kAllBlocked);
-  wait_until_zero(active_inserters_);
-  // Compact rewrites storage timestamps, so existing readers must also drain.
-  wait_until_zero(active_readers_);
+  wait_until_drained(true, true);
 
   return write_ts_.fetch_add(1, std::memory_order_acq_rel);
 }
 
 void VersionManager::release_compact_timestamp(uint32_t ts) {
   // Compact must have blocked new readers.
-  if (admission_state_.load(std::memory_order_acquire) !=
-      AdmissionState::kAllBlocked) {
+  if (UnpackOperationGateState(
+          operation_gate_state_.load(std::memory_order_acquire))
+          .phase != AdmissionState::kAllBlocked) {
     THROW_INTERNAL_EXCEPTION(
         "release_compact_timestamp called while not in compact state");
   }
@@ -296,13 +379,14 @@ void VersionManager::release_compact_timestamp(uint32_t ts) {
   complete_write_timestamp(ts);
 
   // Restore normal operation.
-  admission_state_.store(AdmissionState::kOpen, std::memory_order_release);
+  set_admission_state(AdmissionState::kAllBlocked, AdmissionState::kOpen);
 }
 
 void VersionManager::revert_compact_timestamp(uint32_t ts) {
   // Compact must have blocked new readers.
-  if (admission_state_.load(std::memory_order_acquire) !=
-      AdmissionState::kAllBlocked) {
+  if (UnpackOperationGateState(
+          operation_gate_state_.load(std::memory_order_acquire))
+          .phase != AdmissionState::kAllBlocked) {
     THROW_INTERNAL_EXCEPTION(
         "revert_compact_timestamp called while not in compact state");
   }
@@ -311,7 +395,7 @@ void VersionManager::revert_compact_timestamp(uint32_t ts) {
   complete_write_timestamp(ts);
 
   // Restore normal operation.
-  admission_state_.store(AdmissionState::kOpen, std::memory_order_release);
+  set_admission_state(AdmissionState::kAllBlocked, AdmissionState::kOpen);
 }
 
 }  // namespace neug

--- a/src/transaction/version_manager.cc
+++ b/src/transaction/version_manager.cc
@@ -94,7 +94,6 @@ PublishedReadView VersionManager::acquire_read_view() {
                       OperationGateWord::kMaxCount)) {
       THROW_RUNTIME_ERROR("Reader admission counter exhausted");
     }
-
     const uint64_t desired = OperationGateWord::increment_reader(observed);
     if (operation_gate_state_.compare_exchange_weak(
             observed, desired, std::memory_order_acq_rel,
@@ -133,7 +132,6 @@ uint32_t VersionManager::acquire_insert_timestamp() {
                       OperationGateWord::kMaxCount)) {
       THROW_RUNTIME_ERROR("Inserter admission counter exhausted");
     }
-
     const uint64_t desired = OperationGateWord::increment_inserter(observed);
     if (operation_gate_state_.compare_exchange_weak(
             observed, desired, std::memory_order_acq_rel,
@@ -212,11 +210,8 @@ void VersionManager::enter_admission_phase(AdmissionState desired_phase) {
       observed = operation_gate_state_.load(std::memory_order_acquire);
       continue;
     }
-    const uint64_t desired =
-        OperationGateWord::with_phase(observed, desired_phase);
-    if (operation_gate_state_.compare_exchange_weak(
-            observed, desired, std::memory_order_acq_rel,
-            std::memory_order_acquire)) {
+    if (OperationGateWord::try_change_phase(operation_gate_state_, observed,
+                                            desired_phase)) {
       return;
     }
   }
@@ -229,41 +224,29 @@ void VersionManager::transition_admission_phase(AdmissionState expected_phase,
     if (OperationGateWord::phase(observed) != expected_phase) {
       THROW_INTERNAL_EXCEPTION("Invalid transaction admission transition");
     }
-    const uint64_t desired =
-        OperationGateWord::with_phase(observed, desired_phase);
-    if (operation_gate_state_.compare_exchange_weak(
-            observed, desired, std::memory_order_acq_rel,
-            std::memory_order_acquire)) {
+    if (OperationGateWord::try_change_phase(operation_gate_state_, observed,
+                                            desired_phase)) {
       return;
     }
   }
 }
 
-void VersionManager::reopen_admission_after_update() {
-  uint64_t observed = operation_gate_state_.load(std::memory_order_acquire);
-  while (true) {
-    const AdmissionState phase = OperationGateWord::phase(observed);
-    if (phase != AdmissionState::kInsertsBlocked &&
-        phase != AdmissionState::kAllBlocked) {
-      THROW_INTERNAL_EXCEPTION("Update released outside update state");
-    }
-    const uint64_t desired =
-        OperationGateWord::with_phase(observed, AdmissionState::kOpen);
-    if (operation_gate_state_.compare_exchange_weak(
-            observed, desired, std::memory_order_acq_rel,
-            std::memory_order_acquire)) {
-      return;
-    }
-  }
-}
-
-void VersionManager::wait_until_operations_drained(bool readers,
-                                                   bool inserters) {
+void VersionManager::wait_for_readers_to_drain() {
   while (true) {
     const uint64_t observed =
         operation_gate_state_.load(std::memory_order_acquire);
-    if ((!readers || OperationGateWord::readers(observed) == 0) &&
-        (!inserters || OperationGateWord::inserters(observed) == 0)) {
+    if (OperationGateWord::readers(observed) == 0) {
+      return;
+    }
+    wait_for_gate_state_change(observed);
+  }
+}
+
+void VersionManager::wait_for_inserters_to_drain() {
+  while (true) {
+    const uint64_t observed =
+        operation_gate_state_.load(std::memory_order_acquire);
+    if (OperationGateWord::inserters(observed) == 0) {
       return;
     }
     wait_for_gate_state_change(observed);
@@ -276,7 +259,7 @@ RuntimeWaitFn VersionManager::runtime_wait_impl() const noexcept {
 
 uint32_t VersionManager::acquire_update_timestamp() {
   enter_admission_phase(AdmissionState::kInsertsBlocked);
-  wait_until_operations_drained(false, true);
+  wait_for_inserters_to_drain();
 
   return write_ts_.fetch_add(1, std::memory_order_acq_rel);
 }
@@ -297,7 +280,7 @@ void VersionManager::drain_readers() {
     THROW_INTERNAL_EXCEPTION(
         "drain_readers called while readers are not blocked");
   }
-  wait_until_operations_drained(true, false);
+  wait_for_readers_to_drain();
 }
 
 void VersionManager::finish_update_timestamp(
@@ -311,12 +294,23 @@ void VersionManager::finish_update_timestamp(
 
   // Timestamp completion and any matching snapshot generation are visible
   // through published_read_view_ before the packed gate admits new work.
-  reopen_admission_after_update();
+  uint64_t observed = operation_gate_state_.load(std::memory_order_acquire);
+  while (true) {
+    const AdmissionState phase = OperationGateWord::phase(observed);
+    DCHECK(phase == AdmissionState::kInsertsBlocked ||
+           phase == AdmissionState::kAllBlocked)
+        << "Update released outside update state";
+    if (OperationGateWord::try_change_phase(operation_gate_state_, observed,
+                                            AdmissionState::kOpen)) {
+      return;
+    }
+  }
 }
 
 uint32_t VersionManager::acquire_compact_timestamp() {
   enter_admission_phase(AdmissionState::kAllBlocked);
-  wait_until_operations_drained(true, true);
+  wait_for_readers_to_drain();
+  wait_for_inserters_to_drain();
 
   return write_ts_.fetch_add(1, std::memory_order_acq_rel);
 }

--- a/src/transaction/version_manager.cc
+++ b/src/transaction/version_manager.cc
@@ -93,7 +93,7 @@ PublishedReadView VersionManager::acquire_read_view() {
     // this old-word check closes the race with a concurrent phase transition.
     const uint64_t previous = operation_gate_state_.fetch_add(
         OperationGateWord::kReaderUnit, std::memory_order_acquire);
-    const bool counter_exhausted = OperationGateWord::reader_field(previous) >=
+    const bool counter_exhausted = OperationGateWord::readers(previous) >=
                                    OperationGateWord::kMaxReaderCount;
     if (NEUG_LIKELY(OperationGateWord::phase(previous) !=
                         AdmissionState::kAllBlocked &&
@@ -102,8 +102,7 @@ PublishedReadView VersionManager::acquire_read_view() {
           published_read_view_.load(std::memory_order_acquire));
     }
 
-    // The guard bit keeps this rollback inside the reader field even when the
-    // count was already at its maximum.
+    // Roll back the speculative increment and retry with backoff.
     operation_gate_state_.fetch_sub(OperationGateWord::kReaderUnit,
                                     std::memory_order_release);
     if (NEUG_UNLIKELY(counter_exhausted)) {
@@ -120,14 +119,14 @@ PublishedReadView VersionManager::acquire_read_view() {
 void VersionManager::release_read_view() {
   const uint64_t observed =
       operation_gate_state_.load(std::memory_order_relaxed);
-  if (NEUG_UNLIKELY(OperationGateWord::reader_field(observed) == 0)) {
+  if (NEUG_UNLIKELY(OperationGateWord::readers(observed) == 0)) {
     THROW_INTERNAL_EXCEPTION("release_read_view without admission");
   }
-  // A valid caller owns one count. The overflow guard keeps both releases and
-  // overflow rollbacks inside the reader field.
+  // A valid caller owns one count, so valid concurrent releases cannot borrow
+  // from an adjacent field.
   const uint64_t previous = operation_gate_state_.fetch_sub(
       OperationGateWord::kReaderUnit, std::memory_order_release);
-  DCHECK_GT(OperationGateWord::reader_field(previous), 0U);
+  DCHECK_GT(OperationGateWord::readers(previous), 0U);
 }
 
 uint32_t VersionManager::acquire_insert_timestamp() {
@@ -252,7 +251,7 @@ void VersionManager::transition_admission_phase(AdmissionState expected_phase,
 
 void VersionManager::wait_for_readers_to_drain() {
   uint64_t observed = operation_gate_state_.load(std::memory_order_acquire);
-  if (OperationGateWord::reader_field(observed) == 0) {
+  if (OperationGateWord::readers(observed) == 0) {
     return;
   }
 
@@ -260,7 +259,7 @@ void VersionManager::wait_for_readers_to_drain() {
   do {
     wait();
     observed = operation_gate_state_.load(std::memory_order_acquire);
-  } while (OperationGateWord::reader_field(observed) != 0);
+  } while (OperationGateWord::readers(observed) != 0);
 }
 
 void VersionManager::wait_for_inserters_to_drain() {

--- a/tests/transaction/test_runtime_wait.cc
+++ b/tests/transaction/test_runtime_wait.cc
@@ -117,11 +117,10 @@ void ExpectRuntimeWaitWhile(WaitOperation wait, UnblockOperation unblock) {
 TEST(OperationGateWordTest, AdmissionsBeforeCompactTransitionRemainCounted) {
   std::atomic<uint64_t> gate{
       detail::OperationGateWord::empty(detail::AdmissionState::kOpen)};
-  uint64_t reader_observation = gate.load(std::memory_order_acquire);
-  ASSERT_TRUE(gate.compare_exchange_strong(
-      reader_observation,
-      detail::OperationGateWord::increment_reader(reader_observation),
-      std::memory_order_acq_rel, std::memory_order_acquire));
+  const uint64_t reader_observation = gate.fetch_add(
+      detail::OperationGateWord::kReaderUnit, std::memory_order_acquire);
+  ASSERT_EQ(detail::OperationGateWord::phase(reader_observation),
+            detail::AdmissionState::kOpen);
   uint64_t inserter_observation = gate.load(std::memory_order_acquire);
   ASSERT_TRUE(gate.compare_exchange_strong(
       inserter_observation,
@@ -139,20 +138,19 @@ TEST(OperationGateWordTest, AdmissionsBeforeCompactTransitionRemainCounted) {
 TEST(OperationGateWordTest, DelayedReaderRetriesAfterUpdateCommitTransition) {
   std::atomic<uint64_t> gate{detail::OperationGateWord::empty(
       detail::AdmissionState::kInsertsBlocked)};
-  uint64_t delayed_observation = gate.load(std::memory_order_acquire);
 
   ChangeGatePhase(gate, detail::AdmissionState::kInsertsBlocked,
                   detail::AdmissionState::kAllBlocked);
 
-  EXPECT_FALSE(gate.compare_exchange_strong(
-      delayed_observation,
-      detail::OperationGateWord::increment_reader(delayed_observation),
-      std::memory_order_acq_rel, std::memory_order_acquire));
-  EXPECT_EQ(detail::OperationGateWord::phase(delayed_observation),
+  const uint64_t reader_observation = gate.fetch_add(
+      detail::OperationGateWord::kReaderUnit, std::memory_order_acquire);
+  EXPECT_EQ(detail::OperationGateWord::phase(reader_observation),
             detail::AdmissionState::kAllBlocked);
-  EXPECT_EQ(
-      detail::OperationGateWord::readers(gate.load(std::memory_order_acquire)),
-      0U);
+  gate.fetch_sub(detail::OperationGateWord::kReaderUnit,
+                 std::memory_order_release);
+  EXPECT_EQ(detail::OperationGateWord::reader_field(
+                gate.load(std::memory_order_acquire)),
+            0U);
 }
 
 TEST(OperationGateWordTest,
@@ -179,23 +177,22 @@ TEST(OperationGateWordTest,
      DelayedReaderAndInserterRetryAfterCompactTransition) {
   std::atomic<uint64_t> gate{
       detail::OperationGateWord::empty(detail::AdmissionState::kOpen)};
-  uint64_t delayed_reader_observation = gate.load(std::memory_order_acquire);
-  uint64_t delayed_inserter_observation = delayed_reader_observation;
+  uint64_t delayed_inserter_observation = gate.load(std::memory_order_acquire);
 
   ChangeGatePhase(gate, detail::AdmissionState::kOpen,
                   detail::AdmissionState::kAllBlocked);
 
-  EXPECT_FALSE(gate.compare_exchange_strong(
-      delayed_reader_observation,
-      detail::OperationGateWord::increment_reader(delayed_reader_observation),
-      std::memory_order_acq_rel, std::memory_order_acquire));
+  const uint64_t reader_observation = gate.fetch_add(
+      detail::OperationGateWord::kReaderUnit, std::memory_order_acquire);
+  EXPECT_EQ(detail::OperationGateWord::phase(reader_observation),
+            detail::AdmissionState::kAllBlocked);
+  gate.fetch_sub(detail::OperationGateWord::kReaderUnit,
+                 std::memory_order_release);
   EXPECT_FALSE(gate.compare_exchange_strong(
       delayed_inserter_observation,
       detail::OperationGateWord::increment_inserter(
           delayed_inserter_observation),
       std::memory_order_acq_rel, std::memory_order_acquire));
-  EXPECT_EQ(detail::OperationGateWord::phase(delayed_reader_observation),
-            detail::AdmissionState::kAllBlocked);
   EXPECT_EQ(detail::OperationGateWord::phase(delayed_inserter_observation),
             detail::AdmissionState::kAllBlocked);
 
@@ -205,23 +202,66 @@ TEST(OperationGateWordTest,
 }
 
 TEST(OperationGateWordTest, DetectsReaderAndInserterCounterExhaustion) {
+  constexpr uint32_t kInserters = 7;
   const uint64_t reader_word =
       detail::OperationGateWord::empty(detail::AdmissionState::kOpen) |
-      detail::OperationGateWord::kReaderMask;
-  EXPECT_EQ(detail::OperationGateWord::readers(reader_word),
-            detail::OperationGateWord::kMaxCount);
-  EXPECT_EQ(detail::OperationGateWord::phase(reader_word),
+      detail::OperationGateWord::kReaderMask | (uint64_t{kInserters} << 31);
+  std::atomic<uint64_t> gate{reader_word};
+  const uint64_t reader_observation = gate.fetch_add(
+      detail::OperationGateWord::kReaderUnit, std::memory_order_acquire);
+  EXPECT_EQ(detail::OperationGateWord::readers(reader_observation),
+            detail::OperationGateWord::kMaxReaderCount);
+  const uint64_t overflow = gate.load(std::memory_order_acquire);
+  EXPECT_EQ(detail::OperationGateWord::readers(overflow), 0U);
+  EXPECT_EQ(detail::OperationGateWord::reader_field(overflow),
+            detail::OperationGateWord::kReaderOverflowMask);
+  EXPECT_EQ(detail::OperationGateWord::phase(overflow),
             detail::AdmissionState::kOpen);
-  EXPECT_EQ(detail::OperationGateWord::inserters(reader_word), 0U);
+  EXPECT_EQ(detail::OperationGateWord::inserters(overflow), kInserters);
+
+  gate.fetch_sub(detail::OperationGateWord::kReaderUnit,
+                 std::memory_order_release);
+  EXPECT_EQ(gate.load(std::memory_order_acquire), reader_word);
 
   const uint64_t inserter_word =
       detail::OperationGateWord::empty(detail::AdmissionState::kOpen) |
       detail::OperationGateWord::kInserterMask;
   EXPECT_EQ(detail::OperationGateWord::inserters(inserter_word),
-            detail::OperationGateWord::kMaxCount);
+            detail::OperationGateWord::kMaxInserterCount);
   EXPECT_EQ(detail::OperationGateWord::phase(inserter_word),
             detail::AdmissionState::kOpen);
   EXPECT_EQ(detail::OperationGateWord::readers(inserter_word), 0U);
+}
+
+TEST(OperationGateWordTest,
+     ReaderOverflowRollbackAndReleaseStayWithinReaderField) {
+  constexpr uint32_t kInserters = 7;
+  const uint64_t initial = detail::OperationGateWord::empty(
+                               detail::AdmissionState::kInsertsBlocked) |
+                           detail::OperationGateWord::kReaderMask |
+                           (uint64_t{kInserters} << 31);
+
+  std::atomic<uint64_t> gate{initial};
+  gate.fetch_add(detail::OperationGateWord::kReaderUnit,
+                 std::memory_order_acquire);
+  EXPECT_EQ(detail::OperationGateWord::reader_field(
+                gate.load(std::memory_order_acquire)),
+            detail::OperationGateWord::kReaderOverflowMask);
+  // A valid release and the overflow rollback are identical decrements, so
+  // either order must leave the logical reader count one below the initial
+  // maximum without borrowing from the inserter field.
+  gate.fetch_sub(detail::OperationGateWord::kReaderUnit,
+                 std::memory_order_release);
+  gate.fetch_sub(detail::OperationGateWord::kReaderUnit,
+                 std::memory_order_release);
+
+  const uint64_t expected = initial - detail::OperationGateWord::kReaderUnit;
+  EXPECT_EQ(gate.load(std::memory_order_acquire), expected);
+  EXPECT_EQ(detail::OperationGateWord::phase(expected),
+            detail::AdmissionState::kInsertsBlocked);
+  EXPECT_EQ(detail::OperationGateWord::inserters(expected), kInserters);
+  EXPECT_EQ(detail::OperationGateWord::readers(expected),
+            detail::OperationGateWord::kMaxReaderCount - 1);
 }
 
 TEST(UpdateTimestampLeaseTest, MoveTransfersAdmissionOwnership) {

--- a/tests/transaction/test_runtime_wait.cc
+++ b/tests/transaction/test_runtime_wait.cc
@@ -148,9 +148,9 @@ TEST(OperationGateWordTest, DelayedReaderRetriesAfterUpdateCommitTransition) {
             detail::AdmissionState::kAllBlocked);
   gate.fetch_sub(detail::OperationGateWord::kReaderUnit,
                  std::memory_order_release);
-  EXPECT_EQ(detail::OperationGateWord::reader_field(
-                gate.load(std::memory_order_acquire)),
-            0U);
+  EXPECT_EQ(
+      detail::OperationGateWord::readers(gate.load(std::memory_order_acquire)),
+      0U);
 }
 
 TEST(OperationGateWordTest,
@@ -207,17 +207,18 @@ TEST(OperationGateWordTest, DetectsReaderAndInserterCounterExhaustion) {
       detail::OperationGateWord::empty(detail::AdmissionState::kOpen) |
       detail::OperationGateWord::kReaderMask | (uint64_t{kInserters} << 31);
   std::atomic<uint64_t> gate{reader_word};
+  // Admission rejects once the observed old word is already at the maximum,
+  // so the counter never actually wraps into the adjacent inserter field.
   const uint64_t reader_observation = gate.fetch_add(
       detail::OperationGateWord::kReaderUnit, std::memory_order_acquire);
   EXPECT_EQ(detail::OperationGateWord::readers(reader_observation),
             detail::OperationGateWord::kMaxReaderCount);
-  const uint64_t overflow = gate.load(std::memory_order_acquire);
-  EXPECT_EQ(detail::OperationGateWord::readers(overflow), 0U);
-  EXPECT_EQ(detail::OperationGateWord::reader_field(overflow),
-            detail::OperationGateWord::kReaderOverflowMask);
-  EXPECT_EQ(detail::OperationGateWord::phase(overflow),
+  EXPECT_GE(detail::OperationGateWord::readers(reader_observation),
+            detail::OperationGateWord::kMaxReaderCount);
+  EXPECT_EQ(detail::OperationGateWord::phase(reader_observation),
             detail::AdmissionState::kOpen);
-  EXPECT_EQ(detail::OperationGateWord::inserters(overflow), kInserters);
+  EXPECT_EQ(detail::OperationGateWord::inserters(reader_observation),
+            kInserters);
 
   gate.fetch_sub(detail::OperationGateWord::kReaderUnit,
                  std::memory_order_release);
@@ -231,37 +232,6 @@ TEST(OperationGateWordTest, DetectsReaderAndInserterCounterExhaustion) {
   EXPECT_EQ(detail::OperationGateWord::phase(inserter_word),
             detail::AdmissionState::kOpen);
   EXPECT_EQ(detail::OperationGateWord::readers(inserter_word), 0U);
-}
-
-TEST(OperationGateWordTest,
-     ReaderOverflowRollbackAndReleaseStayWithinReaderField) {
-  constexpr uint32_t kInserters = 7;
-  const uint64_t initial = detail::OperationGateWord::empty(
-                               detail::AdmissionState::kInsertsBlocked) |
-                           detail::OperationGateWord::kReaderMask |
-                           (uint64_t{kInserters} << 31);
-
-  std::atomic<uint64_t> gate{initial};
-  gate.fetch_add(detail::OperationGateWord::kReaderUnit,
-                 std::memory_order_acquire);
-  EXPECT_EQ(detail::OperationGateWord::reader_field(
-                gate.load(std::memory_order_acquire)),
-            detail::OperationGateWord::kReaderOverflowMask);
-  // A valid release and the overflow rollback are identical decrements, so
-  // either order must leave the logical reader count one below the initial
-  // maximum without borrowing from the inserter field.
-  gate.fetch_sub(detail::OperationGateWord::kReaderUnit,
-                 std::memory_order_release);
-  gate.fetch_sub(detail::OperationGateWord::kReaderUnit,
-                 std::memory_order_release);
-
-  const uint64_t expected = initial - detail::OperationGateWord::kReaderUnit;
-  EXPECT_EQ(gate.load(std::memory_order_acquire), expected);
-  EXPECT_EQ(detail::OperationGateWord::phase(expected),
-            detail::AdmissionState::kInsertsBlocked);
-  EXPECT_EQ(detail::OperationGateWord::inserters(expected), kInserters);
-  EXPECT_EQ(detail::OperationGateWord::readers(expected),
-            detail::OperationGateWord::kMaxReaderCount - 1);
 }
 
 TEST(UpdateTimestampLeaseTest, MoveTransfersAdmissionOwnership) {

--- a/tests/transaction/test_runtime_wait.cc
+++ b/tests/transaction/test_runtime_wait.cc
@@ -20,6 +20,7 @@
 #include <chrono>
 #include <cstdint>
 #include <limits>
+#include <stdexcept>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -28,19 +29,10 @@
 #include "bthread/bthread.h"
 #include "neug/server/bthread_runtime_wait.h"
 #endif
+#include "neug/transaction/timestamp_lease.h"
 #include "neug/transaction/version_manager.h"
 
 namespace neug {
-
-struct VersionManagerTestPeer {
-  static void lock_advancement(VersionManager& manager) {
-    manager.lock_.lock();
-  }
-
-  static void unlock_advancement(VersionManager& manager) {
-    manager.lock_.unlock();
-  }
-};
 
 namespace {
 
@@ -110,6 +102,33 @@ void ExpectRuntimeWaitWhile(WaitOperation wait, UnblockOperation unblock) {
   EXPECT_TRUE(WaitForRuntimeWait());
   unblock();
   waiter.join();
+}
+
+TEST(UpdateTimestampLeaseTest, MoveTransfersAdmissionOwnership) {
+  VersionManager manager;
+  InitManager(manager);
+
+  {
+    UpdateTimestampLease original(manager);
+    UpdateTimestampLease owner(std::move(original));
+    EXPECT_FALSE(manager.try_set_runtime_wait_if_quiescent(&NativeRuntimeWait));
+  }
+
+  EXPECT_TRUE(manager.try_set_runtime_wait_if_quiescent(&NativeRuntimeWait));
+}
+
+TEST(UpdateTimestampLeaseTest, ScopeExitAfterExceptionReleasesAdmission) {
+  VersionManager manager;
+  InitManager(manager);
+
+  EXPECT_THROW(
+      {
+        UpdateTimestampLease lease(manager);
+        throw std::runtime_error("construction failed");
+      },
+      std::runtime_error);
+
+  EXPECT_TRUE(manager.try_set_runtime_wait_if_quiescent(&NativeRuntimeWait));
 }
 
 TEST(VersionManagerWaitTest, UncontendedPathsDoNotInvokeBackoff) {
@@ -208,16 +227,6 @@ TEST(VersionManagerWaitTest, AllContendedPathsUseBackoff) {
         [&]() { manager.release_read_view(); });
     manager.release_compact_timestamp(compact_ts);
   }
-}
-
-TEST(VersionManagerWaitTest, TimestampAdvancementLockUsesBackoffOnlyUnlocked) {
-  VersionManager manager;
-  InitManager(manager);
-  const auto insert_ts = manager.acquire_insert_timestamp();
-  VersionManagerTestPeer::lock_advancement(manager);
-  ExpectRuntimeWaitWhile(
-      [&]() { manager.release_insert_timestamp(insert_ts); },
-      [&]() { VersionManagerTestPeer::unlock_advancement(manager); });
 }
 
 TEST(VersionManagerAdmissionTest,
@@ -341,10 +350,6 @@ TEST(VersionManagerWaitTest, RuntimeWaitSwitchRequiresQuiescence) {
   const auto compact_ts = manager.acquire_compact_timestamp();
   EXPECT_FALSE(manager.try_set_runtime_wait_if_quiescent(&NativeRuntimeWait));
   manager.release_compact_timestamp(compact_ts);
-
-  VersionManagerTestPeer::lock_advancement(manager);
-  EXPECT_FALSE(manager.try_set_runtime_wait_if_quiescent(&NativeRuntimeWait));
-  VersionManagerTestPeer::unlock_advancement(manager);
 
   EXPECT_TRUE(manager.try_set_runtime_wait_if_quiescent(&NativeRuntimeWait));
 }

--- a/tests/transaction/test_runtime_wait.cc
+++ b/tests/transaction/test_runtime_wait.cc
@@ -69,6 +69,16 @@ void FinishUpdate(VersionManager& manager, uint32_t timestamp) {
   manager.finish_update_timestamp(timestamp, std::nullopt);
 }
 
+void ChangeGatePhase(std::atomic<uint64_t>& gate,
+                     detail::AdmissionState expected_phase,
+                     detail::AdmissionState desired_phase) {
+  uint64_t observed = gate.load(std::memory_order_acquire);
+  while (!detail::OperationGateWord::try_change_phase(gate, observed,
+                                                      desired_phase)) {
+    ASSERT_EQ(detail::OperationGateWord::phase(observed), expected_phase);
+  }
+}
+
 template <typename Predicate>
 bool WaitUntil(Predicate predicate) {
   const auto deadline = std::chrono::steady_clock::now() + kWaitTimeout;
@@ -102,6 +112,116 @@ void ExpectRuntimeWaitWhile(WaitOperation wait, UnblockOperation unblock) {
   EXPECT_TRUE(WaitForRuntimeWait());
   unblock();
   waiter.join();
+}
+
+TEST(OperationGateWordTest, AdmissionsBeforeCompactTransitionRemainCounted) {
+  std::atomic<uint64_t> gate{
+      detail::OperationGateWord::empty(detail::AdmissionState::kOpen)};
+  uint64_t reader_observation = gate.load(std::memory_order_acquire);
+  ASSERT_TRUE(gate.compare_exchange_strong(
+      reader_observation,
+      detail::OperationGateWord::increment_reader(reader_observation),
+      std::memory_order_acq_rel, std::memory_order_acquire));
+  uint64_t inserter_observation = gate.load(std::memory_order_acquire);
+  ASSERT_TRUE(gate.compare_exchange_strong(
+      inserter_observation,
+      detail::OperationGateWord::increment_inserter(inserter_observation),
+      std::memory_order_acq_rel, std::memory_order_acquire));
+
+  ChangeGatePhase(gate, detail::AdmissionState::kOpen,
+                  detail::AdmissionState::kAllBlocked);
+
+  const uint64_t blocked = gate.load(std::memory_order_acquire);
+  EXPECT_EQ(detail::OperationGateWord::readers(blocked), 1U);
+  EXPECT_EQ(detail::OperationGateWord::inserters(blocked), 1U);
+}
+
+TEST(OperationGateWordTest, DelayedReaderRetriesAfterUpdateCommitTransition) {
+  std::atomic<uint64_t> gate{detail::OperationGateWord::empty(
+      detail::AdmissionState::kInsertsBlocked)};
+  uint64_t delayed_observation = gate.load(std::memory_order_acquire);
+
+  ChangeGatePhase(gate, detail::AdmissionState::kInsertsBlocked,
+                  detail::AdmissionState::kAllBlocked);
+
+  EXPECT_FALSE(gate.compare_exchange_strong(
+      delayed_observation,
+      detail::OperationGateWord::increment_reader(delayed_observation),
+      std::memory_order_acq_rel, std::memory_order_acquire));
+  EXPECT_EQ(detail::OperationGateWord::phase(delayed_observation),
+            detail::AdmissionState::kAllBlocked);
+  EXPECT_EQ(
+      detail::OperationGateWord::readers(gate.load(std::memory_order_acquire)),
+      0U);
+}
+
+TEST(OperationGateWordTest,
+     DelayedInserterRetriesAfterUpdateExecutionTransition) {
+  std::atomic<uint64_t> gate{
+      detail::OperationGateWord::empty(detail::AdmissionState::kOpen)};
+  uint64_t delayed_observation = gate.load(std::memory_order_acquire);
+
+  ChangeGatePhase(gate, detail::AdmissionState::kOpen,
+                  detail::AdmissionState::kInsertsBlocked);
+
+  EXPECT_FALSE(gate.compare_exchange_strong(
+      delayed_observation,
+      detail::OperationGateWord::increment_inserter(delayed_observation),
+      std::memory_order_acq_rel, std::memory_order_acquire));
+  EXPECT_EQ(detail::OperationGateWord::phase(delayed_observation),
+            detail::AdmissionState::kInsertsBlocked);
+  EXPECT_EQ(detail::OperationGateWord::inserters(
+                gate.load(std::memory_order_acquire)),
+            0U);
+}
+
+TEST(OperationGateWordTest,
+     DelayedReaderAndInserterRetryAfterCompactTransition) {
+  std::atomic<uint64_t> gate{
+      detail::OperationGateWord::empty(detail::AdmissionState::kOpen)};
+  uint64_t delayed_reader_observation = gate.load(std::memory_order_acquire);
+  uint64_t delayed_inserter_observation = delayed_reader_observation;
+
+  ChangeGatePhase(gate, detail::AdmissionState::kOpen,
+                  detail::AdmissionState::kAllBlocked);
+
+  EXPECT_FALSE(gate.compare_exchange_strong(
+      delayed_reader_observation,
+      detail::OperationGateWord::increment_reader(delayed_reader_observation),
+      std::memory_order_acq_rel, std::memory_order_acquire));
+  EXPECT_FALSE(gate.compare_exchange_strong(
+      delayed_inserter_observation,
+      detail::OperationGateWord::increment_inserter(
+          delayed_inserter_observation),
+      std::memory_order_acq_rel, std::memory_order_acquire));
+  EXPECT_EQ(detail::OperationGateWord::phase(delayed_reader_observation),
+            detail::AdmissionState::kAllBlocked);
+  EXPECT_EQ(detail::OperationGateWord::phase(delayed_inserter_observation),
+            detail::AdmissionState::kAllBlocked);
+
+  const uint64_t blocked = gate.load(std::memory_order_acquire);
+  EXPECT_EQ(detail::OperationGateWord::readers(blocked), 0U);
+  EXPECT_EQ(detail::OperationGateWord::inserters(blocked), 0U);
+}
+
+TEST(OperationGateWordTest, DetectsReaderAndInserterCounterExhaustion) {
+  const uint64_t reader_word =
+      detail::OperationGateWord::empty(detail::AdmissionState::kOpen) |
+      detail::OperationGateWord::kReaderMask;
+  EXPECT_EQ(detail::OperationGateWord::readers(reader_word),
+            detail::OperationGateWord::kMaxCount);
+  EXPECT_EQ(detail::OperationGateWord::phase(reader_word),
+            detail::AdmissionState::kOpen);
+  EXPECT_EQ(detail::OperationGateWord::inserters(reader_word), 0U);
+
+  const uint64_t inserter_word =
+      detail::OperationGateWord::empty(detail::AdmissionState::kOpen) |
+      detail::OperationGateWord::kInserterMask;
+  EXPECT_EQ(detail::OperationGateWord::inserters(inserter_word),
+            detail::OperationGateWord::kMaxCount);
+  EXPECT_EQ(detail::OperationGateWord::phase(inserter_word),
+            detail::AdmissionState::kOpen);
+  EXPECT_EQ(detail::OperationGateWord::readers(inserter_word), 0U);
 }
 
 TEST(UpdateTimestampLeaseTest, MoveTransfersAdmissionOwnership) {


### PR DESCRIPTION
## Summary

- Replace the independent admission phase, reader count, and inserter count atomics with one packed 64-bit operation gate.
- Linearize reader/inserter admission and update/compact phase transitions through CAS on the same control word.
- Preserve adaptive backoff on contended paths and exact quiescence checks for runtime-wait lifecycle changes.
- Add deterministic delayed-admission tests plus packed-counter overflow coverage.

## Why

With independent atomics, a delayed reader or inserter could legally observe an old phase while a writer observed a zero counter. A single control-word modification order makes every operation either admitted and counted before the transition or rejected and retried after it.


Fixes #794