### PR TITLE
fix: handle LIST/ARRAY columns in C++ QueryResult API

### DIFF
--- a/src/main/query_result.cc
+++ b/src/main/query_result.cc
@@ -157,6 +157,43 @@ static void get_value(const neug::Array& array, size_t row_index,
     }
     break;
   }
+  case neug::Array::kListArray: {
+    const auto& list_array = array.list_array();
+    if (!is_valid(list_array.validity(), row_index)) {
+      ss << "null";
+      break;
+    }
+    // Offsets are size = row_count + 1; elements between
+    // [offsets[i], offsets[i+1]).
+    const auto list_size =
+        list_array.offsets(row_index + 1) - list_array.offsets(row_index);
+    const size_t offset = list_array.offsets(row_index);
+    ss << '[';
+    for (uint32_t i = 0; i < list_size; ++i) {
+      if (i > 0) {
+        ss << ", ";
+      }
+      get_value(list_array.elements(), offset + i, ss);
+    }
+    ss << ']';
+    break;
+  }
+  case neug::Array::kStructArray: {
+    const auto& struct_array = array.struct_array();
+    if (!is_valid(struct_array.validity(), row_index)) {
+      ss << "null";
+      break;
+    }
+    ss << '[';
+    for (int i = 0; i < struct_array.fields_size(); ++i) {
+      if (i > 0) {
+        ss << ", ";
+      }
+      get_value(struct_array.fields(i), row_index, ss);
+    }
+    ss << ']';
+    break;
+  }
   default: {
     LOG(WARNING) << "Unsupported array type in QueryResult: "
                  << array.typed_array_case();
@@ -314,6 +351,12 @@ bool QueryResult::IsNull(size_t column_index) const {
     break;
   case neug::Array::kPathArray:
     validity = &array.path_array().validity();
+    break;
+  case neug::Array::kListArray:
+    validity = &array.list_array().validity();
+    break;
+  case neug::Array::kStructArray:
+    validity = &array.struct_array().validity();
     break;
   default:
     return true;

--- a/tests/unittest/CMakeLists.txt
+++ b/tests/unittest/CMakeLists.txt
@@ -24,6 +24,8 @@ add_neug_test(test_connection test_connection.cc)
 
 add_neug_test(test_query_result test_query_result.cc)
 
+add_neug_test(test_query_result_list test_query_result_list.cc)
+
 add_neug_test(test_column test_column.cc)
 
 add_neug_test(test_explain_profile test_explain_profile.cpp)

--- a/tests/unittest/test_query_result.cc
+++ b/tests/unittest/test_query_result.cc
@@ -394,4 +394,52 @@ TEST(QueryResultTest, GetCurrentRowAsStringWithNull) {
   EXPECT_EQ(result.GetCurrentRowAsString(), "null");
 }
 
+// Build a result with a LIST column (serialized as list_array protobuf).
+// Row 0: [1, 2], row 1: NULL, row 2: [3]
+static QueryResult BuildListResult() {
+  neug::QueryResponse response;
+  response.set_row_count(3);
+
+  auto* schema = response.mutable_schema();
+  schema->add_name("nums");
+
+  auto* col = response.add_arrays();
+  auto* list_arr = col->mutable_list_array();
+  // offsets: [0, 2, 2, 3] → lengths 2, 0, 1
+  list_arr->add_offsets(0);
+  list_arr->add_offsets(2);
+  list_arr->add_offsets(2);
+  list_arr->add_offsets(3);
+
+  auto* elements = list_arr->mutable_elements()->mutable_int32_array();
+  elements->add_values(1);
+  elements->add_values(2);
+  elements->add_values(3);
+
+  // validity: row0 valid, row1 null, row2 valid → bits 0b101 = 0x05
+  list_arr->set_validity(std::string(1, static_cast<char>(0x05)));
+
+  std::string serialized;
+  response.SerializeToString(&serialized);
+  return QueryResult::From(std::move(serialized));
+}
+
+TEST(QueryResultTest, ListArrayGetStringAndIsNull) {
+  auto result = BuildListResult();
+
+  EXPECT_FALSE(result.IsNull(0));
+  EXPECT_EQ(result.GetString(0), "[1, 2]");
+  EXPECT_EQ(result.GetCurrentRowAsString(), "[1, 2]");
+
+  result.next();
+  EXPECT_TRUE(result.IsNull(0));
+  EXPECT_EQ(result.GetString(0), "null");
+  EXPECT_EQ(result.GetCurrentRowAsString(), "null");
+
+  result.next();
+  EXPECT_FALSE(result.IsNull(0));
+  EXPECT_EQ(result.GetString(0), "[3]");
+  EXPECT_EQ(result.GetCurrentRowAsString(), "[3]");
+}
+
 }  // namespace neug

--- a/tests/unittest/test_query_result_list.cc
+++ b/tests/unittest/test_query_result_list.cc
@@ -1,0 +1,81 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+
+#include "neug/main/connection.h"
+#include "neug/main/neug_db.h"
+
+namespace neug {
+namespace test {
+
+// End-to-end coverage for C++ QueryResult LIST/ARRAY decoding (#607):
+// Connection::Query → sink list_array → GetString / IsNull / GetCurrentRowAsString.
+TEST(QueryResultListTest, ListAndArrayColumnsViaConnection) {
+  const auto test_dir =
+      std::filesystem::temp_directory_path() / "neug_query_result_list_e2e";
+  std::filesystem::remove_all(test_dir);
+  std::filesystem::create_directories(test_dir);
+
+  NeugDB db;
+  NeugDBConfig config;
+  config.data_dir = (test_dir / "graph").string();
+  config.mode = DBMode::READ_WRITE;
+  config.checkpoint_on_close = false;
+  ASSERT_TRUE(db.Open(config));
+  auto conn = db.Connect();
+  ASSERT_NE(conn, nullptr);
+
+  // LIST literal
+  {
+    auto res = conn->Query("RETURN [1, 2] AS nums;");
+    ASSERT_TRUE(res) << res.error().ToString();
+    auto& qr = res.value();
+    ASSERT_TRUE(qr.hasNext());
+    EXPECT_FALSE(qr.IsNull(0));
+    EXPECT_EQ(qr.GetString(0), "[1, 2]");
+    EXPECT_EQ(qr.GetCurrentRowAsString(), "[1, 2]");
+  }
+
+  // Fixed-size ARRAY property (serialized as list_array on the wire)
+  {
+    auto ddl = conn->Query(
+        "CREATE NODE TABLE Sensor(id INT64, readings INT32[3], "
+        "PRIMARY KEY(id));");
+    ASSERT_TRUE(ddl) << ddl.error().ToString();
+
+    auto insert =
+        conn->Query("CREATE (s:Sensor {id: 1, readings: [10, 20, 30]});");
+    ASSERT_TRUE(insert) << insert.error().ToString();
+
+    auto res =
+        conn->Query("MATCH (s:Sensor) WHERE s.id = 1 RETURN s.readings;");
+    ASSERT_TRUE(res) << res.error().ToString();
+    auto& qr = res.value();
+    ASSERT_TRUE(qr.hasNext());
+    EXPECT_FALSE(qr.IsNull(0));
+    EXPECT_EQ(qr.GetString(0), "[10, 20, 30]");
+    EXPECT_EQ(qr.GetCurrentRowAsString(), "[10, 20, 30]");
+  }
+
+  conn->Close();
+  db.Close();
+  std::filesystem::remove_all(test_dir);
+}
+
+}  // namespace test
+}  // namespace neug

--- a/tests/unittest/test_query_result_list.cc
+++ b/tests/unittest/test_query_result_list.cc
@@ -24,7 +24,8 @@ namespace neug {
 namespace test {
 
 // End-to-end coverage for C++ QueryResult LIST/ARRAY decoding (#607):
-// Connection::Query → sink list_array → GetString / IsNull / GetCurrentRowAsString.
+// Connection::Query → sink list_array → GetString / IsNull /
+// GetCurrentRowAsString.
 TEST(QueryResultListTest, ListAndArrayColumnsViaConnection) {
   const auto test_dir =
       std::filesystem::temp_directory_path() / "neug_query_result_list_e2e";


### PR DESCRIPTION
Decode kListArray (and kStructArray) in get_value/IsNull so LIST and ARRAY result columns are not silently returned as null.


Fixes #607 

