### PR TITLE
fix: support concurrent read-only database processes

### DIFF
--- a/doc/source/reference/cpp_api/neug_db.md
+++ b/doc/source/reference/cpp_api/neug_db.md
@@ -39,7 +39,10 @@ separate connections can execute queries concurrently. Individual `Connection`
 instances are not thread-safe.
 
 **Resource Management:**
-- File locking prevents concurrent database access from multiple processes
+- File locking serializes write access across processes: a database opened in
+  read-write mode is exclusive, while multiple read-only processes (or
+  multiple read-only instances within one process) can share the same
+  database directory concurrently
 - Automatic WAL (Write-Ahead Log) for crash recovery
 - Configurable checkpoint on close
 

--- a/doc/source/reference/nodejs_api/database.md
+++ b/doc/source/reference/nodejs_api/database.md
@@ -26,6 +26,10 @@ read-only mode, inside the same process or in different processes.
 When the database is opened in read-write mode, no other databases could open the same database directory in
 either read-only or read-write mode, inside the same process or in different processes.
 
+Note that opening a database in read-only mode still requires a writable data directory: the lock file is
+created on demand if missing, and read-only processes copy temporary working files into the database's
+`checkpoint-N/runtime/` directory. Read-only mode cannot be used on a read-only file system or mount.
+
 When the database is closed, all the connections to the database will be closed automatically.
 
 ```javascript

--- a/doc/source/reference/python_api/database.md
+++ b/doc/source/reference/python_api/database.md
@@ -26,6 +26,10 @@ read-only mode, inside the same process or in different processes.
 When the database is opened in read-write mode, no other databases could open the same database directory in
 either read-only or read-write mode, inside the same process or in different processes.
 
+Note that opening a database in read-only mode still requires a writable data directory: the lock file is
+created on demand if missing, and read-only processes copy temporary working files into the database's
+`checkpoint-N/runtime/` directory. Read-only mode cannot be used on a read-only file system or mount.
+
 When the database is closed, all the connections to the database will be closed automatically.
 
 ```python

--- a/include/neug/main/file_lock.h
+++ b/include/neug/main/file_lock.h
@@ -41,9 +41,7 @@ class FileLock {
   void unlock();
 
  private:
-  bool lock(short type, bool wait, std::string& error_msg);
   std::string lock_file_path_;
-  int fd_;
   bool locked_ = false;
 };
 

--- a/include/neug/main/file_lock.h
+++ b/include/neug/main/file_lock.h
@@ -14,6 +14,7 @@
  */
 #pragma once
 
+#include <sys/types.h>
 #include <cstdio>
 #include <filesystem>
 #include <set>
@@ -36,13 +37,18 @@ class FileLock {
 
   ~FileLock();
 
+  FileLock(const FileLock&) = delete;
+  FileLock& operator=(const FileLock&) = delete;
+
   bool lock(std::string& error_msg, DBMode mode);
 
   void unlock();
 
  private:
   std::string lock_file_path_;
+  std::string data_dir_;
   bool locked_ = false;
+  pid_t locked_pid_ = 0;
 };
 
 }  // namespace neug

--- a/include/neug/storages/checkpoint.h
+++ b/include/neug/storages/checkpoint.h
@@ -67,11 +67,15 @@ class Checkpoint {
   /**
    * @brief Create and initialize a checkpoint at @p path.
    *
-   * Creates directories, loads meta JSON, absolutizes paths, and cleans up
-   * orphaned runtime files.  Returns nullptr only on unrecoverable errors
-   * (currently throws instead).
+   * Creates directories, loads meta JSON, and absolutizes paths. When
+   * @p cleanup_orphan_runtime_files is true, also removes orphaned runtime
+   * files. Read-only database opens disable that cleanup because another
+   * read-only process may own those temporary files.
+   *
+   * Returns nullptr only on unrecoverable errors (currently throws instead).
    */
-  static std::shared_ptr<Checkpoint> Open(std::string path, uint32_t id);
+  static std::shared_ptr<Checkpoint> Open(
+      std::string path, uint32_t id, bool cleanup_orphan_runtime_files = true);
 
   ~Checkpoint();  // defined in .cc where CheckpointManifest is complete
   Checkpoint(const Checkpoint&) = delete;
@@ -156,8 +160,9 @@ class Checkpoint {
   /// Private constructor — only initializes members. Use Open() to create.
   Checkpoint(std::string path, uint32_t id);
 
-  /// Performs all I/O: create dirs, load meta, absolutize paths, clean orphans.
-  void initialize();
+  /// Performs all I/O: create dirs, load meta, absolutize paths, and optionally
+  /// clean orphaned runtime files.
+  void initialize(bool cleanup_orphan_runtime_files);
 
   void create_dirs() const;
 

--- a/src/main/file_lock.cc
+++ b/src/main/file_lock.cc
@@ -17,6 +17,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <glog/logging.h>
+#include <pthread.h>
 #include <stdint.h>
 #include <string.h>
 #include <sys/stat.h>
@@ -42,22 +43,28 @@ class CurrentHoldDbs {
     return instance;
   }
 
-  bool lock(const std::string& db_path, DBMode mode, std::string& error_msg) {
+  bool lock(const std::string& lock_file_path, DBMode mode,
+            std::string& error_msg, const std::string& data_dir) {
     std::lock_guard<std::mutex> lock(mutex_);
-    auto existing = opened_dbs_.find(db_path);
+    resetInheritedLockStateIfForkedLocked();
+    auto existing = opened_dbs_.find(lock_file_path);
     if (existing != opened_dbs_.end()) {
       if (existing->second.mode == DBMode::READ_ONLY &&
           mode == DBMode::READ_ONLY) {
         ++existing->second.references;
         return true;
       }
-      error_msg = mode == DBMode::READ_ONLY
-                      ? "Lock file is already locked in write mode by the "
-                        "current process: " +
-                            db_path
-                      : "Lock file is already locked in read or write mode "
-                        "by the current process: " +
-                            db_path;
+      error_msg =
+          mode == DBMode::READ_ONLY
+              ? "Database is already opened in write mode by the current "
+                "process: " +
+                    data_dir +
+                    ", you can't open it in read-only mode in the same "
+                    "process"
+              : "Database is already opened in read or write mode by the "
+                "current process: " +
+                    data_dir +
+                    ", you can't open it in write mode in the same process";
       return false;
     }
 
@@ -65,28 +72,40 @@ class CurrentHoldDbs {
     // state. Create it on demand for legacy databases that predate the file;
     // read-only opens still use a read-only descriptor and a shared lock.
     const int flags = (mode == DBMode::READ_ONLY ? O_RDONLY : O_RDWR) | O_CREAT;
-    const int fd = ::open(db_path.c_str(), flags, 0600);
+    const int fd = ::open(lock_file_path.c_str(), flags, 0600);
     if (fd == -1) {
-      if (errno == EACCES) {
+      const int open_error = errno;
+      if (mode == DBMode::READ_ONLY &&
+          (open_error == EACCES || open_error == EROFS)) {
         THROW_PERMISSION_DENIED(
-            "Permission denied when opening lock file: " + db_path +
+            "Failed to open lock file: " + lock_file_path +
+            ", error: " + std::string(strerror(open_error)) +
+            ". Read-only mode still requires a writable data directory (" +
+            data_dir +
+            ") to create the lock file and runtime working files on "
+            "demand; please check the permissions of the data directory.");
+      }
+      if (open_error == EACCES) {
+        THROW_PERMISSION_DENIED(
+            "Permission denied when opening lock file: " + lock_file_path +
             ", please check the permissions of the data directory.");
       }
-      THROW_RUNTIME_ERROR("Failed to open lock file: " + db_path +
-                          ", error: " + std::string(strerror(errno)));
+      THROW_RUNTIME_ERROR("Failed to open lock file: " + lock_file_path +
+                          ", error: " + std::string(strerror(open_error)));
     }
     if (!setLock(fd, mode == DBMode::READ_ONLY ? F_RDLCK : F_WRLCK, false,
                  error_msg)) {
       ::close(fd);
       return false;
     }
-    opened_dbs_.emplace(db_path, Entry{fd, mode, 1});
+    opened_dbs_.emplace(lock_file_path, Entry{fd, mode, 1});
     return true;
   }
 
-  void unlock(const std::string& db_path) {
+  void unlock(const std::string& lock_file_path) {
     std::lock_guard<std::mutex> lock(mutex_);
-    auto existing = opened_dbs_.find(db_path);
+    resetInheritedLockStateIfForkedLocked();
+    auto existing = opened_dbs_.find(lock_file_path);
     if (existing == opened_dbs_.end()) {
       return;
     }
@@ -101,12 +120,55 @@ class CurrentHoldDbs {
     opened_dbs_.erase(existing);
   }
 
+  void discardInheritedLockStateIfForked() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    resetInheritedLockStateIfForkedLocked();
+  }
+
  private:
+  CurrentHoldDbs() : owner_pid_(::getpid()) {
+    instance_ = this;
+    const int error =
+        ::pthread_atfork(lockBeforeFork, unlockAfterFork, unlockAfterFork);
+    if (error != 0) {
+      instance_ = nullptr;
+      THROW_RUNTIME_ERROR("Failed to register file-lock fork handlers: " +
+                          std::string(strerror(error)));
+    }
+  }
+
   struct Entry {
     int fd;
     DBMode mode;
     size_t references;
   };
+
+  static void lockBeforeFork() noexcept {
+    if (instance_ != nullptr) {
+      (void) ::pthread_mutex_lock(instance_->mutex_.native_handle());
+    }
+  }
+
+  static void unlockAfterFork() noexcept {
+    if (instance_ != nullptr) {
+      (void) ::pthread_mutex_unlock(instance_->mutex_.native_handle());
+    }
+  }
+
+  void resetInheritedLockStateIfForkedLocked() {
+    const auto current_pid = ::getpid();
+    if (owner_pid_ == current_pid) {
+      return;
+    }
+    // POSIX process-associated record locks are not inherited across fork().
+    // Drop the copied descriptors and accounting so the child acquires its own
+    // lock instead of treating the parent's entry as a local reference.
+    for (const auto& [_, entry] : opened_dbs_) {
+      ::close(entry.fd);
+    }
+    opened_dbs_.clear();
+    owner_pid_ = current_pid;
+  }
 
   static bool setLock(int fd, short type, bool wait, std::string& error_msg) {
     struct flock fl;
@@ -122,7 +184,9 @@ class CurrentHoldDbs {
         return true;
       }
       if (errno == EACCES || errno == EAGAIN) {
-        error_msg = "Lock file is already locked by another process.";
+        error_msg =
+            "Lock file is already locked by another process, please check "
+            "if another instance of the database is running.";
         return false;
       }
       if (errno != EINTR) {
@@ -134,19 +198,33 @@ class CurrentHoldDbs {
 
   std::mutex mutex_;
   std::map<std::string, Entry> opened_dbs_;
+  pid_t owner_pid_;
+  static inline CurrentHoldDbs* instance_ = nullptr;
 };
 
 FileLock::FileLock(const std::string& data_dir)
-    : lock_file_path_(data_dir + "/" + LOCK_FILE_NAME), locked_(false) {}
+    : lock_file_path_(data_dir + "/" + LOCK_FILE_NAME),
+      data_dir_(data_dir),
+      locked_(false) {}
 
 FileLock::~FileLock() { unlock(); }
 
 bool FileLock::lock(std::string& error_msg, DBMode mode) {
+  const auto current_pid = ::getpid();
+  if (locked_ && locked_pid_ != current_pid) {
+    // The handle was copied by fork(), but its process-associated lock was not.
+    locked_ = false;
+    locked_pid_ = 0;
+  }
   if (locked_) {
     error_msg = "File lock is already held by this object: " + lock_file_path_;
     return false;
   }
-  locked_ = CurrentHoldDbs::get().lock(lock_file_path_, mode, error_msg);
+  locked_ =
+      CurrentHoldDbs::get().lock(lock_file_path_, mode, error_msg, data_dir_);
+  if (locked_) {
+    locked_pid_ = current_pid;
+  }
   return locked_;
 }
 
@@ -154,8 +232,13 @@ void FileLock::unlock() {
   if (!locked_) {
     return;  // Not locked, nothing to do
   }
-  CurrentHoldDbs::get().unlock(lock_file_path_);
+  if (locked_pid_ == ::getpid()) {
+    CurrentHoldDbs::get().unlock(lock_file_path_);
+  } else {
+    CurrentHoldDbs::get().discardInheritedLockStateIfForked();
+  }
   locked_ = false;
+  locked_pid_ = 0;
 }
 
 }  // namespace neug

--- a/src/main/file_lock.cc
+++ b/src/main/file_lock.cc
@@ -42,131 +42,118 @@ class CurrentHoldDbs {
     return instance;
   }
 
-  bool lock(const std::string& db_path, DBMode mode) {
+  bool lock(const std::string& db_path, DBMode mode, std::string& error_msg) {
     std::lock_guard<std::mutex> lock(mutex_);
-    if (opened_dbs_.find(db_path) != opened_dbs_.end()) {
-      if (opened_dbs_[db_path] > 0 && mode == DBMode::READ_ONLY) {
-        opened_dbs_[db_path] += 1;
-        return true;  // Database is already opened in the same mode
-      } else {
-        // Database is already opened in a different mode, which is not allowed
-        return false;
+    auto existing = opened_dbs_.find(db_path);
+    if (existing != opened_dbs_.end()) {
+      if (existing->second.mode == DBMode::READ_ONLY &&
+          mode == DBMode::READ_ONLY) {
+        ++existing->second.references;
+        return true;
       }
+      error_msg = mode == DBMode::READ_ONLY
+                      ? "Lock file is already locked in write mode by the "
+                        "current process: " +
+                            db_path
+                      : "Lock file is already locked in read or write mode "
+                        "by the current process: " +
+                            db_path;
+      return false;
     }
-    opened_dbs_[db_path] = (mode == DBMode::READ_ONLY);
+
+    const int flags = mode == DBMode::READ_ONLY ? O_RDONLY : (O_RDWR | O_CREAT);
+    const int fd = ::open(db_path.c_str(), flags, 0600);
+    if (fd == -1) {
+      if (mode == DBMode::READ_ONLY && errno == ENOENT) {
+        THROW_NO_CHECKPOINT_EXCEPTION(
+            "Read-only database is missing lock file: " + db_path +
+            ". Open it once in read-write mode to initialize the lock file.");
+      }
+      if (errno == EACCES) {
+        THROW_PERMISSION_DENIED(
+            "Permission denied when opening lock file: " + db_path +
+            ", please check the permissions of the data directory.");
+      }
+      THROW_RUNTIME_ERROR("Failed to open lock file: " + db_path +
+                          ", error: " + std::string(strerror(errno)));
+    }
+    if (!setLock(fd, mode == DBMode::READ_ONLY ? F_RDLCK : F_WRLCK, false,
+                 error_msg)) {
+      ::close(fd);
+      return false;
+    }
+    opened_dbs_.emplace(db_path, Entry{fd, mode, 1});
     return true;
   }
 
   void unlock(const std::string& db_path) {
     std::lock_guard<std::mutex> lock(mutex_);
-    if (opened_dbs_.find(db_path) != opened_dbs_.end()) {
-      opened_dbs_[db_path] -= 1;
-      if (opened_dbs_[db_path] <= 0) {
-        opened_dbs_.erase(db_path);
+    auto existing = opened_dbs_.find(db_path);
+    if (existing == opened_dbs_.end()) {
+      return;
+    }
+    if (--existing->second.references != 0) {
+      return;
+    }
+    std::string error_msg;
+    if (!setLock(existing->second.fd, F_UNLCK, true, error_msg)) {
+      LOG(ERROR) << "Failed to unlock file lock: " << error_msg;
+    }
+    ::close(existing->second.fd);
+    opened_dbs_.erase(existing);
+  }
+
+ private:
+  struct Entry {
+    int fd;
+    DBMode mode;
+    size_t references;
+  };
+
+  static bool setLock(int fd, short type, bool wait, std::string& error_msg) {
+    struct flock fl;
+    std::memset(&fl, 0, sizeof(fl));
+    fl.l_type = type;
+    fl.l_whence = SEEK_SET;
+    fl.l_start = 0;
+    fl.l_len = 0;
+
+    const int cmd = wait ? F_SETLKW : F_SETLK;
+    while (true) {
+      if (::fcntl(fd, cmd, &fl) == 0) {
+        return true;
+      }
+      if (errno == EACCES || errno == EAGAIN) {
+        error_msg = "Lock file is already locked by another process.";
+        return false;
+      }
+      if (errno != EINTR) {
+        error_msg = "Failed to acquire lock: " + std::string(strerror(errno));
+        return false;
       }
     }
   }
 
- private:
   std::mutex mutex_;
-  std::map<std::string, int> opened_dbs_;
+  std::map<std::string, Entry> opened_dbs_;
 };
 
 FileLock::FileLock(const std::string& data_dir)
-    : lock_file_path_(data_dir + "/" + LOCK_FILE_NAME),
-      fd_(-1),
-      locked_(false) {
-  fd_ = ::open(lock_file_path_.c_str(), O_RDWR | O_CREAT, 0600);
-  if (fd_ == -1) {
-    if (errno == EACCES) {
-      THROW_PERMISSION_DENIED(
-          "Permission denied when creating lock file: " + lock_file_path_ +
-          ", please check the permissions of the data directory.");
-    }
-    THROW_RUNTIME_ERROR("Failed to create lock file: " + lock_file_path_ +
-                        ", error: " + std::string(strerror(errno)));
-  }
-}
+    : lock_file_path_(data_dir + "/" + LOCK_FILE_NAME), locked_(false) {}
 
-FileLock::~FileLock() {
-  if (fd_ != -1) {
-    unlock();
-    ::close(fd_);
-  }
-}
+FileLock::~FileLock() { unlock(); }
 
 bool FileLock::lock(std::string& error_msg, DBMode mode) {
-  // If the current process has already locked the database, check if the lock
-  // mode is compatible. If not, return an error message.
-  if (CurrentHoldDbs::get().lock(lock_file_path_, mode)) {
-    // Try to acquire the file lock. If it fails, return an error message.
-    if (lock(mode == DBMode::READ_ONLY ? F_RDLCK : F_WRLCK, false, error_msg)) {
-      locked_ = true;
-    } else {
-      locked_ = false;
-      CurrentHoldDbs::get().unlock(lock_file_path_);
-    }
-    return locked_;
-  } else {
-    // The database is already locked by the current process, but in a different
-    // mode, which is not allowed. Return an error message.
-    locked_ = false;
-    if (mode == DBMode::READ_ONLY) {
-      error_msg =
-          "Lock file is already locked in write mode by the current process: " +
-          lock_file_path_ +
-          ", you can't open the database in read-only mode in the same "
-          "process";
-    } else {
-      error_msg =
-          "Lock file is already locked in read or write mode by the current "
-          "process: " +
-          lock_file_path_ +
-          ", you can't open the database in write mode in the same process";
-    }
-    return false;
-  }
+  locked_ = CurrentHoldDbs::get().lock(lock_file_path_, mode, error_msg);
+  return locked_;
 }
 
 void FileLock::unlock() {
   if (!locked_) {
     return;  // Not locked, nothing to do
   }
-  std::string error_msg;
-  if (!lock(F_UNLCK, true, error_msg)) {
-    LOG(ERROR) << "Failed to unlock file lock: " << error_msg;
-  }
   CurrentHoldDbs::get().unlock(lock_file_path_);
   locked_ = false;
-}
-
-bool FileLock::lock(short type, bool wait, std::string& error_msg) {
-  struct flock fl;
-  std::memset(&fl, 0, sizeof(fl));
-  fl.l_type = type;
-  fl.l_whence = SEEK_SET;
-  fl.l_start = 0;
-  fl.l_len = 0;  // Lock the whole file
-
-  int cmd = wait ? F_SETLKW : F_SETLK;
-  while (true) {
-    if (::fcntl(fd_, cmd, &fl) == 0) {
-      return true;  // Lock acquired successfully
-    } else if (errno == EACCES || errno == EAGAIN) {
-      // The file is already locked by another process
-      error_msg =
-          "Lock file is already locked by another process: " + lock_file_path_ +
-          ", please check if another instance of the database is running.";
-      return false;
-    } else if (errno == EINTR) {
-      // Interrupted by a signal, retry
-      continue;
-    } else {
-      // An unexpected error occurred
-      error_msg = "Failed to acquire lock: " + std::string(strerror(errno));
-      return false;
-    }
-  }
 }
 
 }  // namespace neug

--- a/src/main/file_lock.cc
+++ b/src/main/file_lock.cc
@@ -61,14 +61,12 @@ class CurrentHoldDbs {
       return false;
     }
 
-    const int flags = mode == DBMode::READ_ONLY ? O_RDONLY : (O_RDWR | O_CREAT);
+    // The lock file is runtime coordination metadata rather than database
+    // state. Create it on demand for legacy databases that predate the file;
+    // read-only opens still use a read-only descriptor and a shared lock.
+    const int flags = (mode == DBMode::READ_ONLY ? O_RDONLY : O_RDWR) | O_CREAT;
     const int fd = ::open(db_path.c_str(), flags, 0600);
     if (fd == -1) {
-      if (mode == DBMode::READ_ONLY && errno == ENOENT) {
-        THROW_NO_CHECKPOINT_EXCEPTION(
-            "Read-only database is missing lock file: " + db_path +
-            ". Open it once in read-write mode to initialize the lock file.");
-      }
       if (errno == EACCES) {
         THROW_PERMISSION_DENIED(
             "Permission denied when opening lock file: " + db_path +

--- a/src/main/file_lock.cc
+++ b/src/main/file_lock.cc
@@ -144,6 +144,10 @@ FileLock::FileLock(const std::string& data_dir)
 FileLock::~FileLock() { unlock(); }
 
 bool FileLock::lock(std::string& error_msg, DBMode mode) {
+  if (locked_) {
+    error_msg = "File lock is already held by this object: " + lock_file_path_;
+    return false;
+  }
   locked_ = CurrentHoldDbs::get().lock(lock_file_path_, mode, error_msg);
   return locked_;
 }

--- a/src/main/neug_db.cc
+++ b/src/main/neug_db.cc
@@ -131,7 +131,12 @@ bool NeugDB::Open(const NeugDBConfig& config) {
     file_lock_ = std::make_unique<FileLock>(config_.data_dir);
 
     std::string error_msg;
-    if (!file_lock_->lock(error_msg, config.mode)) {
+    // A pure-memory database owns a fresh private workspace, so it needs an
+    // exclusive lock to initialize the lock file even when its data access
+    // mode is read-only. Persistent read-only databases still use a shared
+    // lock and never create the lock file.
+    const auto lock_mode = is_pure_memory_ ? DBMode::READ_WRITE : config.mode;
+    if (!file_lock_->lock(error_msg, lock_mode)) {
       THROW_DATABASE_LOCKED_EXCEPTION(
           "Failed to lock data directory: " + config_.data_dir +
           ", error: " + error_msg);

--- a/src/main/neug_db.cc
+++ b/src/main/neug_db.cc
@@ -133,8 +133,8 @@ bool NeugDB::Open(const NeugDBConfig& config) {
     std::string error_msg;
     // A pure-memory database owns a fresh private workspace, so it needs an
     // exclusive lock to initialize the lock file even when its data access
-    // mode is read-only. Persistent read-only databases still use a shared
-    // lock and never create the lock file.
+    // mode is read-only. Persistent read-only databases use a shared lock and
+    // may create missing runtime coordination metadata for legacy databases.
     const auto lock_mode = is_pure_memory_ ? DBMode::READ_WRITE : config.mode;
     if (!file_lock_->lock(error_msg, lock_mode)) {
       THROW_DATABASE_LOCKED_EXCEPTION(

--- a/src/main/neug_db.cc
+++ b/src/main/neug_db.cc
@@ -125,6 +125,9 @@ bool NeugDB::Open(const NeugDBConfig& config) {
           config_.data_dir);
     }
 
+    config_.data_dir =
+        std::filesystem::weakly_canonical(config_.data_dir).string();
+
     file_lock_ = std::make_unique<FileLock>(config_.data_dir);
 
     std::string error_msg;
@@ -387,16 +390,22 @@ void NeugDB::cleanupTemporaryWorkspace() noexcept {
 }
 
 void NeugDB::initAllocators(const std::string& allocator_dir) {
-  // Initialize the default allocator for ingesting wals
+  // WAL replay needs an allocator even in read-only mode. Read-only opens
+  // must not alter the checkpoint allocator workspace, so use transient
+  // in-memory backing there. Read-write opens retain the durable workspace.
   allocators_.clear();
-  remove_directory(allocator_dir);
-  std::filesystem::create_directories(allocator_dir);
+  const bool read_only = config_.mode == DBMode::READ_ONLY;
+  if (!read_only) {
+    remove_directory(allocator_dir);
+    std::filesystem::create_directories(allocator_dir);
+  }
   assert(config_.max_thread_num > 0);
   for (int i = 0; i < config_.max_thread_num; ++i) {
     allocators_.emplace_back(std::make_shared<Allocator>(
-        config_.memory_level, config_.memory_level != MemoryLevel::kSyncToFile
-                                  ? ""
-                                  : allocator_prefix(allocator_dir, i)));
+        read_only ? MemoryLevel::kInMemory : config_.memory_level,
+        !read_only && config_.memory_level == MemoryLevel::kSyncToFile
+            ? allocator_prefix(allocator_dir, i)
+            : ""));
   }
 }
 

--- a/src/storages/graph/checkpoint.cc
+++ b/src/storages/graph/checkpoint.cc
@@ -52,14 +52,15 @@ Checkpoint::~Checkpoint() = default;
 Checkpoint::Checkpoint(std::string path, uint32_t id)
     : path_(std::move(path)), id_(id) {}
 
-std::shared_ptr<Checkpoint> Checkpoint::Open(std::string path, uint32_t id) {
+std::shared_ptr<Checkpoint> Checkpoint::Open(
+    std::string path, uint32_t id, bool cleanup_orphan_runtime_files) {
   // Can't use make_shared because constructor is private.
   auto ckp = std::shared_ptr<Checkpoint>(new Checkpoint(std::move(path), id));
-  ckp->initialize();
+  ckp->initialize(cleanup_orphan_runtime_files);
   return ckp;
 }
 
-void Checkpoint::initialize() {
+void Checkpoint::initialize(bool cleanup_orphan_runtime_files) {
   create_dirs();
   file_mgr_ =
       std::make_unique<CheckpointFileManager>(snapshot_dir(), runtime_dir());
@@ -74,7 +75,13 @@ void Checkpoint::initialize() {
     meta_->set_module(key, std::move(absolute_desc));
   }
 
-  // Clean orphaned runtime files not referenced by meta.
+  if (!cleanup_orphan_runtime_files) {
+    return;
+  }
+
+  // Clean orphaned runtime files not referenced by meta. This is only safe for
+  // a writer holding the exclusive database lock: a shared read-only process
+  // may otherwise delete another reader's active temporary backing file.
   std::set<std::string> referenced_runtime_files;
   for (auto& [key, desc] : meta_->modules()) {
     CollectReferencedFiles(desc, runtime_dir(), referenced_runtime_files);

--- a/src/storages/graph/checkpoint.cc
+++ b/src/storages/graph/checkpoint.cc
@@ -92,7 +92,10 @@ void Checkpoint::initialize(bool cleanup_orphan_runtime_files) {
          std::filesystem::directory_iterator(runtime_dir())) {
       if (entry.is_regular_file()) {
         std::string name = entry.path().filename().string();
-        if (is_valid_uuid(name) && referenced_runtime_files.count(name) == 0) {
+        // Everything under runtime/ is temporary working state. In addition to
+        // UUID reservations, remove copy staging files left by a process that
+        // exited before its exception/RAII cleanup ran.
+        if (referenced_runtime_files.count(name) == 0) {
           std::filesystem::remove(entry.path());
           VLOG(1) << "Checkpoint::initialize: cleaned orphan file " << name;
         }

--- a/src/storages/graph/checkpoint_file_manager.cc
+++ b/src/storages/graph/checkpoint_file_manager.cc
@@ -192,10 +192,11 @@ std::string CheckpointFileManager::CreateRuntimeContainerPath() {
       ::close(fd);
       return runtime_path;
     }
-    if (errno == EEXIST) {
+    const int open_errno = errno;
+    if (open_errno == EEXIST || open_errno == EINTR) {
       continue;
     }
-    const auto error = std::error_code(errno, std::generic_category());
+    const auto error = std::error_code(open_errno, std::generic_category());
     THROW_IO_EXCEPTION("Failed to reserve runtime file " + runtime_path + ": " +
                        error.message());
   }

--- a/src/storages/graph/checkpoint_file_manager.cc
+++ b/src/storages/graph/checkpoint_file_manager.cc
@@ -15,7 +15,12 @@
 
 #include "neug/storages/checkpoint_file_manager.h"
 
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cerrno>
 #include <filesystem>
+#include <system_error>
 #include <utility>
 
 #include "neug/utils/io/file/file_utils.h"
@@ -166,15 +171,34 @@ std::string CheckpointFileManager::Commit(IDataContainer& buffer) {
 
 CheckpointFileManager::RuntimeFileHandle
 CheckpointFileManager::CreateRuntimeFile() {
-  std::lock_guard<std::mutex> lock(mutex_);
-  auto uuid = CreateRuntimeObjectNameLocked();
-  return RuntimeFileHandle(runtime_cleanup_, uuid, runtime_dir_ + "/" + uuid);
+  auto path = CreateRuntimeContainerPath();
+  auto uuid = std::filesystem::path(path).filename().string();
+  return RuntimeFileHandle(runtime_cleanup_, std::move(uuid), std::move(path));
 }
 
 std::string CheckpointFileManager::CreateRuntimeContainerPath() {
   std::lock_guard<std::mutex> lock(mutex_);
-  auto uuid = CreateRuntimeObjectNameLocked();
-  return runtime_dir_ + "/" + uuid;
+  while (true) {
+    auto uuid = UUIDGenerator::Generate();
+    auto runtime_path = runtime_dir_ + "/" + uuid;
+    auto snapshot_path = snapshot_dir_ + "/" + uuid;
+    if (std::filesystem::exists(snapshot_path)) {
+      continue;
+    }
+
+    const int fd =
+        ::open(runtime_path.c_str(), O_WRONLY | O_CREAT | O_EXCL, 0644);
+    if (fd >= 0) {
+      ::close(fd);
+      return runtime_path;
+    }
+    if (errno == EEXIST) {
+      continue;
+    }
+    const auto error = std::error_code(errno, std::generic_category());
+    THROW_IO_EXCEPTION("Failed to reserve runtime file " + runtime_path + ": " +
+                       error.message());
+  }
 }
 
 std::string CheckpointFileManager::CreateRuntimeObjectNameLocked() const {

--- a/src/storages/graph/checkpoint_manager.cc
+++ b/src/storages/graph/checkpoint_manager.cc
@@ -132,8 +132,10 @@ void cleanup_staging_checkpoints(const std::string& db_dir,
 }
 
 std::shared_ptr<Checkpoint> open_checkpoint_checked(
-    const std::filesystem::path& path, int32_t id) {
-  auto checkpoint = Checkpoint::Open(path.string(), id);
+    const std::filesystem::path& path, int32_t id,
+    bool cleanup_orphan_runtime_files) {
+  auto checkpoint =
+      Checkpoint::Open(path.string(), id, cleanup_orphan_runtime_files);
   if (!checkpoint->GetMeta().has_schema()) {
     THROW_CHECKPOINT_EXCEPTION("Checkpoint " + path.string() +
                                " is incomplete");
@@ -188,7 +190,8 @@ CheckpointOpenResult open_current_checkpoint(const std::string& db_dir,
   auto dirs = discover_published_checkpoints(db_dir);
   for (const auto& dir : dirs) {
     try {
-      result.current_checkpoint = open_checkpoint_checked(dir.path, dir.id);
+      result.current_checkpoint =
+          open_checkpoint_checked(dir.path, dir.id, recover_workspace);
       result.current_generation = dir.id;
       break;
     } catch (const std::exception& e) {

--- a/src/utils/io/file/file_utils.cc
+++ b/src/utils/io/file/file_utils.cc
@@ -18,6 +18,8 @@
 #include <glog/logging.h>
 
 #include <fcntl.h>
+#include <atomic>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <sstream>
@@ -80,16 +82,12 @@ static bool try_reflink(const std::string& src_path,
                         const std::string& dst_path,
                         const struct stat& src_stat) {
 #if defined(__APPLE__)
-  // clonefile() requires dst to not exist. The overwrite policy was
-  // already enforced by the caller; remove any leftover dst here.
-  ::unlink(dst_path.c_str());
+  (void) src_stat;
   if (::clonefile(src_path.c_str(), dst_path.c_str(), 0) == 0) {
     // clonefile preserves mode/timestamps/ACLs by default; no need to
     // re-apply metadata.
     return true;
   }
-  // Not on APFS or unsupported — leave no partial file behind.
-  ::unlink(dst_path.c_str());
   return false;
 #elif defined(FICLONE)
   int src_fd = ::open(src_path.c_str(), O_RDONLY);
@@ -349,6 +347,41 @@ void fallback_copy(const std::string& src_path, const std::string& dst_path,
 
 CopyResult copy_file(const std::string& src_path, const std::string& dst_path,
                      bool overwrite) {
+  if (overwrite) {
+    // Keep dst present while copying. Some callers reserve it with O_EXCL so
+    // concurrent processes cannot claim the same runtime path. All copy fast
+    // paths are allowed to create/remove the unique staging path; only the
+    // final rename replaces dst, atomically and without exposing a gap.
+    static std::atomic<uint64_t> copy_sequence{0};
+    std::string copy_path;
+    while (true) {
+      auto sequence = copy_sequence.fetch_add(1, std::memory_order_relaxed);
+      copy_path = dst_path + ".copy-" + std::to_string(::getpid()) + "-" +
+                  std::to_string(sequence);
+      struct stat copy_stat;
+      if (::lstat(copy_path.c_str(), &copy_stat) != 0) {
+        if (errno == ENOENT) {
+          break;
+        }
+        throw std::runtime_error("Failed to inspect temporary copy path: " +
+                                 copy_path + ": " + std::strerror(errno));
+      }
+    }
+
+    try {
+      auto result = copy_file(src_path, copy_path, /*overwrite=*/false);
+      if (::rename(copy_path.c_str(), dst_path.c_str()) != 0) {
+        const int rename_errno = errno;
+        throw std::runtime_error("Failed to atomically replace destination: " +
+                                 dst_path + ": " + std::strerror(rename_errno));
+      }
+      return result;
+    } catch (...) {
+      ::unlink(copy_path.c_str());
+      throw;
+    }
+  }
+
   // Verify source file exists
   struct stat src_stat;
   if (stat(src_path.c_str(), &src_stat) < 0) {
@@ -356,11 +389,9 @@ CopyResult copy_file(const std::string& src_path, const std::string& dst_path,
   }
 
   // Check if destination exists
-  if (!overwrite) {
-    struct stat dst_stat;
-    if (stat(dst_path.c_str(), &dst_stat) == 0) {
-      throw std::runtime_error("Destination file already exists: " + dst_path);
-    }
+  struct stat dst_stat;
+  if (stat(dst_path.c_str(), &dst_stat) == 0) {
+    throw std::runtime_error("Destination file already exists: " + dst_path);
   }
 
   // Try reflink (COW) first - fastest if supported

--- a/tests/main/CMakeLists.txt
+++ b/tests/main/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_neug_test(test_request test_query_request.cc)
 add_neug_test(test_execution_slot test_execution_slot.cc)
+add_neug_test(test_file_lock test_file_lock.cc)

--- a/tests/main/test_file_lock.cc
+++ b/tests/main/test_file_lock.cc
@@ -1,0 +1,76 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unistd.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/wait.h>
+
+#include <filesystem>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "neug/main/file_lock.h"
+
+namespace neug {
+namespace test {
+
+TEST(FileLockTest, ClosingOneReaderKeepsProcessLock) {
+  const auto db_dir = std::filesystem::temp_directory_path() /
+                      ("neug_file_lock_test_" + std::to_string(::getpid()));
+  std::filesystem::remove_all(db_dir);
+  std::filesystem::create_directories(db_dir);
+
+  std::string error;
+  FileLock writer(db_dir.string());
+  ASSERT_TRUE(writer.lock(error, DBMode::READ_WRITE)) << error;
+  writer.unlock();
+
+  FileLock first_reader(db_dir.string());
+  FileLock second_reader(db_dir.string());
+  ASSERT_TRUE(first_reader.lock(error, DBMode::READ_ONLY)) << error;
+  ASSERT_TRUE(second_reader.lock(error, DBMode::READ_ONLY)) << error;
+  first_reader.unlock();
+
+  const pid_t child = ::fork();
+  ASSERT_GE(child, 0);
+  if (child == 0) {
+    const auto lock_path = db_dir / FileLock::LOCK_FILE_NAME;
+    const int fd = ::open(lock_path.c_str(), O_RDWR);
+    if (fd == -1) {
+      ::_exit(1);
+    }
+    struct flock lock {};
+    lock.l_type = F_WRLCK;
+    lock.l_whence = SEEK_SET;
+    lock.l_len = 0;
+    const int result = ::fcntl(fd, F_SETLK, &lock);
+    ::close(fd);
+    ::_exit(result == -1 && (errno == EACCES || errno == EAGAIN) ? 0 : 1);
+  }
+
+  int child_status = 0;
+  ASSERT_EQ(::waitpid(child, &child_status, 0), child);
+  EXPECT_TRUE(WIFEXITED(child_status));
+  EXPECT_EQ(WEXITSTATUS(child_status), 0);
+
+  second_reader.unlock();
+  std::filesystem::remove_all(db_dir);
+}
+
+}  // namespace test
+}  // namespace neug

--- a/tests/main/test_file_lock.cc
+++ b/tests/main/test_file_lock.cc
@@ -30,6 +30,7 @@
 #include <gtest/gtest.h>
 
 #include "neug/main/file_lock.h"
+#include "neug/utils/exception/exception.h"
 
 namespace neug {
 namespace test {
@@ -76,6 +77,45 @@ TEST(FileLockTest, ReadOnlyLockDoesNotRequireWritePermission) {
   reader.unlock();
 
   ASSERT_EQ(::chmod(lock_path.c_str(), S_IRUSR | S_IWUSR), 0);
+  std::filesystem::remove_all(db_dir);
+}
+
+TEST(FileLockTest, ReadOnlyOpenOnReadOnlyDirectoryReportsWritableHint) {
+  if (::geteuid() == 0) {
+    GTEST_SKIP() << "chmod-based permission checks do not apply to root";
+  }
+  const auto db_dir =
+      std::filesystem::temp_directory_path() /
+      ("neug_read_only_dir_lock_test_" + std::to_string(::getpid()));
+  std::filesystem::remove_all(db_dir);
+  std::filesystem::create_directories(db_dir);
+
+  // The lock file is missing and the directory is not writable, so the
+  // O_RDONLY | O_CREAT open must fail and explain that read-only mode still
+  // requires a writable data directory.
+  ASSERT_EQ(::chmod(db_dir.c_str(),
+                    S_IRUSR | S_IXUSR | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH),
+            0);
+
+  std::string error;
+  FileLock reader(db_dir.string());
+  bool permission_denied = false;
+  try {
+    (void) reader.lock(error, DBMode::READ_ONLY);
+  } catch (const exception::PermissionDeniedException& err) {
+    permission_denied = true;
+    EXPECT_NE(std::string(err.what())
+                  .find("Read-only mode still requires a writable data "
+                        "directory"),
+              std::string::npos)
+        << err.what();
+  }
+  EXPECT_TRUE(permission_denied)
+      << "read-only lock on a read-only directory should report a "
+         "permission error, got: "
+      << error;
+
+  ASSERT_EQ(::chmod(db_dir.c_str(), S_IRWXU), 0);
   std::filesystem::remove_all(db_dir);
 }
 

--- a/tests/main/test_file_lock.cc
+++ b/tests/main/test_file_lock.cc
@@ -17,11 +17,15 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <signal.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
 
 #include <filesystem>
 #include <string>
+#include <type_traits>
+
+#include <poll.h>
 
 #include <gtest/gtest.h>
 
@@ -29,6 +33,9 @@
 
 namespace neug {
 namespace test {
+
+static_assert(!std::is_copy_constructible_v<FileLock>);
+static_assert(!std::is_copy_assignable_v<FileLock>);
 
 TEST(FileLockTest, ReadOnlyCreatesMissingCoordinationFile) {
   const auto db_dir =
@@ -97,6 +104,55 @@ TEST(FileLockTest, RejectsRepeatedLockOnSameObject) {
   std::filesystem::remove_all(db_dir);
 }
 
+TEST(FileLockTest, RejectsIncompatibleModeInSameProcess) {
+  const auto db_dir =
+      std::filesystem::temp_directory_path() /
+      ("neug_mixed_mode_file_lock_test_" + std::to_string(::getpid()));
+  std::filesystem::remove_all(db_dir);
+  std::filesystem::create_directories(db_dir);
+
+  std::string error;
+  // A held read lock rejects a same-process writer. The message must point
+  // at the data directory (not the internal lock file) and tell the user
+  // what to do next.
+  {
+    FileLock reader(db_dir.string());
+    ASSERT_TRUE(reader.lock(error, DBMode::READ_ONLY)) << error;
+
+    FileLock writer(db_dir.string());
+    EXPECT_FALSE(writer.lock(error, DBMode::READ_WRITE));
+    EXPECT_NE(error.find("you can't open it in write mode in the same process"),
+              std::string::npos)
+        << error;
+    EXPECT_NE(error.find(db_dir.string()), std::string::npos) << error;
+    EXPECT_EQ(error.find(FileLock::LOCK_FILE_NAME), std::string::npos) << error;
+
+    // The rejected writer must not disturb the held read lock.
+    FileLock second_reader(db_dir.string());
+    EXPECT_TRUE(second_reader.lock(error, DBMode::READ_ONLY)) << error;
+  }
+
+  // A held write lock rejects a same-process reader.
+  {
+    FileLock writer(db_dir.string());
+    ASSERT_TRUE(writer.lock(error, DBMode::READ_WRITE)) << error;
+
+    FileLock reader(db_dir.string());
+    EXPECT_FALSE(reader.lock(error, DBMode::READ_ONLY));
+    EXPECT_NE(
+        error.find("you can't open it in read-only mode in the same process"),
+        std::string::npos)
+        << error;
+  }
+
+  // Once the conflicting handle is gone, the lock can be taken again.
+  FileLock reader(db_dir.string());
+  EXPECT_TRUE(reader.lock(error, DBMode::READ_ONLY)) << error;
+  reader.unlock();
+
+  std::filesystem::remove_all(db_dir);
+}
+
 TEST(FileLockTest, ClosingOneReaderKeepsProcessLock) {
   const auto db_dir = std::filesystem::temp_directory_path() /
                       ("neug_file_lock_test_" + std::to_string(::getpid()));
@@ -142,6 +198,88 @@ TEST(FileLockTest, ClosingOneReaderKeepsProcessLock) {
   ASSERT_TRUE(final_writer.lock(error, DBMode::READ_WRITE)) << error;
   final_writer.unlock();
 
+  std::filesystem::remove_all(db_dir);
+}
+
+TEST(FileLockTest, ForkedChildReacquiresProcessLock) {
+  const auto db_dir =
+      std::filesystem::temp_directory_path() /
+      ("neug_forked_file_lock_test_" + std::to_string(::getpid()));
+  std::filesystem::remove_all(db_dir);
+  std::filesystem::create_directories(db_dir);
+
+  std::string error;
+  FileLock parent_reader(db_dir.string());
+  FileLock second_parent_reader(db_dir.string());
+  ASSERT_TRUE(parent_reader.lock(error, DBMode::READ_ONLY)) << error;
+  ASSERT_TRUE(second_parent_reader.lock(error, DBMode::READ_ONLY)) << error;
+
+  int ready_pipe[2];
+  int release_pipe[2];
+  ASSERT_EQ(::pipe(ready_pipe), 0);
+  ASSERT_EQ(::pipe(release_pipe), 0);
+
+  const pid_t child = ::fork();
+  ASSERT_GE(child, 0);
+  if (child == 0) {
+    ::close(ready_pipe[0]);
+    ::close(release_pipe[1]);
+
+    std::string child_error;
+    // Discard descriptors and accounting copied from the parent before the
+    // child acquires any locks of its own.
+    parent_reader.unlock();
+    FileLock child_reader(db_dir.string());
+    const bool acquired = child_reader.lock(child_error, DBMode::READ_ONLY);
+    if (acquired) {
+      // This inherited handle belongs to the parent process and must not
+      // release the child process's newly acquired lock.
+      second_parent_reader.unlock();
+    }
+    const char status = acquired ? '1' : '0';
+    (void) ::write(ready_pipe[1], &status, 1);
+
+    char release = 0;
+    (void) ::read(release_pipe[0], &release, 1);
+    child_reader.unlock();
+    ::_exit(acquired ? 0 : 1);
+  }
+
+  ::close(ready_pipe[1]);
+  ::close(release_pipe[0]);
+  pollfd ready{ready_pipe[0], POLLIN, 0};
+  if (::poll(&ready, 1, 5000) != 1) {
+    (void) ::kill(child, SIGKILL);
+    int child_wait_status = 0;
+    (void) ::waitpid(child, &child_wait_status, 0);
+    ::close(ready_pipe[0]);
+    ::close(release_pipe[1]);
+    parent_reader.unlock();
+    second_parent_reader.unlock();
+    std::filesystem::remove_all(db_dir);
+    FAIL() << "Timed out waiting for forked child to acquire the lock";
+    return;
+  }
+  char child_status = '0';
+  EXPECT_EQ(::read(ready_pipe[0], &child_status, 1), 1);
+  EXPECT_EQ(child_status, '1');
+
+  parent_reader.unlock();
+  second_parent_reader.unlock();
+  FileLock writer(db_dir.string());
+  EXPECT_FALSE(writer.lock(error, DBMode::READ_WRITE));
+
+  EXPECT_EQ(::write(release_pipe[1], "1", 1), 1);
+  ::close(ready_pipe[0]);
+  ::close(release_pipe[1]);
+
+  int wait_status = 0;
+  ASSERT_EQ(::waitpid(child, &wait_status, 0), child);
+  EXPECT_TRUE(WIFEXITED(wait_status));
+  EXPECT_EQ(WEXITSTATUS(wait_status), 0);
+
+  ASSERT_TRUE(writer.lock(error, DBMode::READ_WRITE)) << error;
+  writer.unlock();
   std::filesystem::remove_all(db_dir);
 }
 

--- a/tests/main/test_file_lock.cc
+++ b/tests/main/test_file_lock.cc
@@ -17,6 +17,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <sys/stat.h>
 #include <sys/wait.h>
 
 #include <filesystem>
@@ -28,6 +29,29 @@
 
 namespace neug {
 namespace test {
+
+TEST(FileLockTest, ReadOnlyLockDoesNotRequireWritePermission) {
+  const auto db_dir =
+      std::filesystem::temp_directory_path() /
+      ("neug_read_only_file_lock_test_" + std::to_string(::getpid()));
+  std::filesystem::remove_all(db_dir);
+  std::filesystem::create_directories(db_dir);
+
+  std::string error;
+  FileLock initializer(db_dir.string());
+  ASSERT_TRUE(initializer.lock(error, DBMode::READ_WRITE)) << error;
+  initializer.unlock();
+
+  const auto lock_path = db_dir / FileLock::LOCK_FILE_NAME;
+  ASSERT_EQ(::chmod(lock_path.c_str(), S_IRUSR | S_IRGRP | S_IROTH), 0);
+
+  FileLock reader(db_dir.string());
+  ASSERT_TRUE(reader.lock(error, DBMode::READ_ONLY)) << error;
+  reader.unlock();
+
+  ASSERT_EQ(::chmod(lock_path.c_str(), S_IRUSR | S_IWUSR), 0);
+  std::filesystem::remove_all(db_dir);
+}
 
 TEST(FileLockTest, RejectsRepeatedLockOnSameObject) {
   const auto db_dir =
@@ -94,6 +118,11 @@ TEST(FileLockTest, ClosingOneReaderKeepsProcessLock) {
   EXPECT_EQ(WEXITSTATUS(child_status), 0);
 
   second_reader.unlock();
+
+  FileLock final_writer(db_dir.string());
+  ASSERT_TRUE(final_writer.lock(error, DBMode::READ_WRITE)) << error;
+  final_writer.unlock();
+
   std::filesystem::remove_all(db_dir);
 }
 

--- a/tests/main/test_file_lock.cc
+++ b/tests/main/test_file_lock.cc
@@ -30,6 +30,25 @@
 namespace neug {
 namespace test {
 
+TEST(FileLockTest, ReadOnlyCreatesMissingCoordinationFile) {
+  const auto db_dir =
+      std::filesystem::temp_directory_path() /
+      ("neug_missing_file_lock_test_" + std::to_string(::getpid()));
+  std::filesystem::remove_all(db_dir);
+  std::filesystem::create_directories(db_dir);
+
+  const auto lock_path = db_dir / FileLock::LOCK_FILE_NAME;
+  ASSERT_FALSE(std::filesystem::exists(lock_path));
+
+  std::string error;
+  FileLock reader(db_dir.string());
+  ASSERT_TRUE(reader.lock(error, DBMode::READ_ONLY)) << error;
+  EXPECT_TRUE(std::filesystem::exists(lock_path));
+  reader.unlock();
+
+  std::filesystem::remove_all(db_dir);
+}
+
 TEST(FileLockTest, ReadOnlyLockDoesNotRequireWritePermission) {
   const auto db_dir =
       std::filesystem::temp_directory_path() /

--- a/tests/main/test_file_lock.cc
+++ b/tests/main/test_file_lock.cc
@@ -29,6 +29,31 @@
 namespace neug {
 namespace test {
 
+TEST(FileLockTest, RejectsRepeatedLockOnSameObject) {
+  const auto db_dir =
+      std::filesystem::temp_directory_path() /
+      ("neug_repeated_file_lock_test_" + std::to_string(::getpid()));
+  std::filesystem::remove_all(db_dir);
+  std::filesystem::create_directories(db_dir);
+
+  std::string error;
+  FileLock initializer(db_dir.string());
+  ASSERT_TRUE(initializer.lock(error, DBMode::READ_WRITE)) << error;
+  initializer.unlock();
+
+  FileLock reader(db_dir.string());
+  ASSERT_TRUE(reader.lock(error, DBMode::READ_ONLY)) << error;
+  EXPECT_FALSE(reader.lock(error, DBMode::READ_ONLY));
+  EXPECT_NE(error.find("already held by this object"), std::string::npos);
+  reader.unlock();
+
+  FileLock writer(db_dir.string());
+  ASSERT_TRUE(writer.lock(error, DBMode::READ_WRITE)) << error;
+  writer.unlock();
+
+  std::filesystem::remove_all(db_dir);
+}
+
 TEST(FileLockTest, ClosingOneReaderKeepsProcessLock) {
   const auto db_dir = std::filesystem::temp_directory_path() /
                       ("neug_file_lock_test_" + std::to_string(::getpid()));

--- a/tests/storage/test_checkpoint.cc
+++ b/tests/storage/test_checkpoint.cc
@@ -14,6 +14,10 @@
  */
 
 #include <gtest/gtest.h>
+#include <poll.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
 #include <algorithm>
 #include <array>
 #include <cstring>
@@ -1293,6 +1297,126 @@ TEST(CheckpointFileManagerTest,
   EXPECT_EQ(container->GetDataSize(), 0u);
   EXPECT_FALSE(std::filesystem::exists(runtime_path));
   EXPECT_TRUE(std::filesystem::exists(committed_snapshot));
+}
+
+TEST(CheckpointFileManagerTest,
+     ConcurrentProcessesOpenSnapshotIntoDistinctRuntimeFiles) {
+  auto db_path = make_checkpoint_gc_test_dir("checkpoint_file_manager");
+  auto snapshot_dir = std::filesystem::path(db_path) / "snapshot";
+  auto runtime_dir = std::filesystem::path(db_path) / "runtime";
+  std::filesystem::create_directories(snapshot_dir);
+  std::filesystem::create_directories(runtime_dir);
+
+  std::string source_snapshot;
+  {
+    neug::CheckpointFileManager mgr(snapshot_dir.string(),
+                                    runtime_dir.string());
+    auto source =
+        mgr.CreateRuntimeContainer(64, neug::MemoryLevel::kSyncToFile);
+    write_container_payload(*source, "concurrent-open");
+    source_snapshot = mgr.Commit(*source);
+  }
+
+  int start_pipe[2];
+  int release_pipe[2];
+  int first_result_pipe[2];
+  int second_result_pipe[2];
+  ASSERT_EQ(::pipe(start_pipe), 0);
+  ASSERT_EQ(::pipe(release_pipe), 0);
+  ASSERT_EQ(::pipe(first_result_pipe), 0);
+  ASSERT_EQ(::pipe(second_result_pipe), 0);
+
+  const auto spawn_reader = [&](int result_pipe[2]) {
+    const pid_t pid = ::fork();
+    if (pid != 0) {
+      ::close(result_pipe[1]);
+      return pid;
+    }
+
+    ::close(start_pipe[1]);
+    ::close(release_pipe[1]);
+    ::close(result_pipe[0]);
+    char signal = 0;
+    if (::read(start_pipe[0], &signal, 1) != 1) {
+      ::_exit(1);
+    }
+
+    std::string runtime_path;
+    std::shared_ptr<neug::IDataContainer> container;
+    try {
+      neug::CheckpointFileManager mgr(snapshot_dir.string(),
+                                      runtime_dir.string());
+      container = mgr.OpenFile(source_snapshot, neug::MemoryLevel::kSyncToFile);
+      runtime_path = container->GetPath();
+    } catch (...) {}
+
+    const uint32_t path_size = static_cast<uint32_t>(runtime_path.size());
+    bool reported =
+        ::write(result_pipe[1], &path_size, sizeof(path_size)) ==
+            sizeof(path_size) &&
+        (path_size == 0 ||
+         ::write(result_pipe[1], runtime_path.data(), path_size) == path_size);
+    if (reported) {
+      (void) ::read(release_pipe[0], &signal, 1);
+    }
+    container.reset();
+    ::_exit(reported && path_size > 0 ? 0 : 1);
+  };
+
+  const pid_t first = spawn_reader(first_result_pipe);
+  ASSERT_GT(first, 0);
+  const pid_t second = spawn_reader(second_result_pipe);
+  ASSERT_GT(second, 0);
+  ::close(start_pipe[0]);
+  ::close(release_pipe[0]);
+  ASSERT_EQ(::write(start_pipe[1], "12", 2), 2);
+  ::close(start_pipe[1]);
+
+  const auto read_path = [](int fd) {
+    pollfd ready{fd, POLLIN, 0};
+    if (::poll(&ready, 1, 5000) != 1) {
+      return std::string{};
+    }
+    uint32_t path_size = 0;
+    if (::read(fd, &path_size, sizeof(path_size)) != sizeof(path_size) ||
+        path_size == 0) {
+      return std::string{};
+    }
+    std::string path(path_size, '\0');
+    size_t offset = 0;
+    while (offset < path.size()) {
+      auto bytes = ::read(fd, path.data() + offset, path.size() - offset);
+      if (bytes <= 0) {
+        return std::string{};
+      }
+      offset += static_cast<size_t>(bytes);
+    }
+    return path;
+  };
+
+  auto first_path = read_path(first_result_pipe[0]);
+  auto second_path = read_path(second_result_pipe[0]);
+  EXPECT_FALSE(first_path.empty());
+  EXPECT_FALSE(second_path.empty());
+  EXPECT_NE(first_path, second_path);
+  EXPECT_TRUE(std::filesystem::exists(first_path));
+  EXPECT_TRUE(std::filesystem::exists(second_path));
+
+  ASSERT_EQ(::write(release_pipe[1], "12", 2), 2);
+  ::close(release_pipe[1]);
+  ::close(first_result_pipe[0]);
+  ::close(second_result_pipe[0]);
+
+  int first_status = 0;
+  int second_status = 0;
+  ASSERT_EQ(::waitpid(first, &first_status, 0), first);
+  ASSERT_EQ(::waitpid(second, &second_status, 0), second);
+  EXPECT_TRUE(WIFEXITED(first_status));
+  EXPECT_EQ(WEXITSTATUS(first_status), 0);
+  EXPECT_TRUE(WIFEXITED(second_status));
+  EXPECT_EQ(WEXITSTATUS(second_status), 0);
+  EXPECT_FALSE(std::filesystem::exists(first_path));
+  EXPECT_FALSE(std::filesystem::exists(second_path));
 }
 
 TEST(CheckpointFileManagerTest,

--- a/tests/storage/test_checkpoint.cc
+++ b/tests/storage/test_checkpoint.cc
@@ -1085,6 +1085,9 @@ TEST(CheckpointGCTest, neugdb_readonly_open_does_not_recover_workspace) {
                               "runtime" /
                               "00000000-0000-0000-0000-000000000001";
   write_raw_file(orphan_runtime.string(), "reader-owned-runtime");
+  const auto orphan_runtime_copy =
+      std::filesystem::path(orphan_runtime.string() + ".copy-123-0");
+  write_raw_file(orphan_runtime_copy.string(), "interrupted-copy");
 
   neug::NeugDBConfig config(db_path);
   config.mode = neug::DBMode::READ_ONLY;
@@ -1099,6 +1102,7 @@ TEST(CheckpointGCTest, neugdb_readonly_open_does_not_recover_workspace) {
   EXPECT_TRUE(std::filesystem::exists(bad_path));
   EXPECT_TRUE(std::filesystem::exists(staging));
   EXPECT_TRUE(std::filesystem::exists(orphan_runtime));
+  EXPECT_TRUE(std::filesystem::exists(orphan_runtime_copy));
 
   // A writer holds the exclusive database lock, so it can safely recover
   // runtime files left behind by readers that exited without RAII cleanup.
@@ -1107,6 +1111,7 @@ TEST(CheckpointGCTest, neugdb_readonly_open_does_not_recover_workspace) {
   writer.Open(write_config);
   writer.Close();
   EXPECT_FALSE(std::filesystem::exists(orphan_runtime));
+  EXPECT_FALSE(std::filesystem::exists(orphan_runtime_copy));
 }
 
 TEST(CheckpointGCTest,

--- a/tests/storage/test_checkpoint.cc
+++ b/tests/storage/test_checkpoint.cc
@@ -35,6 +35,7 @@
 #include "column_assertions.h"
 #include "neug/config.h"
 #include "neug/main/connection.h"
+#include "neug/main/file_lock.h"
 #include "neug/main/neug_db.h"
 #include "neug/server/neug_db_service.h"
 #include "neug/storages/allocators.h"
@@ -1060,14 +1061,9 @@ TEST(CheckpointGCTest, neugdb_readonly_open_does_not_recover_workspace) {
     create_valid_checkpoint(mgr);
     mgr.Close();
   }
-  {
-    // Initialize the process lock through the public DB path. Read-only opens
-    // intentionally do not create the lock file themselves.
-    neug::NeugDB initializer;
-    neug::NeugDBConfig init_config(db_path);
-    initializer.Open(init_config);
-    initializer.Close();
-  }
+  const auto lock_path =
+      std::filesystem::path(db_path) / neug::FileLock::LOCK_FILE_NAME;
+  ASSERT_FALSE(std::filesystem::exists(lock_path));
 
   auto bad_path = std::filesystem::path(db_path) / "checkpoint-1";
   auto bad_ckp = neug::Checkpoint::Open(bad_path.string(), 1);
@@ -1098,6 +1094,7 @@ TEST(CheckpointGCTest, neugdb_readonly_open_does_not_recover_workspace) {
   db.Open(config);
   db.Close();
 
+  EXPECT_TRUE(std::filesystem::exists(lock_path));
   EXPECT_TRUE(std::filesystem::exists(db_path + "/checkpoint-0"));
   EXPECT_TRUE(std::filesystem::exists(bad_path));
   EXPECT_TRUE(std::filesystem::exists(staging));

--- a/tests/storage/test_checkpoint.cc
+++ b/tests/storage/test_checkpoint.cc
@@ -1056,6 +1056,14 @@ TEST(CheckpointGCTest, neugdb_readonly_open_does_not_recover_workspace) {
     create_valid_checkpoint(mgr);
     mgr.Close();
   }
+  {
+    // Initialize the process lock through the public DB path. Read-only opens
+    // intentionally do not create the lock file themselves.
+    neug::NeugDB initializer;
+    neug::NeugDBConfig init_config(db_path);
+    initializer.Open(init_config);
+    initializer.Close();
+  }
 
   auto bad_path = std::filesystem::path(db_path) / "checkpoint-1";
   auto bad_ckp = neug::Checkpoint::Open(bad_path.string(), 1);
@@ -1073,6 +1081,11 @@ TEST(CheckpointGCTest, neugdb_readonly_open_does_not_recover_workspace) {
   auto staging = std::filesystem::path(db_path) / "checkpoint-999.next";
   std::filesystem::create_directories(staging);
 
+  const auto orphan_runtime = std::filesystem::path(db_path) / "checkpoint-0" /
+                              "runtime" /
+                              "00000000-0000-0000-0000-000000000001";
+  write_raw_file(orphan_runtime.string(), "reader-owned-runtime");
+
   neug::NeugDBConfig config(db_path);
   config.mode = neug::DBMode::READ_ONLY;
   config.checkpoint_on_close = false;
@@ -1084,6 +1097,15 @@ TEST(CheckpointGCTest, neugdb_readonly_open_does_not_recover_workspace) {
   EXPECT_TRUE(std::filesystem::exists(db_path + "/checkpoint-0"));
   EXPECT_TRUE(std::filesystem::exists(bad_path));
   EXPECT_TRUE(std::filesystem::exists(staging));
+  EXPECT_TRUE(std::filesystem::exists(orphan_runtime));
+
+  // A writer holds the exclusive database lock, so it can safely recover
+  // runtime files left behind by readers that exited without RAII cleanup.
+  neug::NeugDB writer;
+  neug::NeugDBConfig write_config(db_path);
+  writer.Open(write_config);
+  writer.Close();
+  EXPECT_FALSE(std::filesystem::exists(orphan_runtime));
 }
 
 TEST(CheckpointGCTest,
@@ -1286,6 +1308,7 @@ TEST(CheckpointFileManagerTest,
   {
     auto file = mgr.CreateRuntimeFile();
     abandoned_path = file.path();
+    ASSERT_TRUE(std::filesystem::exists(abandoned_path));
     write_raw_file(abandoned_path, "abandoned");
     ASSERT_TRUE(std::filesystem::exists(abandoned_path));
   }

--- a/tests/unittest/test_connection.cc
+++ b/tests/unittest/test_connection.cc
@@ -34,8 +34,10 @@
 #include "neug/compiler/main/metadata_registry.h"
 #include "neug/compiler/transaction/transaction.h"
 #include "neug/main/connection.h"
+#include "neug/main/file_lock.h"
 #include "neug/main/neug_db.h"
 #include "neug/storages/graph/graph_interface.h"
+#include "neug/utils/exception/exception.h"
 #include "unittest/utils.h"
 
 namespace neug {
@@ -220,6 +222,12 @@ TEST(ConnectionReadOnlyTest, MultipleProcessesShareDatabase) {
   }
   ASSERT_TRUE(std::filesystem::exists(allocator_marker));
 
+  NeugDBConfig parent_read_config(db_dir.string(), 1);
+  parent_read_config.mode = DBMode::READ_ONLY;
+  parent_read_config.memory_level = MemoryLevel::kSyncToFile;
+  NeugDB parent_reader;
+  ASSERT_TRUE(parent_reader.Open(parent_read_config));
+
   int ready_pipe[2];
   int release_pipe[2];
   ASSERT_EQ(::pipe(ready_pipe), 0);
@@ -291,6 +299,14 @@ TEST(ConnectionReadOnlyTest, MultipleProcessesShareDatabase) {
   }
   EXPECT_TRUE(std::filesystem::exists(allocator_marker));
 
+  // The children were forked while this reader was open. After releasing the
+  // parent's lock, their independently reacquired locks must still exclude a
+  // writer.
+  parent_reader.Close();
+  std::string lock_error;
+  FileLock writer(db_dir.string());
+  EXPECT_FALSE(writer.lock(lock_error, DBMode::READ_WRITE));
+
   ::close(release_pipe[1]);
   const auto wait_for_child = [](pid_t child_pid) {
     int status = 0;
@@ -315,8 +331,80 @@ TEST(ConnectionReadOnlyTest, MultipleProcessesShareDatabase) {
     EXPECT_FALSE(std::filesystem::exists(path));
   }
   EXPECT_TRUE(std::filesystem::exists(allocator_marker));
+  ASSERT_TRUE(writer.lock(lock_error, DBMode::READ_WRITE)) << lock_error;
+  writer.unlock();
 
   ::close(ready_pipe[0]);
+  std::filesystem::remove_all(db_dir);
+}
+
+// weakly_canonical normalizes the data directory before locking, so opening
+// the same database through a symlink resolves to the same lock-table entry.
+TEST(ConnectionReadOnlyTest, SymlinkedDirectoryResolvesToSameLockEntry) {
+  const auto db_dir =
+      std::filesystem::temp_directory_path() /
+      ("neug_symlink_lock_db_test_" + std::to_string(::getpid()));
+  const auto link_dir =
+      std::filesystem::temp_directory_path() /
+      ("neug_symlink_lock_link_test_" + std::to_string(::getpid()));
+  std::filesystem::remove_all(db_dir);
+  std::filesystem::remove_all(link_dir);
+
+  NeugDBConfig write_config(db_dir.string(), 1);
+  write_config.checkpoint_on_close = true;
+  write_config.memory_level = MemoryLevel::kInMemory;
+  {
+    NeugDB db;
+    ASSERT_TRUE(db.Open(write_config));
+    auto connection = db.Connect();
+    ASSERT_TRUE(connection->Query(
+        "CREATE NODE TABLE person(id INT64, PRIMARY KEY(id));", "schema"));
+    connection->Close();
+    db.Close();
+  }
+
+  std::filesystem::create_directory_symlink(db_dir, link_dir);
+
+  // A writer opened through the real path conflicts with a read-only open
+  // through the symlink.
+  {
+    NeugDB writer;
+    ASSERT_TRUE(writer.Open(write_config));
+
+    NeugDBConfig symlink_read_config(link_dir.string(), 1);
+    symlink_read_config.mode = DBMode::READ_ONLY;
+    symlink_read_config.memory_level = MemoryLevel::kSyncToFile;
+    NeugDB symlink_reader;
+    EXPECT_THROW(symlink_reader.Open(symlink_read_config),
+                 neug::exception::DatabaseLockedException);
+
+    writer.Close();
+  }
+
+  // Read-only opens through the real path and the symlink share the lock
+  // entry and coexist.
+  {
+    NeugDBConfig read_config(db_dir.string(), 1);
+    read_config.mode = DBMode::READ_ONLY;
+    read_config.memory_level = MemoryLevel::kSyncToFile;
+    NeugDB first_reader;
+    ASSERT_TRUE(first_reader.Open(read_config));
+
+    NeugDBConfig symlink_read_config(link_dir.string(), 1);
+    symlink_read_config.mode = DBMode::READ_ONLY;
+    symlink_read_config.memory_level = MemoryLevel::kSyncToFile;
+    NeugDB second_reader;
+    ASSERT_TRUE(second_reader.Open(symlink_read_config));
+
+    auto connection = second_reader.Connect();
+    ASSERT_NE(connection, nullptr);
+    EXPECT_TRUE(connection->Query("MATCH (n:person) RETURN count(n);", "read"));
+    connection->Close();
+    second_reader.Close();
+    first_reader.Close();
+  }
+
+  std::filesystem::remove_all(link_dir);
   std::filesystem::remove_all(db_dir);
 }
 

--- a/tests/unittest/test_connection.cc
+++ b/tests/unittest/test_connection.cc
@@ -408,6 +408,75 @@ TEST(ConnectionReadOnlyTest, SymlinkedDirectoryResolvesToSameLockEntry) {
   std::filesystem::remove_all(db_dir);
 }
 
+// Two processes opening the same database read-only at the same time must
+// both succeed: they race on the fcntl lock and on the O_EXCL runtime-file
+// reservation, and the retries must converge instead of failing.
+TEST(ConnectionReadOnlyTest, ConcurrentProcessesOpenDatabaseSimultaneously) {
+  const auto db_dir =
+      std::filesystem::temp_directory_path() /
+      ("neug_concurrent_open_test_" + std::to_string(::getpid()));
+  std::filesystem::remove_all(db_dir);
+
+  NeugDBConfig write_config(db_dir.string(), 1);
+  write_config.checkpoint_on_close = true;
+  write_config.memory_level = MemoryLevel::kInMemory;
+  {
+    NeugDB db;
+    ASSERT_TRUE(db.Open(write_config));
+    auto connection = db.Connect();
+    ASSERT_TRUE(connection->Query(
+        "CREATE NODE TABLE person(id INT64, PRIMARY KEY(id));", "schema"));
+    connection->Close();
+    db.Close();
+  }
+
+  int start_pipe[2];
+  ASSERT_EQ(::pipe(start_pipe), 0);
+
+  pid_t children[2];
+  for (auto& child_pid : children) {
+    const pid_t pid = ::fork();
+    ASSERT_GE(pid, 0);
+    if (pid == 0) {
+      ::close(start_pipe[1]);
+      char token = 0;
+      // Block until the parent closes the write end, releasing every child
+      // at the same moment to start the open race.
+      while (::read(start_pipe[0], &token, 1) == -1 && errno == EINTR) {}
+      ::close(start_pipe[0]);
+
+      char status = '0';
+      try {
+        NeugDBConfig read_config(db_dir.string(), 1);
+        read_config.mode = DBMode::READ_ONLY;
+        read_config.memory_level = MemoryLevel::kSyncToFile;
+        NeugDB db;
+        const bool opened = db.Open(read_config);
+        auto connection = db.Connect();
+        const bool queried =
+            connection->Query("MATCH (n:person) RETURN count(n);", "read")
+                .has_value();
+        status = opened && queried ? '1' : '0';
+        db.Close();
+      } catch (...) {}
+      ::_exit(status == '1' ? 0 : 1);
+    }
+    child_pid = pid;
+  }
+  ::close(start_pipe[0]);
+  // Let both children block on the pipe, then release them simultaneously.
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  ::close(start_pipe[1]);
+
+  for (const auto child_pid : children) {
+    int status = 0;
+    ASSERT_EQ(::waitpid(child_pid, &status, 0), child_pid);
+    EXPECT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 0);
+  }
+  std::filesystem::remove_all(db_dir);
+}
+
 // Explicit access_mode=read: read-only CALL is allowed, mutating CALL is not.
 TEST_F(ConnectionTest, TestExplicitReadAccessModeForCall) {
   NeugDB db;

--- a/tests/unittest/test_connection.cc
+++ b/tests/unittest/test_connection.cc
@@ -13,8 +13,20 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <signal.h>
+#include <sys/wait.h>
+
+#include <atomic>
+#include <chrono>
 #include <filesystem>
+#include <string>
+#include <thread>
+
+#include <poll.h>
+
+#include <gtest/gtest.h>
 
 #include "neug/compiler/extension/extension_api.h"
 #include "neug/compiler/function/neug_call_function.h"
@@ -176,6 +188,104 @@ TEST_F(ConnectionTest, ReadOnlyConnectionsExecuteConcurrently) {
 
   EXPECT_EQ(successful_queries.load(),
             kConnectionCount * kQueriesPerConnection);
+}
+
+TEST(ConnectionReadOnlyTest, MultipleProcessesShareDatabase) {
+  const auto db_dir =
+      std::filesystem::temp_directory_path() /
+      ("neug_read_only_process_test_" + std::to_string(::getpid()));
+  std::filesystem::remove_all(db_dir);
+
+  NeugDBConfig write_config(db_dir.string(), 1);
+  write_config.checkpoint_on_close = true;
+  write_config.memory_level = MemoryLevel::kInMemory;
+  {
+    NeugDB db;
+    ASSERT_TRUE(db.Open(write_config));
+    auto connection = db.Connect();
+    ASSERT_TRUE(connection->Query(
+        "CREATE NODE TABLE person(id INT64, PRIMARY KEY(id));", "schema"));
+    connection->Close();
+    db.Close();
+  }
+
+  int ready_pipe[2];
+  int release_pipe[2];
+  ASSERT_EQ(::pipe(ready_pipe), 0);
+  ASSERT_EQ(::pipe(release_pipe), 0);
+
+  const auto child = [&]() -> pid_t {
+    const pid_t pid = ::fork();
+    if (pid != 0) {
+      return pid;
+    }
+    ::close(ready_pipe[0]);
+    ::close(release_pipe[1]);
+    NeugDBConfig read_config(db_dir.string(), 1);
+    read_config.mode = DBMode::READ_ONLY;
+    read_config.memory_level = MemoryLevel::kSyncToFile;
+    char status = '0';
+    NeugDB db;
+    try {
+      const bool opened = db.Open(read_config);
+      auto connection = db.Connect();
+      const bool queried =
+          connection->Query("MATCH (n:person) RETURN count(n);", "read")
+              .has_value();
+      status = opened && queried ? '1' : '0';
+    } catch (...) {}
+    (void) ::write(ready_pipe[1], &status, 1);
+    char release = 0;
+    (void) ::read(release_pipe[0], &release, 1);
+    if (status == '1') {
+      db.Close();
+    }
+    ::_exit(status == '1' ? 0 : 1);
+  };
+
+  const pid_t first = child();
+  const pid_t second = child();
+  EXPECT_GT(first, 0);
+  EXPECT_GT(second, 0);
+  ::close(ready_pipe[1]);
+  ::close(release_pipe[0]);
+
+  const auto read_status = [&]() {
+    pollfd fd{ready_pipe[0], POLLIN, 0};
+    char status = '0';
+    if (::poll(&fd, 1, 5000) == 1 && ::read(ready_pipe[0], &status, 1) == 1) {
+      return status;
+    }
+    return '0';
+  };
+  const char first_ready = read_status();
+  const char second_ready = read_status();
+  EXPECT_EQ(first_ready, '1');
+  EXPECT_EQ(second_ready, '1');
+
+  ::close(release_pipe[1]);
+  const auto wait_for_child = [](pid_t child_pid) {
+    int status = 0;
+    for (int attempt = 0; attempt < 50; ++attempt) {
+      const auto result = ::waitpid(child_pid, &status, WNOHANG);
+      if (result == child_pid || result == -1) {
+        return status;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    (void) ::kill(child_pid, SIGKILL);
+    (void) ::waitpid(child_pid, &status, 0);
+    return status;
+  };
+  const int first_status = wait_for_child(first);
+  const int second_status = wait_for_child(second);
+  EXPECT_TRUE(WIFEXITED(first_status));
+  EXPECT_EQ(WEXITSTATUS(first_status), 0);
+  EXPECT_TRUE(WIFEXITED(second_status));
+  EXPECT_EQ(WEXITSTATUS(second_status), 0);
+
+  ::close(ready_pipe[0]);
+  std::filesystem::remove_all(db_dir);
 }
 
 // Explicit access_mode=read: read-only CALL is allowed, mutating CALL is not.

--- a/tests/unittest/test_connection.cc
+++ b/tests/unittest/test_connection.cc
@@ -21,6 +21,7 @@
 #include <atomic>
 #include <chrono>
 #include <filesystem>
+#include <fstream>
 #include <string>
 #include <thread>
 
@@ -209,6 +210,16 @@ TEST(ConnectionReadOnlyTest, MultipleProcessesShareDatabase) {
     db.Close();
   }
 
+  const auto allocator_marker =
+      db_dir / "checkpoint-1" / "allocator" / "read_only_marker";
+  ASSERT_TRUE(std::filesystem::is_directory(allocator_marker.parent_path()));
+  {
+    std::ofstream marker(allocator_marker);
+    ASSERT_TRUE(marker.is_open());
+    marker << "preserve across read-only opens";
+  }
+  ASSERT_TRUE(std::filesystem::exists(allocator_marker));
+
   int ready_pipe[2];
   int release_pipe[2];
   ASSERT_EQ(::pipe(ready_pipe), 0);
@@ -262,6 +273,7 @@ TEST(ConnectionReadOnlyTest, MultipleProcessesShareDatabase) {
   const char second_ready = read_status();
   EXPECT_EQ(first_ready, '1');
   EXPECT_EQ(second_ready, '1');
+  EXPECT_TRUE(std::filesystem::exists(allocator_marker));
 
   ::close(release_pipe[1]);
   const auto wait_for_child = [](pid_t child_pid) {
@@ -283,6 +295,7 @@ TEST(ConnectionReadOnlyTest, MultipleProcessesShareDatabase) {
   EXPECT_EQ(WEXITSTATUS(first_status), 0);
   EXPECT_TRUE(WIFEXITED(second_status));
   EXPECT_EQ(WEXITSTATUS(second_status), 0);
+  EXPECT_TRUE(std::filesystem::exists(allocator_marker));
 
   ::close(ready_pipe[0]);
   std::filesystem::remove_all(db_dir);

--- a/tests/unittest/test_connection.cc
+++ b/tests/unittest/test_connection.cc
@@ -254,13 +254,6 @@ TEST(ConnectionReadOnlyTest, MultipleProcessesShareDatabase) {
     ::_exit(status == '1' ? 0 : 1);
   };
 
-  const pid_t first = child();
-  const pid_t second = child();
-  EXPECT_GT(first, 0);
-  EXPECT_GT(second, 0);
-  ::close(ready_pipe[1]);
-  ::close(release_pipe[0]);
-
   const auto read_status = [&]() {
     pollfd fd{ready_pipe[0], POLLIN, 0};
     char status = '0';
@@ -269,10 +262,33 @@ TEST(ConnectionReadOnlyTest, MultipleProcessesShareDatabase) {
     }
     return '0';
   };
+
+  // Fully open the first reader before starting the second. This ensures the
+  // second Checkpoint::Open sees the first process's active runtime files and
+  // exercises the cross-process orphan-cleanup race deterministically.
+  const pid_t first = child();
+  EXPECT_GT(first, 0);
   const char first_ready = read_status();
-  const char second_ready = read_status();
   EXPECT_EQ(first_ready, '1');
+
+  std::vector<std::filesystem::path> first_runtime_files;
+  const auto runtime_dir = db_dir / "checkpoint-1" / "runtime";
+  for (const auto& entry : std::filesystem::directory_iterator(runtime_dir)) {
+    if (entry.is_regular_file()) {
+      first_runtime_files.emplace_back(entry.path());
+    }
+  }
+  EXPECT_FALSE(first_runtime_files.empty());
+
+  const pid_t second = child();
+  EXPECT_GT(second, 0);
+  ::close(ready_pipe[1]);
+  ::close(release_pipe[0]);
+  const char second_ready = read_status();
   EXPECT_EQ(second_ready, '1');
+  for (const auto& path : first_runtime_files) {
+    EXPECT_TRUE(std::filesystem::exists(path));
+  }
   EXPECT_TRUE(std::filesystem::exists(allocator_marker));
 
   ::close(release_pipe[1]);
@@ -295,6 +311,9 @@ TEST(ConnectionReadOnlyTest, MultipleProcessesShareDatabase) {
   EXPECT_EQ(WEXITSTATUS(first_status), 0);
   EXPECT_TRUE(WIFEXITED(second_status));
   EXPECT_EQ(WEXITSTATUS(second_status), 0);
+  for (const auto& path : first_runtime_files) {
+    EXPECT_FALSE(std::filesystem::exists(path));
+  }
   EXPECT_TRUE(std::filesystem::exists(allocator_marker));
 
   ::close(ready_pipe[0]);

--- a/tests/utils/test_file_utils.cc
+++ b/tests/utils/test_file_utils.cc
@@ -147,6 +147,40 @@ TEST_F(FileUtilsCopyTest, CopyFile_SparseFilePreservesContentAndSparseness) {
   }
 }
 
+TEST_F(FileUtilsCopyTest, CopyFile_OverwritesExistingDestination) {
+  const std::string src = path("src");
+  const std::string dst = path("dst");
+  ASSERT_NO_FATAL_FAILURE(make_file(src, {{0, "replacement"}}));
+  ASSERT_NO_FATAL_FAILURE(make_file(dst, {{0, "reservation"}}));
+
+  ASSERT_NO_THROW(file_utils::copy_file(src, dst, /*overwrite=*/true));
+  EXPECT_EQ(read_at(dst, 0, std::string("replacement").size()), "replacement");
+
+  const auto copy_prefix =
+      std::filesystem::path(dst).filename().string() + ".copy-";
+  for (const auto& entry : std::filesystem::directory_iterator(tmp_dir_)) {
+    EXPECT_FALSE(entry.path().filename().string().starts_with(copy_prefix))
+        << "temporary copy was not cleaned up: " << entry.path();
+  }
+}
+
+TEST_F(FileUtilsCopyTest, CopyFile_FailurePreservesExistingDestination) {
+  const std::string missing_src = path("missing");
+  const std::string dst = path("dst");
+  ASSERT_NO_FATAL_FAILURE(make_file(dst, {{0, "reservation"}}));
+
+  EXPECT_THROW(file_utils::copy_file(missing_src, dst, /*overwrite=*/true),
+               std::runtime_error);
+  EXPECT_EQ(read_at(dst, 0, std::string("reservation").size()), "reservation");
+
+  const auto copy_prefix =
+      std::filesystem::path(dst).filename().string() + ".copy-";
+  for (const auto& entry : std::filesystem::directory_iterator(tmp_dir_)) {
+    EXPECT_FALSE(entry.path().filename().string().starts_with(copy_prefix))
+        << "temporary copy was not cleaned up: " << entry.path();
+  }
+}
+
 // Direct test of fallback_copy on a sparse source. This is the core
 // regression test for issue #440 — without sparse-awareness, dst would
 // materialize the hole bytes and bloat to logical size. Necessary as a


### PR DESCRIPTION
## Summary

- share one `fcntl` lock descriptor per database path within a process and release it only after the final local reader closes
- reject repeated acquisition through the same `FileLock` handle so process-level references cannot leak
- open the lock file without write access in read-only mode and canonicalize database paths before tracking locks
- use transient in-memory allocators for read-only WAL replay so concurrent readers do not reset a shared allocator workspace
- add focused same-process lock-lifetime and cross-process `kSyncToFile` read-only regression tests

## Root cause

POSIX record locks are process-scoped: closing any descriptor for the same lock file can release the process lock. Each `FileLock` previously owned and closed its own descriptor, so closing one of multiple local readers could silently drop the lock protecting the remaining readers. Read-only open also created the lock file with write access and reset the checkpoint allocator directory.

## Impact

Multiple processes can open and query the same initialized database concurrently in read-only mode. Read-only processes may still use checkpoint `runtime/` files as temporary working state, but they no longer destructively share allocator backing.

## Validation

- `cmake --build build --target test_file_lock test_connection -j2`
- `build/tests/main/test_file_lock '--gtest_filter=FileLockTest.*'`
- `build/tests/unittest/test_connection --gtest_filter=ConnectionReadOnlyTest.MultipleProcessesShareDatabase`
- `git diff --check`

Closes #233
