### PR TITLE
refactor: unify COW update transaction lifecycle for AP and TP

### DIFF
--- a/doc/source/transaction/transaction.md
+++ b/doc/source/transaction/transaction.md
@@ -25,7 +25,19 @@ conn.execute("CREATE (p:Person {name: 'Alice'})")  # Transaction 1
 conn.execute("CREATE (p:Person {name: 'Bob'})")    # Transaction 2
 ```
 
-> **Coming in v0.2:** Multi-statement execution (multiple statements separated by `;` in a single `execute()` call) and explicit transaction control (`BEGIN`/`COMMIT`/`ABORT`) will be supported in NeuG v0.2.
+> **Planned for NeuG v0.3:** Explicit transaction control (`BEGIN`/`COMMIT`/`ABORT`).
+> This is not available in current releases.
+
+### Explicit Transaction Scope (v0.3)
+
+NeuG does **not** plan to support multi-statement batches in the near term:
+
+- One `execute()` call continues to accept exactly one Cypher statement.
+- Statements separated by `;` in one `execute()` call are not a transaction feature and are not on the v0.3 roadmap.
+- Savepoints are out of scope for v0.3.
+
+The exact lifecycle, error and isolation rules for explicit transaction control will be published with
+the v0.3 implementation. Until then, callers must rely on the current auto-commit behavior.
 
 ## Deployment Modes Overview
 
@@ -289,10 +301,10 @@ finally:
 
 ## Roadmap
 
-**v0.2: Transaction Control**
-- Multi-statement execution: multiple statements separated by `;` in a single `execute()` call, sharing the same transaction boundary
-- Explicit transaction primitives (`BEGIN`/`COMMIT`/`ABORT`) for fine-grained transaction control
-- Savepoint support for partial rollback within transactions
+**v0.3: Explicit Transaction Control**
+- Explicit transaction primitives (`BEGIN`/`COMMIT`/`ABORT`)
+- No multi-statement batches: a single `execute()` call continues to execute one statement only
+- Savepoints are out of scope for v0.3
 
 **Recovery & Durability**
 - More transparent recovery mechanisms for Embedded mode

--- a/include/neug/main/execution_slot.h
+++ b/include/neug/main/execution_slot.h
@@ -157,6 +157,8 @@ class ExecutionSlot {
 
   UpdateTransaction GetUpdateTransaction();
 
+  Status CommitUpdateTransaction(UpdateTransaction& transaction);
+
   CompactTransaction GetCompactTransaction();
 
   /**

--- a/include/neug/storages/graph/graph_interface.h
+++ b/include/neug/storages/graph/graph_interface.h
@@ -34,6 +34,21 @@ struct IndexMeta;
 struct IndexQueryParams;
 struct SearchResult;
 
+namespace index_ddl {
+
+using CatalogChangedCallback = std::function<void()>;
+
+neug::result<StorageIndex*> CreateIndex(
+    PropertyGraph& graph, GraphView& view, timestamp_t timestamp,
+    neug::Allocator& alloc, std::unique_ptr<IndexMeta> meta,
+    const CatalogChangedCallback& on_catalog_changed = {});
+
+Status DropIndex(PropertyGraph& graph, GraphView& view, timestamp_t timestamp,
+                 neug::Allocator& alloc, const std::string& name,
+                 const CatalogChangedCallback& on_catalog_changed = {});
+
+}  // namespace index_ddl
+
 namespace graph_interface_impl {
 
 using neug::label_t;
@@ -970,7 +985,6 @@ class StorageAPUpdateInterface : public StorageUpdateInterface,
         mut_view_(view),
         alloc_(alloc),
         timestamp_(timestamp),
-        index_manager_(graph_.mutable_index_manager()),
         on_planning_changed_(std::move(on_planning_changed)) {}
   ~StorageAPUpdateInterface() {}
 
@@ -1047,7 +1061,6 @@ class StorageAPUpdateInterface : public StorageUpdateInterface,
   GraphView& mut_view_;
   neug::Allocator& alloc_;
   timestamp_t timestamp_;
-  StorageIndexManager& index_manager_;
   PlanningChangedCallback on_planning_changed_;
 };
 

--- a/include/neug/storages/graph/graph_interface.h
+++ b/include/neug/storages/graph/graph_interface.h
@@ -946,7 +946,7 @@ class StorageUpdateInterface : public StorageReadInterface,
  * @brief Admin interface for storage index DDL (create/drop).
  *
  * Index management is only implemented by the AP update path
- * (StorageAPUpdateInterface). The execution layer obtains this interface
+ * (StorageAPInPlaceUpdateInterface). The execution layer obtains this interface
  * via dynamic_cast from IStorageInterface; a null result means the current
  * storage mode does not support index management.
  *
@@ -972,12 +972,12 @@ class StorageIndexDDLInterface {
   virtual Status DropIndex(const std::string& name) = 0;
 };
 
-class StorageAPUpdateInterface : public StorageUpdateInterface,
-                                 public StorageIndexDDLInterface {
+class StorageAPInPlaceUpdateInterface : public StorageUpdateInterface,
+                                        public StorageIndexDDLInterface {
  public:
   using PlanningChangedCallback = std::function<void()>;
 
-  explicit StorageAPUpdateInterface(
+  explicit StorageAPInPlaceUpdateInterface(
       PropertyGraph& graph, GraphView& view, timestamp_t timestamp,
       neug::Allocator& alloc, PlanningChangedCallback on_planning_changed = {})
       : StorageUpdateInterface(view, timestamp),
@@ -986,7 +986,7 @@ class StorageAPUpdateInterface : public StorageUpdateInterface,
         alloc_(alloc),
         timestamp_(timestamp),
         on_planning_changed_(std::move(on_planning_changed)) {}
-  ~StorageAPUpdateInterface() {}
+  ~StorageAPInPlaceUpdateInterface() {}
 
   neug::result<StorageIndex*> CreateIndex(
       std::unique_ptr<IndexMeta> meta) override;

--- a/include/neug/storages/graph/property_graph_cow_state.h
+++ b/include/neug/storages/graph/property_graph_cow_state.h
@@ -51,8 +51,14 @@ struct PropertyGraphCowState {
   std::unordered_map<uint32_t, EdgeTableCowState> edge_tables;
   // record index detach state according to unique index name
   std::unordered_map<std::string, bool> index_detached;
+  // Schema/catalog changes cannot always be inferred from detach state (for
+  // example rename and delete operations), so track them explicitly.
+  bool schema_changed{false};
 
   static PropertyGraphCowState FromSchema(const Schema& schema);
+
+  bool HasDetachedStorage() const;
+  bool HasChanges() const { return schema_changed || HasDetachedStorage(); }
 };
 
 }  // namespace neug

--- a/include/neug/storages/graph/property_graph_cow_state.h
+++ b/include/neug/storages/graph/property_graph_cow_state.h
@@ -54,6 +54,8 @@ struct PropertyGraphCowState {
   // Schema/catalog changes cannot always be inferred from detach state (for
   // example rename and delete operations), so track them explicitly.
   bool schema_changed{false};
+  // Whether publishing this COW workspace must advance the planning generation.
+  bool planning_changed{false};
 
   static PropertyGraphCowState FromSchema(const Schema& schema);
 

--- a/include/neug/storages/index/index_utils.h
+++ b/include/neug/storages/index/index_utils.h
@@ -16,10 +16,24 @@
 
 #pragma once
 
+#include <functional>
+#include <vector>
+
+#include "neug/utils/property/types.h"
+#include "neug/utils/result.h"
+
 namespace neug {
 
 struct IndexMeta;
+class PropertyGraph;
+class StorageIndex;
 
 bool IsHNSWIndex(const IndexMeta& meta);
+
+// Adds index entries for newly inserted vertices. COW callers use
+// prepare_index to detach each index before its first mutation.
+Status AddBatchVertexIndexData(
+    PropertyGraph& graph, label_t label, const std::vector<vid_t>& vids,
+    const std::function<Status(StorageIndex&)>& prepare_index = nullptr);
 
 }  // namespace neug

--- a/include/neug/transaction/README.md
+++ b/include/neug/transaction/README.md
@@ -6,9 +6,10 @@
 
 For ordinary queries, the transactional `ExecutionSlot` strategy uses
 `ReadTransaction`, `InsertTransaction`, and `UpdateTransaction`. The direct
-strategy usually owns an `UpdateTimestampLease` or `ReadSnapshotLease` and uses
-`StorageReadInterface` or `StorageAPUpdateInterface`. `CompactTransaction` and
-`CheckpointCoordinator` implement maintenance paths.
+strategy uses `ReadSnapshotLease` for reads, keeps the current in-place path for
+automatic insert-only statements, and uses the same COW `UpdateTransaction` as
+the transactional strategy for update and schema statements.
+`CompactTransaction` and `CheckpointCoordinator` implement maintenance paths.
 
 These objects use RAII: terminal operations disarm their resources, and
 destruction releases any active transaction or lease. Acquisition is ordered
@@ -60,19 +61,22 @@ discards buffered operations and completes the timestamp without applying them.
 Acquiring an update timestamp changes admission from `kOpen` to
 `kInsertsBlocked`, blocking new inserts and updates and waiting for active
 inserts to finish. Reads remain allowed. `ExecutionSlot` then clones the
-current `PropertyGraph`, and `StorageTPUpdateInterface` applies DML or DDL to
-that COW clone.
+current `PropertyGraph`, and `StorageCOWUpdateInterface` applies DML or DDL to
+that COW clone. `UpdateTransaction` owns the clone, CowState and timestamp
+lease; each statement temporarily supplies its allocator, and commit
+temporarily supplies the snapshot store and, when required, the WAL writer.
 
-A non-empty `Commit()` checks snapshot-slot capacity, appends the finalized WAL,
-and calls `UpdateTimestampLease::BeginCommit()`. This changes admission to
-`kAllBlocked`, preventing new readers and writers while the clone is published.
-Readers that already hold a `SnapshotGuard` are not drained and continue using
-their pinned slot. The snapshot is published before the update timestamp is
-completed, so a reader cannot observe the new timestamp with the old snapshot.
+A non-empty `Commit()` first reserves a snapshot slot. A `kWal` transaction then
+appends its finalized redo, while a `kNoWal` transaction performs no WAL
+work. Commit next calls `UpdateTimestampLease::BeginCommit()`, publishes the
+prepared clone, and completes the timestamp with the published snapshot
+generation. New readers and writers are briefly blocked during publication;
+already-pinned readers continue using their old slot.
 
-Schema changes invalidate the shared query cache before publication. An empty
-commit, `Abort()`, or destruction discards the clone, completes the timestamp,
-and reopens admission without publishing a snapshot.
+`PropertyGraphCowState::HasChanges()` decides whether a snapshot must be
+published. Data-only commits retain the planning generation; schema or index
+changes advance it once. An empty commit, `Abort()`, or destruction discards the
+clone, closes the timestamp gap, and reopens admission without publishing.
 
 ## Compact Transaction
 
@@ -121,9 +125,10 @@ includes commit, abort, and empty transactions, but only commits modify graph
 state. `TimestampWindow` records out-of-order completions so a later writer
 cannot advance `read_ts_` past an earlier unfinished transaction.
 
-Insert commit appends WAL before replaying into the live graph. Update commit
-appends WAL before publishing its COW snapshot. Both complete their timestamps
-only after the graph change is visible.
+Insert commit appends WAL before replaying into the live graph. A `kWal` update
+appends WAL before publishing its COW snapshot; a `kNoWal` update publishes
+without WAL and relies on a later checkpoint for crash persistence. Both
+complete their timestamps only after the graph change is visible.
 
 Update waiters directly contend the existing admission phase; acquisition order
 is unspecified. The public manager API retains its no-deadline fast path.
@@ -148,4 +153,4 @@ existing inserts.
 
 For a `ReadTransaction`, it will be assigned a graph timestamp. All insert or update transactions with timestamp less than or equal to that timestamp have been committed and are visible through timestamp filtering and the pinned snapshot.
 
-For each `InsertTransaction` or `UpdateTransaction`, a unique timestamp will be assigned. When committing, a write-ahead log will be written to the disk and all modifications will be applied to the graph atomically.
+For each `InsertTransaction` or `UpdateTransaction`, a unique timestamp is assigned. Commit makes all modifications visible atomically. Transactional `kWal` writes are logged before publication; embedded `kNoWal` writes are not crash-durable until a later checkpoint.

--- a/include/neug/transaction/update_transaction.h
+++ b/include/neug/transaction/update_transaction.h
@@ -16,6 +16,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <chrono>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -34,6 +35,7 @@
 #include "neug/storages/graph/property_graph.h"
 #include "neug/storages/graph/property_graph_cow_state.h"
 #include "neug/storages/graph_snapshot_store.h"
+#include "neug/storages/index/storage_index.h"
 #include "neug/transaction/timestamp_lease.h"
 #include "neug/transaction/transaction_utils.h"
 #include "neug/transaction/wal/wal_builder.h"
@@ -48,19 +50,22 @@ class IWalWriter;
 class IVersionManager;
 class Schema;
 
+enum class TransactionDurability : uint8_t { kNoWal, kWal };
+
 /**
  * @brief Resource holder and lifecycle manager for update transactions.
  *
- * UpdateTransaction owns the COW-cloned PropertyGraph and all associated
- * resources (WAL buffer, allocator, timestamp lease, snapshot store).
- * Graph modification logic (DDL/DML) is implemented by StorageTPUpdateInterface
- * which accesses UpdateTransaction's private members via friend declaration.
+ * UpdateTransaction owns one COW workspace and one update timestamp lease.
+ * Statement-local allocators and commit-time publication/WAL resources are
+ * borrowed by the caller and never retained by the transaction.
  *
  * **COW Design:**
  * - Holds a shared_ptr to a COW-cloned PropertyGraph
- * - StorageTPUpdateInterface performs all DDL/DML modifications on the COW copy
- * - Commit prepares the COW snapshot before WAL, then performs a no-fail
- *   publication after WAL succeeds.
+ * - StorageCOWUpdateInterface performs all DDL/DML modifications on the COW
+ *   copy
+ * - kNoWal commits publish without constructing or writing redo
+ * - kWal commits prepare the snapshot before WAL, then perform a no-fail
+ *   publication after WAL succeeds
  * - Abort discards the COW copy (no effect on original)
  *
  * **Concurrency contract** (VersionManager state machine):
@@ -75,24 +80,19 @@ class Schema;
  */
 class UpdateTransaction {
  public:
-  /**
-   * @brief Construct an UpdateTransaction with a COW PropertyGraph.
-   *
-   * @param cow_graph PropertyGraph COW clone
-   * @param planning_generation Planning generation of the cloned snapshot
-   * @param alloc Reference to memory allocator
-   * @param logger Reference to WAL writer
-   * @param snapshot_store Reference to GraphSnapshotStore for commit
-   * @param timestamp_lease Owned update timestamp and admission lifecycle
-   *
-   * @note The caller is responsible for acquiring the timestamp lease before
-   * creating the COW copy via Clone().
-   * @since v0.1.0
-   */
-  UpdateTransaction(std::shared_ptr<PropertyGraph> cow_graph,
-                    uint64_t planning_generation, Allocator& alloc,
-                    IWalWriter& logger, GraphSnapshotStore& snapshot_store,
-                    UpdateTimestampLease timestamp_lease);
+  static UpdateTransaction Begin(IVersionManager& version_manager,
+                                 GraphSnapshotStore& snapshot_store,
+                                 TransactionDurability durability);
+
+  static UpdateTransaction BeginUntil(
+      IVersionManager& version_manager, GraphSnapshotStore& snapshot_store,
+      TransactionDurability durability,
+      std::chrono::steady_clock::time_point deadline);
+
+  UpdateTransaction(UpdateTransaction&& other) noexcept;
+  UpdateTransaction(const UpdateTransaction&) = delete;
+  UpdateTransaction& operator=(const UpdateTransaction&) = delete;
+  UpdateTransaction& operator=(UpdateTransaction&&) = delete;
 
   /**
    * @brief Destructor that calls Abort().
@@ -106,9 +106,10 @@ class UpdateTransaction {
    */
   timestamp_t timestamp() const { return timestamp_lease_.Timestamp(); }
 
-  bool Commit();
+  Status Commit(GraphSnapshotStore& snapshot_store,
+                IWalWriter* wal_writer = nullptr);
 
-  void Abort();
+  void Abort() noexcept;
 
   static void IngestWal(PropertyGraph& graph, uint32_t timestamp, char* data,
                         size_t length, Allocator& alloc);
@@ -116,7 +117,7 @@ class UpdateTransaction {
   const GraphView& view() const { return view_; }
 
   GraphStats statistic() const {
-    return GraphStats(view_, planning_generation_);
+    return GraphStats(view_, base_planning_generation_);
   }
 
   // --- Read-only accessors (not graph modifications) ---
@@ -151,37 +152,45 @@ class UpdateTransaction {
                                            prop_id);
   }
 
-  friend class StorageTPUpdateInterface;
+  friend class StorageCOWUpdateInterface;
 
  private:
-  void release(std::optional<uint32_t> installed_snapshot_generation);
+  UpdateTransaction(TransactionDurability durability,
+                    std::shared_ptr<PropertyGraph> cow_graph,
+                    uint64_t planning_generation,
+                    UpdateTimestampLease timestamp_lease);
 
+  void release(std::optional<uint32_t> installed_snapshot_generation) noexcept;
+
+  TransactionDurability durability_;
   // COW storage - the cloned PropertyGraph
   std::shared_ptr<PropertyGraph> cow_graph_;
   PropertyGraphCowState cow_state_;
   GraphView view_;
 
-  Allocator& alloc_;
-  IWalWriter& logger_;
-  GraphSnapshotStore& snapshot_store_;
   UpdateTimestampLease timestamp_lease_;
-  uint64_t planning_generation_;
+  uint64_t base_planning_generation_;
 
   std::shared_ptr<Checkpoint> ckp_;
-  WalBuilder wal_builder_;
+  std::optional<WalBuilder> wal_builder_;
 };
 
-class StorageTPUpdateInterface : public StorageUpdateInterface {
+class StorageCOWUpdateInterface : public StorageUpdateInterface {
  public:
-  explicit StorageTPUpdateInterface(UpdateTransaction& txn)
+  StorageCOWUpdateInterface(UpdateTransaction& txn, Allocator& alloc)
       : StorageUpdateInterface(txn.view(), txn.timestamp()),
         cow_graph_(txn.cow_graph_),
         cow_state_(txn.cow_state_),
         mut_view_(txn.view_),
-        alloc_(txn.alloc_),
+        alloc_(alloc),
         ckp_(txn.ckp_),
-        wal_(txn.wal_builder_) {}
-  ~StorageTPUpdateInterface() = default;
+        wal_(txn.wal_builder_ ? &*txn.wal_builder_ : nullptr) {}
+  ~StorageCOWUpdateInterface() = default;
+
+ protected:
+  neug::result<StorageIndex*> CreateIndexDDLForAP(
+      std::unique_ptr<IndexMeta> meta);
+  Status DropIndexDDLForAP(const std::string& name);
 
  private:
   // Marks go to the COW clone; abort discards them with the clone.
@@ -191,7 +200,10 @@ class StorageTPUpdateInterface : public StorageUpdateInterface {
   void MarkEdgeTableDirty(label_t src, label_t dst, label_t edge) override {
     cow_graph_->MarkEdgeTableDirty(src, dst, edge);
   }
-  void MarkSchemaDirty() override { cow_graph_->MarkSchemaDirty(); }
+  void MarkSchemaDirty() override {
+    cow_graph_->MarkSchemaDirty();
+    cow_state_.schema_changed = true;
+  }
 
   // --- DML *Impl ---
   Status UpdateVertexPropertyImpl(label_t label, vid_t lid, int col_id,
@@ -269,7 +281,23 @@ class StorageTPUpdateInterface : public StorageUpdateInterface {
   GraphView& mut_view_;
   Allocator& alloc_;
   std::shared_ptr<Checkpoint>& ckp_;
-  WalBuilder& wal_;
+  WalBuilder* wal_;
+};
+
+class StorageAPCOWUpdateInterface final : public StorageCOWUpdateInterface,
+                                          public StorageIndexDDLInterface {
+ public:
+  StorageAPCOWUpdateInterface(UpdateTransaction& txn, Allocator& alloc)
+      : StorageCOWUpdateInterface(txn, alloc) {}
+
+  neug::result<StorageIndex*> CreateIndex(
+      std::unique_ptr<IndexMeta> meta) override {
+    return CreateIndexDDLForAP(std::move(meta));
+  }
+
+  Status DropIndex(const std::string& name) override {
+    return DropIndexDDLForAP(name);
+  }
 };
 
 }  // namespace neug

--- a/include/neug/transaction/update_transaction.h
+++ b/include/neug/transaction/update_transaction.h
@@ -109,6 +109,8 @@ class UpdateTransaction {
   Status Commit(GraphSnapshotStore& snapshot_store,
                 IWalWriter* wal_writer = nullptr);
 
+  void MarkPlanningChanged() noexcept { cow_state_.planning_changed = true; }
+
   void Abort() noexcept;
 
   static void IngestWal(PropertyGraph& graph, uint32_t timestamp, char* data,
@@ -188,9 +190,14 @@ class StorageCOWUpdateInterface : public StorageUpdateInterface {
   ~StorageCOWUpdateInterface() = default;
 
  protected:
-  neug::result<StorageIndex*> CreateIndexDDLForAP(
-      std::unique_ptr<IndexMeta> meta);
-  Status DropIndexDDLForAP(const std::string& name);
+  // Non-virtual COW implementations exposed only by the AP capability adapter.
+  neug::result<StorageIndex*> CreateIndexForAP(std::unique_ptr<IndexMeta> meta);
+  Status DropIndexForAP(const std::string& name);
+  result<std::vector<vid_t>> BatchAddVerticesForAP(
+      label_t v_label_id, std::shared_ptr<IDataChunkSupplier> supplier);
+  Status BatchAddEdgesForAP(label_t src_label, label_t dst_label,
+                            label_t edge_label,
+                            std::shared_ptr<IDataChunkSupplier> supplier);
 
  private:
   // Marks go to the COW clone; abort discards them with the clone.
@@ -203,6 +210,7 @@ class StorageCOWUpdateInterface : public StorageUpdateInterface {
   void MarkSchemaDirty() override {
     cow_graph_->MarkSchemaDirty();
     cow_state_.schema_changed = true;
+    cow_state_.planning_changed = true;
   }
 
   // --- DML *Impl ---
@@ -292,11 +300,24 @@ class StorageAPCOWUpdateInterface final : public StorageCOWUpdateInterface,
 
   neug::result<StorageIndex*> CreateIndex(
       std::unique_ptr<IndexMeta> meta) override {
-    return CreateIndexDDLForAP(std::move(meta));
+    return CreateIndexForAP(std::move(meta));
   }
 
   Status DropIndex(const std::string& name) override {
-    return DropIndexDDLForAP(name);
+    return DropIndexForAP(name);
+  }
+
+ private:
+  result<std::vector<vid_t>> BatchAddVerticesImpl(
+      label_t v_label_id,
+      std::shared_ptr<IDataChunkSupplier> supplier) override {
+    return BatchAddVerticesForAP(v_label_id, std::move(supplier));
+  }
+  Status BatchAddEdgesImpl(
+      label_t src_label, label_t dst_label, label_t edge_label,
+      std::shared_ptr<IDataChunkSupplier> supplier) override {
+    return BatchAddEdgesForAP(src_label, dst_label, edge_label,
+                              std::move(supplier));
   }
 };
 

--- a/src/main/execution_slot.cc
+++ b/src/main/execution_slot.cc
@@ -83,7 +83,8 @@ void ExecutionSlotLease::reset() noexcept {
 
 namespace {
 
-void markPlanningChangedIfNeeded(InPlaceWriteScope& write_scope,
+template <typename WriteContext>
+void markPlanningChangedIfNeeded(WriteContext& write_context,
                                  ExplainMode explain_mode,
                                  const execution::CacheValue* prepared_query,
                                  const Status& execution_status) {
@@ -95,7 +96,7 @@ void markPlanningChangedIfNeeded(InPlaceWriteScope& write_scope,
   }
   const auto& flags = prepared_query->flags;
   if (flags.batch() || flags.update()) {
-    write_scope.MarkPlanningChanged();
+    write_context.MarkPlanningChanged();
   }
 }
 
@@ -372,7 +373,7 @@ Status ExecutionSlot::executeCore(const std::string& query,
     } else if (access_mode == AccessMode::kInsert) {
       InPlaceWriteScope write_scope(version_manager_, snapshot_store_);
       auto& slot = write_scope.Snapshot();
-      StorageAPUpdateInterface storage(
+      StorageAPInPlaceUpdateInterface storage(
           *slot.mutable_graph(), slot.mutable_view(), write_scope.Timestamp(),
           alloc_, [&write_scope]() { write_scope.MarkPlanningChanged(); });
       status = execute_on_storage(
@@ -386,6 +387,8 @@ Status ExecutionSlot::executeCore(const std::string& query,
       StorageAPCOWUpdateInterface storage(transaction, alloc_);
       status = execute_on_storage(transaction.statistic(), storage);
       if (status.ok()) {
+        markPlanningChangedIfNeeded(transaction, analysis.explain_mode,
+                                    prepared_query.get(), status);
         status = transaction.Commit(snapshot_store_);
       } else {
         transaction.Abort();

--- a/src/main/execution_slot.cc
+++ b/src/main/execution_slot.cc
@@ -194,12 +194,13 @@ InsertTransaction ExecutionSlot::GetInsertTransaction() {
 }
 
 UpdateTransaction ExecutionSlot::GetUpdateTransaction() {
-  UpdateTimestampLease timestamp_lease(version_manager_);
-  auto [cow_graph, planning_generation] =
-      snapshot_store_.CloneCurrentForUpdate();
-  return UpdateTransaction(std::move(cow_graph), planning_generation, alloc_,
-                           *wal_writer_, snapshot_store_,
-                           std::move(timestamp_lease));
+  CHECK(execution_strategy_ == QueryExecutionStrategy::kTransactional);
+  return UpdateTransaction::Begin(version_manager_, snapshot_store_,
+                                  TransactionDurability::kWal);
+}
+
+Status ExecutionSlot::CommitUpdateTransaction(UpdateTransaction& transaction) {
+  return transaction.Commit(snapshot_store_, wal_writer_);
 }
 
 CompactTransaction ExecutionSlot::GetCompactTransaction() {
@@ -321,22 +322,23 @@ Status ExecutionSlot::executeCore(const std::string& query,
     if (NEUG_UNLIKELY(!prepared)) {
       return prepared.error();
     }
-    prepared_query = std::move(prepared).value();
+    auto prepared_query_for_execution = std::move(prepared).value();
 
-    RETURN_IF_NOT_OK(validateQueryAnalysis(analysis, *prepared_query));
     RETURN_IF_NOT_OK(
-        validatePlan(access_mode, prepared_query->flags,
+        validateQueryAnalysis(analysis, *prepared_query_for_execution));
+    RETURN_IF_NOT_OK(
+        validatePlan(access_mode, prepared_query_for_execution->flags,
                      analysis.explain_mode == ExplainMode::kExplain));
-
-    auto parsed_parameters =
-        execution::parseJsonParameters(prepared_query->params_type, parameters);
+    auto parsed_parameters = execution::parseJsonParameters(
+        prepared_query_for_execution->params_type, parameters);
     if (NEUG_UNLIKELY(!parsed_parameters)) {
       return parsed_parameters.error();
     }
 
-    RETURN_IF_NOT_OK(
-        executePreparedQuery(*prepared_query, analysis.explain_mode,
-                             parsed_parameters.value(), storage, response));
+    RETURN_IF_NOT_OK(executePreparedQuery(
+        *prepared_query_for_execution, analysis.explain_mode,
+        parsed_parameters.value(), storage, response));
+    prepared_query = std::move(prepared_query_for_execution);
     return Status::OK();
   };
 
@@ -367,9 +369,7 @@ Status ExecutionSlot::executeCore(const std::string& query,
       StorageReadInterface storage(lease.view(), lease.timestamp());
       status = execute_on_storage(
           GraphStats(lease.view(), lease.planning_generation()), storage);
-    } else if (access_mode == AccessMode::kInsert ||
-               access_mode == AccessMode::kUpdate ||
-               access_mode == AccessMode::kSchema) {
+    } else if (access_mode == AccessMode::kInsert) {
       InPlaceWriteScope write_scope(version_manager_, snapshot_store_);
       auto& slot = write_scope.Snapshot();
       StorageAPUpdateInterface storage(
@@ -379,6 +379,17 @@ Status ExecutionSlot::executeCore(const std::string& query,
           GraphStats(slot.view(), slot.planning_generation()), storage);
       markPlanningChangedIfNeeded(write_scope, analysis.explain_mode,
                                   prepared_query.get(), status);
+    } else if (access_mode == AccessMode::kUpdate ||
+               access_mode == AccessMode::kSchema) {
+      auto transaction = UpdateTransaction::Begin(
+          version_manager_, snapshot_store_, TransactionDurability::kNoWal);
+      StorageAPCOWUpdateInterface storage(transaction, alloc_);
+      status = execute_on_storage(transaction.statistic(), storage);
+      if (status.ok()) {
+        status = transaction.Commit(snapshot_store_);
+      } else {
+        transaction.Abort();
+      }
     } else {
       return Status(
           StatusCode::ERR_NOT_SUPPORTED,
@@ -386,28 +397,30 @@ Status ExecutionSlot::executeCore(const std::string& query,
               std::to_string(static_cast<int>(access_mode)));
     }
   } else {
-    auto execute_and_commit = [&execute_on_storage](auto& transaction,
-                                                    auto& storage) -> Status {
-      RETURN_IF_NOT_OK(execute_on_storage(transaction.statistic(), storage));
-      if (NEUG_UNLIKELY(!transaction.Commit())) {
-        return Status::InternalError("Transaction commit failed.");
-      }
-      return Status::OK();
-    };
-
     if (access_mode == AccessMode::kRead) {
       auto transaction = GetReadTransaction();
       StorageReadInterface storage(transaction.view(), transaction.timestamp());
-      status = execute_and_commit(transaction, storage);
+      status = execute_on_storage(transaction.statistic(), storage);
+      if (status.ok() && NEUG_UNLIKELY(!transaction.Commit())) {
+        status = Status::InternalError("Transaction commit failed.");
+      }
     } else if (access_mode == AccessMode::kInsert) {
       auto transaction = GetInsertTransaction();
       StorageTPInsertInterface storage(transaction);
-      status = execute_and_commit(transaction, storage);
+      status = execute_on_storage(transaction.statistic(), storage);
+      if (status.ok() && NEUG_UNLIKELY(!transaction.Commit())) {
+        status = Status::InternalError("Transaction commit failed.");
+      }
     } else if (access_mode == AccessMode::kUpdate ||
                access_mode == AccessMode::kSchema) {
       auto transaction = GetUpdateTransaction();
-      StorageTPUpdateInterface storage(transaction);
-      status = execute_and_commit(transaction, storage);
+      StorageCOWUpdateInterface storage(transaction, alloc_);
+      status = execute_on_storage(transaction.statistic(), storage);
+      if (status.ok()) {
+        status = transaction.Commit(snapshot_store_, wal_writer_);
+      } else {
+        transaction.Abort();
+      }
     } else {
       return Status(StatusCode::ERR_NOT_SUPPORTED,
                     "Access mode not supported in transactional ExecutionSlot "

--- a/src/storages/graph/graph_interface.cc
+++ b/src/storages/graph/graph_interface.cc
@@ -169,58 +169,6 @@ static Status addVertexIndexData(PropertyGraph& graph, label_t label, vid_t lid,
   return Status::OK();
 }
 
-// Appends index entries for a batch of newly inserted vertex rows.
-static Status batchAddVertexIndexData(PropertyGraph& graph, label_t label,
-                                      const std::vector<vid_t>& vids) {
-  const auto& v_schema = graph.schema().get_vertex_schema(label);
-  const auto& vtable = graph.get_vertex_table(label);
-  auto& index_manager = graph.mutable_index_manager();
-
-  // Primary keys are stored outside property_names in the vertex indexer, so
-  // read their column explicitly when maintaining indexes for a batch.
-  const auto& pk_name = std::get<1>(v_schema->primary_keys[0]);
-  auto pk_indexes = index_manager.GetIndex(label, pk_name);
-  if (!pk_indexes) {
-    return pk_indexes.error();
-  }
-  if (!pk_indexes->empty()) {
-    auto pk_col = vtable.GetPropertyColumn(pk_name);
-    if (!pk_col) {
-      return Status::InternalError("Primary key column does not exist");
-    }
-    for (auto* index : pk_indexes.value()) {
-      for (vid_t vid : vids) {
-        RETURN_IF_NOT_OK(index->Upsert(vid, pk_col->get_any(vid)));
-      }
-    }
-  }
-
-  for (size_t prop_idx = 0; prop_idx < v_schema->property_names.size();
-       ++prop_idx) {
-    if (v_schema->vprop_soft_deleted[prop_idx]) {
-      continue;
-    }
-    auto indexes =
-        index_manager.GetIndex(label, v_schema->property_names[prop_idx]);
-    if (!indexes) {
-      return indexes.error();
-    }
-    if (indexes->empty()) {
-      continue;
-    }
-    auto col = vtable.GetPropertyColumn(static_cast<int32_t>(prop_idx));
-    if (!col) {
-      continue;
-    }
-    for (auto* index : indexes.value()) {
-      for (vid_t vid : vids) {
-        RETURN_IF_NOT_OK(index->Upsert(vid, col->get_any(vid)));
-      }
-    }
-  }
-  return Status::OK();
-}
-
 // Updates index entries for one changed vertex property. Primary keys are not
 // handled here because PropertyGraph does not allow modifying the primary key
 // of an existing vertex.
@@ -293,15 +241,14 @@ result<std::vector<SearchResult>> StorageReadInterface::IndexSearch(
   return index->Search(params);
 }
 
-Status StorageAPUpdateInterface::UpdateVertexPropertyImpl(label_t label,
-                                                          vid_t lid, int col_id,
-                                                          const Value& value) {
+Status StorageAPInPlaceUpdateInterface::UpdateVertexPropertyImpl(
+    label_t label, vid_t lid, int col_id, const Value& value) {
   RETURN_IF_NOT_OK(
       graph_.UpdateVertexProperty(label, lid, col_id, value, timestamp_));
   return updateVertexIndexData(graph_, label, lid, col_id, value);
 }
 
-Status StorageAPUpdateInterface::UpdateEdgePropertyImpl(
+Status StorageAPInPlaceUpdateInterface::UpdateEdgePropertyImpl(
     label_t src_label, vid_t src, label_t dst_label, vid_t dst,
     label_t edge_label, int32_t oe_offset, int32_t ie_offset, int32_t col_id,
     const Value& value) {
@@ -310,9 +257,9 @@ Status StorageAPUpdateInterface::UpdateEdgePropertyImpl(
                                    neug::timestamp_t(0));
 }
 
-Status StorageAPUpdateInterface::AddVertexImpl(label_t label, const Value& id,
-                                               const std::vector<Value>& props,
-                                               vid_t& vid) {
+Status StorageAPInPlaceUpdateInterface::AddVertexImpl(
+    label_t label, const Value& id, const std::vector<Value>& props,
+    vid_t& vid) {
   const auto& vertex_table = graph_.get_vertex_table(label);
   if (vertex_table.Size() >= vertex_table.Capacity()) {
     auto new_cap = vertex_table.Size() < 4096
@@ -338,7 +285,7 @@ Status StorageAPUpdateInterface::AddVertexImpl(label_t label, const Value& id,
   return Status::OK();
 }
 
-Status StorageAPUpdateInterface::AddEdgeImpl(
+Status StorageAPInPlaceUpdateInterface::AddEdgeImpl(
     label_t src_label, vid_t src, label_t dst_label, vid_t dst,
     label_t edge_label, const std::vector<Value>& properties,
     const void*& prop) {
@@ -366,29 +313,31 @@ Status StorageAPUpdateInterface::AddEdgeImpl(
   return status;
 }
 
-Status StorageAPUpdateInterface::DeleteVertexImpl(label_t label, vid_t lid) {
+Status StorageAPInPlaceUpdateInterface::DeleteVertexImpl(label_t label,
+                                                         vid_t lid) {
   RETURN_IF_NOT_OK(graph_.DeleteVertex(label, lid, timestamp_));
   return deleteVertexIndexData(graph_, label, {lid});
 }
 
-Status StorageAPUpdateInterface::DeleteEdgeImpl(label_t src_label, vid_t src,
-                                                label_t dst_label, vid_t dst,
-                                                label_t edge_label,
-                                                int32_t oe_offset,
-                                                int32_t ie_offset) {
+Status StorageAPInPlaceUpdateInterface::DeleteEdgeImpl(
+    label_t src_label, vid_t src, label_t dst_label, vid_t dst,
+    label_t edge_label, int32_t oe_offset, int32_t ie_offset) {
   return graph_.DeleteEdge(src_label, src, dst_label, dst, edge_label,
                            oe_offset, ie_offset, timestamp_);
 }
 
-Status StorageAPUpdateInterface::DeleteEdgesImpl(label_t src_label, vid_t src,
-                                                 label_t dst_label, vid_t dst,
-                                                 label_t edge_label) {
+Status StorageAPInPlaceUpdateInterface::DeleteEdgesImpl(label_t src_label,
+                                                        vid_t src,
+                                                        label_t dst_label,
+                                                        vid_t dst,
+                                                        label_t edge_label) {
   // AP mode: delegate to batch version with single pair
   std::vector<std::tuple<vid_t, vid_t>> edges = {{src, dst}};
   return graph_.BatchDeleteEdges(src_label, dst_label, edge_label, edges);
 }
 
-result<std::vector<vid_t>> StorageAPUpdateInterface::BatchAddVerticesImpl(
+result<std::vector<vid_t>>
+StorageAPInPlaceUpdateInterface::BatchAddVerticesImpl(
     label_t v_label_id, std::shared_ptr<IDataChunkSupplier> supplier) {
   auto new_vids = graph_.BatchAddVertices(v_label_id, std::move(supplier));
   if (!new_vids) {
@@ -399,34 +348,34 @@ result<std::vector<vid_t>> StorageAPUpdateInterface::BatchAddVerticesImpl(
     return new_vids;
   }
 
-  auto status = batchAddVertexIndexData(graph_, v_label_id, new_vids.value());
+  auto status = AddBatchVertexIndexData(graph_, v_label_id, new_vids.value());
   if (!status.ok()) {
     return tl::unexpected(std::move(status));
   }
   return new_vids;
 }
 
-Status StorageAPUpdateInterface::BatchAddEdgesImpl(
+Status StorageAPInPlaceUpdateInterface::BatchAddEdgesImpl(
     label_t src_label, label_t dst_label, label_t edge_label,
     std::shared_ptr<IDataChunkSupplier> supplier) {
   return graph_.BatchAddEdges(src_label, dst_label, edge_label,
                               std::move(supplier));
 }
 
-Status StorageAPUpdateInterface::BatchDeleteVerticesImpl(
+Status StorageAPInPlaceUpdateInterface::BatchDeleteVerticesImpl(
     label_t v_label_id, const std::vector<vid_t>& vids) {
   RETURN_IF_NOT_OK(graph_.BatchDeleteVertices(v_label_id, vids));
   return deleteVertexIndexData(graph_, v_label_id, vids);
 }
 
-Status StorageAPUpdateInterface::BatchDeleteEdgesImpl(
+Status StorageAPInPlaceUpdateInterface::BatchDeleteEdgesImpl(
     label_t src_v_label_id, label_t dst_v_label_id, label_t edge_label_id,
     const std::vector<std::tuple<vid_t, vid_t>>& edges) {
   return graph_.BatchDeleteEdges(src_v_label_id, dst_v_label_id, edge_label_id,
                                  edges);
 }
 
-Status StorageAPUpdateInterface::BatchDeleteEdgesImpl(
+Status StorageAPInPlaceUpdateInterface::BatchDeleteEdgesImpl(
     label_t src_v_label_id, label_t dst_v_label_id, label_t edge_label_id,
     const std::vector<std::pair<vid_t, int32_t>>& oe_edges,
     const std::vector<std::pair<vid_t, int32_t>>& ie_edges) {
@@ -434,7 +383,7 @@ Status StorageAPUpdateInterface::BatchDeleteEdgesImpl(
                                  oe_edges, ie_edges);
 }
 
-Status StorageAPUpdateInterface::CreateVertexTypeImpl(
+Status StorageAPInPlaceUpdateInterface::CreateVertexTypeImpl(
     const CreateVertexTypeParam& config) {
   auto status = graph_.CreateVertexType(config);
   if (status.ok()) {
@@ -443,7 +392,7 @@ Status StorageAPUpdateInterface::CreateVertexTypeImpl(
   return status;
 }
 
-Status StorageAPUpdateInterface::CreateEdgeTypeImpl(
+Status StorageAPInPlaceUpdateInterface::CreateEdgeTypeImpl(
     const CreateEdgeTypeParam& config) {
   auto status = graph_.CreateEdgeType(config);
   if (status.ok()) {
@@ -452,7 +401,7 @@ Status StorageAPUpdateInterface::CreateEdgeTypeImpl(
   return status;
 }
 
-Status StorageAPUpdateInterface::AddVertexPropertiesImpl(
+Status StorageAPInPlaceUpdateInterface::AddVertexPropertiesImpl(
     label_t label, const AddVertexPropertiesParam& config) {
   auto status = graph_.AddVertexProperties(label, config);
   if (status.ok()) {
@@ -463,7 +412,7 @@ Status StorageAPUpdateInterface::AddVertexPropertiesImpl(
   return status;
 }
 
-Status StorageAPUpdateInterface::AddEdgePropertiesImpl(
+Status StorageAPInPlaceUpdateInterface::AddEdgePropertiesImpl(
     label_t src, label_t dst, label_t edge,
     const AddEdgePropertiesParam& config) {
   auto status = graph_.AddEdgeProperties(src, dst, edge, config);
@@ -477,7 +426,7 @@ Status StorageAPUpdateInterface::AddEdgePropertiesImpl(
   return status;
 }
 
-Status StorageAPUpdateInterface::RenameVertexPropertiesImpl(
+Status StorageAPInPlaceUpdateInterface::RenameVertexPropertiesImpl(
     label_t label, const RenameVertexPropertiesParam& config) {
   RETURN_IF_NOT_OK(graph_.RenameVertexProperties(label, config));
   for (const auto& [old_name, new_name] : config.GetRenameProperties()) {
@@ -488,13 +437,13 @@ Status StorageAPUpdateInterface::RenameVertexPropertiesImpl(
   return Status::OK();
 }
 
-Status StorageAPUpdateInterface::RenameEdgePropertiesImpl(
+Status StorageAPInPlaceUpdateInterface::RenameEdgePropertiesImpl(
     label_t src, label_t dst, label_t edge,
     const RenameEdgePropertiesParam& config) {
   return graph_.RenameEdgeProperties(src, dst, edge, config);
 }
 
-Status StorageAPUpdateInterface::DeleteVertexPropertiesImpl(
+Status StorageAPInPlaceUpdateInterface::DeleteVertexPropertiesImpl(
     label_t label, const DeleteVertexPropertiesParam& config) {
   RETURN_IF_NOT_OK(graph_.DeleteVertexProperties(label, config));
   for (const auto& prop_name : config.GetDeleteProperties()) {
@@ -505,7 +454,7 @@ Status StorageAPUpdateInterface::DeleteVertexPropertiesImpl(
   return Status::OK();
 }
 
-Status StorageAPUpdateInterface::DeleteEdgePropertiesImpl(
+Status StorageAPInPlaceUpdateInterface::DeleteEdgePropertiesImpl(
     label_t src, label_t dst, label_t edge,
     const DeleteEdgePropertiesParam& config) {
   auto status = graph_.DeleteEdgeProperties(src, dst, edge, config);
@@ -518,7 +467,7 @@ Status StorageAPUpdateInterface::DeleteEdgePropertiesImpl(
   return status;
 }
 
-Status StorageAPUpdateInterface::DeleteVertexTypeImpl(label_t label) {
+Status StorageAPInPlaceUpdateInterface::DeleteVertexTypeImpl(label_t label) {
   const auto& v_schema = graph_.schema().get_vertex_schema(label);
   std::vector<std::string> indexed_properties;
   indexed_properties.reserve(v_schema->property_names.size() + 1);
@@ -539,8 +488,9 @@ Status StorageAPUpdateInterface::DeleteVertexTypeImpl(label_t label) {
   return Status::OK();
 }
 
-Status StorageAPUpdateInterface::DeleteEdgeTypeImpl(label_t src, label_t dst,
-                                                    label_t edge) {
+Status StorageAPInPlaceUpdateInterface::DeleteEdgeTypeImpl(label_t src,
+                                                           label_t dst,
+                                                           label_t edge) {
   auto status = graph_.DeleteEdgeType(src, dst, edge);
   if (status.ok()) {
     mut_view_.Rebuild(graph_);
@@ -717,13 +667,13 @@ Status index_ddl::DropIndex(PropertyGraph& graph, GraphView& view,
   return Status::OK();
 }
 
-neug::result<StorageIndex*> StorageAPUpdateInterface::CreateIndex(
+neug::result<StorageIndex*> StorageAPInPlaceUpdateInterface::CreateIndex(
     std::unique_ptr<IndexMeta> meta) {
   return index_ddl::CreateIndex(graph_, mut_view_, timestamp_, alloc_,
                                 std::move(meta), on_planning_changed_);
 }
 
-Status StorageAPUpdateInterface::DropIndex(const std::string& name) {
+Status StorageAPInPlaceUpdateInterface::DropIndex(const std::string& name) {
   return index_ddl::DropIndex(graph_, mut_view_, timestamp_, alloc_, name,
                               on_planning_changed_);
 }

--- a/src/storages/graph/graph_interface.cc
+++ b/src/storages/graph/graph_interface.cc
@@ -556,19 +556,21 @@ Status StorageAPUpdateInterface::DeleteEdgeTypeImpl(label_t src, label_t dst,
  * without copying its data. Subsequent incremental vector updates avoid
  * copy-on-write by letting the VecColumn maintain separate buffer versions.
  */
-neug::result<StorageIndex*> StorageAPUpdateInterface::CreateIndex(
-    std::unique_ptr<IndexMeta> meta) {
+neug::result<StorageIndex*> index_ddl::CreateIndex(
+    PropertyGraph& graph, GraphView& view, timestamp_t timestamp,
+    neug::Allocator& /*alloc*/, std::unique_ptr<IndexMeta> meta,
+    const CatalogChangedCallback& on_catalog_changed) {
   if (!meta) {
     RETURN_STATUS_ERROR(StatusCode::ERR_INVALID_ARGUMENT,
                         "Cannot create index with null metadata");
   }
   auto label_id = meta->schema.label_id;
-  if (!graph_.schema().is_vertex_label_valid(label_id)) {
+  if (!graph.schema().is_vertex_label_valid(label_id)) {
     RETURN_STATUS_ERROR(StatusCode::ERR_INVALID_ARGUMENT,
                         "Index label id is out of range");
   }
 
-  auto& vertex_table = graph_.get_vertex_table(label_id);
+  auto& vertex_table = graph.get_vertex_table(label_id);
   const auto schema = vertex_table.get_vertex_schema_ptr();
   const auto& property_name = meta->schema.property_name;
   const bool is_primary_key =
@@ -585,7 +587,8 @@ neug::result<StorageIndex*> StorageAPUpdateInterface::CreateIndex(
   std::unique_ptr<IndexIDAccessor> index_id_accessor;
 
   if (IsHNSWIndex(*meta)) {
-    GS_AUTO(existing_indexes, index_manager_.GetIndex(label_id, property_name));
+    GS_AUTO(existing_indexes,
+            graph.mutable_index_manager().GetIndex(label_id, property_name));
     const bool has_non_hnsw = std::any_of(
         existing_indexes.begin(), existing_indexes.end(),
         [](StorageIndex* index) { return !IsHNSWIndex(index->GetMeta()); });
@@ -608,7 +611,7 @@ neug::result<StorageIndex*> StorageAPUpdateInterface::CreateIndex(
     if (const auto* array = dynamic_cast<const ArrayColumn*>(column)) {
       const auto& default_value = schema->default_property_values[property_col];
       vec_column = FromArrayColumn(*array, vertex_table.Size(), default_value,
-                                   graph_.checkpoint(), graph_.memory_level());
+                                   graph.checkpoint(), graph.memory_level());
       column = vec_column.get();
     }
 
@@ -631,17 +634,17 @@ neug::result<StorageIndex*> StorageAPUpdateInterface::CreateIndex(
     index_id_accessor = std::make_unique<DefaultIndexIDAccessor>();
   }
 
-  GS_AUTO(index, index_manager_.CreateIndex(
+  GS_AUTO(index, graph.mutable_index_manager().CreateIndex(
                      std::move(meta), std::move(index_id_accessor), column,
-                     graph_.GetVertexSet(label_id, timestamp_)));
+                     graph.GetVertexSet(label_id, timestamp)));
 
-  if (on_planning_changed_) {
-    on_planning_changed_();
+  if (on_catalog_changed) {
+    on_catalog_changed();
   }
   if (vec_column) {
     vertex_table.SetColumn(static_cast<size_t>(property_col),
                            std::move(vec_column));
-    mut_view_.Rebuild(graph_);
+    view.Rebuild(graph);
   }
   return index;
 }
@@ -654,8 +657,12 @@ neug::result<StorageIndex*> StorageAPUpdateInterface::CreateIndex(
  * vectors from the VecColumn by vertex ID. This is equivalent to compaction:
  * obsolete vector versions addressed by previous index IDs are discarded.
  */
-Status StorageAPUpdateInterface::DropIndex(const std::string& name) {
-  auto target = index_manager_.GetIndexByName(name);
+Status index_ddl::DropIndex(PropertyGraph& graph, GraphView& view,
+                            timestamp_t /*timestamp*/,
+                            neug::Allocator& /*alloc*/, const std::string& name,
+                            const CatalogChangedCallback& on_catalog_changed) {
+  auto& index_manager = graph.mutable_index_manager();
+  auto target = index_manager.GetIndexByName(name);
   if (!target) {
     return target.error();
   }
@@ -665,8 +672,8 @@ Status StorageAPUpdateInterface::DropIndex(const std::string& name) {
   int32_t property_col = -1;
 
   if (IsHNSWIndex(meta)) {
-    auto indexes = index_manager_.GetIndex(meta.schema.label_id,
-                                           meta.schema.property_name);
+    auto indexes =
+        index_manager.GetIndex(meta.schema.label_id, meta.schema.property_name);
     if (!indexes) {
       return indexes.error();
     }
@@ -675,7 +682,7 @@ Status StorageAPUpdateInterface::DropIndex(const std::string& name) {
           return index->GetMeta().name != name && IsHNSWIndex(index->GetMeta());
         });
     if (!has_other_hnsw) {
-      auto& vertex_table = graph_.get_vertex_table(meta.schema.label_id);
+      auto& vertex_table = graph.get_vertex_table(meta.schema.label_id);
       const auto schema = vertex_table.get_vertex_schema_ptr();
       property_col = schema->get_property_index(meta.schema.property_name);
       if (property_col < 0) {
@@ -687,9 +694,9 @@ Status StorageAPUpdateInterface::DropIndex(const std::string& name) {
       const auto& default_value = schema->default_property_values[property_col];
       auto* column = vertex_table.get_table().get_column_by_id(property_col);
       if (auto* vec = dynamic_cast<VecColumn*>(column)) {
-        array_column = FromVecColumn(
-            *vec, vertex_table.Size(), vertex_table.Capacity(), default_value,
-            graph_.checkpoint(), graph_.memory_level());
+        array_column = FromVecColumn(*vec, vertex_table.Size(),
+                                     vertex_table.Capacity(), default_value,
+                                     graph.checkpoint(), graph.memory_level());
       } else {
         return Status(StatusCode::ERR_INVALID_ARGUMENT,
                       "DropIndex: HNSW index can only be created on VecColumn");
@@ -697,17 +704,28 @@ Status StorageAPUpdateInterface::DropIndex(const std::string& name) {
     }
   }
 
-  RETURN_IF_NOT_OK(index_manager_.DropIndex(name));
-  if (on_planning_changed_) {
-    on_planning_changed_();
+  RETURN_IF_NOT_OK(index_manager.DropIndex(name));
+  if (on_catalog_changed) {
+    on_catalog_changed();
   }
   if (array_column) {
-    auto& vertex_table = graph_.get_vertex_table(meta.schema.label_id);
+    auto& vertex_table = graph.get_vertex_table(meta.schema.label_id);
     vertex_table.SetColumn(static_cast<size_t>(property_col),
                            std::move(array_column));
-    mut_view_.Rebuild(graph_);
+    view.Rebuild(graph);
   }
   return Status::OK();
+}
+
+neug::result<StorageIndex*> StorageAPUpdateInterface::CreateIndex(
+    std::unique_ptr<IndexMeta> meta) {
+  return index_ddl::CreateIndex(graph_, mut_view_, timestamp_, alloc_,
+                                std::move(meta), on_planning_changed_);
+}
+
+Status StorageAPUpdateInterface::DropIndex(const std::string& name) {
+  return index_ddl::DropIndex(graph_, mut_view_, timestamp_, alloc_, name,
+                              on_planning_changed_);
 }
 
 }  // namespace neug

--- a/src/storages/graph/property_graph.cc
+++ b/src/storages/graph/property_graph.cc
@@ -691,12 +691,12 @@ Status PropertyGraph::DeleteVertex(label_t label, vid_t lid, timestamp_t ts) {
       if (schema_.has_edge_triplet(i, label, j)) {
         size_t index = schema_.generate_edge_label(i, label, j);
         assert(edge_tables_.count(index) > 0);
-        edge_tables_.at(index).DeleteVertex(true, lid, ts);
+        edge_tables_.at(index).DeleteVertex(/*is_src=*/false, lid, ts);
       }
       if (schema_.has_edge_triplet(label, i, j)) {
         size_t index = schema_.generate_edge_label(label, i, j);
         assert(edge_tables_.count(index) > 0);
-        edge_tables_.at(index).DeleteVertex(false, lid, ts);
+        edge_tables_.at(index).DeleteVertex(/*is_src=*/true, lid, ts);
       }
     }
   }

--- a/src/storages/graph/property_graph_cow_state.cc
+++ b/src/storages/graph/property_graph_cow_state.cc
@@ -43,4 +43,37 @@ PropertyGraphCowState PropertyGraphCowState::FromSchema(const Schema& schema) {
   return bitmap;
 }
 
+bool PropertyGraphCowState::HasDetachedStorage() const {
+  for (const auto& state : vertex_tables) {
+    if (state.indexer_detached || state.vertex_timestamp_detached) {
+      return true;
+    }
+    for (bool detached : state.columns_detached) {
+      if (detached) {
+        return true;
+      }
+    }
+  }
+
+  for (const auto& [_, state] : edge_tables) {
+    if (state.out_csr_detached || state.in_csr_detached ||
+        !state.out_adjlists_detached.empty() ||
+        !state.in_adjlists_detached.empty()) {
+      return true;
+    }
+    for (bool detached : state.columns_detached) {
+      if (detached) {
+        return true;
+      }
+    }
+  }
+
+  for (const auto& [_, detached] : index_detached) {
+    if (detached) {
+      return true;
+    }
+  }
+  return false;
+}
+
 }  // namespace neug

--- a/src/storages/index/index_utils.cc
+++ b/src/storages/index/index_utils.cc
@@ -16,8 +16,12 @@
 
 #include "neug/storages/index/index_utils.h"
 
+#include <tuple>
+
 #include "neug/compiler/common/string_utils.h"
+#include "neug/storages/graph/property_graph.h"
 #include "neug/storages/index/storage_index.h"
+#include "neug/storages/index/storage_index_manager.h"
 
 namespace neug {
 
@@ -25,6 +29,62 @@ bool IsHNSWIndex(const IndexMeta& meta) {
   auto type = meta.type;
   common::StringUtils::toLower(type);
   return type == "hnsw";
+}
+
+Status AddBatchVertexIndexData(
+    PropertyGraph& graph, label_t label, const std::vector<vid_t>& vids,
+    const std::function<Status(StorageIndex&)>& prepare_index) {
+  const auto& v_schema = graph.schema().get_vertex_schema(label);
+  const auto& vtable = graph.get_vertex_table(label);
+  auto& index_manager = graph.mutable_index_manager();
+
+  const auto& pk_name = std::get<1>(v_schema->primary_keys[0]);
+  auto pk_indexes = index_manager.GetIndex(label, pk_name);
+  if (!pk_indexes) {
+    return pk_indexes.error();
+  }
+  if (!pk_indexes->empty()) {
+    auto pk_col = vtable.GetPropertyColumn(pk_name);
+    if (!pk_col) {
+      return Status::InternalError("Primary key column does not exist");
+    }
+    for (auto* index : pk_indexes.value()) {
+      if (prepare_index) {
+        RETURN_IF_NOT_OK(prepare_index(*index));
+      }
+      for (vid_t vid : vids) {
+        RETURN_IF_NOT_OK(index->Upsert(vid, pk_col->get_any(vid)));
+      }
+    }
+  }
+
+  for (size_t prop_idx = 0; prop_idx < v_schema->property_names.size();
+       ++prop_idx) {
+    if (v_schema->vprop_soft_deleted[prop_idx]) {
+      continue;
+    }
+    auto indexes =
+        index_manager.GetIndex(label, v_schema->property_names[prop_idx]);
+    if (!indexes) {
+      return indexes.error();
+    }
+    if (indexes->empty()) {
+      continue;
+    }
+    auto col = vtable.GetPropertyColumn(static_cast<int32_t>(prop_idx));
+    if (!col) {
+      continue;
+    }
+    for (auto* index : indexes.value()) {
+      if (prepare_index) {
+        RETURN_IF_NOT_OK(prepare_index(*index));
+      }
+      for (vid_t vid : vids) {
+        RETURN_IF_NOT_OK(index->Upsert(vid, col->get_any(vid)));
+      }
+    }
+  }
+  return Status::OK();
 }
 
 }  // namespace neug

--- a/src/transaction/update_transaction.cc
+++ b/src/transaction/update_transaction.cc
@@ -34,6 +34,7 @@
 #include "neug/storages/csr/csr_view_utils.h"
 #include "neug/storages/graph/property_graph.h"
 #include "neug/storages/graph/schema.h"
+#include "neug/storages/index/index_utils.h"
 #include "neug/storages/index/storage_index_manager.h"
 #include "neug/transaction/transaction_utils.h"
 #include "neug/transaction/version_manager.h"
@@ -389,15 +390,15 @@ Status UpdateTransaction::Commit(GraphSnapshotStore& snapshot_store,
     return Status::OK();
   }
 
-  const bool schema_changed = cow_state_.schema_changed;
-  if (schema_changed &&
+  const bool planning_changed = cow_state_.planning_changed;
+  if (planning_changed &&
       base_planning_generation_ == std::numeric_limits<uint64_t>::max()) {
     LOG(ERROR) << "Planning generation space exhausted";
     Abort();
     return Status::InternalError("Planning generation space exhausted");
   }
   const uint64_t committed_planning_generation =
-      base_planning_generation_ + (schema_changed ? 1 : 0);
+      base_planning_generation_ + (planning_changed ? 1 : 0);
 
   auto prepared_result =
       snapshot_store.PrepareSnapshot(cow_graph_, committed_planning_generation);
@@ -634,7 +635,7 @@ Status StorageCOWUpdateInterface::DeleteVertexPropertiesImpl(
       cow_graph_->schema().get_vertex_label_name(v_label);
   for (const auto& prop_name : properties) {
     if (!cow_graph_->schema().vertex_has_property(v_label, prop_name)) {
-      return Status(StatusCode::ERR_INVALID_ARGUMENT,
+      return Status(StatusCode::ERR_SCHEMA_MISMATCH,
                     "Property [" + prop_name + "] does not exist in vertex [" +
                         vertex_type_name + "].");
     }
@@ -681,7 +682,7 @@ Status StorageCOWUpdateInterface::DeleteEdgePropertiesImpl(
   for (const auto& prop_name : config.GetDeleteProperties()) {
     if (!schema.edge_has_property(src_label_id, dst_label_id, edge_label_id,
                                   prop_name)) {
-      return Status(StatusCode::ERR_INVALID_ARGUMENT,
+      return Status(StatusCode::ERR_SCHEMA_MISMATCH,
                     "Property [" + prop_name + "] does not exist in edge [" +
                         edge_type + "] between [" + src_type + "] and [" +
                         dst_type + "].");
@@ -822,7 +823,7 @@ Status StorageCOWUpdateInterface::DeleteEdgeTypeImpl(label_t src_label_id,
   return status;
 }
 
-neug::result<StorageIndex*> StorageCOWUpdateInterface::CreateIndexDDLForAP(
+neug::result<StorageIndex*> StorageCOWUpdateInterface::CreateIndexForAP(
     std::unique_ptr<IndexMeta> meta) {
   if (!meta) {
     RETURN_STATUS_ERROR(StatusCode::ERR_INVALID_ARGUMENT,
@@ -847,7 +848,7 @@ neug::result<StorageIndex*> StorageCOWUpdateInterface::CreateIndexDDLForAP(
   return index;
 }
 
-Status StorageCOWUpdateInterface::DropIndexDDLForAP(const std::string& name) {
+Status StorageCOWUpdateInterface::DropIndexForAP(const std::string& name) {
   RETURN_IF_NOT_OK(index_ddl::DropIndex(*cow_graph_, mut_view_, read_ts_,
                                         alloc_, name,
                                         [this]() { MarkSchemaDirty(); }));
@@ -1588,6 +1589,32 @@ Status StorageCOWUpdateInterface::BatchAddEdgesImpl(
   LOG(ERROR) << "BatchAddEdges is not supported in TP mode currently.";
   return Status(StatusCode::ERR_NOT_SUPPORTED,
                 "BatchAddEdges is not supported in TP mode currently.");
+}
+
+result<std::vector<vid_t>> StorageCOWUpdateInterface::BatchAddVerticesForAP(
+    label_t v_label_id, std::shared_ptr<IDataChunkSupplier> supplier) {
+  RETURN_STATUS_ERROR_IF_NOT_OK(detachVertexTableForInsert(v_label_id));
+  auto new_vids = cow_graph_->BatchAddVertices(v_label_id, std::move(supplier));
+  if (!new_vids || new_vids->empty()) {
+    return new_vids;
+  }
+  auto status = AddBatchVertexIndexData(
+      *cow_graph_, v_label_id, new_vids.value(),
+      [this](StorageIndex& index) { return detachIndex(index); });
+  if (!status.ok()) {
+    RETURN_ERROR(std::move(status));
+  }
+  return new_vids;
+}
+
+Status StorageCOWUpdateInterface::BatchAddEdgesForAP(
+    label_t src_label, label_t dst_label, label_t edge_label,
+    std::shared_ptr<IDataChunkSupplier> supplier) {
+  uint32_t edge_triplet_id = cow_graph_->schema().generate_edge_label(
+      src_label, dst_label, edge_label);
+  RETURN_IF_NOT_OK(detachEdgeTableForInsert(edge_triplet_id));
+  return cow_graph_->BatchAddEdges(src_label, dst_label, edge_label,
+                                   std::move(supplier));
 }
 
 Status StorageCOWUpdateInterface::BatchDeleteVerticesImpl(

--- a/src/transaction/update_transaction.cc
+++ b/src/transaction/update_transaction.cc
@@ -320,58 +320,110 @@ static Status deleteVertexIndexData(
 // UpdateTransaction — lifecycle methods only
 // =============================================================================
 
-UpdateTransaction::UpdateTransaction(std::shared_ptr<PropertyGraph> cow_graph,
+UpdateTransaction UpdateTransaction::Begin(IVersionManager& version_manager,
+                                           GraphSnapshotStore& snapshot_store,
+                                           TransactionDurability durability) {
+  UpdateTimestampLease timestamp_lease(version_manager);
+  auto [cow_graph, planning_generation] =
+      snapshot_store.CloneCurrentForUpdate();
+  return UpdateTransaction(durability, std::move(cow_graph),
+                           planning_generation, std::move(timestamp_lease));
+}
+
+UpdateTransaction UpdateTransaction::BeginUntil(
+    IVersionManager& version_manager, GraphSnapshotStore& snapshot_store,
+    TransactionDurability durability,
+    std::chrono::steady_clock::time_point deadline) {
+  UpdateTimestampLease timestamp_lease(version_manager, deadline);
+  auto [cow_graph, planning_generation] =
+      snapshot_store.CloneCurrentForUpdate();
+  return UpdateTransaction(durability, std::move(cow_graph),
+                           planning_generation, std::move(timestamp_lease));
+}
+
+UpdateTransaction::UpdateTransaction(TransactionDurability durability,
+                                     std::shared_ptr<PropertyGraph> cow_graph,
                                      uint64_t planning_generation,
-                                     Allocator& alloc, IWalWriter& logger,
-                                     GraphSnapshotStore& snapshot_store,
                                      UpdateTimestampLease timestamp_lease)
-    : cow_graph_(std::move(cow_graph)),
+    : durability_(durability),
+      cow_graph_(std::move(cow_graph)),
       cow_state_(PropertyGraphCowState::FromSchema(cow_graph_->schema())),
       view_(*cow_graph_),
-      alloc_(alloc),
-      logger_(logger),
-      snapshot_store_(snapshot_store),
       timestamp_lease_(std::move(timestamp_lease)),
-      planning_generation_(planning_generation),
-      ckp_(cow_graph_->checkpoint_ptr()) {}
+      base_planning_generation_(planning_generation),
+      ckp_(cow_graph_->checkpoint_ptr()) {
+  if (durability_ == TransactionDurability::kWal) {
+    wal_builder_.emplace();
+  }
+}
+
+UpdateTransaction::UpdateTransaction(UpdateTransaction&& other) noexcept
+    : durability_(other.durability_),
+      cow_graph_(std::move(other.cow_graph_)),
+      cow_state_(std::move(other.cow_state_)),
+      view_(std::move(other.view_)),
+      timestamp_lease_(std::move(other.timestamp_lease_)),
+      base_planning_generation_(other.base_planning_generation_),
+      ckp_(std::move(other.ckp_)),
+      wal_builder_(std::move(other.wal_builder_)) {}
 
 UpdateTransaction::~UpdateTransaction() { Abort(); }
 
-bool UpdateTransaction::Commit() {
+Status UpdateTransaction::Commit(GraphSnapshotStore& snapshot_store,
+                                 IWalWriter* wal_writer) {
   if (timestamp() == INVALID_TIMESTAMP) {
-    return true;
+    return Status::OK();
   }
-  if (wal_builder_.op_num() == 0 && wal_builder_.content_size() == 0) {
+  if (durability_ == TransactionDurability::kWal && wal_writer == nullptr) {
+    Abort();
+    return Status(StatusCode::ERR_INVALID_ARGUMENT,
+                  "WAL durability requires a WAL writer");
+  }
+  if (durability_ == TransactionDurability::kNoWal && wal_writer != nullptr) {
+    Abort();
+    return Status(StatusCode::ERR_INVALID_ARGUMENT,
+                  "No-WAL durability must not use a WAL writer");
+  }
+  if (!cow_state_.HasChanges()) {
     release(std::nullopt);
-    return true;
+    return Status::OK();
   }
 
-  const bool schema_changed = wal_builder_.schema_changed();
+  const bool schema_changed = cow_state_.schema_changed;
   if (schema_changed &&
-      planning_generation_ == std::numeric_limits<uint64_t>::max()) {
+      base_planning_generation_ == std::numeric_limits<uint64_t>::max()) {
     LOG(ERROR) << "Planning generation space exhausted";
     Abort();
-    return false;
+    return Status::InternalError("Planning generation space exhausted");
   }
   const uint64_t committed_planning_generation =
-      planning_generation_ + (schema_changed ? 1 : 0);
+      base_planning_generation_ + (schema_changed ? 1 : 0);
 
-  auto prepared_result = snapshot_store_.PrepareSnapshot(
-      cow_graph_, committed_planning_generation);
+  auto prepared_result =
+      snapshot_store.PrepareSnapshot(cow_graph_, committed_planning_generation);
   if (!prepared_result) {
     LOG(ERROR) << "Failed to prepare graph snapshot: "
                << prepared_result.error().ToString();
+    const auto error = prepared_result.error();
     Abort();
-    return false;
+    return error;
   }
 
   auto prepared = std::move(prepared_result).value();
 
-  wal_builder_.finalize(timestamp());
-  if (!logger_.append(wal_builder_.data(), wal_builder_.size())) {
-    LOG(ERROR) << "Failed to append wal log";
-    Abort();
-    return false;
+  if (durability_ == TransactionDurability::kWal) {
+    CHECK(wal_builder_.has_value());
+    if (wal_builder_->op_num() == 0) {
+      Abort();
+      return Status::InternalError(
+          "Modified WAL transaction contains no redo operations");
+    }
+    wal_builder_->finalize(timestamp());
+    if (!wal_writer->append(wal_builder_->data(), wal_builder_->size())) {
+      LOG(ERROR) << "Failed to append wal log";
+      Abort();
+      return Status::InternalError("Failed to append WAL log");
+    }
   }
 
   timestamp_lease_.BeginCommit();
@@ -381,27 +433,27 @@ bool UpdateTransaction::Commit() {
   // before admission reopens.
   const uint32_t snapshot_generation = std::move(prepared).Publish();
   release(snapshot_generation);
-  return true;
+  return Status::OK();
 }
 
-void UpdateTransaction::Abort() {
+void UpdateTransaction::Abort() noexcept {
   if (timestamp() != INVALID_TIMESTAMP) {
     release(std::nullopt);
   }
 }
 
 void UpdateTransaction::release(
-    std::optional<uint32_t> installed_snapshot_generation) {
-  if (timestamp() != INVALID_TIMESTAMP) {
-    wal_builder_.clear();
-    timestamp_lease_.Finish(installed_snapshot_generation);
-  }
+    std::optional<uint32_t> installed_snapshot_generation) noexcept {
+  wal_builder_.reset();
   view_ = GraphView();
   cow_graph_.reset();
   ckp_.reset();
+  if (timestamp() != INVALID_TIMESTAMP) {
+    timestamp_lease_.Finish(installed_snapshot_generation);
+  }
 }
 
-Status StorageTPUpdateInterface::CreateVertexTypeImpl(
+Status StorageCOWUpdateInterface::CreateVertexTypeImpl(
     const CreateVertexTypeParam& config) {
   const auto& name = config.GetVertexLabel();
   if (cow_graph_->schema().is_vertex_label_valid(name)) {
@@ -409,7 +461,9 @@ Status StorageTPUpdateInterface::CreateVertexTypeImpl(
     return Status(StatusCode::ERR_SCHEMA_MISMATCH,
                   "Vertex type " + name + " already exists.");
   }
-  wal_.LogCreateVertexType(config);
+  if (wal_) {
+    wal_->LogCreateVertexType(config);
+  }
   auto status = cow_graph_->CreateVertexType(config);
   if (!status.ok()) {
     LOG(ERROR) << "Failed to create vertex type " << name << ": "
@@ -432,7 +486,7 @@ Status StorageTPUpdateInterface::CreateVertexTypeImpl(
   return status;
 }
 
-Status StorageTPUpdateInterface::CreateEdgeTypeImpl(
+Status StorageCOWUpdateInterface::CreateEdgeTypeImpl(
     const CreateEdgeTypeParam& config) {
   const auto& src_type = config.GetSrcLabel();
   const auto& dst_type = config.GetDstLabel();
@@ -445,7 +499,9 @@ Status StorageTPUpdateInterface::CreateEdgeTypeImpl(
                   "Edge type " + edge_type + " already exists between " +
                       src_type + " and " + dst_type + ".");
   }
-  wal_.LogCreateEdgeType(config);
+  if (wal_) {
+    wal_->LogCreateEdgeType(config);
+  }
   auto status = cow_graph_->CreateEdgeType(config);
   if (!status.ok()) {
     LOG(ERROR) << "Failed to create edge type " << edge_type << " between "
@@ -469,10 +525,12 @@ Status StorageTPUpdateInterface::CreateEdgeTypeImpl(
   return status;
 }
 
-Status StorageTPUpdateInterface::AddVertexPropertiesImpl(
+Status StorageCOWUpdateInterface::AddVertexPropertiesImpl(
     label_t v_label, const AddVertexPropertiesParam& config) {
-  wal_.LogAddVertexProperties(
-      cow_graph_->schema().get_vertex_label_name(v_label), config);
+  if (wal_) {
+    wal_->LogAddVertexProperties(
+        cow_graph_->schema().get_vertex_label_name(v_label), config);
+  }
   auto status = cow_graph_->AddVertexProperties(v_label, config);
   if (!status.ok()) {
     LOG(ERROR) << "Failed to add properties to vertex type "
@@ -490,13 +548,16 @@ Status StorageTPUpdateInterface::AddVertexPropertiesImpl(
   return status;
 }
 
-Status StorageTPUpdateInterface::AddEdgePropertiesImpl(
+Status StorageCOWUpdateInterface::AddEdgePropertiesImpl(
     label_t src_label_id, label_t dst_label_id, label_t edge_label_id,
     const AddEdgePropertiesParam& config) {
   const auto& schema = cow_graph_->schema();
-  wal_.LogAddEdgeProperties(schema.get_vertex_label_name(src_label_id),
-                            schema.get_vertex_label_name(dst_label_id),
-                            schema.get_edge_label_name(edge_label_id), config);
+  if (wal_) {
+    wal_->LogAddEdgeProperties(schema.get_vertex_label_name(src_label_id),
+                               schema.get_vertex_label_name(dst_label_id),
+                               schema.get_edge_label_name(edge_label_id),
+                               config);
+  }
   auto status = cow_graph_->AddEdgeProperties(src_label_id, dst_label_id,
                                               edge_label_id, config);
   if (!status.ok()) {
@@ -519,11 +580,13 @@ Status StorageTPUpdateInterface::AddEdgePropertiesImpl(
   return status;
 }
 
-Status StorageTPUpdateInterface::RenameVertexPropertiesImpl(
+Status StorageCOWUpdateInterface::RenameVertexPropertiesImpl(
     label_t v_label, const RenameVertexPropertiesParam& config) {
   const auto vertex_type_name =
       cow_graph_->schema().get_vertex_label_name(v_label);
-  wal_.LogRenameVertexProperties(vertex_type_name, config);
+  if (wal_) {
+    wal_->LogRenameVertexProperties(vertex_type_name, config);
+  }
   auto status = cow_graph_->RenameVertexProperties(v_label, config);
   if (!status.ok()) {
     LOG(ERROR) << "Failed to rename properties of vertex type "
@@ -532,22 +595,25 @@ Status StorageTPUpdateInterface::RenameVertexPropertiesImpl(
     return status;
   }
   for (const auto& [old_name, new_name] : config.GetRenameProperties()) {
-    if (old_name == new_name)
+    if (old_name == new_name) {
       continue;
+    }
     RETURN_IF_NOT_OK(
         renameVertexIndex(*cow_graph_, v_label, old_name, new_name));
   }
   return status;
 }
 
-Status StorageTPUpdateInterface::RenameEdgePropertiesImpl(
+Status StorageCOWUpdateInterface::RenameEdgePropertiesImpl(
     label_t src_label_id, label_t dst_label_id, label_t edge_label_id,
     const RenameEdgePropertiesParam& config) {
   const auto& schema = cow_graph_->schema();
-  wal_.LogRenameEdgeProperties(schema.get_vertex_label_name(src_label_id),
-                               schema.get_vertex_label_name(dst_label_id),
-                               schema.get_edge_label_name(edge_label_id),
-                               config);
+  if (wal_) {
+    wal_->LogRenameEdgeProperties(schema.get_vertex_label_name(src_label_id),
+                                  schema.get_vertex_label_name(dst_label_id),
+                                  schema.get_edge_label_name(edge_label_id),
+                                  config);
+  }
   auto status = cow_graph_->RenameEdgeProperties(src_label_id, dst_label_id,
                                                  edge_label_id, config);
   if (!status.ok()) {
@@ -561,7 +627,7 @@ Status StorageTPUpdateInterface::RenameEdgePropertiesImpl(
   return status;
 }
 
-Status StorageTPUpdateInterface::DeleteVertexPropertiesImpl(
+Status StorageCOWUpdateInterface::DeleteVertexPropertiesImpl(
     label_t v_label, const DeleteVertexPropertiesParam& config) {
   const auto& properties = config.GetDeleteProperties();
   const auto& vertex_type_name =
@@ -583,7 +649,9 @@ Status StorageTPUpdateInterface::DeleteVertexPropertiesImpl(
     }
   }
 
-  wal_.LogDeleteVertexProperties(vertex_type_name, config);
+  if (wal_) {
+    wal_->LogDeleteVertexProperties(vertex_type_name, config);
+  }
   auto status = cow_graph_->DeleteVertexProperties(v_label, config);
   if (!status.ok()) {
     return status;
@@ -603,7 +671,7 @@ Status StorageTPUpdateInterface::DeleteVertexPropertiesImpl(
   return status;
 }
 
-Status StorageTPUpdateInterface::DeleteEdgePropertiesImpl(
+Status StorageCOWUpdateInterface::DeleteEdgePropertiesImpl(
     label_t src_label_id, label_t dst_label_id, label_t edge_label_id,
     const DeleteEdgePropertiesParam& config) {
   const auto& schema = cow_graph_->schema();
@@ -645,7 +713,9 @@ Status StorageTPUpdateInterface::DeleteEdgePropertiesImpl(
     }
   }
 
-  wal_.LogDeleteEdgeProperties(src_type, dst_type, edge_type, config);
+  if (wal_) {
+    wal_->LogDeleteEdgeProperties(src_type, dst_type, edge_type, config);
+  }
   auto status = cow_graph_->DeleteEdgeProperties(src_label_id, dst_label_id,
                                                  edge_label_id, config);
   if (status.ok()) {
@@ -675,7 +745,7 @@ Status StorageTPUpdateInterface::DeleteEdgePropertiesImpl(
   return status;
 }
 
-Status StorageTPUpdateInterface::DeleteVertexTypeImpl(label_t v_label) {
+Status StorageCOWUpdateInterface::DeleteVertexTypeImpl(label_t v_label) {
   // Collect related edge triplet IDs before deletion.
   // PropertyGraph::DeleteVertexType removes them from edge_tables_, so
   // we must capture them while the schema is still intact.
@@ -711,7 +781,9 @@ Status StorageTPUpdateInterface::DeleteVertexTypeImpl(label_t v_label) {
     }
     indexed_properties.push_back(v_schema->property_names[prop_idx]);
   }
-  wal_.LogDeleteVertexType(vertex_type_name);
+  if (wal_) {
+    wal_->LogDeleteVertexType(vertex_type_name);
+  }
   auto status = cow_graph_->DeleteVertexType(v_label);
   if (!status.ok()) {
     return status;
@@ -728,9 +800,9 @@ Status StorageTPUpdateInterface::DeleteVertexTypeImpl(label_t v_label) {
   return status;
 }
 
-Status StorageTPUpdateInterface::DeleteEdgeTypeImpl(label_t src_label_id,
-                                                    label_t dst_label_id,
-                                                    label_t edge_label_id) {
+Status StorageCOWUpdateInterface::DeleteEdgeTypeImpl(label_t src_label_id,
+                                                     label_t dst_label_id,
+                                                     label_t edge_label_id) {
   const auto& schema = cow_graph_->schema();
   const auto& src_type = schema.get_vertex_label_name(src_label_id);
   const auto& dst_type = schema.get_vertex_label_name(dst_label_id);
@@ -738,7 +810,9 @@ Status StorageTPUpdateInterface::DeleteEdgeTypeImpl(label_t src_label_id,
   uint32_t triplet_id =
       schema.generate_edge_label(src_label_id, dst_label_id, edge_label_id);
 
-  wal_.LogDeleteEdgeType(src_type, dst_type, edge_type);
+  if (wal_) {
+    wal_->LogDeleteEdgeType(src_type, dst_type, edge_type);
+  }
   auto status =
       cow_graph_->DeleteEdgeType(src_label_id, dst_label_id, edge_label_id);
   if (status.ok()) {
@@ -748,9 +822,42 @@ Status StorageTPUpdateInterface::DeleteEdgeTypeImpl(label_t src_label_id,
   return status;
 }
 
-Status StorageTPUpdateInterface::AddVertexImpl(label_t label, const Value& oid,
-                                               const std::vector<Value>& props,
-                                               vid_t& vid) {
+neug::result<StorageIndex*> StorageCOWUpdateInterface::CreateIndexDDLForAP(
+    std::unique_ptr<IndexMeta> meta) {
+  if (!meta) {
+    RETURN_STATUS_ERROR(StatusCode::ERR_INVALID_ARGUMENT,
+                        "Cannot create index with null metadata");
+  }
+  const auto name = meta->name;
+  const auto label = meta->schema.label_id;
+  const auto property_name = meta->schema.property_name;
+  GS_AUTO(index, index_ddl::CreateIndex(*cow_graph_, mut_view_, read_ts_,
+                                        alloc_, std::move(meta),
+                                        [this]() { MarkSchemaDirty(); }));
+  cow_state_.index_detached[name] = true;
+  if (label < cow_state_.vertex_tables.size()) {
+    const auto schema = cow_graph_->schema().get_vertex_schema(label);
+    const auto column = schema->get_property_index(property_name);
+    if (column >= 0 &&
+        static_cast<size_t>(column) <
+            cow_state_.vertex_tables[label].columns_detached.size()) {
+      cow_state_.vertex_tables[label].columns_detached[column] = true;
+    }
+  }
+  return index;
+}
+
+Status StorageCOWUpdateInterface::DropIndexDDLForAP(const std::string& name) {
+  RETURN_IF_NOT_OK(index_ddl::DropIndex(*cow_graph_, mut_view_, read_ts_,
+                                        alloc_, name,
+                                        [this]() { MarkSchemaDirty(); }));
+  cow_state_.index_detached.erase(name);
+  return Status::OK();
+}
+
+Status StorageCOWUpdateInterface::AddVertexImpl(label_t label, const Value& oid,
+                                                const std::vector<Value>& props,
+                                                vid_t& vid) {
   std::vector<DataType> types =
       cow_graph_->schema().get_vertex_properties(label);
   if (types.size() != props.size()) {
@@ -783,7 +890,9 @@ Status StorageTPUpdateInterface::AddVertexImpl(label_t label, const Value& oid,
   }
 
   RETURN_IF_NOT_OK(detachVertexTableForInsert(label));
-  wal_.LogInsertVertex(label, oid, props);
+  if (wal_) {
+    wal_->LogInsertVertex(label, oid, props);
+  }
   auto status = cow_graph_->AddVertex(label, oid, props, vid, read_ts_, true);
   if (!status.ok()) {
     LOG(ERROR) << "Failed to add vertex of label "
@@ -797,7 +906,7 @@ Status StorageTPUpdateInterface::AddVertexImpl(label_t label, const Value& oid,
   return Status::OK();
 }
 
-Status StorageTPUpdateInterface::DeleteVertexImpl(label_t label, vid_t lid) {
+Status StorageCOWUpdateInterface::DeleteVertexImpl(label_t label, vid_t lid) {
   if (!cow_graph_->IsValidLid(label, lid, read_ts_)) {
     return Status(StatusCode::ERR_INVALID_ARGUMENT,
                   "Vertex id is out of range or already deleted");
@@ -805,14 +914,16 @@ Status StorageTPUpdateInterface::DeleteVertexImpl(label_t label, vid_t lid) {
   auto oid = cow_graph_->GetOid(label, lid, read_ts_);
 
   prepareVertexDelete(label, {lid});
-  wal_.LogRemoveVertex(label, oid);
+  if (wal_) {
+    wal_->LogRemoveVertex(label, oid);
+  }
   RETURN_IF_NOT_OK(cow_graph_->DeleteVertex(label, lid, read_ts_));
   return deleteVertexIndexData(
       *cow_graph_, label, {lid},
       [this](StorageIndex& index) { return detachIndex(index); });
 }
 
-Status StorageTPUpdateInterface::AddEdgeImpl(
+Status StorageCOWUpdateInterface::AddEdgeImpl(
     label_t src_label, vid_t src_lid, label_t dst_label, vid_t dst_lid,
     label_t edge_label, const std::vector<Value>& properties,
     const void*& prop) {
@@ -837,19 +948,22 @@ Status StorageTPUpdateInterface::AddEdgeImpl(
       src_label, dst_label, edge_label);
   RETURN_IF_NOT_OK(detachEdgeTableForInsert(edge_idx));
   RETURN_IF_NOT_OK(detachAdjlists(edge_idx, src_lid, dst_lid, alloc_));
-  wal_.LogInsertEdge(src_label, GetVertexId(src_label, src_lid), dst_label,
-                     GetVertexId(dst_label, dst_lid), edge_label, properties);
+  if (wal_) {
+    wal_->LogInsertEdge(src_label, GetVertexId(src_label, src_lid), dst_label,
+                        GetVertexId(dst_label, dst_lid), edge_label,
+                        properties);
+  }
   int32_t oe_offset = 0;
   return cow_graph_->AddEdge(src_label, src_lid, dst_label, dst_lid, edge_label,
                              properties, read_ts_, alloc_, oe_offset, prop,
                              true);
 }
 
-Status StorageTPUpdateInterface::DeleteEdgesImpl(label_t src_label,
-                                                 vid_t src_lid,
-                                                 label_t dst_label,
-                                                 vid_t dst_lid,
-                                                 label_t edge_label) {
+Status StorageCOWUpdateInterface::DeleteEdgesImpl(label_t src_label,
+                                                  vid_t src_lid,
+                                                  label_t dst_label,
+                                                  vid_t dst_lid,
+                                                  label_t edge_label) {
   if (!cow_graph_->IsValidLid(src_label, src_lid, read_ts_) ||
       !cow_graph_->IsValidLid(dst_label, dst_lid, read_ts_)) {
     return Status(StatusCode::ERR_INVALID_ARGUMENT,
@@ -874,9 +988,11 @@ Status StorageTPUpdateInterface::DeleteEdgesImpl(label_t src_label,
     if (it.get_vertex() == dst_lid) {
       auto ie_offset = fuzzy_search_offset_from_nbr_list(
           ie_edges, src_lid, it.get_data_ptr(), search_edge_prop_type);
-      wal_.LogRemoveEdge(src_label, GetVertexId(src_label, src_lid), dst_label,
-                         GetVertexId(dst_label, dst_lid), edge_label, oe_offset,
-                         ie_offset);
+      if (wal_) {
+        wal_->LogRemoveEdge(src_label, GetVertexId(src_label, src_lid),
+                            dst_label, GetVertexId(dst_label, dst_lid),
+                            edge_label, oe_offset, ie_offset);
+      }
       auto status =
           cow_graph_->DeleteEdge(src_label, src_lid, dst_label, dst_lid,
                                  edge_label, oe_offset, ie_offset, read_ts_);
@@ -891,7 +1007,7 @@ Status StorageTPUpdateInterface::DeleteEdgesImpl(label_t src_label,
   return Status::OK();
 }
 
-Status StorageTPUpdateInterface::DeleteEdgeImpl(
+Status StorageCOWUpdateInterface::DeleteEdgeImpl(
     label_t src_label, vid_t src_lid, label_t dst_label, vid_t dst_lid,
     label_t edge_label, int32_t oe_offset, int32_t ie_offset) {
   if (!cow_graph_->IsValidLid(src_label, src_lid, read_ts_) ||
@@ -906,9 +1022,11 @@ Status StorageTPUpdateInterface::DeleteEdgeImpl(
   RETURN_IF_NOT_OK(detachEdgeTableForDelete(edge_idx));
   RETURN_IF_NOT_OK(detachAdjlists(edge_idx, src_lid, dst_lid, alloc_));
 
-  wal_.LogRemoveEdge(src_label, GetVertexId(src_label, src_lid), dst_label,
-                     GetVertexId(dst_label, dst_lid), edge_label, oe_offset,
-                     ie_offset);
+  if (wal_) {
+    wal_->LogRemoveEdge(src_label, GetVertexId(src_label, src_lid), dst_label,
+                        GetVertexId(dst_label, dst_lid), edge_label, oe_offset,
+                        ie_offset);
+  }
 
   return cow_graph_->DeleteEdge(src_label, src_lid, dst_label, dst_lid,
                                 edge_label, oe_offset, ie_offset, read_ts_);
@@ -936,9 +1054,10 @@ bool UpdateTransaction::GetVertexIndex(label_t label, const Value& id,
   return cow_graph_->get_lid(label, id, index, timestamp());
 }
 
-Status StorageTPUpdateInterface::UpdateVertexPropertyImpl(label_t label,
-                                                          vid_t lid, int col_id,
-                                                          const Value& value) {
+Status StorageCOWUpdateInterface::UpdateVertexPropertyImpl(label_t label,
+                                                           vid_t lid,
+                                                           int col_id,
+                                                           const Value& value) {
   if (!cow_graph_->IsValidLid(label, lid, read_ts_)) {
     return Status(StatusCode::ERR_INVALID_ARGUMENT,
                   "Vertex lid " + std::to_string(lid) + " of label " +
@@ -956,7 +1075,9 @@ Status StorageTPUpdateInterface::UpdateVertexPropertyImpl(label_t label,
                   "Type mismatch for column " + std::to_string(col_id) + ".");
   }
   RETURN_IF_NOT_OK(detachVertexColumn(label, col_id));
-  wal_.LogUpdateVertexProp(label, GetVertexId(label, lid), col_id, value);
+  if (wal_) {
+    wal_->LogUpdateVertexProp(label, GetVertexId(label, lid), col_id, value);
+  }
 
   RETURN_IF_NOT_OK(
       cow_graph_->UpdateVertexProperty(label, lid, col_id, value, read_ts_));
@@ -966,7 +1087,7 @@ Status StorageTPUpdateInterface::UpdateVertexPropertyImpl(label_t label,
       [this](StorageIndex& index) { return detachIndex(index); });
 }
 
-Status StorageTPUpdateInterface::UpdateEdgePropertyImpl(
+Status StorageCOWUpdateInterface::UpdateEdgePropertyImpl(
     label_t src_label, vid_t src, label_t dst_label, vid_t dst,
     label_t edge_label, int32_t oe_offset, int32_t ie_offset, int32_t col_id,
     const Value& value) {
@@ -980,9 +1101,11 @@ Status StorageTPUpdateInterface::UpdateEdgePropertyImpl(
       src_label, dst_label, edge_label);
   RETURN_IF_NOT_OK(detachEdgeColumn(edge_idx, col_id));
   RETURN_IF_NOT_OK(detachAdjlists(edge_idx, src, dst, alloc_));
-  wal_.LogUpdateEdgeProp(src_label, GetVertexId(src_label, src), dst_label,
-                         GetVertexId(dst_label, dst), edge_label, oe_offset,
-                         ie_offset, col_id, value);
+  if (wal_) {
+    wal_->LogUpdateEdgeProp(src_label, GetVertexId(src_label, src), dst_label,
+                            GetVertexId(dst_label, dst), edge_label, oe_offset,
+                            ie_offset, col_id, value);
+  }
   return cow_graph_->UpdateEdgeProperty(src_label, src, dst_label, dst,
                                         edge_label, oe_offset, ie_offset,
                                         col_id, value, read_ts_);
@@ -1130,8 +1253,9 @@ void UpdateTransaction::IngestWal(PropertyGraph& graph, uint32_t timestamp,
           "Failed to rename vertex properties in redo: ", ret);
       for (const auto& [old_name, new_name] :
            redo.config.GetRenameProperties()) {
-        if (old_name == new_name)
+        if (old_name == new_name) {
           continue;
+        }
         ret = renameVertexIndex(graph, label, old_name, new_name);
         THROW_STORAGE_EXCEPTION_STATUS(
             "Failed to rename vertex index metadata in redo: ", ret);
@@ -1210,7 +1334,7 @@ void UpdateTransaction::IngestWal(PropertyGraph& graph, uint32_t timestamp,
   }
 }
 
-Status StorageTPUpdateInterface::detachVertexTableForInsert(label_t label) {
+Status StorageCOWUpdateInterface::detachVertexTableForInsert(label_t label) {
   auto& state = cow_state_.vertex_tables[label];
   auto& vertex_table = cow_graph_->get_vertex_table(label);
   bool did_detach = false;
@@ -1238,7 +1362,7 @@ Status StorageTPUpdateInterface::detachVertexTableForInsert(label_t label) {
   return Status::OK();
 }
 
-Status StorageTPUpdateInterface::detachVertexTableForDelete(label_t label) {
+Status StorageCOWUpdateInterface::detachVertexTableForDelete(label_t label) {
   auto& state = cow_state_.vertex_tables[label];
   auto& vertex_table = cow_graph_->get_vertex_table(label);
   bool did_detach = false;
@@ -1263,8 +1387,8 @@ Status StorageTPUpdateInterface::detachVertexTableForDelete(label_t label) {
   return Status::OK();
 }
 
-Status StorageTPUpdateInterface::detachVertexColumn(label_t label,
-                                                    int32_t col_id) {
+Status StorageCOWUpdateInterface::detachVertexColumn(label_t label,
+                                                     int32_t col_id) {
   auto& state = cow_state_.vertex_tables[label];
   if (col_id >= 0 &&
       static_cast<size_t>(col_id) < state.columns_detached.size() &&
@@ -1278,7 +1402,7 @@ Status StorageTPUpdateInterface::detachVertexColumn(label_t label,
   return Status::OK();
 }
 
-Status StorageTPUpdateInterface::detachEdgeTableForInsert(
+Status StorageCOWUpdateInterface::detachEdgeTableForInsert(
     uint32_t edge_triplet_id) {
   if (!cow_graph_->HasEdgeTable(edge_triplet_id)) {
     return Status(StatusCode::ERR_INVALID_ARGUMENT,
@@ -1312,7 +1436,7 @@ Status StorageTPUpdateInterface::detachEdgeTableForInsert(
   return Status::OK();
 }
 
-Status StorageTPUpdateInterface::detachEdgeTableForDelete(
+Status StorageCOWUpdateInterface::detachEdgeTableForDelete(
     uint32_t edge_triplet_id) {
   if (!cow_graph_->HasEdgeTable(edge_triplet_id)) {
     return Status(StatusCode::ERR_INVALID_ARGUMENT,
@@ -1337,8 +1461,8 @@ Status StorageTPUpdateInterface::detachEdgeTableForDelete(
   return Status::OK();
 }
 
-Status StorageTPUpdateInterface::detachEdgeColumn(uint32_t edge_triplet_id,
-                                                  int32_t col_id) {
+Status StorageCOWUpdateInterface::detachEdgeColumn(uint32_t edge_triplet_id,
+                                                   int32_t col_id) {
   RETURN_IF_NOT_OK(detachEdgeTableForDelete(edge_triplet_id));
   auto& state = cow_state_.edge_tables[edge_triplet_id];
   auto& edge_table = cow_graph_->get_edge_table_by_index(edge_triplet_id);
@@ -1353,9 +1477,9 @@ Status StorageTPUpdateInterface::detachEdgeColumn(uint32_t edge_triplet_id,
   return Status::OK();
 }
 
-Status StorageTPUpdateInterface::detachAdjlists(uint32_t edge_triplet_id,
-                                                vid_t src_lid, vid_t dst_lid,
-                                                Allocator& alloc) {
+Status StorageCOWUpdateInterface::detachAdjlists(uint32_t edge_triplet_id,
+                                                 vid_t src_lid, vid_t dst_lid,
+                                                 Allocator& alloc) {
   auto& state = cow_state_.edge_tables[edge_triplet_id];
   auto& edge_table = cow_graph_->get_edge_table_by_index(edge_triplet_id);
   if (state.out_adjlists_detached.find(src_lid) ==
@@ -1371,8 +1495,8 @@ Status StorageTPUpdateInterface::detachAdjlists(uint32_t edge_triplet_id,
   return Status::OK();
 }
 
-Status StorageTPUpdateInterface::detachForResize(label_t label,
-                                                 size_t capacity) {
+Status StorageCOWUpdateInterface::detachForResize(label_t label,
+                                                  size_t capacity) {
   const auto& vertex_table = cow_graph_->get_vertex_table(label);
   if (capacity <= vertex_table.Capacity()) {
     return Status::OK();
@@ -1399,16 +1523,16 @@ Status StorageTPUpdateInterface::detachForResize(label_t label,
   return Status::OK();
 }
 
-Status StorageTPUpdateInterface::detachForResize(label_t src_label,
-                                                 label_t dst_label,
-                                                 label_t edge_label,
-                                                 size_t capacity) {
+Status StorageCOWUpdateInterface::detachForResize(label_t src_label,
+                                                  label_t dst_label,
+                                                  label_t edge_label,
+                                                  size_t capacity) {
   uint32_t idx = cow_graph_->schema().generate_edge_label(src_label, dst_label,
                                                           edge_label);
   return detachEdgeTableForInsert(idx);
 }
 
-Status StorageTPUpdateInterface::prepareVertexDelete(
+Status StorageCOWUpdateInterface::prepareVertexDelete(
     label_t label, const std::vector<vid_t>& lids) {
   // Step 1: detach vertex timestamp for delete.
   RETURN_IF_NOT_OK(detachVertexTableForDelete(label));
@@ -1418,8 +1542,9 @@ Status StorageTPUpdateInterface::prepareVertexDelete(
   auto vertex_label_count = schema.vertex_label_frontier();
   auto edge_label_count = schema.edge_label_frontier();
   for (label_t i = 0; i < vertex_label_count; ++i) {
-    if (!schema.is_vertex_label_valid(i))
+    if (!schema.is_vertex_label_valid(i)) {
       continue;
+    }
     for (label_t e = 0; e < edge_label_count; ++e) {
       if (schema.is_edge_triplet_valid(i, label, e)) {
         uint32_t idx = schema.generate_edge_label(i, label, e);
@@ -1449,7 +1574,7 @@ Status StorageTPUpdateInterface::prepareVertexDelete(
   return Status::OK();
 }
 
-result<std::vector<vid_t>> StorageTPUpdateInterface::BatchAddVerticesImpl(
+result<std::vector<vid_t>> StorageCOWUpdateInterface::BatchAddVerticesImpl(
     label_t v_label_id, std::shared_ptr<IDataChunkSupplier> supplier) {
   LOG(ERROR) << "BatchAddVertices is not supported in TP mode currently.";
   RETURN_STATUS_ERROR(
@@ -1457,7 +1582,7 @@ result<std::vector<vid_t>> StorageTPUpdateInterface::BatchAddVerticesImpl(
       "BatchAddVertices is not supported in TP mode currently.");
 }
 
-Status StorageTPUpdateInterface::BatchAddEdgesImpl(
+Status StorageCOWUpdateInterface::BatchAddEdgesImpl(
     label_t src_label, label_t dst_label, label_t edge_label,
     std::shared_ptr<IDataChunkSupplier> supplier) {
   LOG(ERROR) << "BatchAddEdges is not supported in TP mode currently.";
@@ -1465,7 +1590,7 @@ Status StorageTPUpdateInterface::BatchAddEdgesImpl(
                 "BatchAddEdges is not supported in TP mode currently.");
 }
 
-Status StorageTPUpdateInterface::BatchDeleteVerticesImpl(
+Status StorageCOWUpdateInterface::BatchDeleteVerticesImpl(
     label_t v_label_id, const std::vector<vid_t>& vids) {
   for (vid_t lid : vids) {
     if (!DeleteVertex(v_label_id, lid)) {
@@ -1478,7 +1603,7 @@ Status StorageTPUpdateInterface::BatchDeleteVerticesImpl(
   return Status::OK();
 }
 
-Status StorageTPUpdateInterface::BatchDeleteEdgesImpl(
+Status StorageCOWUpdateInterface::BatchDeleteEdgesImpl(
     label_t src_v_label_id, label_t dst_v_label_id, label_t edge_label_id,
     const std::vector<std::tuple<vid_t, vid_t>>& edges) {
   for (const auto& edge : edges) {
@@ -1497,7 +1622,7 @@ Status StorageTPUpdateInterface::BatchDeleteEdgesImpl(
   return Status::OK();
 }
 
-Status StorageTPUpdateInterface::BatchDeleteEdgesImpl(
+Status StorageCOWUpdateInterface::BatchDeleteEdgesImpl(
     label_t src_v_label_id, label_t dst_v_label_id, label_t edge_label_id,
     const std::vector<std::pair<vid_t, int32_t>>& oe_edges,
     const std::vector<std::pair<vid_t, int32_t>>& ie_edges) {
@@ -1520,7 +1645,7 @@ Status StorageTPUpdateInterface::BatchDeleteEdgesImpl(
   return Status::OK();
 }
 
-Status StorageTPUpdateInterface::detachIndex(StorageIndex& index) {
+Status StorageCOWUpdateInterface::detachIndex(StorageIndex& index) {
   const auto& name = index.GetMeta().name;
   auto it = cow_state_.index_detached.find(name);
   if (it != cow_state_.index_detached.end() && it->second) {

--- a/tests/storage/CMakeLists.txt
+++ b/tests/storage/CMakeLists.txt
@@ -9,6 +9,9 @@ if (BUILD_HTTP_SERVER)
     list(APPEND storage_test_src test_recovery.cc test_checkpoint.cc)
 endif()
 add_neug_test(storage_test ${storage_test_src})
+if (TARGET rt_server)
+    add_dependencies(storage_test rt_server)
+endif()
 
 add_neug_test(ap_index_test test_ap_index.cc)
 

--- a/tests/storage/test_ap_index.cc
+++ b/tests/storage/test_ap_index.cc
@@ -175,7 +175,7 @@ class APIndexTest : public ::testing::Test {
     graph_ = std::make_unique<PropertyGraph>();
     graph_->Open(ckp, MemoryLevel::kInMemory);
     view_ = std::make_unique<GraphView>(*graph_);
-    ap_ = std::make_unique<StorageAPUpdateInterface>(
+    ap_ = std::make_unique<StorageAPInPlaceUpdateInterface>(
         *graph_, *view_, 0, allocator_, [this]() {
           ++planning_change_count_;
           if (planning_change_hook_) {
@@ -194,7 +194,7 @@ class APIndexTest : public ::testing::Test {
     graph_ = std::make_unique<PropertyGraph>();
     graph_->Open(checkpoint_mgr_.CurrentCheckpoint(), MemoryLevel::kInMemory);
     view_ = std::make_unique<GraphView>(*graph_);
-    ap_ = std::make_unique<StorageAPUpdateInterface>(
+    ap_ = std::make_unique<StorageAPInPlaceUpdateInterface>(
         *graph_, *view_, 0, allocator_, [this]() {
           ++planning_change_count_;
           if (planning_change_hook_) {
@@ -368,7 +368,7 @@ class APIndexTest : public ::testing::Test {
   std::unique_ptr<PropertyGraph> graph_;
   std::unique_ptr<GraphView> view_;
   Allocator allocator_{MemoryLevel::kInMemory, ""};
-  std::unique_ptr<StorageAPUpdateInterface> ap_;
+  std::unique_ptr<StorageAPInPlaceUpdateInterface> ap_;
   int planning_change_count_{0};
   std::function<void()> planning_change_hook_;
 };

--- a/tests/storage/test_checkpoint.cc
+++ b/tests/storage/test_checkpoint.cc
@@ -530,9 +530,13 @@ TYPED_TEST(CheckpointTest, recover_from_checkpoint) {
       {1, 4, 4, 6}, {2020, 2022, 2021, 2023}, {3, 3, 5, 3});
 
   this->ExpectQuery(*conn, "MATCH (v:person) WHERE v.id = 1 DELETE v;");
+  AssertSingleInt64Result(
+      this->RunQuery(*conn, "MATCH (v)-[e]->(a) RETURN COUNT(e);"), 3);
   this->ExpectQuery(
       *conn,
       "MATCH (v:person)-[e:created]->(f:software) WHERE v.id > 4 DELETE e;");
+  AssertSingleInt64Result(
+      this->RunQuery(*conn, "MATCH (v)-[e]->(a) RETURN COUNT(e);"), 2);
   conn->Close();
   db.Close();
 

--- a/tests/storage/test_recovery.cc
+++ b/tests/storage/test_recovery.cc
@@ -213,7 +213,8 @@ class NeugDBWALRecoverySubprocessTest : public ::testing::Test {
     }
 #endif
     if (!std::filesystem::exists(neugdb_bin_)) {
-      throw std::runtime_error("NeugDB binary not found at " + neugdb_bin_);
+      GTEST_SKIP() << "NeugDB binary not found at " << neugdb_bin_
+                   << "; configure with BUILD_EXECUTABLES=ON to run this test";
     }
     neugdb_bin_ = std::filesystem::absolute(neugdb_bin_).string();
     LOG(INFO) << "Using neugdb binary: " << neugdb_bin_;

--- a/tests/storage/test_tp_index.cc
+++ b/tests/storage/test_tp_index.cc
@@ -124,12 +124,8 @@ class TPIndexTest : public ::testing::Test {
   }
 
   UpdateTransaction NewUpdateTransaction() {
-    UpdateTimestampLease timestamp_lease(version_manager_);
-    auto [cow_graph, planning_generation] =
-        snapshot_store_->CloneCurrentForUpdate();
-    return UpdateTransaction(std::move(cow_graph), planning_generation,
-                             allocator_, wal_writer_, *snapshot_store_,
-                             std::move(timestamp_lease));
+    return UpdateTransaction::Begin(version_manager_, *snapshot_store_,
+                                    TransactionDurability::kWal);
   }
 
   ReadTransaction NewReadTransaction() {
@@ -137,7 +133,9 @@ class TPIndexTest : public ::testing::Test {
         ReadSnapshotLease::Acquire(version_manager_, *snapshot_store_));
   }
 
-  void Commit(UpdateTransaction& txn) { ASSERT_TRUE(txn.Commit()); }
+  void Commit(UpdateTransaction& txn) {
+    ASSERT_TRUE(txn.Commit(*snapshot_store_, &wal_writer_).ok());
+  }
 
   void CreatePersonTableAP() {
     CreateVertexTypeParamBuilder builder;
@@ -212,7 +210,7 @@ class TPIndexTest : public ::testing::Test {
   void CreatePersonTableTP() {
     StartSnapshotStore();
     auto txn = NewUpdateTransaction();
-    StorageTPUpdateInterface tp(txn);
+    StorageCOWUpdateInterface tp(txn, allocator_);
     CreateVertexTypeParamBuilder builder;
     auto status =
         tp.CreateVertexType(builder.VertexLabel("Person")
@@ -294,7 +292,7 @@ class TPIndexTest : public ::testing::Test {
     return indexes.value();
   }
 
-  void AddPersonTP(StorageTPUpdateInterface& tp, int64_t id,
+  void AddPersonTP(StorageCOWUpdateInterface& tp, int64_t id,
                    const std::string& name, int32_t age, vid_t* out = nullptr) {
     auto label = tp.schema().get_vertex_label_id("Person");
     vid_t vid = 0;
@@ -360,6 +358,79 @@ class TPIndexTest : public ::testing::Test {
   CapturingWalWriter wal_writer_;
 };
 
+TEST_F(TPIndexTest, UpdateTransactionDurabilityControlsWalPublication) {
+  StartSnapshotStore();
+
+  {
+    auto txn = NewUpdateTransaction();
+    StorageCOWUpdateInterface storage(txn, allocator_);
+    CreateVertexTypeParamBuilder builder;
+    ASSERT_TRUE(storage
+                    .CreateVertexType(builder.VertexLabel("Person")
+                                          .AddProperty("id", Value::INT64(0))
+                                          .AddPrimaryKeyName("id")
+                                          .Build())
+                    .ok());
+
+    auto status = txn.Commit(*snapshot_store_);
+    ASSERT_FALSE(status.ok());
+    EXPECT_EQ(status.error_code(), StatusCode::ERR_INVALID_ARGUMENT);
+    EXPECT_FALSE(
+        snapshot_store_->CurrentSnapshot().schema().is_vertex_label_valid(
+            "Person"));
+    EXPECT_TRUE(wal_writer_.records.empty());
+  }
+
+  {
+    auto txn = UpdateTransaction::Begin(version_manager_, *snapshot_store_,
+                                        TransactionDurability::kNoWal);
+    StorageCOWUpdateInterface storage(txn, allocator_);
+    CreateVertexTypeParamBuilder builder;
+    ASSERT_TRUE(storage
+                    .CreateVertexType(builder.VertexLabel("Person")
+                                          .AddProperty("id", Value::INT64(0))
+                                          .AddPrimaryKeyName("id")
+                                          .Build())
+                    .ok());
+
+    ASSERT_TRUE(txn.Commit(*snapshot_store_).ok());
+    EXPECT_TRUE(
+        snapshot_store_->CurrentSnapshot().schema().is_vertex_label_valid(
+            "Person"));
+    EXPECT_TRUE(wal_writer_.records.empty());
+  }
+}
+
+TEST_F(TPIndexTest, APUpdateTransactionSupportsIndexDDL) {
+  CreatePersonTableAP();
+  StartSnapshotStore();
+
+  {
+    auto txn = UpdateTransaction::Begin(version_manager_, *snapshot_store_,
+                                        TransactionDurability::kNoWal);
+    StorageAPCOWUpdateInterface ap(txn, allocator_);
+    auto meta = std::make_unique<IndexMeta>();
+    meta->name = "idx_person_age";
+    meta->type = "example";
+    meta->schema.label_id = ap.schema().get_vertex_label_id("Person");
+    meta->schema.property_name = "age";
+    meta->schema.property_type = DataType::INT32;
+
+    ASSERT_TRUE(ap.CreateIndex(std::move(meta))) << "CREATE INDEX failed";
+    ASSERT_TRUE(txn.Commit(*snapshot_store_).ok());
+  }
+  EXPECT_NE(GetIndexByName("idx_person_age"), nullptr);
+
+  {
+    auto txn = UpdateTransaction::Begin(version_manager_, *snapshot_store_,
+                                        TransactionDurability::kNoWal);
+    StorageAPCOWUpdateInterface ap(txn, allocator_);
+    ASSERT_TRUE(ap.DropIndex("idx_person_age").ok());
+    ASSERT_TRUE(txn.Commit(*snapshot_store_).ok());
+  }
+  EXPECT_EQ(GetIndexByName("idx_person_age"), nullptr);
+}
+
 TEST_F(TPIndexTest, CreateIndexEmptyGraphAndDuplicateName) {
   CreatePersonTableTP();
 
@@ -382,7 +453,7 @@ TEST_F(TPIndexTest, IndexAdminInterfaceIsAPOnly) {
 
   CreatePersonTableTP();
   auto txn = NewUpdateTransaction();
-  StorageTPUpdateInterface tp(txn);
+  StorageCOWUpdateInterface tp(txn, allocator_);
   EXPECT_EQ(dynamic_cast<StorageIndexDDLInterface*>(&tp), nullptr);
 }
 
@@ -397,7 +468,7 @@ TEST_F(TPIndexTest, DropVertexTypeDeletesBoundIndex) {
   ASSERT_EQ(GetIndexes(person_label, "age").size(), 1);
 
   auto txn = NewUpdateTransaction();
-  StorageTPUpdateInterface tp(txn);
+  StorageCOWUpdateInterface tp(txn, allocator_);
   auto status = tp.DeleteVertexType(person_label);
   ASSERT_TRUE(status.ok()) << status.ToString();
   Commit(txn);
@@ -415,7 +486,7 @@ TEST_F(TPIndexTest, DropAndRenameVertexPropertyDeleteBoundIndex) {
 
   {
     auto txn = NewUpdateTransaction();
-    StorageTPUpdateInterface tp(txn);
+    StorageCOWUpdateInterface tp(txn, allocator_);
     DeleteVertexPropertiesParamBuilder delete_builder;
     auto status = tp.DeleteVertexProperties(
         person_label, delete_builder.AddDeleteProperty("age").Build());
@@ -426,7 +497,7 @@ TEST_F(TPIndexTest, DropAndRenameVertexPropertyDeleteBoundIndex) {
 
   {
     auto txn = NewUpdateTransaction();
-    StorageTPUpdateInterface tp(txn);
+    StorageCOWUpdateInterface tp(txn, allocator_);
     AddVertexPropertiesParamBuilder add_builder;
     auto status = tp.AddVertexProperties(
         person_label,
@@ -441,7 +512,7 @@ TEST_F(TPIndexTest, DropAndRenameVertexPropertyDeleteBoundIndex) {
 
   {
     auto txn = NewUpdateTransaction();
-    StorageTPUpdateInterface tp(txn);
+    StorageCOWUpdateInterface tp(txn, allocator_);
     RenameVertexPropertiesParamBuilder rename_builder;
     auto status = tp.RenameVertexProperties(
         person_label,
@@ -469,7 +540,7 @@ TEST_F(TPIndexTest, InsertDeleteAndUpdateMaintainIndex) {
   vid_t alice = 0;
   {
     auto txn = NewUpdateTransaction();
-    StorageTPUpdateInterface tp(txn);
+    StorageCOWUpdateInterface tp(txn, allocator_);
     AddPersonTP(tp, 1, "Alice", 30, &alice);
     AddPersonTP(tp, 2, "Bob", 25);
     AddPersonTP(tp, 3, "Charlie", 30);
@@ -519,7 +590,7 @@ TEST_F(TPIndexTest, APCreateVecColumnAndTPUpdateMaintainsVecIndexSearch) {
   StartSnapshotStore();
   {
     auto txn = NewUpdateTransaction();
-    StorageTPUpdateInterface tp(txn);
+    StorageCOWUpdateInterface tp(txn, allocator_);
     auto vector_type = DataType::Array(DataType::FLOAT, 2);
     auto updated_vector =
         Value::ARRAY(vector_type, {Value::FLOAT(12.0f), Value::FLOAT(12.0f)});
@@ -553,7 +624,7 @@ TEST_F(TPIndexTest, AbortedVectorVertexDeletePreservesReadSnapshot) {
   EXPECT_EQ(before_delete.front().vid, first_vid);
 
   auto update_txn = NewUpdateTransaction();
-  StorageTPUpdateInterface tp(update_txn);
+  StorageCOWUpdateInterface tp(update_txn, allocator_);
   auto label = tp.schema().get_vertex_label_id("Vector");
   ASSERT_TRUE(tp.DeleteVertex(label, first_vid));
   auto update_results = SearchVector(tp, {1.0f, 1.0f});
@@ -587,7 +658,7 @@ TEST_F(TPIndexTest, PrimaryKeyIndexMaintainedAcrossVertexLifecycle) {
       snapshot_store_->CurrentSnapshot().schema().get_vertex_label_id("Item");
   {
     auto txn = NewUpdateTransaction();
-    StorageTPUpdateInterface tp(txn);
+    StorageCOWUpdateInterface tp(txn, allocator_);
     vid_t vid = 0;
     ASSERT_TRUE(
         tp.AddVertex(label, Value::INT32(1), {Value::INT32(10)}, vid).ok());
@@ -609,7 +680,7 @@ TEST_F(TPIndexTest, PrimaryKeyIndexMaintainedAcrossVertexLifecycle) {
 
   {
     auto txn = NewUpdateTransaction();
-    StorageTPUpdateInterface tp(txn);
+    StorageCOWUpdateInterface tp(txn, allocator_);
     ASSERT_TRUE(tp.DeleteVertexType(label).ok());
     Commit(txn);
   }
@@ -622,7 +693,7 @@ TEST_F(TPIndexTest, BatchAddVerticesIsNotSupportedInTPMode) {
   StartSnapshotStore();
 
   auto txn = NewUpdateTransaction();
-  StorageTPUpdateInterface tp(txn);
+  StorageCOWUpdateInterface tp(txn, allocator_);
   auto result =
       tp.BatchAddVertices(tp.schema().get_vertex_label_id("Person"), nullptr);
   EXPECT_FALSE(result);
@@ -637,7 +708,7 @@ TEST_F(TPIndexTest, IndexPersistsAfterCheckpointReopen) {
 
   {
     auto txn = NewUpdateTransaction();
-    StorageTPUpdateInterface tp(txn);
+    StorageCOWUpdateInterface tp(txn, allocator_);
     for (const auto& person : kPersons) {
       AddPersonTP(tp, person.id, person.name, person.age);
     }
@@ -677,7 +748,7 @@ TEST_F(TPIndexTest, AutomaticallyDeletedIndexStaysDeletedAfterReopen) {
 
   {
     auto txn = NewUpdateTransaction();
-    StorageTPUpdateInterface tp(txn);
+    StorageCOWUpdateInterface tp(txn, allocator_);
     auto status = tp.DeleteVertexType(person_label);
     ASSERT_TRUE(status.ok()) << status.ToString();
     Commit(txn);
@@ -707,7 +778,7 @@ TEST_F(TPIndexTest, WalReplayRestoresIndexData) {
 
   {
     auto txn = NewUpdateTransaction();
-    StorageTPUpdateInterface tp(txn);
+    StorageCOWUpdateInterface tp(txn, allocator_);
     AddPersonTP(tp, 1, "Alice", 30);
     AddPersonTP(tp, 2, "Bob", 25);
     AddPersonTP(tp, 3, "Charlie", 30);
@@ -750,14 +821,14 @@ TEST_F(TPIndexTest, AbortDiscardsIndexMutations) {
 
   {
     auto txn = NewUpdateTransaction();
-    StorageTPUpdateInterface tp(txn);
+    StorageCOWUpdateInterface tp(txn, allocator_);
     AddPersonTP(tp, 1, "Alice", 30);
     Commit(txn);
   }
 
   {
     auto txn = NewUpdateTransaction();
-    StorageTPUpdateInterface tp(txn);
+    StorageCOWUpdateInterface tp(txn, allocator_);
     auto label = tp.schema().get_vertex_label_id("Person");
     vid_t alice = 0;
     ASSERT_TRUE(tp.GetVertexIndex(label, Value::INT64(1), alice));
@@ -789,7 +860,7 @@ TEST_F(TPIndexTest, AbortDoesNotReuseAllocatedIndexID) {
   index_id_t next_index_id_after_abort = 0;
   {
     auto txn = NewUpdateTransaction();
-    StorageTPUpdateInterface tp(txn);
+    StorageCOWUpdateInterface tp(txn, allocator_);
     vid_t bob = 0;
     AddPersonTP(tp, 2, "Bob", 25, &bob);
     auto* index = dynamic_cast<ExampleIndex*>(GetIndexByName("idx_person_age"));
@@ -801,7 +872,7 @@ TEST_F(TPIndexTest, AbortDoesNotReuseAllocatedIndexID) {
 
   {
     auto txn = NewUpdateTransaction();
-    StorageTPUpdateInterface tp(txn);
+    StorageCOWUpdateInterface tp(txn, allocator_);
     vid_t charlie = 0;
     AddPersonTP(tp, 3, "Charlie", 30, &charlie);
     auto* index = dynamic_cast<ExampleIndex*>(GetIndexByName("idx_person_age"));
@@ -822,7 +893,7 @@ TEST_F(TPIndexTest, ReadTransactionIsolationFromUpdateTransaction) {
 
   {
     auto txn = NewUpdateTransaction();
-    StorageTPUpdateInterface tp(txn);
+    StorageCOWUpdateInterface tp(txn, allocator_);
     AddPersonTP(tp, 1, "Alice", 30);
     Commit(txn);
   }
@@ -831,7 +902,7 @@ TEST_F(TPIndexTest, ReadTransactionIsolationFromUpdateTransaction) {
   StorageReadInterface read_reader(read_txn.view(), read_txn.timestamp());
 
   auto update_txn = NewUpdateTransaction();
-  StorageTPUpdateInterface tp(update_txn);
+  StorageCOWUpdateInterface tp(update_txn, allocator_);
   auto label = tp.schema().get_vertex_label_id("Person");
   vid_t alice = 0;
   ASSERT_TRUE(tp.GetVertexIndex(label, Value::INT64(1), alice));

--- a/tests/storage/test_tp_index.cc
+++ b/tests/storage/test_tp_index.cc
@@ -109,8 +109,8 @@ class TPIndexTest : public ::testing::Test {
     graph_ = std::make_shared<PropertyGraph>();
     graph_->Open(ckp, MemoryLevel::kInMemory);
     view_ = std::make_unique<GraphView>(*graph_);
-    ap_ = std::make_unique<StorageAPUpdateInterface>(*graph_, *view_, 0,
-                                                     allocator_);
+    ap_ = std::make_unique<StorageAPInPlaceUpdateInterface>(*graph_, *view_, 0,
+                                                            allocator_);
     version_manager_.init_ts({0, 0}, 1);
     wal_writer_.records.clear();
     auto global_cache = std::make_shared<execution::GlobalQueryCache>(
@@ -352,7 +352,7 @@ class TPIndexTest : public ::testing::Test {
   std::shared_ptr<PropertyGraph> graph_;
   std::unique_ptr<GraphView> view_;
   Allocator allocator_{MemoryLevel::kInMemory, ""};
-  std::unique_ptr<StorageAPUpdateInterface> ap_;
+  std::unique_ptr<StorageAPInPlaceUpdateInterface> ap_;
   std::unique_ptr<GraphSnapshotStore> snapshot_store_;
   VersionManager version_manager_;
   CapturingWalWriter wal_writer_;

--- a/tests/transaction/test_acid.cc
+++ b/tests/transaction/test_acid.cc
@@ -154,7 +154,7 @@ bool neug_get_random_vertex(const StorageReadInterface& txn, label_t label_id,
   return false;
 }
 
-auto neug_get_random_vertex(StorageTPUpdateInterface& gi, label_t label_id) {
+auto neug_get_random_vertex(StorageCOWUpdateInterface& gi, label_t label_id) {
   auto vertex_set = gi.GetVertexSet(label_id);
   int num = 0;
   neug::vid_t vid = 0;
@@ -179,7 +179,7 @@ auto neug_get_random_vertex(StorageTPUpdateInterface& gi, label_t label_id) {
 }
 
 // Helper: append string to field
-void neug_append_string_to_field(StorageTPUpdateInterface& gui, label_t label,
+void neug_append_string_to_field(StorageCOWUpdateInterface& gui, label_t label,
                                  neug::vid_t vit, int col_id,
                                  const std::string& str) {
   std::string cur_str = std::string(
@@ -238,7 +238,8 @@ std::shared_ptr<neug::NeugDBService> neug_AtomicityInit(
 bool neug_AtomicityC(neug::ExecutionSlot& db, int64_t person2_id,
                      const std::string& new_email, int64_t since) {
   auto txn = db.GetUpdateTransaction();
-  StorageTPUpdateInterface gui(txn);
+  Allocator gui_alloc(MemoryLevel::kInMemory, "");
+  StorageCOWUpdateInterface gui(txn, gui_alloc);
   auto person_label_id = txn.schema().get_vertex_label_id("PERSON");
   auto knows_label_id = txn.schema().get_edge_label_id("KNOWS");
   auto vit = neug_get_random_vertex(gui, person_label_id);
@@ -261,14 +262,14 @@ bool neug_AtomicityC(neug::ExecutionSlot& db, int64_t person2_id,
     txn.Abort();
     return false;
   }
-  txn.Commit();
-  return true;
+  return db.CommitUpdateTransaction(txn).ok();
 }
 
 bool neug_AtomicityRB(neug::ExecutionSlot& db, int64_t person2_id,
                       const std::string& new_email, int64_t since) {
   auto txn = db.GetUpdateTransaction();
-  StorageTPUpdateInterface gui(txn);
+  Allocator gui_alloc(MemoryLevel::kInMemory, "");
+  StorageCOWUpdateInterface gui(txn, gui_alloc);
   auto person_label_id = txn.schema().get_vertex_label_id("PERSON");
   auto vit1 = neug_get_random_vertex(gui, person_label_id);
   neug_append_string_to_field(gui, person_label_id, vit1, 2, new_email);
@@ -286,8 +287,7 @@ bool neug_AtomicityRB(neug::ExecutionSlot& db, int64_t person2_id,
       {neug::Value::INT64(person2_id), neug::Value::STRING(std::string(name)),
        neug::Value::STRING(std::string(email))},
       vid));
-  EXPECT_TRUE(txn.Commit());
-  return true;
+  return db.CommitUpdateTransaction(txn).ok();
 }
 
 int64_t neug_count_email_num(const std::string_view& sv) {
@@ -378,7 +378,8 @@ std::shared_ptr<neug::NeugDBService> G0Init(NeugDB& db,
 void G0(neug::ExecutionSlot& db, int64_t person1_id, int64_t person2_id,
         int64_t txn_id) {
   auto txn = db.GetUpdateTransaction();
-  StorageTPUpdateInterface gui(txn);
+  Allocator gui_alloc(MemoryLevel::kInMemory, "");
+  StorageCOWUpdateInterface gui(txn, gui_alloc);
   auto person_label_id = txn.schema().get_vertex_label_id("PERSON");
   auto knows_label_id = txn.schema().get_edge_label_id("KNOWS");
 
@@ -439,7 +440,7 @@ void G0(neug::ExecutionSlot& db, int64_t person1_id, int64_t person2_id,
 
   ed_accessor.set_data(oeit, new_value, txn.timestamp());
 
-  txn.Commit();
+  CHECK(db.CommitUpdateTransaction(txn).ok());
 }
 
 std::tuple<std::string, std::string, std::string> G0Check(
@@ -541,13 +542,14 @@ std::shared_ptr<neug::NeugDBService> InitPersonWithVersion(
 
 void G1B1(neug::ExecutionSlot& db, int64_t even, int64_t odd) {
   auto txn = db.GetUpdateTransaction();
-  StorageTPUpdateInterface gui(txn);
+  Allocator gui_alloc(MemoryLevel::kInMemory, "");
+  StorageCOWUpdateInterface gui(txn, gui_alloc);
   auto person_label_id = txn.schema().get_vertex_label_id("PERSON");
   auto vit = neug_get_random_vertex(gui, person_label_id);
   gui.UpdateVertexProperty(person_label_id, vit, 1, neug::Value::INT64(even));
   std::this_thread::sleep_for(std::chrono::milliseconds(SLEEP_TIME_MILLI_SEC));
   gui.UpdateVertexProperty(person_label_id, vit, 1, neug::Value::INT64(odd));
-  txn.Commit();
+  CHECK(db.CommitUpdateTransaction(txn).ok());
 }
 
 int64_t G1B2(neug::ExecutionSlot& db) {
@@ -569,7 +571,8 @@ int64_t G1B2(neug::ExecutionSlot& db) {
 int64_t G1C(neug::ExecutionSlot& db, int64_t person1_id, int64_t person2_id,
             int64_t txn_id) {
   auto txn = db.GetUpdateTransaction();
-  StorageTPUpdateInterface gui(txn);
+  Allocator gui_alloc(MemoryLevel::kInMemory, "");
+  StorageCOWUpdateInterface gui(txn, gui_alloc);
   auto person_label_id = txn.schema().get_vertex_label_id("PERSON");
   neug::vid_t person1_vid;
   bool flag = false;
@@ -601,7 +604,7 @@ int64_t G1C(neug::ExecutionSlot& db, int64_t person1_id, int64_t person2_id,
   int64_t ret = gui.GetVertexProperty(person_label_id, person2_vid, 1)
                     .GetValue<int64_t>();
 
-  txn.Commit();
+  CHECK(db.CommitUpdateTransaction(txn).ok());
 
   return ret;
 }
@@ -610,7 +613,8 @@ int64_t G1C(neug::ExecutionSlot& db, int64_t person1_id, int64_t person2_id,
 
 void G1A1(neug::ExecutionSlot& db) {
   auto txn = db.GetUpdateTransaction();
-  StorageTPUpdateInterface gui(txn);
+  Allocator gui_alloc(MemoryLevel::kInMemory, "");
+  StorageCOWUpdateInterface gui(txn, gui_alloc);
   auto person_label_id = txn.schema().get_vertex_label_id("PERSON");
   // select a random person
   auto vit = neug_get_random_vertex(gui, person_label_id);
@@ -642,13 +646,14 @@ int64_t G1A2(neug::ExecutionSlot& db) {
 void IMP1(neug::ExecutionSlot& db) {
   auto txn = db.GetUpdateTransaction();
   auto person_label_id = txn.schema().get_vertex_label_id("PERSON");
-  StorageTPUpdateInterface gui(txn);
+  Allocator gui_alloc(MemoryLevel::kInMemory, "");
+  StorageCOWUpdateInterface gui(txn, gui_alloc);
   auto vit = neug_get_random_vertex(gui, person_label_id);
   int64_t old_version =
       gui.GetVertexProperty(person_label_id, vit, 1).GetValue<int64_t>();
   gui.UpdateVertexProperty(person_label_id, vit, 1,
                            neug::Value::INT64(old_version + 1));
-  txn.Commit();
+  CHECK(db.CommitUpdateTransaction(txn).ok());
 }
 
 std::tuple<int64_t, int64_t> IMP2(neug::ExecutionSlot& db, int64_t person1_id) {
@@ -730,7 +735,8 @@ std::shared_ptr<neug::NeugDBService> PMPInit(NeugDB& db,
 
 bool PMP1(neug::ExecutionSlot& db, int64_t person_id, int64_t post_id) {
   auto txn = db.GetUpdateTransaction();
-  StorageTPUpdateInterface gui(txn);
+  Allocator gui_alloc(MemoryLevel::kInMemory, "");
+  StorageCOWUpdateInterface gui(txn, gui_alloc);
   auto person_label_id = txn.schema().get_vertex_label_id("PERSON");
   auto post_label_id = txn.schema().get_vertex_label_id("POST");
   auto likes_label_id = txn.schema().get_edge_label_id("LIKES");
@@ -766,8 +772,7 @@ bool PMP1(neug::ExecutionSlot& db, int64_t person_id, int64_t post_id) {
     txn.Abort();
     return false;
   }
-  txn.Commit();
-  return true;
+  return db.CommitUpdateTransaction(txn).ok();
 }
 
 std::tuple<int64_t, int64_t> PMP2(neug::ExecutionSlot& db, int64_t post_id) {
@@ -871,7 +876,8 @@ std::shared_ptr<neug::NeugDBService> OTVInit(NeugDB& db,
 
 void OTV1(neug::ExecutionSlot& db, int64_t person_id) {
   auto txn = db.GetUpdateTransaction();
-  StorageTPUpdateInterface gui(txn);
+  Allocator gui_alloc(MemoryLevel::kInMemory, "");
+  StorageCOWUpdateInterface gui(txn, gui_alloc);
   auto person_label_id = txn.schema().get_vertex_label_id("PERSON");
   auto knows_label_id = txn.schema().get_edge_label_id("KNOWS");
   vid_t vid1;
@@ -931,7 +937,7 @@ void OTV1(neug::ExecutionSlot& db, int64_t person_id) {
                         .GetValue<int64_t>() +
                     1));
 
-            txn.Commit();
+            CHECK(db.CommitUpdateTransaction(txn).ok());
             return;
           }
         }
@@ -1060,7 +1066,8 @@ std::shared_ptr<neug::NeugDBService> LUInit(NeugDB& db,
 
 bool LU1(neug::ExecutionSlot& db, int64_t person_id) {
   auto txn = db.GetUpdateTransaction();
-  StorageTPUpdateInterface gui(txn);
+  Allocator gui_alloc(MemoryLevel::kInMemory, "");
+  StorageCOWUpdateInterface gui(txn, gui_alloc);
   auto person_label_id = txn.schema().get_vertex_label_id("PERSON");
 
   neug::vid_t person_vid;
@@ -1082,8 +1089,7 @@ bool LU1(neug::ExecutionSlot& db, int64_t person_id) {
   gui.UpdateVertexProperty(person_label_id, person_vid, 1,
                            neug::Value::INT64(num_friends + 1));
 
-  txn.Commit();
-  return true;
+  return db.CommitUpdateTransaction(txn).ok();
 }
 
 std::map<int64_t, int64_t> LU2(neug::ExecutionSlot& db) {
@@ -1149,7 +1155,8 @@ std::shared_ptr<neug::NeugDBService> WSInit(NeugDB& db,
 void WS1(neug::ExecutionSlot& db, int64_t person1_id, int64_t person2_id,
          std::mt19937& gen) {
   auto txn = db.GetUpdateTransaction();
-  StorageTPUpdateInterface gui(txn);
+  Allocator gui_alloc(MemoryLevel::kInMemory, "");
+  StorageCOWUpdateInterface gui(txn, gui_alloc);
   auto person_label_id = txn.schema().get_vertex_label_id("PERSON");
 
   vid_t person1_vid;
@@ -1198,7 +1205,7 @@ void WS1(neug::ExecutionSlot& db, int64_t person1_id, int64_t person2_id,
     gui.UpdateVertexProperty(person_label_id, person2_vid, 1,
                              neug::Value::INT64(p2_value - 100));
   }
-  txn.Commit();
+  CHECK(db.CommitUpdateTransaction(txn).ok());
 }
 
 std::vector<std::tuple<int64_t, int64_t, int64_t, int64_t>> WS2(
@@ -1668,14 +1675,16 @@ int64_t cc_read_age_via(const ReadTransaction& txn, NeugDB& db,
   return gi.GetVertexProperty(person_label, vid, 1).GetValue<int64_t>();
 }
 
-// Acquire a slot, open an UpdateTxn, invoke `body(txn)`, then Commit.
+// Acquire a slot, open an UpdateTxn, invoke `body(txn, storage)`, then Commit.
 // Centralizes the boilerplate that recurs in nearly every COW isolation test.
 template <typename Body>
 void cc_run_update(NeugDBService& svc, Body&& body) {
   auto slot = svc.AcquireExecutionSlot();
   auto txn = slot->GetUpdateTransaction();
-  body(txn);
-  EXPECT_TRUE(txn.Commit());
+  Allocator storage_alloc(MemoryLevel::kInMemory, "");
+  StorageCOWUpdateInterface storage(txn, storage_alloc);
+  body(txn, storage);
+  EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
 }
 
 // Acquire a slot, open a fresh ReadTxn, and invoke `body(gi)` against a
@@ -1701,7 +1710,8 @@ vid_t cc_person_vid(Txn& txn, NeugDB& db, int64_t oid) {
 bool cc_update_age(NeugDBService& svc, int64_t person_id, int64_t new_age) {
   auto slot = svc.AcquireExecutionSlot();
   auto txn = slot->GetUpdateTransaction();
-  StorageTPUpdateInterface gui(txn);
+  Allocator gui_alloc(MemoryLevel::kInMemory, "");
+  StorageCOWUpdateInterface gui(txn, gui_alloc);
   auto person_label = svc.db().schema().get_vertex_label_id("person");
   vid_t vid;
   if (!gui.GetVertexIndex(person_label, neug::Value::INT64(person_id), vid)) {
@@ -1709,7 +1719,7 @@ bool cc_update_age(NeugDBService& svc, int64_t person_id, int64_t new_age) {
     return false;
   }
   gui.UpdateVertexProperty(person_label, vid, 1, neug::Value::INT64(new_age));
-  return txn.Commit();
+  return slot->CommitUpdateTransaction(txn).ok();
 }
 
 // Count visible person vertices.
@@ -1817,7 +1827,8 @@ double cc_read_knows_weight_via(const ReadTransaction& txn, NeugDB& db,
 void cc_setup_unbundled_created(NeugDBService& svc) {
   auto slot = svc.AcquireExecutionSlot();
   auto txn = slot->GetUpdateTransaction();
-  StorageTPUpdateInterface gui(txn);
+  Allocator gui_alloc(MemoryLevel::kInMemory, "");
+  StorageCOWUpdateInterface gui(txn, gui_alloc);
 
   CreateVertexTypeParamBuilder sb;
   ASSERT_TRUE(
@@ -1855,7 +1866,7 @@ void cc_setup_unbundled_created(NeugDBService& svc) {
                           {neug::Value::DOUBLE(0.5), neug::Value::INT64(2020)},
                           add_edge_prop));
 
-  ASSERT_TRUE(txn.Commit());
+  ASSERT_TRUE(slot->CommitUpdateTransaction(txn).ok());
 }
 
 // Read the `since` property on the unbundled created edge person 1→software 1
@@ -2083,7 +2094,8 @@ TEST_F(NeugDBACIDTest, UpdateCowCloneDoesNotAffectActiveReaders) {
   // Open U and mutate without committing.
   auto sess_u = svc->AcquireExecutionSlot();
   auto txn_u = sess_u->GetUpdateTransaction();
-  StorageTPUpdateInterface gui(txn_u);
+  Allocator gui_alloc(MemoryLevel::kInMemory, "");
+  StorageCOWUpdateInterface gui(txn_u, gui_alloc);
   auto person_label = db.schema().get_vertex_label_id("person");
   vid_t vid_u;
   ASSERT_TRUE(gui.GetVertexIndex(person_label, neug::Value::INT64(5), vid_u));
@@ -2109,7 +2121,8 @@ TEST_F(NeugDBACIDTest, UpdateRollbackLeavesOriginalIntact) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    StorageTPUpdateInterface gui(txn);
+    Allocator gui_alloc(MemoryLevel::kInMemory, "");
+    StorageCOWUpdateInterface gui(txn, gui_alloc);
     gui.UpdateVertexProperty(person_label, cc_person_vid(gui, db, 5), 1,
                              neug::Value::INT64(125));
     txn.Abort();
@@ -2121,7 +2134,8 @@ TEST_F(NeugDBACIDTest, UpdateRollbackLeavesOriginalIntact) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    Allocator gui_alloc(MemoryLevel::kInMemory, "");
+    StorageCOWUpdateInterface gui(txn, gui_alloc);
     CreateVertexTypeParamBuilder b;
     auto status =
         gui.CreateVertexType(b.VertexLabel("foo")
@@ -2140,7 +2154,8 @@ TEST_F(NeugDBACIDTest, UpdateRollbackLeavesOriginalIntact) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    Allocator gui_alloc(MemoryLevel::kInMemory, "");
+    StorageCOWUpdateInterface gui(txn, gui_alloc);
     DeleteEdgePropertiesParamBuilder b;
     auto config = b.AddDeleteProperty("weight").Build();
     auto status = gui.DeleteEdgeProperties(
@@ -2187,8 +2202,7 @@ TEST_F(NeugDBACIDTest, DMLCommitDoesNotAffectHeldReader) {
       cc_count_oe_from_via(txn_r, p_label, p_label, e_label, r_v1);
 
   // --- AddVertex ---
-  cc_run_update(*svc, [&](auto& txn) {
-    StorageTPUpdateInterface gui(txn);
+  cc_run_update(*svc, [&](auto& txn, auto& gui) {
     vid_t vid;
     ASSERT_TRUE(gui.AddVertex(
         p_label, neug::Value::INT64(900001),
@@ -2207,8 +2221,7 @@ TEST_F(NeugDBACIDTest, DMLCommitDoesNotAffectHeldReader) {
   EXPECT_EQ(cc_read_age(*svc, 900001), 77);
 
   // --- DeleteVertex ---
-  cc_run_update(*svc, [&](auto& txn) {
-    StorageTPUpdateInterface gui(txn);
+  cc_run_update(*svc, [&](auto& txn, auto& gui) {
     EXPECT_TRUE(gui.DeleteVertex(p_label, cc_person_vid(txn, db, 5)));
   });
   // Held reader: vertex 5 still visible.
@@ -2218,8 +2231,7 @@ TEST_F(NeugDBACIDTest, DMLCommitDoesNotAffectHeldReader) {
   EXPECT_EQ(cc_read_age(*svc, 5), -1);
 
   // --- AddEdge ---
-  cc_run_update(*svc, [&](auto& txn) {
-    StorageTPUpdateInterface gui(txn);
+  cc_run_update(*svc, [&](auto& txn, auto& gui) {
     const void* edge_prop = nullptr;
     EXPECT_TRUE(gui.AddEdge(p_label, cc_person_vid(gui, db, 1), p_label,
                             cc_person_vid(gui, db, 2), e_label,
@@ -2232,16 +2244,14 @@ TEST_F(NeugDBACIDTest, DMLCommitDoesNotAffectHeldReader) {
 
   // --- DeleteEdge ---
   // Add another deterministic edge 1→2, then delete all 1→2 edges.
-  cc_run_update(*svc, [&](auto& txn) {
-    StorageTPUpdateInterface gui(txn);
+  cc_run_update(*svc, [&](auto& txn, auto& gui) {
     const void* edge_prop = nullptr;
     EXPECT_TRUE(gui.AddEdge(p_label, cc_person_vid(gui, db, 1), p_label,
                             cc_person_vid(gui, db, 2), e_label,
                             {neug::Value::DOUBLE(0.42)}, edge_prop));
   });
   size_t total_after_adds = cc_count_all_oe(*svc, "person", "person", "knows");
-  cc_run_update(*svc, [&](auto& txn) {
-    StorageTPUpdateInterface gui(txn);
+  cc_run_update(*svc, [&](auto& txn, auto& gui) {
     EXPECT_TRUE(gui.DeleteEdges(p_label, cc_person_vid(txn, db, 1), p_label,
                                 cc_person_vid(txn, db, 2), e_label));
   });
@@ -2270,8 +2280,7 @@ TEST_F(NeugDBACIDTest,
 
   // Set weight on 1→2 (creating the edge if cc_init didn't make one).
   auto set_or_add_weight = [&](double w) {
-    cc_run_update(*svc, [&](auto& txn) {
-      StorageTPUpdateInterface gui(txn);
+    cc_run_update(*svc, [&](auto& txn, auto& gui) {
       vid_t s = cc_person_vid(txn, db, 1);
       vid_t d = cc_person_vid(txn, db, 2);
       auto oe_view = txn.GetGenericOutgoingGraphView(p_label, p_label, e_label);
@@ -2345,8 +2354,7 @@ TEST_F(NeugDBACIDTest,
   EXPECT_EQ(cc_read_created_since_via(txn_r), 2020);
 
   // Writer updates `since` to 2099 on the created edge person 1 → software 1.
-  cc_run_update(*svc, [&](auto& txn) {
-    StorageTPUpdateInterface gui(txn);
+  cc_run_update(*svc, [&](auto& txn, auto& gui) {
     auto p_label = txn.schema().get_vertex_label_id("person");
     auto sw_label = txn.schema().get_vertex_label_id("software");
     auto e_label = txn.schema().get_edge_label_id("created");
@@ -2389,8 +2397,7 @@ TEST_F(NeugDBACIDTest, VertexPropertyDDLCommitDoesNotAffectHeldReader) {
   }
 
   // --- AddVertexProperties ---
-  cc_run_update(*svc, [&](auto& txn) {
-    StorageTPUpdateInterface gui(txn);
+  cc_run_update(*svc, [&](auto& txn, auto& gui) {
     AddVertexPropertiesParamBuilder b;
     auto config = b.AddProperty("email", neug::Value::STRING(std::string("")))
                       .AddProperty("height", neug::Value::DOUBLE(0.0))
@@ -2413,8 +2420,7 @@ TEST_F(NeugDBACIDTest, VertexPropertyDDLCommitDoesNotAffectHeldReader) {
   });
 
   // --- DeleteVertexProperties ---
-  cc_run_update(*svc, [&](auto& txn) {
-    StorageTPUpdateInterface gui(txn);
+  cc_run_update(*svc, [&](auto& txn, auto& gui) {
     DeleteVertexPropertiesParamBuilder b;
     auto config = b.AddDeleteProperty("age").Build();
     EXPECT_TRUE(gui.DeleteVertexProperties(
@@ -2434,8 +2440,7 @@ TEST_F(NeugDBACIDTest, VertexPropertyDDLCommitDoesNotAffectHeldReader) {
   });
 
   // --- RenameVertexProperties ---
-  cc_run_update(*svc, [&](auto& txn) {
-    StorageTPUpdateInterface gui(txn);
+  cc_run_update(*svc, [&](auto& txn, auto& gui) {
     RenameVertexPropertiesParamBuilder b;
     auto config = b.AddRenameProperty("name", "full_name").Build();
     EXPECT_TRUE(gui.RenameVertexProperties(
@@ -2478,8 +2483,7 @@ TEST_F(NeugDBACIDTest, EdgePropertyDDLCommitDoesNotAffectHeldReader) {
   }
 
   // --- AddEdgeProperties ---
-  cc_run_update(*svc, [&](auto& txn) {
-    StorageTPUpdateInterface gui(txn);
+  cc_run_update(*svc, [&](auto& txn, auto& gui) {
     AddEdgePropertiesParamBuilder b;
     auto config =
         b.AddProperty("license", neug::Value::STRING(std::string(""))).Build();
@@ -2502,8 +2506,7 @@ TEST_F(NeugDBACIDTest, EdgePropertyDDLCommitDoesNotAffectHeldReader) {
   });
 
   // --- RenameEdgeProperties ---
-  cc_run_update(*svc, [&](auto& txn) {
-    StorageTPUpdateInterface gui(txn);
+  cc_run_update(*svc, [&](auto& txn, auto& gui) {
     RenameEdgePropertiesParamBuilder b;
     auto config = b.AddRenameProperty("weight", "importance").Build();
     EXPECT_TRUE(gui.RenameEdgeProperties(
@@ -2541,8 +2544,7 @@ TEST_F(NeugDBACIDTest, EdgePropertyDDLCommitDoesNotAffectHeldReader) {
     EXPECT_GE(es->get_property_index("since"), 0);
   }
 
-  cc_run_update(*svc, [&](auto& txn) {
-    StorageTPUpdateInterface gui(txn);
+  cc_run_update(*svc, [&](auto& txn, auto& gui) {
     DeleteEdgePropertiesParamBuilder b;
     auto config = b.AddDeleteProperty("since").Build();
     EXPECT_TRUE(gui.DeleteEdgeProperties(
@@ -2588,8 +2590,7 @@ TEST_F(NeugDBACIDTest, SchemaTypeDDLCommitDoesNotAffectHeldReader) {
   }
 
   // --- CreateVertexType ---
-  cc_run_update(*svc, [&](auto& txn) {
-    StorageTPUpdateInterface gui(txn);
+  cc_run_update(*svc, [&](auto& txn, auto& gui) {
     CreateVertexTypeParamBuilder b;
     EXPECT_TRUE(
         gui.CreateVertexType(
@@ -2611,8 +2612,7 @@ TEST_F(NeugDBACIDTest, SchemaTypeDDLCommitDoesNotAffectHeldReader) {
   });
 
   // --- CreateEdgeType ---
-  cc_run_update(*svc, [&](auto& txn) {
-    StorageTPUpdateInterface gui(txn);
+  cc_run_update(*svc, [&](auto& txn, auto& gui) {
     CreateEdgeTypeParamBuilder b;
     EXPECT_TRUE(gui.CreateEdgeType(b.SrcLabel("person")
                                        .DstLabel("company")
@@ -2631,8 +2631,7 @@ TEST_F(NeugDBACIDTest, SchemaTypeDDLCommitDoesNotAffectHeldReader) {
   });
 
   // --- DeleteEdgeType + DeleteVertexType ---
-  cc_run_update(*svc, [&](auto& txn) {
-    StorageTPUpdateInterface gui(txn);
+  cc_run_update(*svc, [&](auto& txn, auto& gui) {
     EXPECT_TRUE(gui.DeleteEdgeType(gui.schema().get_vertex_label_id("person"),
                                    gui.schema().get_vertex_label_id("person"),
                                    gui.schema().get_edge_label_id("knows"))
@@ -2734,8 +2733,7 @@ TEST_F(NeugDBACIDTest, UpdateStringPropertyCommitDoesNotAffectHeldReader) {
   EXPECT_EQ(name_pre, "person_5");
 
   // Writer updates person 5's name to a new string.
-  cc_run_update(*svc, [&](auto& txn) {
-    StorageTPUpdateInterface gui(txn);
+  cc_run_update(*svc, [&](auto& txn, auto& gui) {
     gui.UpdateVertexProperty(p_label, cc_person_vid(txn, db, 5), 0,
                              neug::Value::STRING(std::string("renamed_5")));
   });
@@ -2774,12 +2772,13 @@ TEST_F(NeugDBACIDTest, WriteMutexExclusionSemantics) {
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
       EXPECT_FALSE(u2_acquired.load())
           << "Second UpdateTxn must NOT acquire while first is still open";
-      StorageTPUpdateInterface gui(txn);
+      Allocator gui_alloc(MemoryLevel::kInMemory, "");
+      StorageCOWUpdateInterface gui(txn, gui_alloc);
       auto person_label = db.schema().get_vertex_label_id("person");
       vid_t vid;
       ASSERT_TRUE(gui.GetVertexIndex(person_label, neug::Value::INT64(1), vid));
       gui.UpdateVertexProperty(person_label, vid, 1, neug::Value::INT64(100));
-      EXPECT_TRUE(txn.Commit());
+      EXPECT_TRUE(sess1->CommitUpdateTransaction(txn).ok());
       u1_committed.store(true);
     });
 
@@ -2790,12 +2789,13 @@ TEST_F(NeugDBACIDTest, WriteMutexExclusionSemantics) {
       u2_acquired.store(true);
       EXPECT_TRUE(u1_committed.load())
           << "Second UpdateTxn must only acquire after first commits";
-      StorageTPUpdateInterface gui(txn);
+      Allocator gui_alloc(MemoryLevel::kInMemory, "");
+      StorageCOWUpdateInterface gui(txn, gui_alloc);
       auto person_label = db.schema().get_vertex_label_id("person");
       vid_t vid;
       ASSERT_TRUE(gui.GetVertexIndex(person_label, neug::Value::INT64(2), vid));
       gui.UpdateVertexProperty(person_label, vid, 1, neug::Value::INT64(200));
-      EXPECT_TRUE(txn.Commit());
+      EXPECT_TRUE(sess2->CommitUpdateTransaction(txn).ok());
     });
 
     t1.join();
@@ -2816,12 +2816,13 @@ TEST_F(NeugDBACIDTest, WriteMutexExclusionSemantics) {
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
       EXPECT_FALSE(insert_acquired.load())
           << "InsertTxn must NOT acquire while UpdateTxn is still open";
-      StorageTPUpdateInterface gui(txn);
+      Allocator gui_alloc(MemoryLevel::kInMemory, "");
+      StorageCOWUpdateInterface gui(txn, gui_alloc);
       auto person_label = db.schema().get_vertex_label_id("person");
       vid_t vid;
       ASSERT_TRUE(gui.GetVertexIndex(person_label, neug::Value::INT64(1), vid));
       gui.UpdateVertexProperty(person_label, vid, 1, neug::Value::INT64(777));
-      EXPECT_TRUE(txn.Commit());
+      EXPECT_TRUE(sess1->CommitUpdateTransaction(txn).ok());
       update_committed.store(true);
     });
 
@@ -2855,7 +2856,8 @@ TEST_F(NeugDBACIDTest, UpdateQueryPlansAfterPreviousUpdateCommits) {
 
   auto first_slot = svc->AcquireExecutionSlot();
   auto first_update = first_slot->GetUpdateTransaction();
-  StorageTPUpdateInterface first_storage(first_update);
+  Allocator first_storage_alloc(MemoryLevel::kInMemory, "");
+  StorageCOWUpdateInterface first_storage(first_update, first_storage_alloc);
   CreateVertexTypeParamBuilder builder;
   auto create_status = first_storage.CreateVertexType(
       builder.VertexLabel("company")
@@ -2886,7 +2888,7 @@ TEST_F(NeugDBACIDTest, UpdateQueryPlansAfterPreviousUpdateCommits) {
       << "The second update must wait before planning against the committed "
          "schema";
 
-  EXPECT_TRUE(first_update.Commit());
+  EXPECT_TRUE(first_slot->CommitUpdateTransaction(first_update).ok());
   second_update.join();
   EXPECT_TRUE(query_finished.load());
 }
@@ -2929,13 +2931,14 @@ TEST_F(NeugDBACIDTest, LongRunningReadDoesNotBlockUpdateCommit) {
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
     auto txn = sess_u->GetUpdateTransaction();
-    StorageTPUpdateInterface gui(txn);
+    Allocator gui_alloc(MemoryLevel::kInMemory, "");
+    StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = db.schema().get_vertex_label_id("person");
     vid_t vid;
     ASSERT_TRUE(gui.GetVertexIndex(person_label, neug::Value::INT64(1), vid));
     gui.UpdateVertexProperty(person_label, vid, 1, neug::Value::INT64(999));
     auto t0 = std::chrono::steady_clock::now();
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(sess_u->CommitUpdateTransaction(txn).ok());
     auto elapsed = std::chrono::steady_clock::now() - t0;
     commit_finished.store(true);
 
@@ -2992,7 +2995,8 @@ TEST_F(NeugDBACIDTest, CommitVisibilitySemantics) {
   {
     auto sess_u = svc->AcquireExecutionSlot();
     auto txn_u = sess_u->GetUpdateTransaction();
-    StorageTPUpdateInterface gui(txn_u);
+    Allocator gui_alloc(MemoryLevel::kInMemory, "");
+    StorageCOWUpdateInterface gui(txn_u, gui_alloc);
     gui.UpdateVertexProperty(db.schema().get_vertex_label_id("person"),
                              cc_person_vid(gui, db, 5), 1,
                              neug::Value::INT64(9999));
@@ -3059,7 +3063,8 @@ TEST_F(NeugDBACIDTest, ConcurrentReadsAndCommitsObserveConsistentValues) {
     std::thread writer([&] {
       auto sess_u = svc->AcquireExecutionSlot();
       auto txn_u = sess_u->GetUpdateTransaction();
-      StorageTPUpdateInterface gui(txn_u);
+      Allocator gui_alloc(MemoryLevel::kInMemory, "");
+      StorageCOWUpdateInterface gui(txn_u, gui_alloc);
       vid_t vid_u;
       ASSERT_TRUE(
           gui.GetVertexIndex(person_label, neug::Value::INT64(5), vid_u));
@@ -3067,7 +3072,7 @@ TEST_F(NeugDBACIDTest, ConcurrentReadsAndCommitsObserveConsistentValues) {
                                neug::Value::INT64(post_value));
       ready.fetch_add(1);
       while (ready.load() < 2) {}
-      txn_u.Commit();
+      EXPECT_TRUE(sess_u->CommitUpdateTransaction(txn_u).ok());
     });
     reader.join();
     writer.join();

--- a/tests/transaction/test_update_transaction.cc
+++ b/tests/transaction/test_update_transaction.cc
@@ -127,7 +127,7 @@ class UpdateTransactionTest : public ::testing::Test {
   }
 
   void create_new_edge_type(neug::UpdateTransaction& txn,
-                            neug::StorageTPUpdateInterface& interface,
+                            neug::StorageCOWUpdateInterface& interface,
                             neug::label_t& cmp_label, neug::label_t& dev_label,
                             neug::label_t& employ_label) {
     auto person_label = interface.schema().get_vertex_label_id("person");
@@ -194,7 +194,7 @@ class UpdateTransactionTest : public ::testing::Test {
   }
 
   std::vector<std::string> create_string_prop_relation(
-      neug::StorageTPUpdateInterface& graph, int num_edges) {
+      neug::StorageCOWUpdateInterface& graph, int num_edges) {
     auto person_label = graph.schema().get_vertex_label_id("person");
     auto software_label = graph.schema().get_vertex_label_id("software");
     std::vector<std::pair<std::string, neug::Value>> edge_props = {
@@ -328,14 +328,15 @@ TEST_F(UpdateTransactionTest, AddVertex) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     neug::vid_t vid;
     EXPECT_TRUE(gui.AddVertex(
         person_label, neug::Value::INT64(3),
         {neug::Value::STRING(std::string("Eve")), neug::Value::INT64(28)},
         vid));
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
   {
     auto slot = svc->AcquireExecutionSlot();
@@ -359,7 +360,8 @@ TEST_F(UpdateTransactionTest, AddVertexBatch) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     for (int i = 4; i <= 10000; i++) {
       neug::vid_t vid;
@@ -368,7 +370,7 @@ TEST_F(UpdateTransactionTest, AddVertexBatch) {
                                  neug::Value::INT64(20 + i % 10)},
                                 vid));
     }
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
   {
     auto slot = svc->AcquireExecutionSlot();
@@ -390,7 +392,8 @@ TEST_F(UpdateTransactionTest, AddEdge) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     auto software_label = txn.schema().get_vertex_label_id("software");
     auto created_label = txn.schema().get_edge_label_id("created");
@@ -403,7 +406,7 @@ TEST_F(UpdateTransactionTest, AddEdge) {
     EXPECT_TRUE(gui.AddEdge(
         person_label, vid, software_label, vid2, created_label,
         {neug::Value::DOUBLE(0.9), neug::Value::INT64(2022)}, edge_prop));
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
   {
     auto slot = svc->AcquireExecutionSlot();
@@ -441,7 +444,8 @@ TEST_F(UpdateTransactionTest, AddVertexEdge) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     auto software_label = txn.schema().get_vertex_label_id("software");
     auto created_label = txn.schema().get_edge_label_id("created");
@@ -467,7 +471,7 @@ TEST_F(UpdateTransactionTest, AddVertexEdge) {
     EXPECT_TRUE(gui.AddEdge(person_label, vid4, person_label, vid1,
                             txn.schema().get_edge_label_id("knows"),
                             {neug::Value::DOUBLE(0.95)}, edge_prop));
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
   {
     auto slot = svc->AcquireExecutionSlot();
@@ -509,7 +513,8 @@ TEST_F(UpdateTransactionTest, AddVertexEdgeAbort) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     auto software_label = txn.schema().get_vertex_label_id("software");
     auto created_label = txn.schema().get_edge_label_id("created");
@@ -562,14 +567,15 @@ TEST_F(UpdateTransactionTest, UpdateVertexProperty) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     neug::vid_t vertex_id;
     CHECK(txn.GetVertexIndex(person_label, neug::Value::INT64(2), vertex_id));
     gui.UpdateVertexProperty(person_label, vertex_id, 1,
                              neug::Value::INT64(26));
 
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
   {
     auto slot = svc->AcquireExecutionSlot();
@@ -599,7 +605,8 @@ TEST_F(UpdateTransactionTest, UpdateEdgeProperty) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     auto software_label = txn.schema().get_vertex_label_id("software");
     auto created_label = txn.schema().get_edge_label_id("created");
@@ -614,7 +621,7 @@ TEST_F(UpdateTransactionTest, UpdateEdgeProperty) {
                                  0, neug::Value::DOUBLE(0.99));
         });
 
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
   {
     auto slot = svc->AcquireExecutionSlot();
@@ -651,7 +658,8 @@ TEST_F(UpdateTransactionTest, AddVertexAbort) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     neug::vid_t vid;
     EXPECT_TRUE(gui.AddVertex(
@@ -686,7 +694,8 @@ TEST_F(UpdateTransactionTest, AddEdgeAbort) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     auto software_label = txn.schema().get_vertex_label_id("software");
     auto created_label = txn.schema().get_edge_label_id("created");
@@ -735,7 +744,8 @@ TEST_F(UpdateTransactionTest, UpdateVertexAbort) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     neug::vid_t vertex_id;
     CHECK(txn.GetVertexIndex(person_label, neug::Value::INT64(2), vertex_id));
@@ -781,7 +791,8 @@ TEST_F(UpdateTransactionTest, UpdateEdgeAbort) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     auto software_label = txn.schema().get_vertex_label_id("software");
     auto created_label = txn.schema().get_edge_label_id("created");
@@ -879,7 +890,8 @@ TEST_F(UpdateTransactionTest, DeleteVertexWithIntraLabelEdgeAbort) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     neug::vid_t vid2;
     CHECK(txn.GetVertexIndex(person_label, neug::Value::INT64(2), vid2));
@@ -934,7 +946,8 @@ TEST_F(UpdateTransactionTest, DeleteVertexPropertiesThenInsertVertex) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
     // person has name(0), age(1) — 2 non-PK columns
     // Delete "name" -> table now has age(0) — 1 column
     EXPECT_TRUE(interface.DeleteVertexProperties(
@@ -949,7 +962,7 @@ TEST_F(UpdateTransactionTest, DeleteVertexPropertiesThenInsertVertex) {
     neug::vid_t vid;
     EXPECT_TRUE(interface.AddVertex(person_label, neug::Value::INT64(3),
                                     {neug::Value::INT64(28)}, vid));
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
 
   // Verify the new vertex is readable and "name" is gone.
@@ -988,7 +1001,8 @@ TEST_F(UpdateTransactionTest, DeleteVertexPropertiesThenUpdateRemaining) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     std::vector<std::pair<std::string, neug::Value>> new_props = {
         std::make_pair("email", neug::Value::STRING(std::string(""))),
         std::make_pair("score", neug::Value::DOUBLE(0.0))};
@@ -1004,7 +1018,7 @@ TEST_F(UpdateTransactionTest, DeleteVertexPropertiesThenUpdateRemaining) {
         person_label, vid, 2,
         neug::Value::STRING(std::string("alice@test.com")));
     gui.UpdateVertexProperty(person_label, vid, 3, neug::Value::DOUBLE(95.5));
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
 
   // Now person has name(0), age(1), email(2), score(3) — 4 non-PK columns
@@ -1020,7 +1034,8 @@ TEST_F(UpdateTransactionTest, DeleteVertexPropertiesThenUpdateRemaining) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     neug::vid_t vid;
     CHECK(txn.GetVertexIndex(person_label, neug::Value::INT64(1), vid));
@@ -1052,7 +1067,7 @@ TEST_F(UpdateTransactionTest, DeleteVertexPropertiesThenUpdateRemaining) {
          neug::Value::STRING(std::string("charlie@test.com")),
          neug::Value::DOUBLE(77.0)},
         new_vid));
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
 
   // Verify data correctness
@@ -1118,7 +1133,8 @@ TEST_F(UpdateTransactionTest, DeleteEdgePropertiesThenInsertEdge) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     std::vector<std::pair<std::string, neug::Value>> new_props = {
         std::make_pair("rating", neug::Value::DOUBLE(0.0))};
     EXPECT_TRUE(
@@ -1126,14 +1142,15 @@ TEST_F(UpdateTransactionTest, DeleteEdgePropertiesThenInsertEdge) {
                               gui.schema().get_vertex_label_id("software"),
                               gui.schema().get_edge_label_id("created"),
                               BuildAddEdgePropertiesParam(new_props)));
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
 
   // Now "created" has weight(0), since(1), rating(2) — 3 columns
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
 
     // Delete "since" -> table now has weight(0), rating(1) — 2 columns
     EXPECT_TRUE(interface.DeleteEdgeProperties(
@@ -1156,7 +1173,7 @@ TEST_F(UpdateTransactionTest, DeleteEdgePropertiesThenInsertEdge) {
     EXPECT_TRUE(interface.AddEdge(
         person_label, p1_vid, software_label, s1_vid, created_label,
         {neug::Value::DOUBLE(0.9), neug::Value::DOUBLE(4.5)}, edge_prop));
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
 
   // Verify the new edge data is correct
@@ -1221,7 +1238,8 @@ TEST_F(UpdateTransactionTest, DeleteVertexTypeWithEdgesThenCreateNewTypes) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
 
     // Delete "software" — this also removes "created" edges
     EXPECT_TRUE(interface.DeleteVertexType(
@@ -1250,7 +1268,7 @@ TEST_F(UpdateTransactionTest, DeleteVertexTypeWithEdgesThenCreateNewTypes) {
     const void* edge_prop = nullptr;
     EXPECT_TRUE(interface.AddEdge(person_label, p1_vid, company_label, cmp_vid,
                                   employ_label, {}, edge_prop));
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
 
   // Verify: "software" and "created" are gone; new types work correctly
@@ -1288,7 +1306,8 @@ TEST_F(UpdateTransactionTest, DeleteEdgeTypeThenCreateNewEdgeType) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
 
     // Delete "knows" edge type
     EXPECT_TRUE(interface.DeleteEdgeType(
@@ -1312,7 +1331,7 @@ TEST_F(UpdateTransactionTest, DeleteEdgeTypeThenCreateNewEdgeType) {
     EXPECT_TRUE(interface.AddEdge(person_label, p1_vid, person_label, p2_vid,
                                   friend_label, {neug::Value::DOUBLE(0.75)},
                                   edge_prop));
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
 
   // Verify: "knows" is gone; "friend_of" works correctly
@@ -1354,7 +1373,8 @@ TEST_F(UpdateTransactionTest, UpdateEdgeAbort2) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     auto knows_label = txn.schema().get_edge_label_id("knows");
     neug::vid_t vertex_id;
@@ -1420,7 +1440,8 @@ TEST_F(UpdateTransactionTest, AddEdgeAndUpdateAndAbort) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     auto software_label = txn.schema().get_vertex_label_id("software");
     auto created_label = txn.schema().get_edge_label_id("created");
@@ -1490,12 +1511,13 @@ TEST_F(UpdateTransactionTest, DeleteVertex) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     neug::vid_t vertex_id;
     CHECK(txn.GetVertexIndex(person_label, neug::Value::INT64(2), vertex_id));
     EXPECT_TRUE(gui.DeleteVertex(person_label, vertex_id));
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
   {
     auto slot = svc->AcquireExecutionSlot();
@@ -1517,7 +1539,8 @@ TEST_F(UpdateTransactionTest, DeleteVertex) {
     // Delete person label and then delete vertex should throw
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     EXPECT_TRUE(
         gui.DeleteVertexType(gui.schema().get_vertex_label_id("person")));
@@ -1540,7 +1563,8 @@ TEST_F(UpdateTransactionTest, DeleteEdgeAbort) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     auto software_label = txn.schema().get_vertex_label_id("software");
     auto created_label = txn.schema().get_edge_label_id("created");
@@ -1550,12 +1574,13 @@ TEST_F(UpdateTransactionTest, DeleteEdgeAbort) {
         txn.GetVertexIndex(software_label, neug::Value::INT64(1), vid1));
     EXPECT_TRUE(gui.DeleteEdges(person_label, vid2, software_label, vid1,
                                 created_label));
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     auto knows_label = txn.schema().get_edge_label_id("knows");
     neug::vid_t vid1, vid2;
@@ -1568,7 +1593,8 @@ TEST_F(UpdateTransactionTest, DeleteEdgeAbort) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     auto knows_label = txn.schema().get_edge_label_id("knows");
     neug::vid_t vid1, vid2;
@@ -1632,7 +1658,8 @@ TEST_F(UpdateTransactionTest, AddDeleteVertexAbort) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
     auto person_label = interface.schema().get_vertex_label_id("person");
     neug::vid_t vertex_id;
     CHECK(txn.GetVertexIndex(person_label, neug::Value::INT64(2), vertex_id));
@@ -1660,14 +1687,15 @@ TEST_F(UpdateTransactionTest, AddDeleteVertexAbort) {
     // Add again
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     neug::vid_t vid;
     EXPECT_TRUE(gui.AddVertex(
         person_label, neug::Value::INT64(3),
         {neug::Value::STRING(std::string("Eve")), neug::Value::INT64(28)},
         vid));
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
   {
     auto slot = svc->AcquireExecutionSlot();
@@ -1695,7 +1723,8 @@ TEST_F(UpdateTransactionTest, CreteEdgeTypeAndAbort) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
     create_new_edge_type(txn, interface, cmp_label, dev_label, employ_label);
     txn.Abort();
   }
@@ -1736,9 +1765,10 @@ TEST_F(UpdateTransactionTest, CreteEdgeTypeAndCommit) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
     create_new_edge_type(txn, interface, cmp_label, dev_label, employ_label);
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
   {
     auto slot = svc->AcquireExecutionSlot();
@@ -1767,7 +1797,8 @@ TEST_F(UpdateTransactionTest, DeleteEdgeTypeAbort) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto created_label = txn.schema().get_edge_label_id("created");
     auto person_label = txn.schema().get_vertex_label_id("person");
     auto software_label = txn.schema().get_vertex_label_id("software");
@@ -1804,7 +1835,8 @@ TEST_F(UpdateTransactionTest, AddVertexProperties) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     std::vector<std::pair<std::string, neug::Value>> new_props = {
         std::make_pair("email", neug::Value::STRING(std::string(""))),
@@ -1818,12 +1850,13 @@ TEST_F(UpdateTransactionTest, AddVertexProperties) {
     gui.UpdateVertexProperty(
         person_label, vid, 2,
         neug::Value::STRING(std::string("eve@example.com")));
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     auto height_accessor =
         txn.get_vertex_property_column(person_label, "height");
@@ -1871,7 +1904,8 @@ TEST_F(UpdateTransactionTest, AddEdgeProperties) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
     std::vector<std::pair<std::string, neug::Value>> new_props = {
         std::make_pair("version", neug::Value::INT64(0)),
         std::make_pair("license", neug::Value::STRING(std::string("")))};
@@ -1880,12 +1914,13 @@ TEST_F(UpdateTransactionTest, AddEdgeProperties) {
         interface.schema().get_vertex_label_id("software"),
         interface.schema().get_edge_label_id("created"),
         BuildAddEdgePropertiesParam(new_props)));
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
     std::vector<std::pair<std::string, neug::Value>> new_props = {
         std::make_pair("contributions", neug::Value::DOUBLE(0.0))};
     EXPECT_TRUE(interface.AddEdgeProperties(
@@ -1937,16 +1972,18 @@ TEST_F(UpdateTransactionTest, RenameVertexProperty) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
     EXPECT_TRUE(interface.RenameVertexProperties(
         interface.schema().get_vertex_label_id("person"),
         BuildRenameVertexPropertiesParam({std::make_pair("age", "years")})));
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
     std::vector<std::pair<std::string, std::string>> rename_props = {
         std::make_pair("lang", "language")};
     EXPECT_TRUE(interface.RenameVertexProperties(
@@ -1979,19 +2016,21 @@ TEST_F(UpdateTransactionTest, RenameEdgeProperty) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
     EXPECT_TRUE(interface.RenameEdgeProperties(
         interface.schema().get_vertex_label_id("person"),
         interface.schema().get_vertex_label_id("software"),
         interface.schema().get_edge_label_id("created"),
         BuildRenameEdgePropertiesParam(
             {std::make_pair("since", "start_year")})));
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
     std::vector<std::pair<std::string, std::string>> rename_props = {
         std::make_pair("weight", "importance")};
     EXPECT_TRUE(interface.RenameEdgeProperties(
@@ -2040,7 +2079,8 @@ TEST_F(UpdateTransactionTest, DeleteEdgeProperties) {
     LOG(INFO) << "Starting delete edge properties transaction.";
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
     EXPECT_TRUE(interface.DeleteEdgeProperties(
         interface.schema().get_vertex_label_id("person"),
         interface.schema().get_vertex_label_id("software"),
@@ -2055,13 +2095,14 @@ TEST_F(UpdateTransactionTest, DeleteEdgeProperties) {
         interface.schema().get_edge_label_id("created"),
         BuildAddEdgePropertiesParam(new_props)));
     LOG(INFO) << "Committing delete edge properties transaction.";
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
     LOG(INFO) << "Committed delete edge properties transaction.";
   }
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
     EXPECT_TRUE(interface.DeleteEdgeProperties(
         interface.schema().get_vertex_label_id("person"),
         interface.schema().get_vertex_label_id("software"),
@@ -2119,7 +2160,8 @@ TEST_F(UpdateTransactionTest, DeleteVertexProperties) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
     // auto person_label = txn.schema().get_vertex_label_id("person");
     // auto software_label = txn.schema().get_vertex_label_id("software");
     EXPECT_TRUE(interface.DeleteVertexProperties(
@@ -2133,12 +2175,13 @@ TEST_F(UpdateTransactionTest, DeleteVertexProperties) {
     EXPECT_TRUE(interface.AddVertexProperties(
         interface.schema().get_vertex_label_id("software"),
         BuildAddVertexPropertiesParam(new_props)));
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
     // auto person_label = txn.schema().get_vertex_label_id("person");
     EXPECT_TRUE(interface.DeleteVertexProperties(
         interface.schema().get_vertex_label_id("person"),
@@ -2175,7 +2218,8 @@ TEST_F(UpdateTransactionTest, TestReplayWal) {
     auto svc = std::make_shared<neug::NeugDBService>(db);
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     neug::vid_t vid;
     EXPECT_TRUE(interface.AddVertex(
@@ -2211,7 +2255,7 @@ TEST_F(UpdateTransactionTest, TestReplayWal) {
                                        oe_offset, ie_offset, 0,
                                        neug::Value::DOUBLE(0.5));
         });
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
   {
     neug::NeugDB db;
@@ -2286,7 +2330,8 @@ TEST_F(UpdateTransactionTest, TestAPIAfterDeleteVertexLabel) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     EXPECT_TRUE(interface.DeleteVertexType(
         interface.schema().get_vertex_label_id("person")));
@@ -2313,7 +2358,8 @@ TEST_F(UpdateTransactionTest, TestAPIAfterDeleteVertexLabel) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
     auto person_label = interface.schema().get_vertex_label_id("person");
     EXPECT_TRUE(interface.DeleteVertexProperties(
         interface.schema().get_vertex_label_id("person"),
@@ -2354,7 +2400,8 @@ TEST_F(UpdateTransactionTest, TestAPIAfterDeleteEdgeLabel) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
     auto person_label = interface.schema().get_vertex_label_id("person");
     auto knows_label = interface.schema().get_edge_label_id("knows");
     neug::vid_t src_vid, dst_vid;
@@ -2413,7 +2460,8 @@ TEST_F(UpdateTransactionTest, TestAPIAfterDeleteEdgeLabel) {
     // Delete Edge Properties
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     auto knows_label = txn.schema().get_edge_label_id("knows");
     EXPECT_TRUE(gui.DeleteEdgeProperties(
@@ -2454,13 +2502,14 @@ TEST_F(UpdateTransactionTest, DeleteVertexWithOutgoingEdges) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     neug::vid_t p1_vid;
     EXPECT_TRUE(
         txn.GetVertexIndex(person_label, neug::Value::INT64(1), p1_vid));
     EXPECT_TRUE(gui.DeleteVertex(person_label, p1_vid));
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
   {
     auto slot = svc->AcquireExecutionSlot();
@@ -2494,7 +2543,8 @@ TEST_F(UpdateTransactionTest, DeleteVertexWithBidirectionalEdges) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     auto knows_label = txn.schema().get_edge_label_id("knows");
     neug::vid_t p1_vid, p2_vid;
@@ -2506,7 +2556,7 @@ TEST_F(UpdateTransactionTest, DeleteVertexWithBidirectionalEdges) {
     EXPECT_TRUE(gui.AddEdge(person_label, p2_vid, person_label, p1_vid,
                             knows_label, {neug::Value::DOUBLE(0.85)},
                             edge_prop_p2_p1));
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
   {
     auto slot = svc->AcquireExecutionSlot();
@@ -2520,13 +2570,14 @@ TEST_F(UpdateTransactionTest, DeleteVertexWithBidirectionalEdges) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     neug::vid_t p1_vid;
     EXPECT_TRUE(
         txn.GetVertexIndex(person_label, neug::Value::INT64(1), p1_vid));
     EXPECT_TRUE(gui.DeleteVertex(person_label, p1_vid));
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
 
   {
@@ -2555,7 +2606,8 @@ TEST_F(UpdateTransactionTest, DeleteVertexAbortRestoresEdges) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     auto software_label = txn.schema().get_vertex_label_id("software");
     auto created_label = txn.schema().get_edge_label_id("created");
@@ -2585,7 +2637,7 @@ TEST_F(UpdateTransactionTest, DeleteVertexAbortRestoresEdges) {
       EXPECT_TRUE(gui.DeleteEdge(person_label, p1_vid, software_label, p2_vid,
                                  created_label, oe_offset, ie_offset));
     }
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
   {
     auto slot = svc->AcquireExecutionSlot();
@@ -2603,7 +2655,8 @@ TEST_F(UpdateTransactionTest, DeleteVertexAbortRestoresEdges) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     neug::vid_t p1_vid;
     EXPECT_TRUE(
@@ -2644,7 +2697,8 @@ TEST_F(UpdateTransactionTest, DeleteVertexWithMultipleEdgeTypes) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     std::vector<std::pair<std::string, neug::Value>> edge_props = {
         std::make_pair("since", neug::Value::INT64(2020))};
@@ -2661,18 +2715,19 @@ TEST_F(UpdateTransactionTest, DeleteVertexWithMultipleEdgeTypes) {
     EXPECT_TRUE(gui.AddEdge(person_label, p1_vid, person_label, p2_vid,
                             follows_label, {neug::Value::INT64(2022)},
                             edge_prop_follows));
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     neug::vid_t p1_vid;
     EXPECT_TRUE(
         txn.GetVertexIndex(person_label, neug::Value::INT64(1), p1_vid));
     EXPECT_TRUE(gui.DeleteVertex(person_label, p1_vid));
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
   {
     // Verify all edge types are deleted
@@ -2706,7 +2761,8 @@ TEST_F(UpdateTransactionTest, TestUnsupportedInterface) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
     std::vector<neug::vid_t> vids;
     std::vector<std::tuple<neug::vid_t, neug::vid_t>> edges;
     std::vector<std::pair<neug::vid_t, int32_t>> oe_edges, ie_edges;
@@ -2727,7 +2783,8 @@ TEST_F(UpdateTransactionTest, BatchDeleteVertices) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     neug::vid_t alice_vid, bob_vid;
     EXPECT_TRUE(
@@ -2737,7 +2794,7 @@ TEST_F(UpdateTransactionTest, BatchDeleteVertices) {
     std::vector<neug::vid_t> lids = {alice_vid, bob_vid};
     EXPECT_EQ(interface.BatchDeleteVertices(person_label, lids).error_code(),
               neug::StatusCode::OK);
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
   {
     auto slot = svc->AcquireExecutionSlot();
@@ -2760,7 +2817,8 @@ TEST_F(UpdateTransactionTest, BatchDeleteEdges) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     auto software_label = txn.schema().get_vertex_label_id("software");
     auto created_label = txn.schema().get_edge_label_id("created");
@@ -2779,7 +2837,7 @@ TEST_F(UpdateTransactionTest, BatchDeleteEdges) {
                                          created_label, edges)
                   .error_code(),
               neug::StatusCode::OK);
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
   {
     auto slot = svc->AcquireExecutionSlot();
@@ -2807,7 +2865,8 @@ TEST_F(UpdateTransactionTest, BatchDeleteVerticesFailure) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     neug::vid_t alice_vid;
     EXPECT_TRUE(
@@ -2839,7 +2898,8 @@ TEST_F(UpdateTransactionTest, BatchDeleteEdgesFailure) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     auto software_label = txn.schema().get_vertex_label_id("software");
     auto created_label = txn.schema().get_edge_label_id("created");
@@ -2876,7 +2936,8 @@ TEST_F(UpdateTransactionTest, TestUpdateStringProperty) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     neug::vid_t p1_vid, p2_vid;
     EXPECT_TRUE(
@@ -2896,7 +2957,7 @@ TEST_F(UpdateTransactionTest, TestUpdateStringProperty) {
     EXPECT_EQ(prop.GetValue<std::string>(), valid_name);
     auto p2_prop = interface.GetVertexProperty(person_label, p2_vid, 0);
     EXPECT_EQ(p2_prop.GetValue<std::string>(), "Bob");  // unchanged
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
   {
     auto slot = svc->AcquireExecutionSlot();
@@ -2925,9 +2986,10 @@ TEST_F(UpdateTransactionTest, TestUpdateEdgeStringPropertyCompact) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
     reviews = create_string_prop_relation(interface, 300);
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
   CHECK_EQ(reviews.size(), 300);
 
@@ -2951,7 +3013,8 @@ TEST_F(UpdateTransactionTest, TestUpdateEdgeStringPropertyCompact) {
     // Update edge string property with suffix: "_updated"
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface interface(txn);
+    neug::Allocator interface_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface interface(txn, interface_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     auto software_label = txn.schema().get_vertex_label_id("software");
     auto review_label = txn.schema().get_edge_label_id("reviewed");
@@ -2987,7 +3050,7 @@ TEST_F(UpdateTransactionTest, TestUpdateEdgeStringPropertyCompact) {
         updated_views.push_back(updated_review);
       }
     }
-    EXPECT_TRUE(txn.Commit());
+    EXPECT_TRUE(slot->CommitUpdateTransaction(txn).ok());
   }
 
   // Verify updated reviews
@@ -3045,7 +3108,8 @@ TEST_F(UpdateTransactionTest, TestTPServiceStart) {
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->GetUpdateTransaction();
-    neug::StorageTPUpdateInterface gui(txn);
+    neug::Allocator gui_alloc(neug::MemoryLevel::kInMemory, "");
+    neug::StorageCOWUpdateInterface gui(txn, gui_alloc);
     auto person_label = txn.schema().get_vertex_label_id("person");
     auto software_label = txn.schema().get_vertex_label_id("software");
     auto created_label = txn.schema().get_edge_label_id("created");

--- a/tests/unittest/test_db_svc.cc
+++ b/tests/unittest/test_db_svc.cc
@@ -689,6 +689,12 @@ TEST_F(NeugDBServiceTest,
   EXPECT_EQ(ReadPlanningGeneration(db_->graph_snapshot_store()),
             initial_generation + 1);
 
+  auto no_op_update = connection->Query(
+      "MATCH (n:person {id: 29999}) SET n.age = 2;", "update");
+  ASSERT_TRUE(no_op_update) << no_op_update.error().ToString();
+  EXPECT_EQ(ReadPlanningGeneration(db_->graph_snapshot_store()),
+            initial_generation + 1);
+
   const auto copy_path = test_dir_ / "direct-cache-copy.csv";
   {
     std::ofstream copy_file(copy_path);


### PR DESCRIPTION
## Summary

This PR unifies the AP and TP update/schema paths around a single copy-on-write (COW) `UpdateTransaction`, introduces explicit `TransactionDurability`, and clarifies resource ownership so that the same transaction object can outlive a single statement.

## What changed

- **Factory-based transaction acquisition**: `UpdateTransaction` is no longer constructed directly. Callers use `UpdateTransaction::Begin` or `BeginUntil` and supply only `IVersionManager`, `GraphSnapshotStore`, and the desired `TransactionDurability`.
- **Clearer resource boundaries**: `UpdateTransaction` now owns only the COW clone, `PropertyGraphCowState`, and `UpdateTimestampLease`. The per-statement allocator and commit-time WAL writer / snapshot store are borrowed by the caller.
- **Shared COW path for AP and TP**:
  - Renamed `StorageTPUpdateInterface` to `StorageCOWUpdateInterface`.
  - Added `StorageAPCOWUpdateInterface` so AP update/schema statements use the same COW workspace as TP.
  - AP update/schema now runs with `TransactionDurability::kNoWal`; TP continues to use `kWal`.
- **Reusable index DDL**: extracted `StorageIndexDDLInterface` and an `index_ddl` helper namespace so index creation/dropping can be shared between in-place AP writes and COW update transactions.
- **Documentation**: updated `doc/source/transaction/transaction.md` and `include/neug/transaction/README.md` to describe the new model and the v0.3 explicit-transaction scope.
- **Tests**: adapted `test_tp_index.cc`, `test_acid.cc`, and `test_update_transaction.cc` to the new `Begin` / `Commit(snapshot_store, wal_writer)` API.

## Why this matters for explicit transactions

Explicit transaction control (`BEGIN` / `COMMIT` / `ABORT`) planned for NeuG v0.3 requires a transaction object that can span multiple statements and be committed or aborted as a unit. This PR provides the foundation:

1. A single `UpdateTransaction` can be held across statement boundaries.
2. `Begin` / `Commit` / `Abort` semantics are mode-agnostic.
3. `kNoWal` vs `kWal` maps naturally to embedded-analytics vs service-transactional durability requirements.
4. Index DDL is decoupled from the write interface, making it usable in both explicit-session contexts.

Fixes #840
