### PR TITLE
refactor: upgrade packaging to manylinux_2_28 for Node.js 20 with C++11 ABI

### DIFF
--- a/.github/workflows/npm-build-test.yml
+++ b/.github/workflows/npm-build-test.yml
@@ -59,12 +59,12 @@ jobs:
             -u 1001:1001 \
             -v ${{ github.workspace }}:/project \
             -w /project \
-            neug-registry.cn-hongkong.cr.aliyuncs.com/neug/neug-manylinux:v0.1.3-x86_64 \
+            neug-registry.cn-hongkong.cr.aliyuncs.com/neug/neug-manylinux:v0.1.3-x86_64-node \
             sleep infinity
 
           docker exec ${{ env.CONTAINER_NAME }} bash -c '
             mkdir -p /home/neug/.local
-            curl -fsSL https://nodejs.org/dist/v16.0.0/node-v16.0.0-linux-x64.tar.xz \
+            curl -fsSL https://nodejs.org/dist/v20.0.0/node-v20.0.0-linux-x64.tar.xz \
               | tar -xJ -C /home/neug/.local --strip-components=1
             export PATH=/home/neug/.local/bin:$PATH
             cp /root/.neug_env /home/neug/.neug_env 2>/dev/null || true
@@ -151,12 +151,12 @@ jobs:
             -u 1001:1001 \
             -v ${{ github.workspace }}:/project \
             -w /project \
-            neug-registry.cn-hongkong.cr.aliyuncs.com/neug/neug-manylinux:v0.1.3-arm64 \
+            neug-registry.cn-hongkong.cr.aliyuncs.com/neug/neug-manylinux:v0.1.3-arm64-node \
             sleep infinity
 
           docker exec ${{ env.CONTAINER_NAME }} bash -c '
             mkdir -p /home/neug/.local
-            curl -fsSL https://nodejs.org/dist/v16.0.0/node-v16.0.0-linux-arm64.tar.xz \
+            curl -fsSL https://nodejs.org/dist/v20.0.0/node-v20.0.0-linux-arm64.tar.xz \
               | tar -xJ -C /home/neug/.local --strip-components=1
             export PATH=/home/neug/.local/bin:$PATH
             cp /root/.neug_env /home/neug/.neug_env 2>/dev/null || true
@@ -232,7 +232,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16.0.0'
+          node-version: '20'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/npm-package-test.yml
+++ b/.github/workflows/npm-package-test.yml
@@ -27,11 +27,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-15
-        node-version: ["16", "20", "24"]
-        # skip Node.js 24 on ubuntu-latest, requires C++11
-        exclude:
-          - os: ubuntu-latest
-            node-version: "24"
+        node-version: ["20", "22", "24"]
 
     steps:
       - name: checkout

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ pip install neug
 </details>
 
 <details>
-<summary><b>Node.js</b> &nbsp;·&nbsp; requires Node.js 18+ &nbsp;(since v0.1.3)</summary>
+<summary><b>Node.js</b> &nbsp;·&nbsp; requires Node.js 20+ &nbsp;(since v0.1.3)</summary>
 
 ```bash
 npm install @graphscope-neug/neug

--- a/doc/source/installation/installation.mdx
+++ b/doc/source/installation/installation.mdx
@@ -72,7 +72,7 @@ pip install --upgrade neug
 
 <Tab>
 
-**Requirements**: Node.js 18.0.0 or later (available since NeuG v0.1.3)
+**Requirements**: Node.js 20.0.0 or later (available since NeuG v0.1.3)
 
 ### Install
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -26,6 +26,7 @@ BUILD_PROGRESS  	?= auto
 
 # Base images and develop images
 .PHONY: neug-manylinux
+.PHONY: neug-manylinux-node
 
 all: neug-dev neug-manylinux neug-release
 
@@ -38,6 +39,15 @@ neug-manylinux:
 		--build-arg MANYLINUXVERSION=${MANYLINUXVERSION} \
 		-t neug/neug-manylinux:${ARCH}  \
 		-f ${DOCKERFILES_DIR}/neug-manylinux.Dockerfile .
+
+neug-manylinux-node:
+	cd .. && \
+	docker build \
+		--build-arg REGISTRY=$(REGISTRY) \
+		--build-arg PLATFORM=${PLATFORM} \
+		--build-arg ARCH=${ARCH} \
+		-t neug/neug-manylinux:v0.1.3-${ARCH}-node \
+		-f ${DOCKERFILES_DIR}/neug-manylinux-node.Dockerfile .
 
 neug-dev:
 	cd .. && \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -46,7 +46,7 @@ neug-manylinux-node:
 		--build-arg REGISTRY=$(REGISTRY) \
 		--build-arg PLATFORM=${PLATFORM} \
 		--build-arg ARCH=${ARCH} \
-		-t neug/neug-manylinux:v0.1.3-${ARCH}-node \
+		-t neug/neug-manylinux:${ARCH}-node \
 		-f ${DOCKERFILES_DIR}/neug-manylinux-node.Dockerfile .
 
 neug-dev:

--- a/docker/README.md
+++ b/docker/README.md
@@ -55,3 +55,19 @@ The `neug-release` image builds and installs a Python wheel. That wheel is a
 portable package artifact, so the release image build passes
 `NEUG_PACKAGE_BUILD=ON` and `NEUG_NATIVE_ARCH=OFF`. Development and manylinux
 images are build environments and do not force package mode by themselves.
+
+## manylinux_2_28 for node
+
+To support Node.js 20 and later, use the newer manylinux_2_28 images for Node.js
+package builds:
+
+```bash
+docker pull neug-registry.cn-hongkong.cr.aliyuncs.com/neug/neug-manylinux:v0.1.3-x86_64-node
+docker pull neug-registry.cn-hongkong.cr.aliyuncs.com/neug/neug-manylinux:v0.1.3-arm64-node
+```
+
+Build the image locally with:
+
+```bash
+make neug-manylinux-node
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -71,3 +71,10 @@ Build the image locally with:
 ```bash
 make neug-manylinux-node
 ```
+
+And tag the image before pushing it to the registry:
+
+```bash
+export ARCH=arm64 # x86_64
+docker tag neug/neug-manylinux:${ARCH}-node neug-registry.cn-hongkong.cr.aliyuncs.com/neug/neug-manylinux:v0.1.3-${ARCH}-node
+```

--- a/docker/neug-manylinux-node.Dockerfile
+++ b/docker/neug-manylinux-node.Dockerfile
@@ -1,0 +1,29 @@
+ARG ARCH=x86_64
+ARG REGISTRY=neug-registry.cn-hongkong.cr.aliyuncs.com
+ARG BASETAG=2026.03.13-2
+FROM quay.io/pypa/manylinux_2_28_$ARCH:${BASETAG} AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# shanghai zoneinfo
+ENV TZ=Asia/Shanghai
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
+    echo '$TZ' > /etc/timezone
+
+RUN useradd -m neug -u 1001 \
+    && echo 'neug ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+RUN mkdir /opt/neug /opt/vineyard && chown -R neug:neug /opt/neug /opt/vineyard
+# For output logs
+RUN mkdir -p /var/log/neug && chown -R neug:neug /var/log/neug
+
+COPY scripts/install_deps.sh /root/install_deps.sh
+RUN cd /root/ && bash install_deps.sh
+
+# change bash as default
+SHELL ["/bin/bash", "-c"]
+
+RUN echo ". ~/.neug_env" >> /root/.bashrc
+
+# Setup environment
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk

--- a/tools/nodejs_bind/README.md
+++ b/tools/nodejs_bind/README.md
@@ -4,11 +4,11 @@
 
 Same system dependencies as NeuG (CMake >= 3.16, C++20 compiler), plus:
 
-- Node.js >= 18.0.0
+- Node.js >= 20.0.0
 
 ### Installing Node.js
 
-NeuG Node.js bindings require **Node.js >= 18.0.0** (N-API v8). Install via nvm:
+NeuG Node.js bindings require **Node.js >= 20.0.0** (N-API v8). Install via nvm:
 
 ```bash
 # Install nvm
@@ -21,11 +21,11 @@ source ~/.zshrc
 
 # Install Node.js LTS (v22)
 nvm install --lts && nvm use --lts
-# Or install a specific version (>= 18)
-nvm install 18 && nvm use 18
+# Or install a specific version (>= 20)
+nvm install 20 && nvm use 20
 
 # Verify
-node -v   # should be >= 18.0.0
+node -v   # should be >= 20.0.0
 npm -v
 ```
 

--- a/tools/nodejs_bind/assets/package.json
+++ b/tools/nodejs_bind/assets/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/alibaba/neug.git"
   },
-  "engines": { "node": ">=16.0.0" },
+  "engines": { "node": ">=20.0.0" },
   "publishConfig": { "access": "public" },
   "optionalDependencies": {
     "@graphscope-neug/linux-x86_64": "0.1.3",

--- a/tools/nodejs_bind/package-lock.json
+++ b/tools/nodejs_bind/package-lock.json
@@ -12,7 +12,7 @@
         "node-addon-api": "^7.0.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/node-addon-api": {

--- a/tools/nodejs_bind/package.json
+++ b/tools/nodejs_bind/package.json
@@ -24,7 +24,7 @@
     "url": "git+https://github.com/alibaba/neug.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "node-addon-api": "^7.0.0"

--- a/tools/nodejs_bind/tests/test-shim.js
+++ b/tools/nodejs_bind/tests/test-shim.js
@@ -20,7 +20,8 @@ const path = require('path');
 const { fork } = require('child_process');
 
 /**
- * Minimal test shim compatible with Node.js 16 (no node:test built-in).
+ * Minimal test shim compatible with Node.js 20 (will migrate to the built-in
+ * node:test in the future).
  * Provides test(), before(), and after() with basic TAP-style output.
  * When run directly, discovers and aggregates all test_*.js files.
  */


### PR DESCRIPTION
## Summary

- add isolated manylinux_2_28 images for Linux npm package builds
- build Linux and macOS npm artifacts with Node.js 20
- test packaged artifacts with Node.js 20, 22, and 24
- raise the minimum supported Node.js version to 20 in package metadata and documentation

## Validation

- git diff --check
- parsed the modified workflow YAML and package JSON files
- npm pack --dry-run
- make -n -C docker neug-manylinux-node

Closes #859
Fixes #687
Fixes #850

Full CI test: https://github.com/Spockkk0225/neug/actions/runs/31482102036