### PR TITLE
fix: use std::atomic for unsorted_since_ in MutableCsr and ImmutableCsr

### DIFF
--- a/include/neug/storages/csr/immutable_csr.h
+++ b/include/neug/storages/csr/immutable_csr.h
@@ -117,9 +117,9 @@ class ImmutableCsr : public TypedCsrBase<EDATA_T> {
     cow_clone->adj_list_buffer_ = adj_list_buffer_;
     cow_clone->degree_list_buffer_ = degree_list_buffer_;
     cow_clone->nbr_list_buffer_ = nbr_list_buffer_;
-    cow_clone->unsorted_since_.store(unsorted_since_.load(
-        std::memory_order_relaxed),
-                                     std::memory_order_relaxed);
+    cow_clone->unsorted_since_.store(
+        unsorted_since_.load(std::memory_order_relaxed),
+        std::memory_order_relaxed);
     cow_clone->edge_num_ = edge_num_.load();
     return cow_clone;
   }

--- a/include/neug/storages/csr/immutable_csr.h
+++ b/include/neug/storages/csr/immutable_csr.h
@@ -49,10 +49,13 @@ class ImmutableCsr : public TypedCsrBase<EDATA_T> {
     return CsrView(reinterpret_cast<const char*>(adj_list_buffer_->GetData()),
                    reinterpret_cast<const int*>(degree_list_buffer_->GetData()),
                    cfg, std::numeric_limits<timestamp_t>::max() - 1,
-                   unsorted_since_, prefetch_policy_);
+                   unsorted_since_.load(std::memory_order_relaxed),
+                   prefetch_policy_);
   }
 
-  timestamp_t unsorted_since() const override { return unsorted_since_; }
+  timestamp_t unsorted_since() const override {
+    return unsorted_since_.load(std::memory_order_relaxed);
+  }
 
   size_t size() const override {
     return degree_list_buffer_
@@ -114,7 +117,9 @@ class ImmutableCsr : public TypedCsrBase<EDATA_T> {
     cow_clone->adj_list_buffer_ = adj_list_buffer_;
     cow_clone->degree_list_buffer_ = degree_list_buffer_;
     cow_clone->nbr_list_buffer_ = nbr_list_buffer_;
-    cow_clone->unsorted_since_ = unsorted_since_;
+    cow_clone->unsorted_since_.store(unsorted_since_.load(
+        std::memory_order_relaxed),
+                                     std::memory_order_relaxed);
     cow_clone->edge_num_ = edge_num_.load();
     return cow_clone;
   }
@@ -134,7 +139,7 @@ class ImmutableCsr : public TypedCsrBase<EDATA_T> {
   std::shared_ptr<IDataContainer> adj_list_buffer_;
   std::shared_ptr<IDataContainer> degree_list_buffer_;
   std::shared_ptr<IDataContainer> nbr_list_buffer_;
-  timestamp_t unsorted_since_;
+  std::atomic<timestamp_t> unsorted_since_;
   std::atomic<uint64_t> edge_num_{0};
   CsrPrefetchPolicy prefetch_policy_;
 

--- a/include/neug/storages/csr/mutable_csr.h
+++ b/include/neug/storages/csr/mutable_csr.h
@@ -68,10 +68,13 @@ class MutableCsr : public TypedCsrBase<EDATA_T> {
     cfg.data_offset = offsetof(nbr_t, data);
     return CsrView(reinterpret_cast<const char*>(adj_list_buffer_->GetData()),
                    reinterpret_cast<const int*>(degree_list_->GetData()), cfg,
-                   ts, unsorted_since_, prefetch_policy_);
+                   ts, unsorted_since_.load(std::memory_order_relaxed),
+                   prefetch_policy_);
   }
 
-  timestamp_t unsorted_since() const override { return unsorted_since_; }
+  timestamp_t unsorted_since() const override {
+    return unsorted_since_.load(std::memory_order_relaxed);
+  }
 
   size_t size() const override { return vertex_capacity(); }
 
@@ -143,8 +146,8 @@ class MutableCsr : public TypedCsrBase<EDATA_T> {
     nbr.timestamp.store(ts);
     edge_num_.fetch_add(1);
     // invalidate sort flag
-    if (ts < unsorted_since_) {
-      unsorted_since_ = 0;
+    if (ts < unsorted_since_.load(std::memory_order_relaxed)) {
+      unsorted_since_.store(0, std::memory_order_relaxed);
     }
     const void* data_ptr = static_cast<const void*>(&nbr.data);
     sizes[src].store(sz + 1, std::memory_order_release);
@@ -215,7 +218,9 @@ class MutableCsr : public TypedCsrBase<EDATA_T> {
     cow_clone->degree_list_ = degree_list_;
     cow_clone->cap_list_ = cap_list_;
     cow_clone->nbr_list_ = nbr_list_;
-    cow_clone->unsorted_since_ = unsorted_since_;
+    cow_clone->unsorted_since_.store(unsorted_since_.load(
+        std::memory_order_relaxed),
+                                     std::memory_order_relaxed);
     cow_clone->edge_num_ = edge_num_.load();
     return cow_clone;
   }
@@ -240,7 +245,7 @@ class MutableCsr : public TypedCsrBase<EDATA_T> {
   std::shared_ptr<IDataContainer> degree_list_;
   std::shared_ptr<IDataContainer> cap_list_;
   std::shared_ptr<IDataContainer> nbr_list_;
-  timestamp_t unsorted_since_;
+  std::atomic<timestamp_t> unsorted_since_;
   std::atomic<uint64_t> edge_num_{0};
   CsrPrefetchPolicy prefetch_policy_;
 

--- a/include/neug/storages/csr/mutable_csr.h
+++ b/include/neug/storages/csr/mutable_csr.h
@@ -218,9 +218,9 @@ class MutableCsr : public TypedCsrBase<EDATA_T> {
     cow_clone->degree_list_ = degree_list_;
     cow_clone->cap_list_ = cap_list_;
     cow_clone->nbr_list_ = nbr_list_;
-    cow_clone->unsorted_since_.store(unsorted_since_.load(
-        std::memory_order_relaxed),
-                                     std::memory_order_relaxed);
+    cow_clone->unsorted_since_.store(
+        unsorted_since_.load(std::memory_order_relaxed),
+        std::memory_order_relaxed);
     cow_clone->edge_num_ = edge_num_.load();
     return cow_clone;
   }

--- a/src/storages/csr/immutable_csr.cc
+++ b/src/storages/csr/immutable_csr.cc
@@ -40,10 +40,9 @@ namespace neug {
 template <typename EDATA_T>
 void ImmutableCsr<EDATA_T>::Open(Checkpoint& ckp, const ModuleDescriptor& desc,
                                  MemoryLevel memory_level) {
-  unsorted_since_.store(
-      static_cast<timestamp_t>(
-          std::stoull(desc.get("unsorted_since").value_or("0"))),
-      std::memory_order_relaxed);
+  unsorted_since_.store(static_cast<timestamp_t>(std::stoull(
+                            desc.get("unsorted_since").value_or("0"))),
+                        std::memory_order_relaxed);
   edge_num_.store(std::stoull(desc.get("edge_num").value_or("0")));
   degree_list_buffer_ = ckp.OpenFile(
       desc.get_path(ModuleDescriptor::kDegreeListPath).value_or(""),

--- a/src/storages/csr/immutable_csr.cc
+++ b/src/storages/csr/immutable_csr.cc
@@ -40,7 +40,10 @@ namespace neug {
 template <typename EDATA_T>
 void ImmutableCsr<EDATA_T>::Open(Checkpoint& ckp, const ModuleDescriptor& desc,
                                  MemoryLevel memory_level) {
-  unsorted_since_ = std::stoull(desc.get("unsorted_since").value_or("0"));
+  unsorted_since_.store(
+      static_cast<timestamp_t>(
+          std::stoull(desc.get("unsorted_since").value_or("0"))),
+      std::memory_order_relaxed);
   edge_num_.store(std::stoull(desc.get("edge_num").value_or("0")));
   degree_list_buffer_ = ckp.OpenFile(
       desc.get_path(ModuleDescriptor::kDegreeListPath).value_or(""),
@@ -79,7 +82,8 @@ void ImmutableCsr<EDATA_T>::Dump(Checkpoint& ckp, CheckpointManifest& meta,
                                  const std::string& key) {
   ModuleDescriptor desc;
   desc.module_type = ModuleTypeName();
-  desc.set("unsorted_since", std::to_string(unsorted_since_));
+  desc.set("unsorted_since",
+           std::to_string(unsorted_since_.load(std::memory_order_relaxed)));
   desc.set("edge_num", std::to_string(edge_num_.load()));
   desc.set_path(ModuleDescriptor::kDegreeListPath,
                 ckp.Commit(*degree_list_buffer_));
@@ -164,7 +168,7 @@ void ImmutableCsr<EDATA_T>::Close() {
 template <typename EDATA_T>
 void ImmutableCsr<EDATA_T>::batch_sort_by_edge_data(timestamp_t ts) {
   if (!degree_list_buffer_) {
-    unsorted_since_ = ts;
+    unsorted_since_.store(ts, std::memory_order_relaxed);
     return;
   }
   vid_t vnum = size();
@@ -176,7 +180,7 @@ void ImmutableCsr<EDATA_T>::batch_sort_by_edge_data(timestamp_t ts) {
         adj_arr[i], adj_arr[i] + deg_arr[i],
         [](const nbr_t& lhs, const nbr_t& rhs) { return lhs.data < rhs.data; });
   }
-  unsorted_since_ = ts;
+  unsorted_since_.store(ts, std::memory_order_relaxed);
 }
 
 template <typename EDATA_T>
@@ -225,7 +229,7 @@ void ImmutableCsr<EDATA_T>::batch_delete_vertices(
     adj_arr[i] = ptr;
     ptr += deg_arr[i];
   }
-  unsorted_since_ = 0;
+  unsorted_since_.store(0, std::memory_order_relaxed);
   refresh_prefetch_policy();
 }
 
@@ -263,7 +267,7 @@ void ImmutableCsr<EDATA_T>::batch_delete_edges(
       }
     }
   }
-  unsorted_since_ = 0;
+  unsorted_since_.store(0, std::memory_order_relaxed);
   refresh_prefetch_policy();
 }
 
@@ -294,7 +298,7 @@ void ImmutableCsr<EDATA_T>::batch_delete_edges(
       }
     }
   }
-  unsorted_since_ = 0;
+  unsorted_since_.store(0, std::memory_order_relaxed);
   refresh_prefetch_policy();
 }
 
@@ -314,7 +318,7 @@ void ImmutableCsr<EDATA_T>::delete_edge(vid_t src, int32_t offset,
   }
   nbrs[offset].neighbor = std::numeric_limits<vid_t>::max();
   edge_num_.fetch_sub(1, std::memory_order_relaxed);
-  unsorted_since_ = 0;
+  unsorted_since_.store(0, std::memory_order_relaxed);
 }
 
 template <typename EDATA_T>
@@ -370,8 +374,8 @@ void ImmutableCsr<EDATA_T>::batch_put_edges(
     edge_num_.fetch_add(1, std::memory_order_relaxed);
   }
   // invalidate sort flag
-  if (ts < unsorted_since_) {
-    unsorted_since_ = 0;
+  if (ts < unsorted_since_.load(std::memory_order_relaxed)) {
+    unsorted_since_.store(0, std::memory_order_relaxed);
   }
   refresh_prefetch_policy();
 }

--- a/src/storages/csr/mutable_csr.cc
+++ b/src/storages/csr/mutable_csr.cc
@@ -46,7 +46,10 @@ template <typename EDATA_T>
 void MutableCsr<EDATA_T>::Open(Checkpoint& ckp,
                                const ModuleDescriptor& descriptor,
                                MemoryLevel memory_level) {
-  unsorted_since_ = std::stoull(descriptor.get("unsorted_since").value_or("0"));
+  unsorted_since_.store(
+      static_cast<timestamp_t>(
+          std::stoull(descriptor.get("unsorted_since").value_or("0"))),
+      std::memory_order_relaxed);
   edge_num_.store(std::stoull(descriptor.get("edge_num").value_or("0")));
   degree_list_ = ckp.OpenFile(
       descriptor.get_path(ModuleDescriptor::kDegreeListPath).value_or(""),
@@ -121,7 +124,8 @@ void MutableCsr<EDATA_T>::Dump(Checkpoint& ckp, CheckpointManifest& meta,
                                const std::string& key) {
   ModuleDescriptor descriptor;
   descriptor.module_type = ModuleTypeName();
-  descriptor.set("unsorted_since", std::to_string(unsorted_since_));
+  descriptor.set("unsorted_since",
+                 std::to_string(unsorted_since_.load(std::memory_order_relaxed)));
   descriptor.set("edge_num", std::to_string(edge_num_.load()));
 
   size_t vnum = vertex_capacity();
@@ -272,7 +276,7 @@ void MutableCsr<EDATA_T>::batch_sort_by_edge_data(timestamp_t ts) {
       });
     }
   }
-  unsorted_since_ = ts;
+  unsorted_since_.store(ts, std::memory_order_relaxed);
 }
 
 template <typename EDATA_T>
@@ -326,7 +330,7 @@ void MutableCsr<EDATA_T>::batch_delete_vertices(
 
     sz_arr[src].store(cur_deg - removed, std::memory_order_relaxed);
   }
-  unsorted_since_ = 0;
+  unsorted_since_.store(0, std::memory_order_relaxed);
   refresh_prefetch_policy();
 }
 
@@ -360,7 +364,7 @@ void MutableCsr<EDATA_T>::batch_delete_edges(
       ++write_ptr;
     }
   }
-  unsorted_since_ = 0;
+  unsorted_since_.store(0, std::memory_order_relaxed);
   refresh_prefetch_policy();
 }
 
@@ -393,7 +397,7 @@ void MutableCsr<EDATA_T>::batch_delete_edges(
           std::numeric_limits<timestamp_t>::max());
     }
   }
-  unsorted_since_ = 0;
+  unsorted_since_.store(0, std::memory_order_relaxed);
   refresh_prefetch_policy();
 }
 
@@ -413,7 +417,7 @@ void MutableCsr<EDATA_T>::delete_edge(vid_t src, int32_t offset,
   if (old_ts <= ts) {
     nbrs[offset].timestamp.store(std::numeric_limits<timestamp_t>::max());
     edge_num_.fetch_sub(1, std::memory_order_relaxed);
-    unsorted_since_ = 0;
+    unsorted_since_.store(0, std::memory_order_relaxed);
   } else if (old_ts == std::numeric_limits<timestamp_t>::max()) {
     LOG(ERROR) << "Attempting to delete already deleted edge.";
   } else {
@@ -520,8 +524,8 @@ void MutableCsr<EDATA_T>::batch_put_edges(const std::vector<vid_t>& src_list,
   }
   edge_num_.fetch_add(added_edge_num, std::memory_order_relaxed);
   // invalidate sort flag
-  if (ts < unsorted_since_) {
-    unsorted_since_ = 0;
+  if (ts < unsorted_since_.load(std::memory_order_relaxed)) {
+    unsorted_since_.store(0, std::memory_order_relaxed);
   }
   refresh_prefetch_policy();
 }

--- a/src/storages/csr/mutable_csr.cc
+++ b/src/storages/csr/mutable_csr.cc
@@ -46,10 +46,9 @@ template <typename EDATA_T>
 void MutableCsr<EDATA_T>::Open(Checkpoint& ckp,
                                const ModuleDescriptor& descriptor,
                                MemoryLevel memory_level) {
-  unsorted_since_.store(
-      static_cast<timestamp_t>(
-          std::stoull(descriptor.get("unsorted_since").value_or("0"))),
-      std::memory_order_relaxed);
+  unsorted_since_.store(static_cast<timestamp_t>(std::stoull(
+                            descriptor.get("unsorted_since").value_or("0"))),
+                        std::memory_order_relaxed);
   edge_num_.store(std::stoull(descriptor.get("edge_num").value_or("0")));
   degree_list_ = ckp.OpenFile(
       descriptor.get_path(ModuleDescriptor::kDegreeListPath).value_or(""),
@@ -124,8 +123,9 @@ void MutableCsr<EDATA_T>::Dump(Checkpoint& ckp, CheckpointManifest& meta,
                                const std::string& key) {
   ModuleDescriptor descriptor;
   descriptor.module_type = ModuleTypeName();
-  descriptor.set("unsorted_since",
-                 std::to_string(unsorted_since_.load(std::memory_order_relaxed)));
+  descriptor.set(
+      "unsorted_since",
+      std::to_string(unsorted_since_.load(std::memory_order_relaxed)));
   descriptor.set("edge_num", std::to_string(edge_num_.load()));
 
   size_t vnum = vertex_capacity();


### PR DESCRIPTION
## Summary

Fix data race on non-atomic `unsorted_since_` field in `MutableCsr` and `ImmutableCsr`.

`unsorted_since_` was a plain `timestamp_t` member read and written from multiple threads without synchronization — different `src` vertices use different spinlocks (`locks_[src]`), so concurrent `put_edge` calls on different vertices race on this field. Additionally, `get_generic_view()` reads the field without any lock.

## Changes

- Changed `unsorted_since_` from `timestamp_t` to `std::atomic<timestamp_t>` in both `MutableCsr` and `ImmutableCsr`
- All reads use `.load(std::memory_order_relaxed)`
- All writes use `.store(..., std::memory_order_relaxed)`
- Relaxed ordering is sufficient since the value is an optimization hint (sorted vs unsorted region boundary for binary search in `CsrView::foreach_nbr_gt/lt`), not a synchronization primitive

Closes #722