### PR TITLE
fix: prepare snapshots before WAL append

### DIFF
--- a/include/neug/storages/graph_snapshot_store.h
+++ b/include/neug/storages/graph_snapshot_store.h
@@ -38,7 +38,7 @@ namespace neug {
  * - Read/Insert: PinCurrentSnapshot() -> slot.view() -> UnpinSnapshot().
  *   InsertTransaction mutates the live slot in-place (timestamp-filtered).
  * - Update: CurrentSnapshot().Clone() -> mutate COW copy ->
- * PublishSnapshot().
+ * PrepareSnapshot() before WAL -> InstallPreparedSnapshot() after WAL.
  *
  * Concurrency:
  * - Lock-free PinCurrentSnapshot via optimistic pin + verify loop.
@@ -50,6 +50,29 @@ namespace neug {
  */
 class GraphSnapshotStore {
  public:
+  /// Move-only ownership of a fully initialized, reader-invisible slot.
+  /// Destruction returns an uninstalled slot to the pool.
+  class PreparedSnapshot {
+   public:
+    PreparedSnapshot() = default;
+    ~PreparedSnapshot() noexcept { reset(); }
+    PreparedSnapshot(const PreparedSnapshot&) = delete;
+    PreparedSnapshot& operator=(const PreparedSnapshot&) = delete;
+    PreparedSnapshot(PreparedSnapshot&& other) noexcept;
+    PreparedSnapshot& operator=(PreparedSnapshot&& other) noexcept;
+
+    bool valid() const { return store_ != nullptr; }
+    void reset() noexcept;
+
+   private:
+    friend class GraphSnapshotStore;
+    PreparedSnapshot(GraphSnapshotStore* store, int slot_index) noexcept
+        : store_(store), slot_index_(slot_index) {}
+
+    GraphSnapshotStore* store_{nullptr};
+    int slot_index_{-1};
+  };
+
   /// A slot holding a PropertyGraph, its GraphView, and a pin count.
   class SnapshotSlot {
    public:
@@ -100,11 +123,17 @@ class GraphSnapshotStore {
   /// (admission_state_==kInsertsBlocked, all inserters drained).
   const PropertyGraph& CurrentSnapshot() const;
 
-  /// Publish a COW PropertyGraph into a free slot and switch cur_slot_index_.
-  /// Steps: reserve free slot -> prep-pin new slot -> write PG + build view
-  /// -> phantom-pin old slot -> switch (release store) -> release phantom pin
-  /// -> release prep pin. Old slots are recycled lazily by UnpinSnapshot.
-  /// Returns ERR_POOL_EXHAUSTED without touching @p new_pg on failure.
+  /// Reserve and fully initialize a reader-invisible slot. All capacity and
+  /// GraphView construction failures happen here, before a caller appends WAL.
+  /// The returned handle rolls the reservation back unless installed.
+  Status PrepareSnapshot(const std::shared_ptr<PropertyGraph>& new_pg,
+                         PreparedSnapshot& prepared);
+
+  /// Make a prepared slot current. This is the bounded, noexcept post-WAL
+  /// operation; invariant violations are fail-stop.
+  void InstallPreparedSnapshot(PreparedSnapshot&& prepared) noexcept;
+
+  /// Convenience wrapper for callers without a durability boundary.
   Status PublishSnapshot(const std::shared_ptr<PropertyGraph>& new_pg);
 
   /// Pool capacity.
@@ -130,6 +159,7 @@ class GraphSnapshotStore {
   void returnFreeSlot(int slot_index);
   void UnpinSnapshotByIndex(int slot_index) noexcept;
   void cleanupSlot(int slot_index);
+  void releasePreparedSlot(int slot_index) noexcept;
 };
 
 /**

--- a/src/storages/graph/graph_snapshot_store.cc
+++ b/src/storages/graph/graph_snapshot_store.cc
@@ -16,6 +16,8 @@
 #include "neug/storages/graph_snapshot_store.h"
 
 #include <glog/logging.h>
+#include <exception>
+#include <string>
 #include <utility>
 
 #include "neug/generated/proto/plan/error.pb.h"
@@ -50,6 +52,34 @@ GraphSnapshotStore::~GraphSnapshotStore() {
   }
 }
 
+GraphSnapshotStore::PreparedSnapshot::PreparedSnapshot(
+    PreparedSnapshot&& other) noexcept
+    : store_(other.store_), slot_index_(other.slot_index_) {
+  other.store_ = nullptr;
+  other.slot_index_ = -1;
+}
+
+GraphSnapshotStore::PreparedSnapshot&
+GraphSnapshotStore::PreparedSnapshot::operator=(
+    PreparedSnapshot&& other) noexcept {
+  if (this != &other) {
+    reset();
+    store_ = other.store_;
+    slot_index_ = other.slot_index_;
+    other.store_ = nullptr;
+    other.slot_index_ = -1;
+  }
+  return *this;
+}
+
+void GraphSnapshotStore::PreparedSnapshot::reset() noexcept {
+  if (store_ != nullptr) {
+    store_->releasePreparedSlot(slot_index_);
+    store_ = nullptr;
+    slot_index_ = -1;
+  }
+}
+
 void GraphSnapshotStore::initFreeList() {
   // Slots 1 to slot_num_-1 are initially free
   for (int i = 1; i < slot_num_; ++i) {
@@ -80,6 +110,18 @@ void GraphSnapshotStore::cleanupSlot(int slot_index) {
   slots_[slot_index].view_ = GraphView();
   slots_[slot_index].reader_count_.fetch_add(-kCleanupSentinel,
                                              std::memory_order_release);
+  returnFreeSlot(slot_index);
+}
+
+void GraphSnapshotStore::releasePreparedSlot(int slot_index) noexcept {
+  CHECK_GE(slot_index, 0);
+  CHECK_LT(slot_index, slot_num_);
+  auto& slot = slots_[slot_index];
+  CHECK_EQ(slot.reader_count_.load(std::memory_order_acquire),
+           kCleanupSentinel);
+  slot.storage_.reset();
+  slot.view_ = GraphView();
+  slot.reader_count_.store(0, std::memory_order_release);
   returnFreeSlot(slot_index);
 }
 
@@ -164,8 +206,16 @@ const PropertyGraph& GraphSnapshotStore::CurrentSnapshot() const {
   return *slots_[slot_index].storage_;
 }
 
-Status GraphSnapshotStore::PublishSnapshot(
-    const std::shared_ptr<PropertyGraph>& new_pg) {
+Status GraphSnapshotStore::PrepareSnapshot(
+    const std::shared_ptr<PropertyGraph>& new_pg, PreparedSnapshot& prepared) {
+  if (prepared.valid()) {
+    return Status(StatusCode::ERR_INVALID_ARGUMENT,
+                  "PreparedSnapshot output is already active");
+  }
+  if (new_pg == nullptr) {
+    return Status(StatusCode::ERR_INVALID_ARGUMENT,
+                  "Snapshot must not be null");
+  }
   int slot_index = getFreeSlot();
   if (slot_index < 0) {
     return Status(StatusCode::ERR_POOL_EXHAUSTED,
@@ -185,15 +235,34 @@ Status GraphSnapshotStore::PublishSnapshot(
   slots_[slot_index].reader_count_.store(kCleanupSentinel,
                                          std::memory_order_relaxed);
 
-  slots_[slot_index].storage_ = new_pg;
-  slots_[slot_index].view_ = GraphView(*new_pg);
+  try {
+    slots_[slot_index].storage_ = new_pg;
+    slots_[slot_index].view_ = GraphView(*new_pg);
+  } catch (const std::exception& e) {
+    releasePreparedSlot(slot_index);
+    return Status(StatusCode::ERR_INTERNAL_ERROR,
+                  std::string("Failed to prepare graph snapshot: ") + e.what());
+  } catch (...) {
+    releasePreparedSlot(slot_index);
+    return Status(StatusCode::ERR_INTERNAL_ERROR,
+                  "Failed to prepare graph snapshot");
+  }
 
-  // Release the write-guard: bump reader_count_ from kCleanupSentinel to 1
-  // (the prep-pin) atomically with a release fence so that all prior writes
-  // to storage_ and view_ are visible to any reader that subsequently observes
-  // old_count >= 0 via fetch_add(1) with acquire semantics.
-  slots_[slot_index].reader_count_.fetch_add(-kCleanupSentinel + 1,
-                                             std::memory_order_release);
+  prepared = PreparedSnapshot(this, slot_index);
+  return Status::OK();
+}
+
+void GraphSnapshotStore::InstallPreparedSnapshot(
+    PreparedSnapshot&& prepared) noexcept {
+  CHECK_EQ(prepared.store_, this);
+  const int slot_index = prepared.slot_index_;
+  CHECK_GE(slot_index, 0);
+  CHECK_LT(slot_index, slot_num_);
+  CHECK_EQ(slots_[slot_index].reader_count_.load(std::memory_order_acquire),
+           kCleanupSentinel);
+
+  // Publish the initialized payload together with the new cur-pin.
+  slots_[slot_index].reader_count_.store(1, std::memory_order_release);
 
   // Load the old cur slot index while holding the invariant that the old
   // cur slot's count >= 1 (its cur-pin).  No need for a phantom-pin: the
@@ -203,9 +272,8 @@ Status GraphSnapshotStore::PublishSnapshot(
   // the cur-pin is still held.
   int old_slot_index = cur_slot_index_.load(std::memory_order_acquire);
 
-  // Switch cur to the new slot.  The new slot already has its cur-pin (= 1)
-  // set by the fetch_add above, so readers that observe the new index will
-  // see old_count >= 1 and pin successfully.
+  // Switch cur to the new slot. The new slot already has its cur-pin (= 1),
+  // so readers that observe the new index can pin it successfully.
   cur_slot_index_.store(slot_index, std::memory_order_release);
 
   // Release the old slot's cur-pin now that the new slot is current.
@@ -216,6 +284,18 @@ Status GraphSnapshotStore::PublishSnapshot(
 
   // The new slot's prep-pin becomes its cur-pin — do NOT release it here.
 
+  prepared.store_ = nullptr;
+  prepared.slot_index_ = -1;
+}
+
+Status GraphSnapshotStore::PublishSnapshot(
+    const std::shared_ptr<PropertyGraph>& new_pg) {
+  PreparedSnapshot prepared;
+  auto status = PrepareSnapshot(new_pg, prepared);
+  if (!status.ok()) {
+    return status;
+  }
+  InstallPreparedSnapshot(std::move(prepared));
   return Status::OK();
 }
 

--- a/src/transaction/update_transaction.cc
+++ b/src/transaction/update_transaction.cc
@@ -348,8 +348,15 @@ bool UpdateTransaction::Commit() {
     return true;
   }
 
-  if (!snapshot_store_.HasFreeSlot()) {
-    LOG(ERROR) << "GraphSnapshotStore slot exhausted; refusing to commit";
+  // Reserve capacity and build GraphView before WAL append. If any normal
+  // preparation step fails, no durable record exists and the RAII handle
+  // returns the slot to the pool.
+  GraphSnapshotStore::PreparedSnapshot prepared_snapshot;
+  auto prepare_status =
+      snapshot_store_.PrepareSnapshot(cow_graph_, prepared_snapshot);
+  if (!prepare_status.ok()) {
+    LOG(ERROR) << "Failed to prepare graph snapshot: "
+               << prepare_status.ToString();
     Abort();
     return false;
   }
@@ -367,15 +374,11 @@ bool UpdateTransaction::Commit() {
     pipeline_cache_.clearGlobalCache();
   }
 
-  // PublishSnapshot MUST happen BEFORE release() which calls
-  // release_update_timestamp (advancing read_ts_). This ordering guarantees
-  // that any new reader observing the advanced read_ts will also see the new
-  // slot.
-  auto status = snapshot_store_.PublishSnapshot(cow_graph_);
-  if (!status.ok()) {
-    // We should never fail to publish the snapshot.
-    LOG(FATAL) << "Failed to publish snapshot: " << status.ToString();
-  }
+  // After WAL append, installation is a bounded noexcept state transition:
+  // the slot capacity and GraphView construction were already handled above.
+  // Install still precedes release_update_timestamp(), so a reader cannot
+  // observe the advanced timestamp with the old graph.
+  snapshot_store_.InstallPreparedSnapshot(std::move(prepared_snapshot));
 
   // The COW PG is now owned by the new slot. Drop our reference so this
   // transaction does not appear to still hold the snapshot. view_ wraps

--- a/tests/storage/test_graph_snapshot_store_concurrency.cc
+++ b/tests/storage/test_graph_snapshot_store_concurrency.cc
@@ -31,6 +31,7 @@
 #include <filesystem>
 #include <random>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "neug/generated/proto/plan/error.pb.h"
@@ -389,6 +390,36 @@ TEST_F(GraphSnapshotStoreConcurrencyTest, CowIsolationAfterCloneMutatePublish) {
   auto& slot = store_->PinCurrentSnapshot();
   EXPECT_EQ(slot.mutable_graph()->VertexNum(0, MAX_TIMESTAMP), 3u);
   store_->UnpinSnapshot(slot);
+}
+
+TEST_F(GraphSnapshotStoreConcurrencyTest,
+       PreparedSnapshotIsInvisibleUntilInstalled) {
+  GraphSnapshotStore store(2, initial_pg_);
+  auto candidate = make_new_pg();
+  GraphSnapshotStore::PreparedSnapshot prepared;
+
+  ASSERT_TRUE(store.PrepareSnapshot(candidate, prepared).ok());
+  ASSERT_TRUE(prepared.valid());
+  EXPECT_EQ(&store.CurrentSnapshot(), initial_pg_.get());
+
+  store.InstallPreparedSnapshot(std::move(prepared));
+  EXPECT_FALSE(prepared.valid());
+  EXPECT_EQ(&store.CurrentSnapshot(), candidate.get());
+}
+
+TEST_F(GraphSnapshotStoreConcurrencyTest,
+       AbandonedPreparedSnapshotReturnsSlotToPool) {
+  GraphSnapshotStore store(2, initial_pg_);
+  GraphSnapshotStore::PreparedSnapshot first;
+  GraphSnapshotStore::PreparedSnapshot second;
+
+  ASSERT_TRUE(store.PrepareSnapshot(make_new_pg(), first).ok());
+  auto exhausted = store.PrepareSnapshot(make_new_pg(), second);
+  ASSERT_FALSE(exhausted.ok());
+  EXPECT_EQ(exhausted.error_code(), StatusCode::ERR_POOL_EXHAUSTED);
+
+  first.reset();
+  EXPECT_TRUE(store.PrepareSnapshot(make_new_pg(), second).ok());
 }
 
 }  // namespace neug

--- a/tests/storage/test_tp_index.cc
+++ b/tests/storage/test_tp_index.cc
@@ -53,10 +53,14 @@ class CapturingWalWriter : public IWalWriter {
   void close() override {}
 
   bool append(const char* data, size_t length) override {
+    if (!succeed) {
+      return false;
+    }
     records.emplace_back(data, data + length);
     return true;
   }
 
+  bool succeed{true};
   std::vector<std::vector<char>> records;
 };
 
@@ -112,6 +116,7 @@ class TPIndexTest : public ::testing::Test {
     ap_ = std::make_unique<StorageAPUpdateInterface>(*graph_, *view_, 0,
                                                      allocator_);
     version_manager_.init_ts(0, 1);
+    wal_writer_.succeed = true;
     wal_writer_.records.clear();
     auto global_cache = std::make_shared<execution::GlobalQueryCache>(
         std::make_shared<StubPlanner>());
@@ -309,6 +314,39 @@ class TPIndexTest : public ::testing::Test {
   CapturingWalWriter wal_writer_;
   std::unique_ptr<execution::LocalQueryCache> local_cache_;
 };
+
+TEST_F(TPIndexTest, FailedWalAppendRecyclesPreparedSnapshot) {
+  StartSnapshotStore();
+  wal_writer_.succeed = false;
+
+  // More failures than available non-current slots prove that each abandoned
+  // pre-WAL reservation is returned to the pool.
+  for (int i = 0; i < 20; ++i) {
+    auto txn = NewUpdateTransaction();
+    StorageTPUpdateInterface tp(txn);
+    CreateVertexTypeParamBuilder builder;
+    ASSERT_TRUE(tp.CreateVertexType(builder.VertexLabel("Person")
+                                        .AddProperty("id", Value::INT64(0))
+                                        .AddPrimaryKeyName("id")
+                                        .Build()));
+    EXPECT_FALSE(txn.Commit());
+    EXPECT_FALSE(
+        snapshot_store_->CurrentSnapshot().schema().is_vertex_label_valid(
+            "Person"));
+  }
+
+  wal_writer_.succeed = true;
+  auto txn = NewUpdateTransaction();
+  StorageTPUpdateInterface tp(txn);
+  CreateVertexTypeParamBuilder builder;
+  ASSERT_TRUE(tp.CreateVertexType(builder.VertexLabel("Person")
+                                      .AddProperty("id", Value::INT64(0))
+                                      .AddPrimaryKeyName("id")
+                                      .Build()));
+  ASSERT_TRUE(txn.Commit());
+  EXPECT_TRUE(snapshot_store_->CurrentSnapshot().schema().is_vertex_label_valid(
+      "Person"));
+}
 
 TEST_F(TPIndexTest, CreateIndexEmptyGraphAndDuplicateName) {
   CreatePersonTableTP();


### PR DESCRIPTION
## Status

Superseded by #803.

The prepared-snapshot publication mechanism proposed here has since been consolidated into #803:

- reserve and fully build the next graph snapshot before appending its WAL record
- keep prepared snapshots reader-invisible and release abandoned slots through a move-only RAII handle
- perform a bounded, non-throwing publication step after WAL durability
- integrate the installed snapshot generation with coherent read-view publication and the transaction lifecycle

#803 is now the canonical implementation and review entry point. This PR is closed to avoid maintaining and merging two divergent implementations.

The focused WAL-failure regression tests here remain useful reference and can be carried over to #803 as needed.

## Original validation

- `cmake --build build --target neug_transaction graph_snapshot_store_test tp_index_test transaction_test -j4`
- `ctest --test-dir build -R 'graph_snapshot_store_test|tp_index_test|transaction_test' --output-on-failure` (3/3 passed)
