### PR TITLE
refactor: Extract index ddl to a separate interface

### DIFF
--- a/include/neug/storages/graph/graph_interface.h
+++ b/include/neug/storages/graph/graph_interface.h
@@ -935,18 +935,19 @@ class StorageUpdateInterface : public StorageReadInterface,
  * via dynamic_cast from IStorageInterface; a null result means the current
  * storage mode does not support index management.
  *
+ * Existence checks are expressed through the DDL calls themselves:
+ * CreateIndex fails with ERR_ILLEGAL_OPERATION when an index with the same
+ * name already exists, and DropIndex fails with ERR_NOT_FOUND when the
+ * target index does not exist.
+ *
  * Read-side index access (GetIndexByName/GetAllIndexes/IndexSearch) stays
  * on StorageReadInterface and remains available to all readable modes.
  *
  * @since v0.1.0
  */
-class StorageIndexInterface : virtual public IStorageInterface {
+class StorageIndexDDLInterface {
  public:
-  virtual ~StorageIndexInterface() {}
-
-  /** @brief Find an index by its unique name. */
-  virtual result<StorageIndex*> GetIndexByName(
-      const std::string& name) const = 0;
+  virtual ~StorageIndexDDLInterface() {}
 
   /** @brief Create, bind, and populate an index. */
   virtual result<StorageIndex*> CreateIndex(
@@ -957,7 +958,7 @@ class StorageIndexInterface : virtual public IStorageInterface {
 };
 
 class StorageAPUpdateInterface : public StorageUpdateInterface,
-                                 public StorageIndexInterface {
+                                 public StorageIndexDDLInterface {
  public:
   using PlanningChangedCallback = std::function<void()>;
 
@@ -973,8 +974,6 @@ class StorageAPUpdateInterface : public StorageUpdateInterface,
         on_planning_changed_(std::move(on_planning_changed)) {}
   ~StorageAPUpdateInterface() {}
 
-  neug::result<StorageIndex*> GetIndexByName(
-      const std::string& name) const override;
   neug::result<StorageIndex*> CreateIndex(
       std::unique_ptr<IndexMeta> meta) override;
   Status DropIndex(const std::string& name) override;

--- a/include/neug/storages/graph/graph_interface.h
+++ b/include/neug/storages/graph/graph_interface.h
@@ -871,13 +871,6 @@ class StorageUpdateInterface : public StorageReadInterface,
     return st;
   }
 
-  /**
-   * @brief Create, bind, and populate an index.
-   */
-  virtual neug::result<StorageIndex*> CreateIndex(
-      std::unique_ptr<IndexMeta> meta) = 0;
-  virtual Status DropIndex(const std::string& name) = 0;
-
  private:
   virtual void MarkSchemaDirty() = 0;
 
@@ -934,7 +927,37 @@ class StorageUpdateInterface : public StorageReadInterface,
   }
 };
 
-class StorageAPUpdateInterface : public StorageUpdateInterface {
+/**
+ * @brief Admin interface for storage index DDL (create/drop).
+ *
+ * Index management is only implemented by the AP update path
+ * (StorageAPUpdateInterface). The execution layer obtains this interface
+ * via dynamic_cast from IStorageInterface; a null result means the current
+ * storage mode does not support index management.
+ *
+ * Read-side index access (GetIndexByName/GetAllIndexes/IndexSearch) stays
+ * on StorageReadInterface and remains available to all readable modes.
+ *
+ * @since v0.1.0
+ */
+class StorageIndexInterface : virtual public IStorageInterface {
+ public:
+  virtual ~StorageIndexInterface() {}
+
+  /** @brief Find an index by its unique name. */
+  virtual result<StorageIndex*> GetIndexByName(
+      const std::string& name) const = 0;
+
+  /** @brief Create, bind, and populate an index. */
+  virtual result<StorageIndex*> CreateIndex(
+      std::unique_ptr<IndexMeta> meta) = 0;
+
+  /** @brief Drop an index by its unique name. */
+  virtual Status DropIndex(const std::string& name) = 0;
+};
+
+class StorageAPUpdateInterface : public StorageUpdateInterface,
+                                 public StorageIndexInterface {
  public:
   using PlanningChangedCallback = std::function<void()>;
 
@@ -950,6 +973,8 @@ class StorageAPUpdateInterface : public StorageUpdateInterface {
         on_planning_changed_(std::move(on_planning_changed)) {}
   ~StorageAPUpdateInterface() {}
 
+  neug::result<StorageIndex*> GetIndexByName(
+      const std::string& name) const override;
   neug::result<StorageIndex*> CreateIndex(
       std::unique_ptr<IndexMeta> meta) override;
   Status DropIndex(const std::string& name) override;

--- a/include/neug/transaction/update_transaction.h
+++ b/include/neug/transaction/update_transaction.h
@@ -183,10 +183,6 @@ class StorageTPUpdateInterface : public StorageUpdateInterface {
         wal_(txn.wal_builder_) {}
   ~StorageTPUpdateInterface() = default;
 
-  neug::result<StorageIndex*> CreateIndex(
-      std::unique_ptr<IndexMeta> meta) override;
-  Status DropIndex(const std::string& name) override;
-
  private:
   // Marks go to the COW clone; abort discards them with the clone.
   void MarkVertexTableDirty(label_t label) override {

--- a/src/execution/execute/ops/ddl/create_index.cc
+++ b/src/execution/execute/ops/ddl/create_index.cc
@@ -65,14 +65,13 @@ class CreateIndexOpr : public IOperator {
 
   neug::result<Context> Eval(IStorageInterface& graph, const ParamsMap& params,
                              Context&& ctx, OprTimer* timer) override {
-    auto* update_interface = dynamic_cast<StorageUpdateInterface*>(&graph);
-    if (!update_interface) {
+    auto* index_interface = dynamic_cast<StorageIndexInterface*>(&graph);
+    if (!index_interface) {
       RETURN_STATUS_ERROR(StatusCode::ERR_NOT_SUPPORTED,
-                          "CREATE INDEX can only be executed in update mode");
+                          "CREATE INDEX is only supported in AP update mode");
     }
 
-    auto existing_index =
-        update_interface->GetIndexByName(create_index_.name());
+    auto existing_index = index_interface->GetIndexByName(create_index_.name());
     if (existing_index) {
       if (ignore_conflict_) {
         return std::move(ctx);
@@ -82,7 +81,7 @@ class CreateIndexOpr : public IOperator {
     }
 
     auto index_meta = CreateIndexMeta(graph.schema(), create_index_);
-    GS_RESULT_CHECK(update_interface->CreateIndex(std::move(index_meta)));
+    GS_RESULT_CHECK(index_interface->CreateIndex(std::move(index_meta)));
     return std::move(ctx);
   }
 

--- a/src/execution/execute/ops/ddl/create_index.cc
+++ b/src/execution/execute/ops/ddl/create_index.cc
@@ -65,23 +65,23 @@ class CreateIndexOpr : public IOperator {
 
   neug::result<Context> Eval(IStorageInterface& graph, const ParamsMap& params,
                              Context&& ctx, OprTimer* timer) override {
-    auto* index_interface = dynamic_cast<StorageIndexInterface*>(&graph);
+    auto* index_interface = dynamic_cast<StorageIndexDDLInterface*>(&graph);
     if (!index_interface) {
       RETURN_STATUS_ERROR(StatusCode::ERR_NOT_SUPPORTED,
                           "CREATE INDEX is only supported in AP update mode");
     }
 
-    auto existing_index = index_interface->GetIndexByName(create_index_.name());
-    if (existing_index) {
-      if (ignore_conflict_) {
+    auto index_meta = CreateIndexMeta(graph.schema(), create_index_);
+    auto index = index_interface->CreateIndex(std::move(index_meta));
+    if (!index) {
+      // The storage layer reports ERR_ILLEGAL_OPERATION when an index with
+      // the same name already exists; honor IF NOT EXISTS in that case.
+      if (ignore_conflict_ &&
+          index.error().error_code() == StatusCode::ERR_ILLEGAL_OPERATION) {
         return std::move(ctx);
       }
-      RETURN_STATUS_ERROR(StatusCode::ERR_ILLEGAL_OPERATION,
-                          "Index already exists: " + create_index_.name());
+      RETURN_ERROR(index.error());
     }
-
-    auto index_meta = CreateIndexMeta(graph.schema(), create_index_);
-    GS_RESULT_CHECK(index_interface->CreateIndex(std::move(index_meta)));
     return std::move(ctx);
   }
 

--- a/src/execution/execute/ops/ddl/drop_index.cc
+++ b/src/execution/execute/ops/ddl/drop_index.cc
@@ -32,21 +32,22 @@ class DropIndexOpr : public IOperator {
 
   neug::result<Context> Eval(IStorageInterface& graph, const ParamsMap&,
                              Context&& ctx, OprTimer*) override {
-    auto* indexInterface = dynamic_cast<StorageIndexInterface*>(&graph);
+    auto* indexInterface = dynamic_cast<StorageIndexDDLInterface*>(&graph);
     if (!indexInterface) {
       RETURN_STATUS_ERROR(StatusCode::ERR_NOT_SUPPORTED,
                           "DROP INDEX is only supported in AP update mode");
     }
 
-    if (!indexInterface->GetIndexByName(indexName_)) {
-      if (ignore_conflict_) {
+    auto status = indexInterface->DropIndex(indexName_);
+    if (!status.ok()) {
+      // The storage layer reports ERR_NOT_FOUND when the target index does
+      // not exist; honor IF EXISTS in that case.
+      if (ignore_conflict_ &&
+          status.error_code() == StatusCode::ERR_NOT_FOUND) {
         return std::move(ctx);
       }
-      RETURN_STATUS_ERROR(StatusCode::ERR_NOT_FOUND,
-                          "Index does not exist: " + indexName_);
+      RETURN_ERROR(status);
     }
-
-    RETURN_STATUS_ERROR_IF_NOT_OK(indexInterface->DropIndex(indexName_));
     return std::move(ctx);
   }
 

--- a/src/execution/execute/ops/ddl/drop_index.cc
+++ b/src/execution/execute/ops/ddl/drop_index.cc
@@ -32,13 +32,13 @@ class DropIndexOpr : public IOperator {
 
   neug::result<Context> Eval(IStorageInterface& graph, const ParamsMap&,
                              Context&& ctx, OprTimer*) override {
-    auto* updateInterface = dynamic_cast<StorageUpdateInterface*>(&graph);
-    if (!updateInterface) {
+    auto* indexInterface = dynamic_cast<StorageIndexInterface*>(&graph);
+    if (!indexInterface) {
       RETURN_STATUS_ERROR(StatusCode::ERR_NOT_SUPPORTED,
-                          "DROP INDEX can only be executed in update mode");
+                          "DROP INDEX is only supported in AP update mode");
     }
 
-    if (!updateInterface->GetIndexByName(indexName_)) {
+    if (!indexInterface->GetIndexByName(indexName_)) {
       if (ignore_conflict_) {
         return std::move(ctx);
       }
@@ -46,7 +46,7 @@ class DropIndexOpr : public IOperator {
                           "Index does not exist: " + indexName_);
     }
 
-    RETURN_STATUS_ERROR_IF_NOT_OK(updateInterface->DropIndex(indexName_));
+    RETURN_STATUS_ERROR_IF_NOT_OK(indexInterface->DropIndex(indexName_));
     return std::move(ctx);
   }
 

--- a/src/storages/graph/graph_interface.cc
+++ b/src/storages/graph/graph_interface.cc
@@ -548,11 +548,6 @@ Status StorageAPUpdateInterface::DeleteEdgeTypeImpl(label_t src, label_t dst,
   return status;
 }
 
-neug::result<StorageIndex*> StorageAPUpdateInterface::GetIndexByName(
-    const std::string& name) const {
-  return index_manager_.GetIndexByName(name);
-}
-
 /**
  * Creates an index for a vertex property.
  *

--- a/src/storages/graph/graph_interface.cc
+++ b/src/storages/graph/graph_interface.cc
@@ -548,6 +548,11 @@ Status StorageAPUpdateInterface::DeleteEdgeTypeImpl(label_t src, label_t dst,
   return status;
 }
 
+neug::result<StorageIndex*> StorageAPUpdateInterface::GetIndexByName(
+    const std::string& name) const {
+  return index_manager_.GetIndexByName(name);
+}
+
 /**
  * Creates an index for a vertex property.
  *

--- a/src/storages/index/storage_index_manager.cc
+++ b/src/storages/index/storage_index_manager.cc
@@ -109,8 +109,7 @@ neug::result<StorageIndex*> StorageIndexManager::GetIndexByName(
     const std::string& name) const {
   auto it = indexes_.find(name);
   if (it == indexes_.end() || !it->second) {
-    RETURN_STATUS_ERROR(StatusCode::ERR_INVALID_ARGUMENT,
-                        "Index not found: " + name);
+    RETURN_STATUS_ERROR(StatusCode::ERR_NOT_FOUND, "Index not found: " + name);
   }
   return it->second.get();
 }

--- a/src/transaction/update_transaction.cc
+++ b/src/transaction/update_transaction.cc
@@ -748,17 +748,6 @@ Status StorageTPUpdateInterface::DeleteEdgeTypeImpl(label_t src_label_id,
   return status;
 }
 
-neug::result<StorageIndex*> StorageTPUpdateInterface::CreateIndex(
-    std::unique_ptr<IndexMeta>) {
-  RETURN_STATUS_ERROR(StatusCode::ERR_NOT_SUPPORTED,
-                      "CreateIndex is not supported in TP mode currently.");
-}
-
-Status StorageTPUpdateInterface::DropIndex(const std::string&) {
-  return Status(StatusCode::ERR_NOT_SUPPORTED,
-                "DropIndex is not supported in TP mode currently.");
-}
-
 Status StorageTPUpdateInterface::AddVertexImpl(label_t label, const Value& oid,
                                                const std::vector<Value>& props,
                                                vid_t& vid) {

--- a/tests/storage/test_ap_index.cc
+++ b/tests/storage/test_ap_index.cc
@@ -391,10 +391,10 @@ TEST_F(APIndexTest, CreateIndexEmptyGraphAndDuplicateName) {
   EXPECT_EQ(planning_change_count_, 2);
 }
 
-TEST_F(APIndexTest, DropMissingIndexReturnsInvalidArgument) {
+TEST_F(APIndexTest, DropMissingIndexReturnsNotFound) {
   auto status = ap_->DropIndex("missing_index");
   EXPECT_FALSE(status.ok());
-  EXPECT_EQ(status.error_code(), StatusCode::ERR_INVALID_ARGUMENT);
+  EXPECT_EQ(status.error_code(), StatusCode::ERR_NOT_FOUND);
   EXPECT_EQ(status.error_message(), "Index not found: missing_index");
 }
 

--- a/tests/storage/test_tp_index.cc
+++ b/tests/storage/test_tp_index.cc
@@ -376,13 +376,14 @@ TEST_F(TPIndexTest, CreateIndexEmptyGraphAndDuplicateName) {
 
 TEST_F(TPIndexTest, IndexAdminInterfaceIsAPOnly) {
   // Index management is an AP-only capability: the AP update interface
-  // implements StorageIndexInterface while the TP update interface does not.
-  EXPECT_NE(dynamic_cast<StorageIndexInterface*>(ap_.get()), nullptr);
+  // implements StorageIndexDDLInterface while the TP update interface does
+  // not.
+  EXPECT_NE(dynamic_cast<StorageIndexDDLInterface*>(ap_.get()), nullptr);
 
   CreatePersonTableTP();
   auto txn = NewUpdateTransaction();
   StorageTPUpdateInterface tp(txn);
-  EXPECT_EQ(dynamic_cast<StorageIndexInterface*>(&tp), nullptr);
+  EXPECT_EQ(dynamic_cast<StorageIndexDDLInterface*>(&tp), nullptr);
 }
 
 TEST_F(TPIndexTest, DropVertexTypeDeletesBoundIndex) {

--- a/tests/storage/test_tp_index.cc
+++ b/tests/storage/test_tp_index.cc
@@ -374,6 +374,17 @@ TEST_F(TPIndexTest, CreateIndexEmptyGraphAndDuplicateName) {
   EXPECT_EQ(duplicate.error().error_code(), StatusCode::ERR_ILLEGAL_OPERATION);
 }
 
+TEST_F(TPIndexTest, IndexAdminInterfaceIsAPOnly) {
+  // Index management is an AP-only capability: the AP update interface
+  // implements StorageIndexInterface while the TP update interface does not.
+  EXPECT_NE(dynamic_cast<StorageIndexInterface*>(ap_.get()), nullptr);
+
+  CreatePersonTableTP();
+  auto txn = NewUpdateTransaction();
+  StorageTPUpdateInterface tp(txn);
+  EXPECT_EQ(dynamic_cast<StorageIndexInterface*>(&tp), nullptr);
+}
+
 TEST_F(TPIndexTest, DropVertexTypeDeletesBoundIndex) {
   CreatePersonTableAP();
   CreateReplacementTableAP();
@@ -685,25 +696,6 @@ TEST_F(TPIndexTest, AutomaticallyDeletedIndexStaysDeletedAfterReopen) {
   auto indexes = reopened->index_manager().GetIndex(person_label, "age");
   ASSERT_TRUE(indexes) << indexes.error().ToString();
   EXPECT_TRUE(indexes->empty());
-}
-
-TEST_F(TPIndexTest, DropIndexIsNotSupportedInTPMode) {
-  CreatePersonTableAP();
-  ASSERT_TRUE(CreateIndex("idx_person_age", "Person", "age"));
-  StartSnapshotStore();
-  auto person_label =
-      snapshot_store_->CurrentSnapshot().schema().get_vertex_label_id("Person");
-  ASSERT_EQ(GetIndexes(person_label, "age").size(), 1);
-
-  auto txn = NewUpdateTransaction();
-  StorageTPUpdateInterface tp(txn);
-  auto status = tp.DropIndex("idx_person_age");
-  EXPECT_FALSE(status.ok());
-  EXPECT_EQ(status.error_code(), StatusCode::ERR_NOT_SUPPORTED);
-  txn.Abort();
-
-  EXPECT_NE(GetIndexByName("idx_person_age"), nullptr);
-  EXPECT_EQ(GetIndexes(person_label, "age").size(), 1);
 }
 
 TEST_F(TPIndexTest, WalReplayRestoresIndexData) {


### PR DESCRIPTION
Closes #838

## Summary

- Extract index administration into `StorageIndexInterface`.
- Restrict CREATE INDEX and DROP INDEX to the AP update path.
- Add coverage for AP-only index-admin capability.