### PR TITLE
fix: support null values in CSV collections and aggregation function

### DIFF
--- a/doc/source/cypher_manual/expression/agg_func.md
+++ b/doc/source/cypher_manual/expression/agg_func.md
@@ -5,8 +5,20 @@ Aggregate Functions are primarily used to group current data and perform aggrega
 Function | Description | Can be used with DISTINCT | Example
 ---------|-------------|---------------------------|--------
 count | return the row counts | YES | RETURN count(a.name);
-collect | collect the non-null elements in a single list | YES | RETURN collect(a.name);
+collect | collect the elements in a single list | YES | RETURN collect(a.name);
 min | return the minimum value | NO | RETURN min(a.age);
 max | return the maximum value | NO | RETURN max(a.age);
 sum | sum up the value | NO | RETURN sum(a.age);
 avg | return the average value | NO | RETURN avg(a.age);
+
+## NULL Value Handling
+
+- When the input is empty, `count()` and `sum` return `0`, `collect` returns
+  `[]`, and `avg`, `min`, and `max` return `NULL`.
+- When the input contains `NULL` values, all aggregate functions ignore them.
+  In particular, `count(*)` counts every input row, including rows containing
+  `NULL` values.
+- When the input consists entirely of `NULL` values, the aggregate results
+  after ignoring `NULL` are the same as for empty input: `count()` and `sum`
+  return `0`, `collect` returns `[]`, and `avg`, `min`, and `max` return
+  `NULL`. `count(*)` still returns the total number of input rows.

--- a/doc/source/cypher_manual/expression/agg_func.md
+++ b/doc/source/cypher_manual/expression/agg_func.md
@@ -22,3 +22,9 @@ avg | return the average value | NO | RETURN avg(a.age);
   after ignoring `NULL` are the same as for empty input: `count()` and `sum`
   return `0`, `collect` returns `[]`, and `avg`, `min`, and `max` return
   `NULL`. `count(*)` still returns the total number of input rows.
+
+Input | `count(expr)` | `count(*)` | `collect` | `min` | `max` | `sum` | `avg`
+------|---------------|------------|-----------|-------|-------|-------|------
+`[]` | `0` | `0` | `[]` | `NULL` | `NULL` | `0` | `NULL`
+`[1, NULL, 2]` | `2` | `3` | `[1, 2]` | `1` | `2` | `3` | `1.5`
+`[NULL, NULL]` | `0` | `2` | `[]` | `NULL` | `NULL` | `0` | `NULL`

--- a/doc/source/cypher_manual/expression/agg_func.md
+++ b/doc/source/cypher_manual/expression/agg_func.md
@@ -5,7 +5,7 @@ Aggregate Functions are primarily used to group current data and perform aggrega
 Function | Description | Can be used with DISTINCT | Example
 ---------|-------------|---------------------------|--------
 count | return the row counts | YES | RETURN count(a.name);
-collect | collect the elements in a single list | YES | RETURN collect(a.name);
+collect | collect the non-null elements in a single list | YES | RETURN collect(a.name);
 min | return the minimum value | NO | RETURN min(a.age);
 max | return the maximum value | NO | RETURN max(a.age);
 sum | sum up the value | NO | RETURN sum(a.age);

--- a/doc/source/cypher_manual/expression/list_op.md
+++ b/doc/source/cypher_manual/expression/list_op.md
@@ -8,6 +8,9 @@ Operator | Description | Example
 `[]` | extract an element from a list or fixed-size array by zero-based index | `[10, 20, 30][0]`
 `UNWIND` | expand a list or fixed-size array into one row per element | `MATCH (s:Sensor) UNWIND s.readings AS x RETURN x`
 
+Note: `UNWIND` preserves NULL values when expanding a list or array. If
+`collect()` is applied afterward, the NULL values are filtered out.
+
 ## Array Values
 
 `ARRAY` is a fixed-size list-like type declared with `T[N]`. It can be used with `UNWIND`:

--- a/src/execution/common/operators/retrieve/group_by.cc
+++ b/src/execution/common/operators/retrieve/group_by.cc
@@ -24,6 +24,9 @@ neug::result<ContextChunk> GroupBy::group_by(ContextChunk&& chunk,
   auto [offsets, groups] = key->group(chunk);
   ContextChunk ret;
   const auto& tag_alias = key->tag_alias();
+  if (groups.empty() && tag_alias.empty()) {
+    groups.emplace_back();
+  }
   for (size_t i = 0; i < tag_alias.size(); ++i) {
     ret.set(tag_alias[i].second, chunk.get(tag_alias[i].first));
   }

--- a/src/execution/execute/ops/retrieve/group_by_utils.cc
+++ b/src/execution/execute/ops/retrieve/group_by_utils.cc
@@ -183,18 +183,12 @@ struct SumReducer<EXPR, IS_OPTIONAL,
     } else {
       for (auto& group : groups) {
         V sum = 0;
-        bool has_value = false;
         for (size_t i = 0; i < group.size(); ++i) {
           if (expr.has_value(group[i])) {
             sum += expr(group[i]);
-            has_value = true;
           }
         }
-        if (has_value) {
-          builder.push_back_opt(sum);
-        } else {
-          builder.push_back_null();
-        }
+        builder.push_back_opt(sum);
       }
     }
     return builder.finish();
@@ -340,6 +334,10 @@ struct MinReducer : public ReducerBase {
     builder.reserve(groups.size());
     if constexpr (!IS_OPTIONAL) {
       for (auto& group : groups) {
+        if (group.empty()) {
+          builder.push_back_null();
+          continue;
+        }
         V min_val = expr(group[0]);
         for (size_t i = 1; i < group.size(); ++i) {
           min_val = std::min(min_val, expr(group[i]));
@@ -385,6 +383,10 @@ struct MaxReducer : public ReducerBase {
     builder.reserve(groups.size());
     if constexpr (!IS_OPTIONAL) {
       for (auto& group : groups) {
+        if (group.empty()) {
+          builder.push_back_null();
+          continue;
+        }
         V max_val = expr(group[0]);
         for (size_t i = 1; i < group.size(); ++i) {
           max_val = std::max(max_val, expr(group[i]));
@@ -429,6 +431,10 @@ struct FirstReducer : public ReducerBase {
     builder.reserve(groups.size());
     if constexpr (!IS_OPTIONAL) {
       for (auto& group : groups) {
+        if (group.empty()) {
+          builder.push_back_null();
+          continue;
+        }
         V val = expr(group[0]);
         builder.push_back_opt(val);
       }
@@ -560,6 +566,10 @@ struct AvgReducer<EXPR, IS_OPTIONAL,
     builder.reserve(groups.size());
     if constexpr (!IS_OPTIONAL) {
       for (auto& group : groups) {
+        if (group.empty()) {
+          builder.push_back_null();
+          continue;
+        }
         double avg = 0.0;
         for (auto idx : group) {
           avg += expr(idx);

--- a/src/storages/loader/loader_utils.cc
+++ b/src/storages/loader/loader_utils.cc
@@ -339,8 +339,14 @@ std::vector<std::string_view> split_array_elements(std::string_view input) {
 }
 
 Value parse_array_element(std::string_view token, const DataType& data_type,
+                          const std::unordered_set<std::string>& null_values,
                           const std::unordered_set<std::string>& true_values,
                           const std::unordered_set<std::string>& false_values) {
+  auto trimmed = trim_array_token(token);
+  if (trimmed.empty() || contains_sv(null_values, trimmed)) {
+    return Value();
+  }
+
   switch (data_type.id()) {
   case DataTypeId::kInt32:
     return Value::INT32(
@@ -372,7 +378,6 @@ Value parse_array_element(std::string_view token, const DataType& data_type,
   case DataTypeId::kVarchar:
     return Value::STRING(unquote_array_string_token(token));
   case DataTypeId::kArray: {
-    auto trimmed = trim_array_token(token);
     if (trimmed.size() < 2 || trimmed.front() != '[' || trimmed.back() != ']') {
       THROW_CONVERSION_EXCEPTION("Expected array value for type " +
                                  data_type.ToString() + ": " +
@@ -390,13 +395,12 @@ Value parse_array_element(std::string_view token, const DataType& data_type,
     std::vector<Value> values;
     values.reserve(elements.size());
     for (const auto& element : elements) {
-      values.push_back(
-          parse_array_element(element, child_type, true_values, false_values));
+      values.push_back(parse_array_element(element, child_type, null_values,
+                                           true_values, false_values));
     }
     return Value::ARRAY(data_type, std::move(values));
   }
   case DataTypeId::kList: {
-    auto trimmed = trim_array_token(token);
     if (trimmed.size() < 2 || trimmed.front() != '[' || trimmed.back() != ']') {
       THROW_CONVERSION_EXCEPTION("Expected list value for type " +
                                  data_type.ToString() + ": " +
@@ -407,8 +411,8 @@ Value parse_array_element(std::string_view token, const DataType& data_type,
     std::vector<Value> values;
     values.reserve(elements.size());
     for (const auto& element : elements) {
-      values.push_back(
-          parse_array_element(element, child_type, true_values, false_values));
+      values.push_back(parse_array_element(element, child_type, null_values,
+                                           true_values, false_values));
     }
     return Value::LIST(child_type, std::move(values));
   }
@@ -503,8 +507,9 @@ void append_array_impl(const FieldAppender& app, csv::CSVField field,
     effective_token = unescaped;
   }
   try {
-    builder->push_back_elem(parse_array_element(
-        effective_token, *app.type, ctx.true_values, ctx.false_values));
+    builder->push_back_elem(
+        parse_array_element(effective_token, *app.type, ctx.null_values,
+                            ctx.true_values, ctx.false_values));
   } catch (const std::exception& error) {
     THROW_CONVERSION_EXCEPTION(
         "Failed to parse CSV field, file=" + ctx.file_path +

--- a/tests/execution/resources/collection_null.csv
+++ b/tests/execution/resources/collection_null.csv
@@ -1,0 +1,2 @@
+id|list_values|array_values
+1|[1,,3]|[4,NULL,6]

--- a/tests/execution/resources/collection_null.csv
+++ b/tests/execution/resources/collection_null.csv
@@ -1,2 +1,2 @@
-id|list_values|array_values
-1|[1,,3]|[4,NULL,6]
+id|list_values|array_values|nested_list_values
+1|[1,,3]|[4,NULL,6]|[[7,NULL],NULL,[9,10]]

--- a/tests/execution/test_runtime_column.cc
+++ b/tests/execution/test_runtime_column.cc
@@ -1464,6 +1464,46 @@ TEST_F(ArrowColumnTest, DataChunkSupplierBasic) {
   EXPECT_GT(total_rows, 0);
 }
 
+TEST_F(ArrowColumnTest, CsvCollectionNullElements) {
+  const char* var = std::getenv("TEST_PATH");
+  std::string test_path = var ? var : "/workspaces/neug/tests";
+  std::string file_path =
+      test_path + "/execution/resources/collection_null.csv";
+
+  CsvReadConfig config;
+  put_boolean_option(config);
+  config.delimiter = '|';
+  config.quoting = false;
+  config.skip_rows = 1;
+  config.column_names = {"id", "list_values", "array_values"};
+  config.include_columns = config.column_names;
+  config.column_types.emplace("id", DataType(DataTypeId::kInt64));
+  config.column_types.emplace("list_values",
+                              DataType::List(DataType(DataTypeId::kInt64)));
+  config.column_types.emplace("array_values",
+                              DataType::Array(DataType(DataTypeId::kInt64), 3));
+  config.null_values = {"NULL"};
+
+  CSVChunkSupplier supplier(file_path, std::move(config));
+  auto chunk = supplier.GetNextChunk();
+  ASSERT_NE(chunk, nullptr);
+  ASSERT_EQ(chunk->row_num(), 1);
+
+  auto list_value = chunk->get(1)->get_elem(0);
+  const auto& list_children = ListValue::GetChildren(list_value);
+  ASSERT_EQ(list_children.size(), 3);
+  EXPECT_EQ(list_children[0].GetValue<int64_t>(), 1);
+  EXPECT_TRUE(list_children[1].IsNull());
+  EXPECT_EQ(list_children[2].GetValue<int64_t>(), 3);
+
+  auto array_value = chunk->get(2)->get_elem(0);
+  const auto& array_children = ArrayValue::GetChildren(array_value);
+  ASSERT_EQ(array_children.size(), 3);
+  EXPECT_EQ(array_children[0].GetValue<int64_t>(), 4);
+  EXPECT_TRUE(array_children[1].IsNull());
+  EXPECT_EQ(array_children[2].GetValue<int64_t>(), 6);
+}
+
 }  // namespace test
 }  // namespace execution
 }  // namespace neug

--- a/tests/execution/test_runtime_column.cc
+++ b/tests/execution/test_runtime_column.cc
@@ -42,7 +42,7 @@ class VertexColumnTest : public ::testing::Test {
     col_builder.push_back_elem(Value::VERTEX(VertexRecord(label, kVid0)));
     col_builder.push_back_vertex(VertexRecord(label, kVid1));
     if (is_optional) {
-      col_builder.push_back_null();
+      col_builder.push_back_elem(Value());
     }
     std::shared_ptr<IContextColumn> col = col_builder.finish();
     return std::dynamic_pointer_cast<SLVertexColumn>(col);
@@ -55,7 +55,7 @@ class VertexColumnTest : public ::testing::Test {
     col_builder.push_back_vertex(VertexRecord(kLabel1, kVid1));
     col_builder.push_back_vertex(VertexRecord(kLabel1, kVid2));
     if (is_optional) {
-      col_builder.push_back_null();
+      col_builder.push_back_elem(Value());
     }
     std::shared_ptr<IContextColumn> col = col_builder.finish();
     return std::dynamic_pointer_cast<MSVertexColumn>(col);
@@ -68,7 +68,7 @@ class VertexColumnTest : public ::testing::Test {
     col_builder.push_back_vertex(VertexRecord(kLabel1, kVid1));
     col_builder.push_back_vertex(VertexRecord(kLabel1, kVid2));
     if (is_optional) {
-      col_builder.push_back_null();
+      col_builder.push_back_elem(Value());
     }
     std::shared_ptr<IContextColumn> col = col_builder.finish();
     return std::dynamic_pointer_cast<MLVertexColumn>(col);
@@ -387,7 +387,7 @@ TEST_F(EdgeColumnTest, SDSLEdgeColumnOptional) {
   EdgeRecord e = EdgeRecord{label, kVid1, kVid2, nullptr, Direction::kOut};
   builder.push_back_elem(Value::EDGE(e));
   builder.push_back_opt(kVid1, kVid2, nullptr);
-  builder.push_back_null();
+  builder.push_back_elem(Value());
   auto col_ptr = builder.finish();
   auto* sl_col = dynamic_cast<SDSLEdgeColumn*>(col_ptr.get());
 
@@ -505,7 +505,7 @@ TEST_F(EdgeColumnTest, BDSLEdgeColumnShuffle) {
 
   BDSLEdgeColumnBuilder optional_builder(label);
   optional_builder.push_back_opt(kVid0, kVid1, nullptr, Direction::kOut);
-  optional_builder.push_back_null();
+  optional_builder.push_back_elem(Value());
   optional_builder.push_back_opt(kVid1, kVid0, nullptr, Direction::kIn);
 
   auto optional_col_ptr = optional_builder.finish();
@@ -605,7 +605,7 @@ TEST_F(EdgeColumnTest, SDMLEdgeColumnShuffle) {
 
   SDMLEdgeColumnBuilder optional_builder(Direction::kOut, labels);
   optional_builder.push_back_opt(label0, kVid0, kVid1, nullptr);
-  optional_builder.push_back_null();
+  optional_builder.push_back_elem(Value());
   optional_builder.push_back_opt(label1, kVid1, kVid0, nullptr);
 
   auto optional_col_ptr = optional_builder.finish();
@@ -707,7 +707,7 @@ TEST_F(EdgeColumnTest, BDMLEdgeColumnShuffle) {
   BDMLEdgeColumnBuilder optional_builder(labels);
   optional_builder.push_back_opt(label0, kVid0, kVid1, nullptr,
                                  Direction::kOut);
-  optional_builder.push_back_null();
+  optional_builder.push_back_elem(Value());
   optional_builder.push_back_opt(label1, kVid1, kVid0, nullptr, Direction::kIn);
 
   auto optional_col_ptr = optional_builder.finish();
@@ -761,7 +761,7 @@ TEST_F(EdgeColumnTest, MSEdgeColumnFromBuilder) {
   builder.push_back_opt(kVid0, kVid1, nullptr);
   builder.start_label_dir(label1, Direction::kIn);
   builder.push_back_opt(kVid1, kVid2, nullptr);
-  builder.push_back_null();
+  builder.push_back_elem(Value());
   auto col_ptr = builder.finish();
   std::shared_ptr<MSEdgeColumn> ms_col =
       std::dynamic_pointer_cast<MSEdgeColumn>(col_ptr);
@@ -1295,7 +1295,7 @@ TEST_F(PathColumnTest, OptionalPathColumnBasic) {
 
   PathColumnBuilder builder(true);
   builder.push_back_opt(p1);
-  builder.push_back_null();
+  builder.push_back_elem(Value());
   builder.push_back_elem(Value::PATH(p2));
 
   auto col = std::dynamic_pointer_cast<PathColumn>(builder.finish());
@@ -1475,13 +1475,17 @@ TEST_F(ArrowColumnTest, CsvCollectionNullElements) {
   config.delimiter = '|';
   config.quoting = false;
   config.skip_rows = 1;
-  config.column_names = {"id", "list_values", "array_values"};
+  config.column_names = {"id", "list_values", "array_values",
+                         "nested_list_values"};
   config.include_columns = config.column_names;
   config.column_types.emplace("id", DataType(DataTypeId::kInt64));
   config.column_types.emplace("list_values",
                               DataType::List(DataType(DataTypeId::kInt64)));
   config.column_types.emplace("array_values",
                               DataType::Array(DataType(DataTypeId::kInt64), 3));
+  config.column_types.emplace(
+      "nested_list_values",
+      DataType::List(DataType::List(DataType(DataTypeId::kInt64))));
   config.null_values = {"NULL"};
 
   CSVChunkSupplier supplier(file_path, std::move(config));
@@ -1502,6 +1506,21 @@ TEST_F(ArrowColumnTest, CsvCollectionNullElements) {
   EXPECT_EQ(array_children[0].GetValue<int64_t>(), 4);
   EXPECT_TRUE(array_children[1].IsNull());
   EXPECT_EQ(array_children[2].GetValue<int64_t>(), 6);
+
+  auto nested_list_value = chunk->get(3)->get_elem(0);
+  const auto& nested_list_children = ListValue::GetChildren(nested_list_value);
+  ASSERT_EQ(nested_list_children.size(), 3);
+  const auto& first_nested_children =
+      ListValue::GetChildren(nested_list_children[0]);
+  ASSERT_EQ(first_nested_children.size(), 2);
+  EXPECT_EQ(first_nested_children[0].GetValue<int64_t>(), 7);
+  EXPECT_TRUE(first_nested_children[1].IsNull());
+  EXPECT_TRUE(nested_list_children[1].IsNull());
+  const auto& last_nested_children =
+      ListValue::GetChildren(nested_list_children[2]);
+  ASSERT_EQ(last_nested_children.size(), 2);
+  EXPECT_EQ(last_nested_children[0].GetValue<int64_t>(), 9);
+  EXPECT_EQ(last_nested_children[1].GetValue<int64_t>(), 10);
 }
 
 }  // namespace test

--- a/tests/execution/test_runtime_column.cc
+++ b/tests/execution/test_runtime_column.cc
@@ -42,7 +42,7 @@ class VertexColumnTest : public ::testing::Test {
     col_builder.push_back_elem(Value::VERTEX(VertexRecord(label, kVid0)));
     col_builder.push_back_vertex(VertexRecord(label, kVid1));
     if (is_optional) {
-      col_builder.push_back_elem(Value());
+      col_builder.push_back_elem(Value(DataType::VERTEX));
     }
     std::shared_ptr<IContextColumn> col = col_builder.finish();
     return std::dynamic_pointer_cast<SLVertexColumn>(col);
@@ -55,7 +55,7 @@ class VertexColumnTest : public ::testing::Test {
     col_builder.push_back_vertex(VertexRecord(kLabel1, kVid1));
     col_builder.push_back_vertex(VertexRecord(kLabel1, kVid2));
     if (is_optional) {
-      col_builder.push_back_elem(Value());
+      col_builder.push_back_elem(Value(DataType::VERTEX));
     }
     std::shared_ptr<IContextColumn> col = col_builder.finish();
     return std::dynamic_pointer_cast<MSVertexColumn>(col);
@@ -68,7 +68,7 @@ class VertexColumnTest : public ::testing::Test {
     col_builder.push_back_vertex(VertexRecord(kLabel1, kVid1));
     col_builder.push_back_vertex(VertexRecord(kLabel1, kVid2));
     if (is_optional) {
-      col_builder.push_back_elem(Value());
+      col_builder.push_back_elem(Value(DataType::VERTEX));
     }
     std::shared_ptr<IContextColumn> col = col_builder.finish();
     return std::dynamic_pointer_cast<MLVertexColumn>(col);
@@ -387,7 +387,7 @@ TEST_F(EdgeColumnTest, SDSLEdgeColumnOptional) {
   EdgeRecord e = EdgeRecord{label, kVid1, kVid2, nullptr, Direction::kOut};
   builder.push_back_elem(Value::EDGE(e));
   builder.push_back_opt(kVid1, kVid2, nullptr);
-  builder.push_back_elem(Value());
+  builder.push_back_elem(Value(DataType::EDGE));
   auto col_ptr = builder.finish();
   auto* sl_col = dynamic_cast<SDSLEdgeColumn*>(col_ptr.get());
 
@@ -505,7 +505,7 @@ TEST_F(EdgeColumnTest, BDSLEdgeColumnShuffle) {
 
   BDSLEdgeColumnBuilder optional_builder(label);
   optional_builder.push_back_opt(kVid0, kVid1, nullptr, Direction::kOut);
-  optional_builder.push_back_elem(Value());
+  optional_builder.push_back_elem(Value(DataType::EDGE));
   optional_builder.push_back_opt(kVid1, kVid0, nullptr, Direction::kIn);
 
   auto optional_col_ptr = optional_builder.finish();
@@ -605,7 +605,7 @@ TEST_F(EdgeColumnTest, SDMLEdgeColumnShuffle) {
 
   SDMLEdgeColumnBuilder optional_builder(Direction::kOut, labels);
   optional_builder.push_back_opt(label0, kVid0, kVid1, nullptr);
-  optional_builder.push_back_elem(Value());
+  optional_builder.push_back_elem(Value(DataType::EDGE));
   optional_builder.push_back_opt(label1, kVid1, kVid0, nullptr);
 
   auto optional_col_ptr = optional_builder.finish();
@@ -707,7 +707,7 @@ TEST_F(EdgeColumnTest, BDMLEdgeColumnShuffle) {
   BDMLEdgeColumnBuilder optional_builder(labels);
   optional_builder.push_back_opt(label0, kVid0, kVid1, nullptr,
                                  Direction::kOut);
-  optional_builder.push_back_elem(Value());
+  optional_builder.push_back_elem(Value(DataType::EDGE));
   optional_builder.push_back_opt(label1, kVid1, kVid0, nullptr, Direction::kIn);
 
   auto optional_col_ptr = optional_builder.finish();
@@ -761,7 +761,7 @@ TEST_F(EdgeColumnTest, MSEdgeColumnFromBuilder) {
   builder.push_back_opt(kVid0, kVid1, nullptr);
   builder.start_label_dir(label1, Direction::kIn);
   builder.push_back_opt(kVid1, kVid2, nullptr);
-  builder.push_back_elem(Value());
+  builder.push_back_elem(Value(DataType::EDGE));
   auto col_ptr = builder.finish();
   std::shared_ptr<MSEdgeColumn> ms_col =
       std::dynamic_pointer_cast<MSEdgeColumn>(col_ptr);
@@ -1295,7 +1295,7 @@ TEST_F(PathColumnTest, OptionalPathColumnBasic) {
 
   PathColumnBuilder builder(true);
   builder.push_back_opt(p1);
-  builder.push_back_elem(Value());
+  builder.push_back_elem(Value(DataType::PATH));
   builder.push_back_elem(Value::PATH(p2));
 
   auto col = std::dynamic_pointer_cast<PathColumn>(builder.finish());

--- a/tests/execution/test_value_column.cc
+++ b/tests/execution/test_value_column.cc
@@ -39,10 +39,10 @@ TEST_F(ValueColumnTest, OptionalArrayShuffleAndUnfold) {
   ContextArrayColumnBuilder builder(array_type);
   builder.push_back_elem(
       Value::ARRAY(array_type, {Value::INT32(1), Value::INT32(2)}));
-  builder.push_back_elem(Value());
+  builder.push_back_elem(Value(array_type));
   builder.push_back_elem(
       Value::ARRAY(array_type, {Value::INT32(3), Value::INT32(4)}));
-  builder.push_back_elem(Value());
+  builder.push_back_elem(Value(array_type));
   auto col = std::dynamic_pointer_cast<ContextArrayColumn>(builder.finish());
 
   ASSERT_NE(col, nullptr);
@@ -1243,7 +1243,7 @@ class OptionalValueColumnTest : public ::testing::Test {};
 TEST_F(OptionalValueColumnTest, BoolOptionalValueColumnBasic) {
   ValueColumnBuilder<bool> builder(true);
   builder.push_back_opt(true);
-  builder.push_back_elem(Value());
+  builder.push_back_elem(Value(DataType::BOOLEAN));
   builder.push_back_elem(Value::BOOLEAN(false));
   auto col = std::dynamic_pointer_cast<ValueColumn<bool>>(builder.finish());
 
@@ -1715,7 +1715,7 @@ TEST_F(OptionalValueColumnTest, TupleOptionalValueColumnBasic) {
   builder.push_back_elem(Value::STRUCT(std::move(values1)));
 
   // Add null
-  builder.push_back_elem(Value());
+  builder.push_back_elem(Value(struct_type));
 
   // Add third element
   std::vector<Value> values2;
@@ -1824,7 +1824,7 @@ TEST_F(ListColumnTest, OptionalListShuffle) {
   auto child_type = DataType(DataTypeId::kInt32);
   ListColumnBuilder builder(child_type);
   builder.push_back_elem(Value::LIST(child_type, {Value::INT32(1)}));
-  builder.push_back_elem(Value());
+  builder.push_back_elem(Value(DataType::List(child_type)));
   builder.push_back_elem(Value::LIST(child_type, {Value::INT32(3)}));
   auto col = std::dynamic_pointer_cast<ListColumn>(builder.finish());
 

--- a/tests/execution/test_value_column.cc
+++ b/tests/execution/test_value_column.cc
@@ -39,10 +39,10 @@ TEST_F(ValueColumnTest, OptionalArrayShuffleAndUnfold) {
   ContextArrayColumnBuilder builder(array_type);
   builder.push_back_elem(
       Value::ARRAY(array_type, {Value::INT32(1), Value::INT32(2)}));
-  builder.push_back_null();
+  builder.push_back_elem(Value());
   builder.push_back_elem(
       Value::ARRAY(array_type, {Value::INT32(3), Value::INT32(4)}));
-  builder.push_back_null();
+  builder.push_back_elem(Value());
   auto col = std::dynamic_pointer_cast<ContextArrayColumn>(builder.finish());
 
   ASSERT_NE(col, nullptr);
@@ -1243,7 +1243,7 @@ class OptionalValueColumnTest : public ::testing::Test {};
 TEST_F(OptionalValueColumnTest, BoolOptionalValueColumnBasic) {
   ValueColumnBuilder<bool> builder(true);
   builder.push_back_opt(true);
-  builder.push_back_null();
+  builder.push_back_elem(Value());
   builder.push_back_elem(Value::BOOLEAN(false));
   auto col = std::dynamic_pointer_cast<ValueColumn<bool>>(builder.finish());
 
@@ -1715,7 +1715,7 @@ TEST_F(OptionalValueColumnTest, TupleOptionalValueColumnBasic) {
   builder.push_back_elem(Value::STRUCT(std::move(values1)));
 
   // Add null
-  builder.push_back_null();
+  builder.push_back_elem(Value());
 
   // Add third element
   std::vector<Value> values2;
@@ -1818,6 +1818,37 @@ TEST_F(ListColumnTest, ListColumnBasic) {
     EXPECT_EQ(list1_children[0].GetValue<int32_t>(), 10);
     EXPECT_EQ(list1_children[1].GetValue<int32_t>(), 20);
   }
+}
+
+TEST_F(ListColumnTest, OptionalListShuffle) {
+  auto child_type = DataType(DataTypeId::kInt32);
+  ListColumnBuilder builder(child_type);
+  builder.push_back_elem(Value::LIST(child_type, {Value::INT32(1)}));
+  builder.push_back_elem(Value());
+  builder.push_back_elem(Value::LIST(child_type, {Value::INT32(3)}));
+  auto col = std::dynamic_pointer_cast<ListColumn>(builder.finish());
+
+  ASSERT_NE(col, nullptr);
+  ASSERT_EQ(col->size(), 3);
+  EXPECT_TRUE(col->has_value(0));
+  EXPECT_FALSE(col->has_value(1));
+  EXPECT_TRUE(col->has_value(2));
+
+  auto shuffled = col->shuffle({2, 1, 0});
+  ASSERT_EQ(shuffled->size(), 3);
+  EXPECT_TRUE(shuffled->has_value(0));
+  EXPECT_FALSE(shuffled->has_value(1));
+  EXPECT_TRUE(shuffled->has_value(2));
+
+  auto first = shuffled->get_elem(0);
+  const auto& first_children = ListValue::GetChildren(first);
+  ASSERT_EQ(first_children.size(), 1);
+  EXPECT_EQ(first_children[0].GetValue<int32_t>(), 3);
+
+  auto last = shuffled->get_elem(2);
+  const auto& last_children = ListValue::GetChildren(last);
+  ASSERT_EQ(last_children.size(), 1);
+  EXPECT_EQ(last_children[0].GetValue<int32_t>(), 1);
 }
 
 TEST_F(ValueColumnTest, ListColumnUnfold) {

--- a/tools/python_bind/tests/test_db_array.py
+++ b/tools/python_bind/tests/test_db_array.py
@@ -617,6 +617,9 @@ def test_array_preserves_null_elements(tmp_path):
     db = Database(db_path=str(tmp_path), mode="w")
     conn = db.connect()
 
+    rows = list(conn.execute("RETURN CAST(NULL, 'INT64[3]');"))
+    assert rows == [[None]]
+
     rows = list(conn.execute("RETURN CAST([1, CAST(NULL, 'INT64'), 3], 'INT64[3]');"))
     assert _nested_list(rows[0][0]) == [1, None, 3]
 

--- a/tools/python_bind/tests/test_db_array.py
+++ b/tools/python_bind/tests/test_db_array.py
@@ -628,6 +628,14 @@ def test_array_preserves_null_elements(tmp_path):
     )
     assert rows == [[1], [None], [3]]
 
+    rows = list(
+        conn.execute(
+            "UNWIND CAST([1, CAST(NULL, 'INT64'), 1, 3], 'INT64[4]') AS value "
+            "RETURN collect(DISTINCT value);"
+        )
+    )
+    assert _nested_list(rows[0][0]) == [1, 3]
+
     conn.close()
     db.close()
 

--- a/tools/python_bind/tests/test_db_list.py
+++ b/tools/python_bind/tests/test_db_list.py
@@ -68,6 +68,9 @@ def test_list_preserves_null_elements_during_unwind(tmp_path):
     db = Database(db_path=str(tmp_path), mode="w", checkpoint_on_close=False)
     conn = db.connect()
 
+    rows = list(conn.execute("RETURN CAST(NULL, 'INT64[]');"))
+    assert rows == [[None]]
+
     rows = list(
         conn.execute(
             "UNWIND CAST([1, CAST(NULL, 'INT64'), 3], 'INT64[]') AS value "
@@ -127,6 +130,35 @@ def test_list_edge_preserves_null_elements_during_unwind(tmp_path):
                 "_DST_ID": 1,
             },
         ],
+        [2, None],
+    ]
+
+    conn.close()
+    db.close()
+
+
+def test_list_vertex_preserves_null_elements_during_unwind(tmp_path):
+    db = Database(db_path=str(tmp_path), mode="w", checkpoint_on_close=False)
+    conn = db.connect()
+
+    conn.execute("CREATE NODE TABLE Person(id INT64, PRIMARY KEY(id));")
+    conn.execute("CREATE REL TABLE Knows(FROM Person TO Person);")
+    conn.execute("CREATE (:Person {id: 1}), (:Person {id: 2});")
+    create_edge = "MATCH (a:Person {id: 1}), "
+    create_edge += "(b:Person {id: 2}) CREATE (a)-[:Knows]->(b);"
+    conn.execute(create_edge)
+
+    rows = list(
+        conn.execute(
+            "MATCH (person:Person) "
+            "OPTIONAL MATCH (person)-[:Knows]->(friend:Person) "
+            "WITH person.id AS id, [friend] AS values "
+            "UNWIND values AS value "
+            "RETURN id, value ORDER BY id;"
+        )
+    )
+    assert rows == [
+        [1, {"_ID": 1, "_LABEL": "Person", "id": 2}],
         [2, None],
     ]
 

--- a/tools/python_bind/tests/test_db_list.py
+++ b/tools/python_bind/tests/test_db_list.py
@@ -78,6 +78,14 @@ def test_list_preserves_null_elements_during_unwind(tmp_path):
 
     rows = list(
         conn.execute(
+            "UNWIND CAST([1, CAST(NULL, 'INT64'), 3], 'INT64[]') AS value "
+            "RETURN collect(value);"
+        )
+    )
+    assert _nested_list(rows[0][0]) == [1, 3]
+
+    rows = list(
+        conn.execute(
             "UNWIND CAST([CAST([1, CAST(NULL, 'INT64'), 3], 'INT64[]')], "
             "'INT64[][]') AS values "
             "UNWIND values AS value RETURN value;"

--- a/tools/python_bind/tests/test_query.py
+++ b/tools/python_bind/tests/test_query.py
@@ -79,6 +79,36 @@ def test_empty_ungrouped_count(empty_db):
     assert list(result) == [[0]]
 
 
+def test_aggregate_over_empty_input(empty_db):
+    _, conn = empty_db
+    conn.execute("CREATE NODE TABLE person(id INT64, score INT64, PRIMARY KEY(id));")
+
+    result = conn.execute(
+        "MATCH (person:person) "
+        "RETURN avg(person.score), min(person.score), max(person.score), "
+        "sum(person.score), collect(person.score);"
+    )
+
+    assert list(result) == [[None, None, None, 0, []]]
+
+
+def test_aggregate_over_all_null_input(empty_db):
+    _, conn = empty_db
+    conn.execute("CREATE NODE TABLE source(id INT64, PRIMARY KEY(id));")
+    conn.execute("CREATE NODE TABLE target(id INT64, score INT64, PRIMARY KEY(id));")
+    conn.execute("CREATE REL TABLE links(FROM source TO target);")
+    conn.execute("CREATE (:source {id: 1}), (:source {id: 2});")
+
+    result = conn.execute(
+        "MATCH (source:source) "
+        "OPTIONAL MATCH (source)-[:links]->(target:target) "
+        "RETURN avg(target.score), min(target.score), max(target.score), "
+        "sum(target.score), collect(target.score);"
+    )
+
+    assert list(result) == [[None, None, None, 0, []]]
+
+
 def test_result_getitem(modern_graph):
     conn = modern_graph
     res = conn.execute("MATCH (n) RETURN count(n);")


### PR DESCRIPTION
## Summary
- support null child elements in CSV LIST and ARRAY values, including nested collections
- document and test that collect filters null inputs while UNWIND preserves null elements
- add regression coverage for null propagation through builders, RETURN, UNWIND, and shuffle

## Testing
- execution_test: 113 passed
- targeted Python LIST/ARRAY null tests passed
- Black and git diff checks passed

Fixes #890