### PR TITLE
fix: preserve null elements in list and array columns

### DIFF
--- a/include/neug/common/columns/array_columns.h
+++ b/include/neug/common/columns/array_columns.h
@@ -132,7 +132,11 @@ class ContextArrayColumnBuilder : public IContextColumnBuilder {
           " elements, got " + std::to_string(children.size()));
     }
     for (const auto& v : children) {
-      child_builder_->push_back_elem(v);
+      if (v.IsNull()) {
+        child_builder_->push_back_null();
+      } else {
+        child_builder_->push_back_elem(v);
+      }
     }
     ++current_size_;
   }

--- a/include/neug/common/columns/array_columns.h
+++ b/include/neug/common/columns/array_columns.h
@@ -120,6 +120,10 @@ class ContextArrayColumnBuilder : public IContextColumnBuilder {
   }
 
   void push_back_elem(const Value& val) override {
+    if (val.IsNull()) {
+      push_back_null();
+      return;
+    }
     if (val.type().id() != DataTypeId::kArray) {
       THROW_INVALID_ARGUMENT_EXCEPTION(
           "ContextArrayColumnBuilder: expected ARRAY value, got " +
@@ -132,11 +136,7 @@ class ContextArrayColumnBuilder : public IContextColumnBuilder {
           " elements, got " + std::to_string(children.size()));
     }
     for (const auto& v : children) {
-      if (v.IsNull()) {
-        child_builder_->push_back_null();
-      } else {
-        child_builder_->push_back_elem(v);
-      }
+      child_builder_->push_back_elem(v);
     }
     ++current_size_;
   }

--- a/include/neug/common/columns/edge_columns.h
+++ b/include/neug/common/columns/edge_columns.h
@@ -134,6 +134,10 @@ class SDSLEdgeColumnBuilder : public IContextColumnBuilder {
 
   void reserve(size_t size) override { edges_.reserve(size); }
   inline void push_back_elem(const Value& val) override {
+    if (val.IsNull()) {
+      push_back_null();
+      return;
+    }
     const auto& e = val.GetValue<edge_t>();
     push_back_opt(e.src, e.dst, e.prop);
   }
@@ -256,6 +260,10 @@ class MSEdgeColumnBuilder : public IContextColumnBuilder {
   void reserve(size_t size) override { cur_edges_.reserve(size); }
 
   inline void push_back_elem(const Value& val) override {
+    if (val.IsNull()) {
+      push_back_null();
+      return;
+    }
     LOG(FATAL) << "not implemented for MSEdgeColumnBuilder";
   }
 
@@ -409,6 +417,10 @@ class BDSLEdgeColumnBuilder : public IContextColumnBuilder {
   void reserve(size_t size) override { edges_.reserve(size); }
 
   inline void push_back_elem(const Value& val) override {
+    if (val.IsNull()) {
+      push_back_null();
+      return;
+    }
     LOG(FATAL) << "not implemented for BDSLEdgeColumnBuilder";
   }
 
@@ -525,6 +537,10 @@ class SDMLEdgeColumnBuilder : public IContextColumnBuilder {
   void reserve(size_t size) override { edges_.reserve(size); }
 
   inline void push_back_elem(const Value& val) override {
+    if (val.IsNull()) {
+      push_back_null();
+      return;
+    }
     LOG(FATAL) << "not implemented for SDMLEdgeColumnBuilder";
   }
 
@@ -648,6 +664,10 @@ class BDMLEdgeColumnBuilder : public IContextColumnBuilder {
   void reserve(size_t size) override { edges_.reserve(size); }
 
   inline void push_back_elem(const Value& val) override {
+    if (val.IsNull()) {
+      push_back_null();
+      return;
+    }
     const auto& edge = val.GetValue<edge_t>();
     insert_label(edge.label);
     push_back_opt(edge.label, edge.src, edge.dst, edge.prop, edge.dir);

--- a/include/neug/common/columns/list_columns.h
+++ b/include/neug/common/columns/list_columns.h
@@ -112,7 +112,12 @@ class ListColumn : public IContextColumn {
     size_t i = 0;
     for (const auto& list : items_) {
       for (size_t j = list.offset; j < list.offset + list.length; ++j) {
-        builder->push_back_elem(datas_->get_elem(j));
+        auto elem = datas_->get_elem(j);
+        if (elem.IsNull()) {
+          builder->push_back_null();
+        } else {
+          builder->push_back_elem(elem);
+        }
         offsets.push_back(i);
       }
       ++i;

--- a/include/neug/common/columns/list_columns.h
+++ b/include/neug/common/columns/list_columns.h
@@ -113,11 +113,7 @@ class ListColumn : public IContextColumn {
     for (const auto& list : items_) {
       for (size_t j = list.offset; j < list.offset + list.length; ++j) {
         auto elem = datas_->get_elem(j);
-        if (elem.IsNull()) {
-          builder->push_back_null();
-        } else {
-          builder->push_back_elem(elem);
-        }
+        builder->push_back_elem(elem);
         offsets.push_back(i);
       }
       ++i;
@@ -149,14 +145,14 @@ class ListColumnBuilder : public IContextColumnBuilder {
     }
   }
   void push_back_elem(const Value& val) override {
+    if (val.IsNull()) {
+      push_back_null();
+      return;
+    }
     assert(val.type().id() == DataTypeId::kList);
     const auto& values = ListValue::GetChildren(val);
     for (const auto& v : values) {
-      if (v.IsNull()) {
-        child_builder_->push_back_null();
-      } else {
-        child_builder_->push_back_elem(v);
-      }
+      child_builder_->push_back_elem(v);
     }
     list_item item = {cur_offset_, values.size()};
     items_.push_back(item);

--- a/include/neug/common/columns/path_columns.h
+++ b/include/neug/common/columns/path_columns.h
@@ -81,6 +81,10 @@ class PathColumnBuilder : public IContextColumnBuilder {
   ~PathColumnBuilder() = default;
   inline void push_back_opt(const Path& p) { data_.push_back(p); }
   inline void push_back_elem(const Value& val) override {
+    if (val.IsNull()) {
+      push_back_null();
+      return;
+    }
     data_.push_back(PathValue::Get(val));
   }
   void push_back_null() override {

--- a/include/neug/common/columns/value_columns.h
+++ b/include/neug/common/columns/value_columns.h
@@ -118,6 +118,10 @@ class ValueColumnBuilder : public IContextColumnBuilder {
     }
   }
   inline void push_back_elem(const Value& val) override {
+    if (val.IsNull()) {
+      push_back_null();
+      return;
+    }
     data_.push_back(val.template GetValue<T>());
   }
 

--- a/include/neug/common/types/i_context_column.h
+++ b/include/neug/common/types/i_context_column.h
@@ -101,6 +101,8 @@ class IContextColumnBuilder {
   virtual ~IContextColumnBuilder() = default;
 
   virtual void reserve(size_t size) = 0;
+  // Implementations must forward null values to push_back_null() before
+  // extracting the underlying value.
   virtual void push_back_elem(const Value& val) = 0;
   virtual void push_back_null() {
     LOG(FATAL) << "push_back_null not implemented";

--- a/src/common/columns/list_columns.cc
+++ b/src/common/columns/list_columns.cc
@@ -37,7 +37,11 @@ std::pair<std::shared_ptr<IContextColumn>, sel_vec_t> ListColumn::unfold()
     for (const auto& list : items_) {
       for (size_t j = list.offset; j < list.offset + list.length; ++j) {
         auto elem = datas_->get_elem(j);
-        builder.push_back_elem(elem);
+        if (elem.IsNull()) {
+          builder.push_back_null();
+        } else {
+          builder.push_back_elem(elem);
+        }
         offsets.push_back(i);
       }
       ++i;
@@ -51,7 +55,11 @@ std::pair<std::shared_ptr<IContextColumn>, sel_vec_t> ListColumn::unfold()
     for (const auto& list : items_) {
       for (size_t j = list.offset; j < list.offset + list.length; ++j) {
         auto elem = datas_->get_elem(j);
-        builder.push_back_elem(elem);
+        if (elem.IsNull()) {
+          builder.push_back_null();
+        } else {
+          builder.push_back_elem(elem);
+        }
         offsets.push_back(i);
       }
       ++i;
@@ -65,7 +73,11 @@ std::pair<std::shared_ptr<IContextColumn>, sel_vec_t> ListColumn::unfold()
     for (const auto& list : items_) {
       for (size_t j = list.offset; j < list.offset + list.length; ++j) {
         auto elem = datas_->get_elem(j);
-        builder.push_back_elem(elem);
+        if (elem.IsNull()) {
+          builder.push_back_null();
+        } else {
+          builder.push_back_elem(elem);
+        }
         offsets.push_back(i);
       }
       ++i;
@@ -79,7 +91,11 @@ std::pair<std::shared_ptr<IContextColumn>, sel_vec_t> ListColumn::unfold()
     for (const auto& list : items_) {
       for (size_t j = list.offset; j < list.offset + list.length; ++j) {
         auto elem = datas_->get_elem(j);
-        builder.push_back_elem(elem);
+        if (elem.IsNull()) {
+          builder.push_back_null();
+        } else {
+          builder.push_back_elem(elem);
+        }
         offsets.push_back(i);
       }
       ++i;

--- a/src/common/columns/list_columns.cc
+++ b/src/common/columns/list_columns.cc
@@ -109,10 +109,14 @@ std::pair<std::shared_ptr<IContextColumn>, sel_vec_t> ListColumn::unfold()
     for (const auto& list : items_) {
       for (size_t j = list.offset; j < list.offset + list.length; ++j) {
         auto elem = datas_->get_elem(j);
-        auto edge = elem.GetValue<edge_t>();
-        builder.insert_label(edge.label);
-        builder.push_back_opt(edge.label, edge.src, edge.dst, edge.prop,
-                              edge.dir);
+        if (elem.IsNull()) {
+          builder.push_back_null();
+        } else {
+          auto edge = elem.GetValue<edge_t>();
+          builder.insert_label(edge.label);
+          builder.push_back_opt(edge.label, edge.src, edge.dst, edge.prop,
+                                edge.dir);
+        }
         offsets.push_back(i);
       }
       ++i;

--- a/src/common/columns/list_columns.cc
+++ b/src/common/columns/list_columns.cc
@@ -37,11 +37,7 @@ std::pair<std::shared_ptr<IContextColumn>, sel_vec_t> ListColumn::unfold()
     for (const auto& list : items_) {
       for (size_t j = list.offset; j < list.offset + list.length; ++j) {
         auto elem = datas_->get_elem(j);
-        if (elem.IsNull()) {
-          builder.push_back_null();
-        } else {
-          builder.push_back_elem(elem);
-        }
+        builder.push_back_elem(elem);
         offsets.push_back(i);
       }
       ++i;
@@ -55,11 +51,7 @@ std::pair<std::shared_ptr<IContextColumn>, sel_vec_t> ListColumn::unfold()
     for (const auto& list : items_) {
       for (size_t j = list.offset; j < list.offset + list.length; ++j) {
         auto elem = datas_->get_elem(j);
-        if (elem.IsNull()) {
-          builder.push_back_null();
-        } else {
-          builder.push_back_elem(elem);
-        }
+        builder.push_back_elem(elem);
         offsets.push_back(i);
       }
       ++i;
@@ -73,11 +65,7 @@ std::pair<std::shared_ptr<IContextColumn>, sel_vec_t> ListColumn::unfold()
     for (const auto& list : items_) {
       for (size_t j = list.offset; j < list.offset + list.length; ++j) {
         auto elem = datas_->get_elem(j);
-        if (elem.IsNull()) {
-          builder.push_back_null();
-        } else {
-          builder.push_back_elem(elem);
-        }
+        builder.push_back_elem(elem);
         offsets.push_back(i);
       }
       ++i;
@@ -91,11 +79,7 @@ std::pair<std::shared_ptr<IContextColumn>, sel_vec_t> ListColumn::unfold()
     for (const auto& list : items_) {
       for (size_t j = list.offset; j < list.offset + list.length; ++j) {
         auto elem = datas_->get_elem(j);
-        if (elem.IsNull()) {
-          builder.push_back_null();
-        } else {
-          builder.push_back_elem(elem);
-        }
+        builder.push_back_elem(elem);
         offsets.push_back(i);
       }
       ++i;
@@ -109,14 +93,7 @@ std::pair<std::shared_ptr<IContextColumn>, sel_vec_t> ListColumn::unfold()
     for (const auto& list : items_) {
       for (size_t j = list.offset; j < list.offset + list.length; ++j) {
         auto elem = datas_->get_elem(j);
-        if (elem.IsNull()) {
-          builder.push_back_null();
-        } else {
-          auto edge = elem.GetValue<edge_t>();
-          builder.insert_label(edge.label);
-          builder.push_back_opt(edge.label, edge.src, edge.dst, edge.prop,
-                                edge.dir);
-        }
+        builder.push_back_elem(elem);
         offsets.push_back(i);
       }
       ++i;

--- a/src/common/columns/struct_columns.cc
+++ b/src/common/columns/struct_columns.cc
@@ -80,13 +80,13 @@ StructColumnBuilder::StructColumnBuilder(DataType type) : type_(type) {
 }
 
 void StructColumnBuilder::push_back_elem(const Value& val) {
+  if (val.IsNull()) {
+    push_back_null();
+    return;
+  }
   const auto& struct_values = StructValue::GetChildren(val);
   for (size_t i = 0; i < child_builders_.size(); ++i) {
-    if (struct_values[i].IsNull()) {
-      child_builders_[i]->push_back_null();
-    } else {
-      child_builders_[i]->push_back_elem(struct_values[i]);
-    }
+    child_builders_[i]->push_back_elem(struct_values[i]);
   }
   ++current_size_;
 }

--- a/src/execution/common/operators/retrieve/unfold.cc
+++ b/src/execution/common/operators/retrieve/unfold.cc
@@ -85,11 +85,7 @@ void unfold_list_like(ContextChunk& chunk, int alias,
     Value val = key.eval_record(chunk.chunk(), i);
     const auto& children = getListLikeChildren(val);
     for (const auto& elem : children) {
-      if (elem.IsNull()) {
-        builder->push_back_null();
-      } else {
-        builder->push_back_elem(elem);
-      }
+      builder->push_back_elem(elem);
       offsets.push_back(i);
     }
   }

--- a/src/execution/common/operators/retrieve/unfold.cc
+++ b/src/execution/common/operators/retrieve/unfold.cc
@@ -85,7 +85,11 @@ void unfold_list_like(ContextChunk& chunk, int alias,
     Value val = key.eval_record(chunk.chunk(), i);
     const auto& children = getListLikeChildren(val);
     for (const auto& elem : children) {
-      builder->push_back_elem(elem);
+      if (elem.IsNull()) {
+        builder->push_back_null();
+      } else {
+        builder->push_back_elem(elem);
+      }
       offsets.push_back(i);
     }
   }

--- a/src/execution/execute/ops/retrieve/project_utils.cc
+++ b/src/execution/execute/ops/retrieve/project_utils.cc
@@ -218,11 +218,7 @@ struct GeneralExpr : public ProjectExprBase {
 
     for (size_t i = 0; i < chunk.row_num(); ++i) {
       const auto& val = e.eval_record(chunk.chunk(), i);
-      if (val.IsNull()) {
-        column_builder->push_back_null();
-      } else {
-        column_builder->push_back_elem(val);
-      }
+      column_builder->push_back_elem(val);
     }
     return column_builder->finish();
   }

--- a/src/utils/io/read/json/json_reader.cc
+++ b/src/utils/io/read/json/json_reader.cc
@@ -277,12 +277,8 @@ class JsonChunkSupplier : public IDataChunkSupplier {
               "' not found in JSON object in file: " + file_path_);
         }
         const auto& json_value = obj[name.c_str()];
-        if (json_value.IsNull()) {
-          builders[col]->push_back_null();
-        } else {
-          builders[col]->push_back_elem(
-              parse_json_value(json_value, selected_types[col]));
-        }
+        builders[col]->push_back_elem(
+            parse_json_value(json_value, selected_types[col]));
       }
       ++rows_in_chunk;
     }

--- a/tools/python_bind/tests/test_db_array.py
+++ b/tools/python_bind/tests/test_db_array.py
@@ -617,11 +617,7 @@ def test_array_preserves_null_elements(tmp_path):
     db = Database(db_path=str(tmp_path), mode="w")
     conn = db.connect()
 
-    rows = list(
-        conn.execute(
-            "RETURN CAST([1, CAST(NULL, 'INT64'), 3], 'INT64[3]');"
-        )
-    )
+    rows = list(conn.execute("RETURN CAST([1, CAST(NULL, 'INT64'), 3], 'INT64[3]');"))
     assert _nested_list(rows[0][0]) == [1, None, 3]
 
     rows = list(
@@ -646,9 +642,7 @@ def test_parquet_list_and_array_preserve_null_elements(tmp_path):
         pa.table(
             {
                 "id": pa.array([1, 2], type=pa.int64()),
-                "values": pa.array(
-                    [[1, None, 3], [4, 5]], type=pa.list_(pa.int64())
-                ),
+                "values": pa.array([[1, None, 3], [4, 5]], type=pa.list_(pa.int64())),
             }
         ),
         list_path,
@@ -672,9 +666,7 @@ def test_parquet_list_and_array_preserve_null_elements(tmp_path):
     conn = db.connect()
     conn.execute("LOAD PARQUET")
 
-    rows = list(
-        conn.execute(f'LOAD FROM "{list_path}" RETURN id, values ORDER BY id')
-    )
+    rows = list(conn.execute(f'LOAD FROM "{list_path}" RETURN id, values ORDER BY id'))
     assert rows == [[1, [1, None, 3]], [2, [4, 5]]]
 
     rows = list(

--- a/tools/python_bind/tests/test_db_array.py
+++ b/tools/python_bind/tests/test_db_array.py
@@ -624,6 +624,14 @@ def test_array_preserves_null_elements(tmp_path):
     )
     assert _nested_list(rows[0][0]) == [1, None, 3]
 
+    rows = list(
+        conn.execute(
+            "UNWIND CAST([1, CAST(NULL, 'INT64'), 3], 'INT64[3]') AS value "
+            "RETURN value;"
+        )
+    )
+    assert rows == [[1], [None], [3]]
+
     conn.close()
     db.close()
 

--- a/tools/python_bind/tests/test_db_array.py
+++ b/tools/python_bind/tests/test_db_array.py
@@ -636,6 +636,72 @@ def test_array_preserves_null_elements(tmp_path):
     db.close()
 
 
+def test_parquet_list_and_array_preserve_null_elements(tmp_path):
+    """Parquet LIST/ARRAY reads and LIST UNWIND preserve inner NULLs."""
+    pa = pytest.importorskip("pyarrow")
+    import pyarrow.parquet as pq
+
+    list_path = tmp_path / "list_nulls.parquet"
+    pq.write_table(
+        pa.table(
+            {
+                "id": pa.array([1, 2], type=pa.int64()),
+                "values": pa.array(
+                    [[1, None, 3], [4, 5]], type=pa.list_(pa.int64())
+                ),
+            }
+        ),
+        list_path,
+    )
+
+    array_path = tmp_path / "array_nulls.parquet"
+    pq.write_table(
+        pa.table(
+            {
+                "id": pa.array([1, 2], type=pa.int64()),
+                "vec": pa.array(
+                    [[1.0, None, 3.0], [4.0, 5.0, 6.0]],
+                    type=pa.list_(pa.float64(), 3),
+                ),
+            }
+        ),
+        array_path,
+    )
+
+    db = Database(db_path=str(tmp_path / "list_db"), mode="w")
+    conn = db.connect()
+    conn.execute("LOAD PARQUET")
+
+    rows = list(
+        conn.execute(f'LOAD FROM "{list_path}" RETURN id, values ORDER BY id')
+    )
+    assert rows == [[1, [1, None, 3]], [2, [4, 5]]]
+
+    rows = list(
+        conn.execute(
+            f'LOAD FROM "{list_path}" '
+            "UNWIND values AS value RETURN value ORDER BY value"
+        )
+    )
+    assert rows == [[1], [None], [3], [4], [5]]
+
+    conn.close()
+    db.close()
+
+    db = Database(db_path=str(tmp_path / "array_db"), mode="w")
+    conn = db.connect()
+    conn.execute("LOAD PARQUET")
+
+    rows = list(conn.execute(f'LOAD FROM "{array_path}" RETURN id, vec ORDER BY id'))
+    assert rows == [
+        [1, [1.0, None, 3.0]],
+        [2, [4.0, 5.0, 6.0]],
+    ]
+
+    conn.close()
+    db.close()
+
+
 def test_array_wrong_size_throws(tmp_path):
     """Inserting an array with wrong number of elements should fail."""
     db = Database(db_path=str(tmp_path), mode="w")

--- a/tools/python_bind/tests/test_db_array.py
+++ b/tools/python_bind/tests/test_db_array.py
@@ -612,6 +612,22 @@ def test_array_null_handling(tmp_path):
     db.close()
 
 
+def test_array_preserves_null_elements(tmp_path):
+    """NULL elements inside a fixed-size array survive result materialization."""
+    db = Database(db_path=str(tmp_path), mode="w")
+    conn = db.connect()
+
+    rows = list(
+        conn.execute(
+            "RETURN CAST([1, CAST(NULL, 'INT64'), 3], 'INT64[3]');"
+        )
+    )
+    assert _nested_list(rows[0][0]) == [1, None, 3]
+
+    conn.close()
+    db.close()
+
+
 def test_array_wrong_size_throws(tmp_path):
     """Inserting an array with wrong number of elements should fail."""
     db = Database(db_path=str(tmp_path), mode="w")

--- a/tools/python_bind/tests/test_db_array.py
+++ b/tools/python_bind/tests/test_db_array.py
@@ -632,68 +632,6 @@ def test_array_preserves_null_elements(tmp_path):
     db.close()
 
 
-def test_parquet_list_and_array_preserve_null_elements(tmp_path):
-    """Parquet LIST/ARRAY reads and LIST UNWIND preserve inner NULLs."""
-    pa = pytest.importorskip("pyarrow")
-    import pyarrow.parquet as pq
-
-    list_path = tmp_path / "list_nulls.parquet"
-    pq.write_table(
-        pa.table(
-            {
-                "id": pa.array([1, 2], type=pa.int64()),
-                "values": pa.array([[1, None, 3], [4, 5]], type=pa.list_(pa.int64())),
-            }
-        ),
-        list_path,
-    )
-
-    array_path = tmp_path / "array_nulls.parquet"
-    pq.write_table(
-        pa.table(
-            {
-                "id": pa.array([1, 2], type=pa.int64()),
-                "vec": pa.array(
-                    [[1.0, None, 3.0], [4.0, 5.0, 6.0]],
-                    type=pa.list_(pa.float64(), 3),
-                ),
-            }
-        ),
-        array_path,
-    )
-
-    db = Database(db_path=str(tmp_path / "list_db"), mode="w")
-    conn = db.connect()
-    conn.execute("LOAD PARQUET")
-
-    rows = list(conn.execute(f'LOAD FROM "{list_path}" RETURN id, values ORDER BY id'))
-    assert rows == [[1, [1, None, 3]], [2, [4, 5]]]
-
-    rows = list(
-        conn.execute(
-            f'LOAD FROM "{list_path}" '
-            "UNWIND values AS value RETURN value ORDER BY value"
-        )
-    )
-    assert rows == [[1], [None], [3], [4], [5]]
-
-    conn.close()
-    db.close()
-
-    db = Database(db_path=str(tmp_path / "array_db"), mode="w")
-    conn = db.connect()
-    conn.execute("LOAD PARQUET")
-
-    rows = list(conn.execute(f'LOAD FROM "{array_path}" RETURN id, vec ORDER BY id'))
-    assert rows == [
-        [1, [1.0, None, 3.0]],
-        [2, [4.0, 5.0, 6.0]],
-    ]
-
-    conn.close()
-    db.close()
-
-
 def test_array_wrong_size_throws(tmp_path):
     """Inserting an array with wrong number of elements should fail."""
     db = Database(db_path=str(tmp_path), mode="w")

--- a/tools/python_bind/tests/test_db_list.py
+++ b/tools/python_bind/tests/test_db_list.py
@@ -64,6 +64,68 @@ def test_list_cast_contract(tmp_path):
     db.close()
 
 
+def test_list_preserves_null_elements_during_unwind(tmp_path):
+    db = Database(db_path=str(tmp_path), mode="w", checkpoint_on_close=False)
+    conn = db.connect()
+
+    rows = list(
+        conn.execute(
+            "UNWIND CAST([1, CAST(NULL, 'INT64'), 3], 'INT64[]') AS value "
+            "RETURN value;"
+        )
+    )
+    assert rows == [[1], [None], [3]]
+
+    rows = list(
+        conn.execute(
+            "UNWIND CAST([CAST([1, CAST(NULL, 'INT64'), 3], 'INT64[]')], "
+            "'INT64[][]') AS values "
+            "UNWIND values AS value RETURN value;"
+        )
+    )
+    assert rows == [[1], [None], [3]]
+
+    conn.close()
+    db.close()
+
+
+def test_list_edge_preserves_null_elements_during_unwind(tmp_path):
+    db = Database(db_path=str(tmp_path), mode="w", checkpoint_on_close=False)
+    conn = db.connect()
+
+    conn.execute("CREATE NODE TABLE Person(id INT64, PRIMARY KEY(id));")
+    conn.execute("CREATE REL TABLE Knows(FROM Person TO Person);")
+    conn.execute("CREATE (:Person {id: 1}), (:Person {id: 2});")
+    conn.execute(
+        "MATCH (a:Person {id: 1}), (b:Person {id: 2}) " "CREATE (a)-[:Knows]->(b);"
+    )
+
+    rows = list(
+        conn.execute(
+            "MATCH (person:Person) "
+            "OPTIONAL MATCH (person)-[edge:Knows]->(:Person) "
+            "WITH person.id AS id, [edge] AS values "
+            "UNWIND values AS value "
+            "RETURN id, value ORDER BY id;"
+        )
+    )
+    assert rows == [
+        [
+            1,
+            {
+                "_ID": 1,
+                "_LABEL": "Knows",
+                "_SRC_ID": 0,
+                "_DST_ID": 1,
+            },
+        ],
+        [2, None],
+    ]
+
+    conn.close()
+    db.close()
+
+
 def test_list_point_edge_update_and_reopen(tmp_path):
     db_path = str(tmp_path)
     db = Database(db_path=db_path, mode="w")

--- a/tools/python_bind/tests/test_load_array.py
+++ b/tools/python_bind/tests/test_load_array.py
@@ -716,11 +716,11 @@ class TestLoadArray:
         ]
 
     @extension_test
-    def test_parquet_variable_length_list_null_elements(self):
-        """LOAD FROM Parquet preserves null elements inside variable-length lists."""
+    def test_parquet_list_and_array_preserve_null_elements(self):
+        """Parquet LIST/ARRAY reads and LIST UNWIND preserve inner NULLs."""
         pa = pytest.importorskip("pyarrow")
-        parquet_path = self._write_parquet(
-            "var_list_null_elems.parquet",
+        list_path = self._write_parquet(
+            "list_nulls.parquet",
             {
                 "id": pa.array([1, 2], type=pa.int64()),
                 "values": pa.array(
@@ -729,15 +729,40 @@ class TestLoadArray:
                 ),
             },
         )
-        self.conn.execute("LOAD PARQUET")
-        result = list(
-            self.conn.execute(
-                f'LOAD FROM "{parquet_path}" RETURN id, values ORDER BY id'
-            )
+        array_path = self._write_parquet(
+            "array_nulls.parquet",
+            {
+                "id": pa.array([1, 2], type=pa.int64()),
+                "vec": pa.array(
+                    [[1.0, None, 3.0], [4.0, 5.0, 6.0]],
+                    type=pa.list_(pa.float64(), 3),
+                ),
+            },
         )
-        assert result == [
+        self.conn.execute("LOAD PARQUET")
+
+        rows = list(
+            self.conn.execute(f'LOAD FROM "{list_path}" RETURN id, values ORDER BY id')
+        )
+        assert rows == [
             [1, [1, None, 3]],
             [2, [4, 5]],
+        ]
+
+        rows = list(
+            self.conn.execute(
+                f'LOAD FROM "{list_path}" '
+                "UNWIND values AS value RETURN value ORDER BY value"
+            )
+        )
+        assert rows == [[1], [None], [3], [4], [5]]
+
+        rows = list(
+            self.conn.execute(f'LOAD FROM "{array_path}" RETURN id, vec ORDER BY id')
+        )
+        assert rows == [
+            [1, [1.0, None, 3.0]],
+            [2, [4.0, 5.0, 6.0]],
         ]
 
     @extension_test


### PR DESCRIPTION
## Summary
- preserve null child elements when building fixed-size ARRAY columns
- preserve null elements across ListColumn unfold and expression-evaluated UNWIND paths
- add Python regression coverage for typed ARRAY nulls and Parquet LIST/ARRAY null elements

## Testing
- /tmp/neug-py314-pa-venv/bin/python -m pytest -s tools/python_bind/tests/test_db_array.py::test_parquet_list_and_array_preserve_null_elements tools/python_bind/tests/test_db_array.py::test_array_preserves_null_elements

Fixes #877
Fixes #881