### PR TITLE
WIP: expose generic operation admission leases

### DIFF
--- a/include/neug/transaction/ap_operation_guard.h
+++ b/include/neug/transaction/ap_operation_guard.h
@@ -1,0 +1,109 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <chrono>
+
+#include "neug/storages/graph_snapshot_store.h"
+#include "neug/transaction/version_manager.h"
+
+namespace neug {
+
+/**
+ * @brief AP read admission paired with a pinned current snapshot.
+ *
+ * The shared admission is acquired before the snapshot pin. AP writers use
+ * the same gate exclusively, so no AP mutation can publish or modify the
+ * current snapshot while this guard is active. PR-02A temporarily takes the
+ * visibility timestamp from the specialized read operation solely for the
+ * legacy direct storage reader; it does not own a TP coherent read view.
+ */
+class APSharedGuard {
+ public:
+  static APSharedGuard Acquire(IVersionManager& version_manager,
+                               GraphSnapshotStore& snapshot_store);
+  static APSharedGuard Acquire(IVersionManager& version_manager,
+                               GraphSnapshotStore& snapshot_store,
+                               std::chrono::steady_clock::time_point deadline);
+
+  APSharedGuard(APSharedGuard&& other) noexcept;
+  APSharedGuard& operator=(APSharedGuard&& other) noexcept;
+
+  APSharedGuard(const APSharedGuard&) = delete;
+  APSharedGuard& operator=(const APSharedGuard&) = delete;
+
+  ~APSharedGuard() noexcept;
+
+  void release() noexcept;
+  bool active() const noexcept { return admission_.active(); }
+
+  const GraphView& view() const { return snapshot_.get().view(); }
+  uint64_t planning_generation() const {
+    return snapshot_.get().planning_generation();
+  }
+  timestamp_t timestamp() const noexcept { return timestamp_; }
+
+ private:
+  APSharedGuard(SharedOperationLease admission, SnapshotGuard snapshot,
+                timestamp_t timestamp) noexcept;
+
+  timestamp_t timestamp_;
+  SharedOperationLease admission_;
+  // Declared last so fallback destruction unpins before reader admission
+  // releases.
+  SnapshotGuard snapshot_;
+};
+
+/**
+ * @brief AP write admission paired with a pinned mutable current snapshot.
+ *
+ * This owns only gate exclusion and the snapshot pin. It never reserves a
+ * write timestamp or changes the VersionManager timeline; AP mutation and
+ * durability semantics are composed by the caller.
+ */
+class APExclusiveGuard {
+ public:
+  static APExclusiveGuard Acquire(IVersionManager& version_manager,
+                                  GraphSnapshotStore& snapshot_store);
+  static APExclusiveGuard Acquire(
+      IVersionManager& version_manager, GraphSnapshotStore& snapshot_store,
+      std::chrono::steady_clock::time_point deadline);
+
+  APExclusiveGuard(APExclusiveGuard&& other) noexcept;
+  APExclusiveGuard& operator=(APExclusiveGuard&& other) noexcept;
+
+  APExclusiveGuard(const APExclusiveGuard&) = delete;
+  APExclusiveGuard& operator=(const APExclusiveGuard&) = delete;
+
+  ~APExclusiveGuard() noexcept;
+
+  void release() noexcept;
+  bool active() const noexcept { return admission_.active(); }
+
+  GraphSnapshotStore::SnapshotSlot& Snapshot() { return snapshot_.get(); }
+  const GraphSnapshotStore::SnapshotSlot& Snapshot() const {
+    return snapshot_.get();
+  }
+
+ private:
+  APExclusiveGuard(ExclusiveOperationLease admission,
+                   SnapshotGuard snapshot) noexcept;
+
+  ExclusiveOperationLease admission_;
+  // Declared last so fallback destruction unpins before reopening the gate.
+  SnapshotGuard snapshot_;
+};
+
+}  // namespace neug

--- a/include/neug/transaction/ap_operation_guard.h
+++ b/include/neug/transaction/ap_operation_guard.h
@@ -26,9 +26,8 @@ namespace neug {
  *
  * The shared admission is acquired before the snapshot pin. AP writers use
  * the same gate exclusively, so no AP mutation can publish or modify the
- * current snapshot while this guard is active. PR-02A temporarily takes the
- * visibility timestamp from the specialized read operation solely for the
- * legacy direct storage reader; it does not own a TP coherent read view.
+ * current snapshot while this guard is active. It does not capture a TP
+ * coherent read view or carry a visibility timestamp.
  */
 class APSharedGuard {
  public:
@@ -53,13 +52,11 @@ class APSharedGuard {
   uint64_t planning_generation() const {
     return snapshot_.get().planning_generation();
   }
-  timestamp_t timestamp() const noexcept { return timestamp_; }
 
  private:
-  APSharedGuard(SharedOperationLease admission, SnapshotGuard snapshot,
-                timestamp_t timestamp) noexcept;
+  APSharedGuard(SharedOperationLease admission,
+                SnapshotGuard snapshot) noexcept;
 
-  timestamp_t timestamp_;
   SharedOperationLease admission_;
   // Declared last so fallback destruction unpins before reader admission
   // releases.

--- a/include/neug/transaction/version_manager.h
+++ b/include/neug/transaction/version_manager.h
@@ -83,9 +83,23 @@ class IVersionManager {
   RuntimeBackoff make_runtime_backoff() const noexcept {
     return RuntimeBackoff(runtime_wait_impl());
   }
-  // Acquire one shared operation lease and the TP coherent read view published
-  // behind it. The returned lease owns the reader admission directly.
+  // Acquire one shared admission only. The returned lease owns one reader
+  // count; it neither captures a published read view nor pins a storage
+  // snapshot.
+  virtual SharedOperationLease acquire_shared_operation() = 0;
+  virtual SharedOperationLease acquire_shared_operation_until(
+      std::chrono::steady_clock::time_point deadline) = 0;
+  // Acquire exclusive admission. A successful lease owns the all-blocked
+  // phase only after active readers and inserters have drained; releasing it
+  // reopens the gate. It never reserves a write timestamp.
+  virtual ExclusiveOperationLease acquire_exclusive_operation() = 0;
+  virtual ExclusiveOperationLease acquire_exclusive_operation_until(
+      std::chrono::steady_clock::time_point deadline) = 0;
+  // TP's specialized shared admission: capture the coherent timestamp and
+  // snapshot-generation pair behind the same reader admission.
   virtual ReadOperationLease acquire_read_operation() = 0;
+  virtual ReadOperationLease acquire_read_operation_until(
+      std::chrono::steady_clock::time_point deadline) = 0;
   virtual uint32_t acquire_insert_timestamp() = 0;
   virtual void release_insert_timestamp(uint32_t ts) = 0;
   // Waiters directly contend the admission phase. Acquisition order is
@@ -175,7 +189,15 @@ class VersionManager : public IVersionManager {
   bool try_set_runtime_wait_if_quiescent(
       RuntimeWaitFn runtime_wait) noexcept override;
 
+  SharedOperationLease acquire_shared_operation() override;
+  SharedOperationLease acquire_shared_operation_until(
+      std::chrono::steady_clock::time_point deadline) override;
+  ExclusiveOperationLease acquire_exclusive_operation() override;
+  ExclusiveOperationLease acquire_exclusive_operation_until(
+      std::chrono::steady_clock::time_point deadline) override;
   ReadOperationLease acquire_read_operation() override;
+  ReadOperationLease acquire_read_operation_until(
+      std::chrono::steady_clock::time_point deadline) override;
   uint32_t acquire_insert_timestamp() override;
   void release_insert_timestamp(uint32_t ts) override;
   uint32_t acquire_update_timestamp() override;

--- a/src/main/execution_slot.cc
+++ b/src/main/execution_slot.cc
@@ -34,6 +34,7 @@
 #include "neug/storages/graph/graph_stats.h"
 #include "neug/storages/graph/property_graph.h"
 #include "neug/storages/graph/schema.h"
+#include "neug/transaction/ap_operation_guard.h"
 #include "neug/transaction/timestamp_lease.h"
 #include "neug/transaction/transaction_utils.h"
 #include "neug/transaction/version_manager.h"
@@ -344,12 +345,19 @@ Status ExecutionSlot::executeCore(const std::string& query,
   // EXPLAIN is strategy-independent and must not acquire a write transaction,
   // including for EXPLAIN CHECKPOINT.
   if (NEUG_UNLIKELY(analysis.explain_mode == ExplainMode::kExplain)) {
-    auto read_lease =
-        ReadSnapshotLease::Acquire(version_manager_, snapshot_store_);
-    StorageReadInterface storage(read_lease.view(), read_lease.timestamp());
-    status = execute_on_storage(
-        GraphStats(read_lease.view(), read_lease.planning_generation()),
-        storage);
+    if (execution_strategy_ == QueryExecutionStrategy::kDirect) {
+      auto guard = APSharedGuard::Acquire(version_manager_, snapshot_store_);
+      StorageReadInterface storage(guard.view(), guard.timestamp());
+      status = execute_on_storage(
+          GraphStats(guard.view(), guard.planning_generation()), storage);
+    } else {
+      auto read_lease =
+          ReadSnapshotLease::Acquire(version_manager_, snapshot_store_);
+      StorageReadInterface storage(read_lease.view(), read_lease.timestamp());
+      status = execute_on_storage(
+          GraphStats(read_lease.view(), read_lease.planning_generation()),
+          storage);
+    }
   } else if (NEUG_UNLIKELY(analysis.checkpoint())) {
     // PROFILE executes the checkpoint and is timed by executeCheckpoint().
     if (NEUG_UNLIKELY(!parameters.IsObject())) {
@@ -362,11 +370,10 @@ Status ExecutionSlot::executeCore(const std::string& query,
   } else if (NEUG_UNLIKELY(execution_strategy_ ==
                            QueryExecutionStrategy::kDirect)) {
     if (access_mode == AccessMode::kRead) {
-      auto lease =
-          ReadSnapshotLease::Acquire(version_manager_, snapshot_store_);
-      StorageReadInterface storage(lease.view(), lease.timestamp());
+      auto guard = APSharedGuard::Acquire(version_manager_, snapshot_store_);
+      StorageReadInterface storage(guard.view(), guard.timestamp());
       status = execute_on_storage(
-          GraphStats(lease.view(), lease.planning_generation()), storage);
+          GraphStats(guard.view(), guard.planning_generation()), storage);
     } else if (access_mode == AccessMode::kInsert ||
                access_mode == AccessMode::kUpdate ||
                access_mode == AccessMode::kSchema) {
@@ -444,6 +451,11 @@ result<std::string> ExecutionSlot::ExecuteTransactionalRequest(
 }
 
 std::string ExecutionSlot::GetSchema() const {
+  if (execution_strategy_ == QueryExecutionStrategy::kDirect) {
+    auto guard = APSharedGuard::Acquire(version_manager_, snapshot_store_);
+    auto yaml = guard.view().schema().to_yaml();
+    return get_json_string_from_yaml(yaml.value()).value();
+  }
   auto lease = ReadSnapshotLease::Acquire(version_manager_, snapshot_store_);
   auto yaml = lease.view().schema().to_yaml();
   return get_json_string_from_yaml(yaml.value()).value();
@@ -452,8 +464,8 @@ std::string ExecutionSlot::GetSchema() const {
 void ExecutionSlot::ClearTemporarySchema() {
   CHECK(execution_strategy_ == QueryExecutionStrategy::kDirect);
   {
-    auto lease = ReadSnapshotLease::Acquire(version_manager_, snapshot_store_);
-    const auto& schema = lease.view().schema();
+    auto guard = APSharedGuard::Acquire(version_manager_, snapshot_store_);
+    const auto& schema = guard.view().schema();
     if (schema.get_temporary_edge_triplet_keys().empty() &&
         schema.get_temporary_vertex_labels().empty()) {
       return;

--- a/src/main/execution_slot.cc
+++ b/src/main/execution_slot.cc
@@ -347,7 +347,7 @@ Status ExecutionSlot::executeCore(const std::string& query,
   if (NEUG_UNLIKELY(analysis.explain_mode == ExplainMode::kExplain)) {
     if (execution_strategy_ == QueryExecutionStrategy::kDirect) {
       auto guard = APSharedGuard::Acquire(version_manager_, snapshot_store_);
-      StorageReadInterface storage(guard.view(), guard.timestamp());
+      StorageReadInterface storage(guard.view(), MAX_TIMESTAMP);
       status = execute_on_storage(
           GraphStats(guard.view(), guard.planning_generation()), storage);
     } else {
@@ -371,7 +371,7 @@ Status ExecutionSlot::executeCore(const std::string& query,
                            QueryExecutionStrategy::kDirect)) {
     if (access_mode == AccessMode::kRead) {
       auto guard = APSharedGuard::Acquire(version_manager_, snapshot_store_);
-      StorageReadInterface storage(guard.view(), guard.timestamp());
+      StorageReadInterface storage(guard.view(), MAX_TIMESTAMP);
       status = execute_on_storage(
           GraphStats(guard.view(), guard.planning_generation()), storage);
     } else if (access_mode == AccessMode::kInsert ||

--- a/src/transaction/ap_operation_guard.cc
+++ b/src/transaction/ap_operation_guard.cc
@@ -20,38 +20,31 @@
 namespace neug {
 
 APSharedGuard::APSharedGuard(SharedOperationLease admission,
-                             SnapshotGuard snapshot,
-                             timestamp_t timestamp) noexcept
-    : timestamp_(timestamp),
-      admission_(std::move(admission)),
-      snapshot_(std::move(snapshot)) {}
+                             SnapshotGuard snapshot) noexcept
+    : admission_(std::move(admission)), snapshot_(std::move(snapshot)) {}
 
 APSharedGuard APSharedGuard::Acquire(IVersionManager& version_manager,
                                      GraphSnapshotStore& snapshot_store) {
-  auto operation = version_manager.acquire_read_operation();
+  auto admission = version_manager.acquire_shared_operation();
   SnapshotGuard snapshot(snapshot_store);
-  return APSharedGuard(std::move(operation.admission), std::move(snapshot),
-                       operation.published_view.visibility_ts);
+  return APSharedGuard(std::move(admission), std::move(snapshot));
 }
 
 APSharedGuard APSharedGuard::Acquire(
     IVersionManager& version_manager, GraphSnapshotStore& snapshot_store,
     std::chrono::steady_clock::time_point deadline) {
-  auto operation = version_manager.acquire_read_operation_until(deadline);
+  auto admission = version_manager.acquire_shared_operation_until(deadline);
   SnapshotGuard snapshot(snapshot_store);
-  return APSharedGuard(std::move(operation.admission), std::move(snapshot),
-                       operation.published_view.visibility_ts);
+  return APSharedGuard(std::move(admission), std::move(snapshot));
 }
 
 APSharedGuard::APSharedGuard(APSharedGuard&& other) noexcept
-    : timestamp_(other.timestamp_),
-      admission_(std::move(other.admission_)),
+    : admission_(std::move(other.admission_)),
       snapshot_(std::move(other.snapshot_)) {}
 
 APSharedGuard& APSharedGuard::operator=(APSharedGuard&& other) noexcept {
   if (this != &other) {
     release();
-    timestamp_ = other.timestamp_;
     admission_ = std::move(other.admission_);
     snapshot_ = std::move(other.snapshot_);
   }

--- a/src/transaction/ap_operation_guard.cc
+++ b/src/transaction/ap_operation_guard.cc
@@ -1,0 +1,114 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "neug/transaction/ap_operation_guard.h"
+
+#include <utility>
+
+namespace neug {
+
+APSharedGuard::APSharedGuard(SharedOperationLease admission,
+                             SnapshotGuard snapshot,
+                             timestamp_t timestamp) noexcept
+    : timestamp_(timestamp),
+      admission_(std::move(admission)),
+      snapshot_(std::move(snapshot)) {}
+
+APSharedGuard APSharedGuard::Acquire(IVersionManager& version_manager,
+                                     GraphSnapshotStore& snapshot_store) {
+  auto operation = version_manager.acquire_read_operation();
+  SnapshotGuard snapshot(snapshot_store);
+  return APSharedGuard(std::move(operation.admission), std::move(snapshot),
+                       operation.published_view.visibility_ts);
+}
+
+APSharedGuard APSharedGuard::Acquire(
+    IVersionManager& version_manager, GraphSnapshotStore& snapshot_store,
+    std::chrono::steady_clock::time_point deadline) {
+  auto operation = version_manager.acquire_read_operation_until(deadline);
+  SnapshotGuard snapshot(snapshot_store);
+  return APSharedGuard(std::move(operation.admission), std::move(snapshot),
+                       operation.published_view.visibility_ts);
+}
+
+APSharedGuard::APSharedGuard(APSharedGuard&& other) noexcept
+    : timestamp_(other.timestamp_),
+      admission_(std::move(other.admission_)),
+      snapshot_(std::move(other.snapshot_)) {}
+
+APSharedGuard& APSharedGuard::operator=(APSharedGuard&& other) noexcept {
+  if (this != &other) {
+    release();
+    timestamp_ = other.timestamp_;
+    admission_ = std::move(other.admission_);
+    snapshot_ = std::move(other.snapshot_);
+  }
+  return *this;
+}
+
+APSharedGuard::~APSharedGuard() noexcept { release(); }
+
+void APSharedGuard::release() noexcept {
+  if (!admission_.active()) {
+    return;
+  }
+  snapshot_.release();
+  admission_.release();
+}
+
+APExclusiveGuard::APExclusiveGuard(ExclusiveOperationLease admission,
+                                   SnapshotGuard snapshot) noexcept
+    : admission_(std::move(admission)), snapshot_(std::move(snapshot)) {}
+
+APExclusiveGuard APExclusiveGuard::Acquire(IVersionManager& version_manager,
+                                           GraphSnapshotStore& snapshot_store) {
+  auto admission = version_manager.acquire_exclusive_operation();
+  SnapshotGuard snapshot(snapshot_store);
+  return APExclusiveGuard(std::move(admission), std::move(snapshot));
+}
+
+APExclusiveGuard APExclusiveGuard::Acquire(
+    IVersionManager& version_manager, GraphSnapshotStore& snapshot_store,
+    std::chrono::steady_clock::time_point deadline) {
+  auto admission = version_manager.acquire_exclusive_operation_until(deadline);
+  SnapshotGuard snapshot(snapshot_store);
+  return APExclusiveGuard(std::move(admission), std::move(snapshot));
+}
+
+APExclusiveGuard::APExclusiveGuard(APExclusiveGuard&& other) noexcept
+    : admission_(std::move(other.admission_)),
+      snapshot_(std::move(other.snapshot_)) {}
+
+APExclusiveGuard& APExclusiveGuard::operator=(
+    APExclusiveGuard&& other) noexcept {
+  if (this != &other) {
+    release();
+    admission_ = std::move(other.admission_);
+    snapshot_ = std::move(other.snapshot_);
+  }
+  return *this;
+}
+
+APExclusiveGuard::~APExclusiveGuard() noexcept { release(); }
+
+void APExclusiveGuard::release() noexcept {
+  if (!admission_.active()) {
+    return;
+  }
+  snapshot_.release();
+  admission_.release();
+}
+
+}  // namespace neug

--- a/src/transaction/version_manager.cc
+++ b/src/transaction/version_manager.cc
@@ -141,8 +141,34 @@ bool VersionManager::try_set_runtime_wait_if_quiescent(
   return true;
 }
 
+SharedOperationLease VersionManager::acquire_shared_operation() {
+  return SharedOperationLease(gate_);
+}
+
+SharedOperationLease VersionManager::acquire_shared_operation_until(
+    std::chrono::steady_clock::time_point deadline) {
+  return SharedOperationLease(gate_, deadline);
+}
+
+ExclusiveOperationLease VersionManager::acquire_exclusive_operation() {
+  return ExclusiveOperationLease(gate_);
+}
+
+ExclusiveOperationLease VersionManager::acquire_exclusive_operation_until(
+    std::chrono::steady_clock::time_point deadline) {
+  return ExclusiveOperationLease(gate_, deadline);
+}
+
 ReadOperationLease VersionManager::acquire_read_operation() {
   SharedOperationLease admission(gate_);
+  const auto published_view = UnpackPublishedReadView(
+      published_read_view_.load(std::memory_order_acquire));
+  return {published_view, std::move(admission)};
+}
+
+ReadOperationLease VersionManager::acquire_read_operation_until(
+    std::chrono::steady_clock::time_point deadline) {
+  SharedOperationLease admission(gate_, deadline);
   const auto published_view = UnpackPublishedReadView(
       published_read_view_.load(std::memory_order_acquire));
   return {published_view, std::move(admission)};

--- a/tests/transaction/test_read_view_publication.cc
+++ b/tests/transaction/test_read_view_publication.cc
@@ -16,21 +16,25 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <chrono>
 #include <filesystem>
 #include <functional>
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <utility>
 
 #include "neug/storages/checkpoint_manager.h"
 #include "neug/storages/graph/operation_params.h"
 #include "neug/storages/graph/property_graph.h"
 #include "neug/storages/graph_snapshot_store.h"
+#include "neug/transaction/ap_operation_guard.h"
 #include "neug/transaction/read_snapshot_lease.h"
 #include "neug/transaction/timestamp_lease.h"
 #include "neug/transaction/transaction_utils.h"
 #include "neug/transaction/version_manager.h"
+#include "neug/utils/exception/exception.h"
 #include "unittest/utils.h"
 
 namespace neug {
@@ -58,6 +62,17 @@ std::atomic<int> runtime_wait_calls{0};
 
 void CountRuntimeWait(RuntimeWaitAction) noexcept {
   runtime_wait_calls.fetch_add(1, std::memory_order_relaxed);
+  std::this_thread::yield();
+}
+
+template <typename Predicate>
+bool WaitUntil(Predicate predicate) {
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(10);
+  while (!predicate() && std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::yield();
+  }
+  return predicate();
 }
 
 class ScriptedVersionManager : public IVersionManager {
@@ -87,8 +102,27 @@ class ScriptedVersionManager : public IVersionManager {
     return true;
   }
 
+  SharedOperationLease acquire_shared_operation() override {
+    return SharedOperationLease(operation_gate_);
+  }
+  SharedOperationLease acquire_shared_operation_until(
+      std::chrono::steady_clock::time_point deadline) override {
+    return SharedOperationLease(operation_gate_, deadline);
+  }
+  ExclusiveOperationLease acquire_exclusive_operation() override {
+    return ExclusiveOperationLease(operation_gate_);
+  }
+  ExclusiveOperationLease acquire_exclusive_operation_until(
+      std::chrono::steady_clock::time_point deadline) override {
+    return ExclusiveOperationLease(operation_gate_, deadline);
+  }
   ReadOperationLease acquire_read_operation() override {
     SharedOperationLease admission(operation_gate_);
+    return {capture_published_view(), std::move(admission)};
+  }
+  ReadOperationLease acquire_read_operation_until(
+      std::chrono::steady_clock::time_point deadline) override {
+    SharedOperationLease admission(operation_gate_, deadline);
     return {capture_published_view(), std::move(admission)};
   }
   uint32_t acquire_insert_timestamp() override { return 1; }
@@ -248,6 +282,87 @@ TEST_F(ReadViewPublicationTest,
   auto lease = ReadSnapshotLease::Acquire(version_manager, *store_);
   EXPECT_EQ(lease.timestamp(), kInitialTimestamp);
   EXPECT_FALSE(lease.view().schema().is_vertex_label_valid("company"));
+}
+
+TEST_F(ReadViewPublicationTest, APSharedGuardBlocksExclusiveAdmission) {
+  VersionManager version_manager;
+  version_manager.init_ts({1, 0}, 2);
+  ASSERT_TRUE(
+      version_manager.try_set_runtime_wait_if_quiescent(&CountRuntimeWait));
+  runtime_wait_calls.store(0, std::memory_order_relaxed);
+
+  auto shared = APSharedGuard::Acquire(version_manager, *store_);
+  std::atomic<bool> exclusive_acquired{false};
+  std::thread exclusive([&] {
+    auto guard = APExclusiveGuard::Acquire(version_manager, *store_);
+    exclusive_acquired.store(true, std::memory_order_release);
+  });
+
+  EXPECT_TRUE(WaitUntil(
+      [] { return runtime_wait_calls.load(std::memory_order_relaxed) != 0; }));
+  EXPECT_FALSE(exclusive_acquired.load(std::memory_order_acquire));
+
+  shared.release();
+  EXPECT_TRUE(WaitUntil(
+      [&] { return exclusive_acquired.load(std::memory_order_acquire); }));
+  exclusive.join();
+}
+
+TEST_F(ReadViewPublicationTest, GenericOperationLeasesShareTheAdmissionGate) {
+  VersionManager version_manager;
+  version_manager.init_ts({1, 0}, 2);
+  const auto expired = std::chrono::steady_clock::time_point::min();
+
+  auto shared = version_manager.acquire_shared_operation();
+  EXPECT_THROW(version_manager.acquire_exclusive_operation_until(expired),
+               exception::TransactionTimeoutException);
+  shared.release();
+
+  auto exclusive = version_manager.acquire_exclusive_operation();
+  EXPECT_THROW(version_manager.acquire_shared_operation_until(expired),
+               exception::TransactionTimeoutException);
+}
+
+TEST_F(ReadViewPublicationTest,
+       APExclusiveGuardBlocksInsertersWithoutReservingTimestamp) {
+  VersionManager version_manager;
+  version_manager.init_ts({1, 0}, 2);
+  ASSERT_TRUE(
+      version_manager.try_set_runtime_wait_if_quiescent(&CountRuntimeWait));
+  runtime_wait_calls.store(0, std::memory_order_relaxed);
+
+  auto exclusive = APExclusiveGuard::Acquire(version_manager, *store_);
+  std::atomic<uint32_t> insert_timestamp{0};
+  std::thread inserter([&] {
+    const uint32_t timestamp = version_manager.acquire_insert_timestamp();
+    insert_timestamp.store(timestamp, std::memory_order_release);
+    version_manager.release_insert_timestamp(timestamp);
+  });
+
+  EXPECT_TRUE(WaitUntil(
+      [] { return runtime_wait_calls.load(std::memory_order_relaxed) != 0; }));
+  EXPECT_EQ(insert_timestamp.load(std::memory_order_acquire), 0U);
+
+  exclusive.release();
+  EXPECT_TRUE(WaitUntil(
+      [&] { return insert_timestamp.load(std::memory_order_acquire) != 0; }));
+  inserter.join();
+  EXPECT_EQ(insert_timestamp.load(std::memory_order_acquire), 2U);
+}
+
+TEST_F(ReadViewPublicationTest, APGuardsPropagateAdmissionDeadlines) {
+  VersionManager version_manager;
+  version_manager.init_ts({1, 0}, 2);
+  const auto expired = std::chrono::steady_clock::time_point::min();
+
+  auto shared = APSharedGuard::Acquire(version_manager, *store_);
+  EXPECT_THROW(APExclusiveGuard::Acquire(version_manager, *store_, expired),
+               exception::TransactionTimeoutException);
+  shared.release();
+
+  auto exclusive = APExclusiveGuard::Acquire(version_manager, *store_);
+  EXPECT_THROW(APSharedGuard::Acquire(version_manager, *store_, expired),
+               exception::TransactionTimeoutException);
 }
 
 TEST_F(ReadViewPublicationTest,

--- a/tests/transaction/test_read_view_publication.cc
+++ b/tests/transaction/test_read_view_publication.cc
@@ -324,6 +324,15 @@ TEST_F(ReadViewPublicationTest, GenericOperationLeasesShareTheAdmissionGate) {
 }
 
 TEST_F(ReadViewPublicationTest,
+       APSharedGuardUsesGenericAdmissionWithoutCapturingReadView) {
+  ScriptedVersionManager version_manager({1, 0});
+
+  auto guard = APSharedGuard::Acquire(version_manager, *store_);
+
+  EXPECT_EQ(version_manager.acquire_count(), 0);
+}
+
+TEST_F(ReadViewPublicationTest,
        APExclusiveGuardBlocksInsertersWithoutReservingTimestamp) {
   VersionManager version_manager;
   version_manager.init_ts({1, 0}, 2);

--- a/tests/transaction/test_transaction_release_order.cc
+++ b/tests/transaction/test_transaction_release_order.cc
@@ -58,8 +58,26 @@ class ReleaseOrderVersionManager : public IVersionManager {
   bool try_set_runtime_wait_if_quiescent(RuntimeWaitFn) noexcept override {
     return true;
   }
+  SharedOperationLease acquire_shared_operation() override {
+    return SharedOperationLease(operation_gate_);
+  }
+  SharedOperationLease acquire_shared_operation_until(
+      std::chrono::steady_clock::time_point deadline) override {
+    return SharedOperationLease(operation_gate_, deadline);
+  }
+  ExclusiveOperationLease acquire_exclusive_operation() override {
+    return ExclusiveOperationLease(operation_gate_);
+  }
+  ExclusiveOperationLease acquire_exclusive_operation_until(
+      std::chrono::steady_clock::time_point deadline) override {
+    return ExclusiveOperationLease(operation_gate_, deadline);
+  }
   ReadOperationLease acquire_read_operation() override {
     return {{1, 0}, SharedOperationLease(operation_gate_)};
+  }
+  ReadOperationLease acquire_read_operation_until(
+      std::chrono::steady_clock::time_point deadline) override {
+    return {{1, 0}, SharedOperationLease(operation_gate_, deadline)};
   }
   uint32_t acquire_insert_timestamp() override { return 1; }
   uint32_t acquire_update_timestamp() override { return 1; }


### PR DESCRIPTION
## Summary

- Expose shared/exclusive operation-admission RAII leases through IVersionManager.
- Add AP operation guards without reserving TP timestamps.
- Keep TP coherent read acquisition on its dedicated read-view lease.

## Scope

This WIP contains only PR-02A code and tests. Explicit-transaction design documents are intentionally excluded.

## Validation

- Built read_view_publication_test and transaction_test.
- read_view_publication_test passed.
- transaction_test did not return a terminal result in the local runner and remains to be re-run.