### PR TITLE
fix: address S3 exit lifecycle and null list elements

### DIFF
--- a/extension/httpfs/src/s3_extension.cc
+++ b/extension/httpfs/src/s3_extension.cc
@@ -54,19 +54,6 @@ static void RegisterHTTPProvider() {
                "http, https";
 }
 
-// Finalize Arrow S3 to prevent exit crash (called at process exit)
-static void FinalizeS3OnExit() {
-  try {
-    auto status = arrow::fs::FinalizeS3();
-    if (!status.ok()) {
-      LOG(WARNING) << "[s3 extension] Failed to finalize Arrow S3: "
-                   << status.ToString();
-    }
-  } catch (const std::exception& e) {
-    LOG(ERROR) << "[s3 extension] cleanup failed: " << e.what();
-  }
-}
-
 }  // namespace httpfs
 }  // namespace extension
 }  // namespace neug
@@ -94,8 +81,11 @@ void Init() {
     // Register HTTP/HTTPS filesystem provider
     neug::extension::httpfs::RegisterHTTPProvider();
 
-    // Register atexit handler to finalize S3 on process exit
-    std::atexit(neug::extension::httpfs::FinalizeS3OnExit);
+    // Do not register arrow::fs::FinalizeS3() with std::atexit. Arrow's S3
+    // state is initialized lazily, so it may be destroyed before an
+    // earlier-registered atexit handler runs. Calling FinalizeS3() then is
+    // explicitly unsupported by Arrow and can cause a use-after-free during
+    // shutdown. Let Arrow manage its own process-exit lifecycle.
 
     LOG(INFO) << "[httpfs extension] initialized (s3, oss, http, https)";
   } catch (const std::exception& e) {

--- a/include/neug/common/columns/list_columns.h
+++ b/include/neug/common/columns/list_columns.h
@@ -147,7 +147,11 @@ class ListColumnBuilder : public IContextColumnBuilder {
     assert(val.type().id() == DataTypeId::kList);
     const auto& values = ListValue::GetChildren(val);
     for (const auto& v : values) {
-      child_builder_->push_back_elem(v);
+      if (v.IsNull()) {
+        child_builder_->push_back_null();
+      } else {
+        child_builder_->push_back_elem(v);
+      }
     }
     list_item item = {cur_offset_, values.size()};
     items_.push_back(item);


### PR DESCRIPTION
## What do these changes do?

- Remove the httpfs `std::atexit` callback that calls `arrow::fs::FinalizeS3()`. Arrow initializes its S3 global state lazily, so the state can be destroyed before an earlier-registered exit handler runs, leading to late finalization, use-after-free, or heap corruption during process shutdown.
- Preserve null children in `ListColumnBuilder` by routing them through `push_back_null()` instead of reading an uninitialized scalar payload with `push_back_elem()`.

## Testing

The changes are isolated to the two reported failure paths. The repository CI covers the Parquet LIST null-element regression and the httpfs shutdown lifecycle.

## Related issue number

Fixes #876
Fixes #877
