### PR TITLE
refactor: Store checkpoints as immutable objects and versioned manifests

### DIFF
--- a/doc/source/reference/cpp_api/neug_db.md
+++ b/doc/source/reference/cpp_api/neug_db.md
@@ -64,20 +64,19 @@ Open the database from persistent storage.
 
 Initializes and opens the NeuG database from the specified data directory. This method loads the graph schema, vertex/edge data, and initializes the query processor and planner.
 
-**Data Directory Structure:** Persistent state is organized into numbered checkpoint generations:
+**Data Directory Structure:** Persistent state is selected by `checkpoint/CURRENT` and stored as immutable checkpoint objects, manifests, WAL epochs, and per-open runtime workspaces:
 
 ```text
 data_dir/
-├── checkpoint-N/
-│   ├── meta
-│   ├── snapshot/
-│   ├── runtime/
-│   ├── allocator/
-│   └── wal/
-└── checkpoint-(N+1).next/  # transient staging generation, when present
+├── checkpoint/
+│   ├── CURRENT
+│   ├── manifests/<id>.manifest
+│   └── objects/<object-id>
+├── wal/<id>/
+└── runtime/open-<epoch>/
 ```
 
-NeuG opens the highest valid published generation. A `.next` directory is not visible as the current checkpoint and is cleaned up during writable recovery if checkpoint creation did not complete.
+`CURRENT` atomically selects the manifest used at open. A manifest stores immutable object IDs and the `base_ts` that bounds replay of its matching WAL epoch. Unreachable staging objects or manifests are not selected. The legacy `checkpoint-N` directory format is unsupported and rejected without modification.
 
 **Usage Example:** 
 ```cpp

--- a/doc/source/reference/nodejs_api/database.md
+++ b/doc/source/reference/nodejs_api/database.md
@@ -26,9 +26,7 @@ read-only mode, inside the same process or in different processes.
 When the database is opened in read-write mode, no other databases could open the same database directory in
 either read-only or read-write mode, inside the same process or in different processes.
 
-Note that opening a database in read-only mode still requires a writable data directory: the lock file is
-created on demand if missing, and read-only processes copy temporary working files into the database's
-`checkpoint-N/runtime/` directory. Read-only mode cannot be used on a read-only file system or mount.
+Note that opening a database in read-only mode still requires a writable data directory: the lock file is created on demand if missing, and read-only processes create temporary working files in their own `runtime/open-<epoch>/` directory. Read-only mode cannot be used on a read-only file system or mount.
 
 When the database is closed, all the connections to the database will be closed automatically.
 

--- a/doc/source/reference/python_api/database.md
+++ b/doc/source/reference/python_api/database.md
@@ -26,9 +26,7 @@ read-only mode, inside the same process or in different processes.
 When the database is opened in read-write mode, no other databases could open the same database directory in
 either read-only or read-write mode, inside the same process or in different processes.
 
-Note that opening a database in read-only mode still requires a writable data directory: the lock file is
-created on demand if missing, and read-only processes copy temporary working files into the database's
-`checkpoint-N/runtime/` directory. Read-only mode cannot be used on a read-only file system or mount.
+Note that opening a database in read-only mode still requires a writable data directory: the lock file is created on demand if missing, and read-only processes create temporary working files in their own `runtime/open-<epoch>/` directory. Read-only mode cannot be used on a read-only file system or mount.
 
 When the database is closed, all the connections to the database will be closed automatically.
 

--- a/doc/source/transaction/checkpoint.md
+++ b/doc/source/transaction/checkpoint.md
@@ -111,9 +111,15 @@ data_dir/
                                 # <id> is an opaque unique suffix (a UUID)
 ```
 
-`CURRENT` is the sole publication selector. Its content is the selected manifest's decimal ID followed by a single trailing newline (for example `3\n`), written via an atomic rename; operators may inspect or rewrite it manually with a plain text editor. A published manifest has the required fields `v`, `id`, `base_ts`, `schema`, and `modules`; it may also contain `scalars`. Module descriptors persist object IDs, not absolute paths. The same ID names the manifest and its WAL epoch. `base_ts` is the highest transaction timestamp already represented by the manifest, so recovery replays the selected epoch from `base_ts + 1`. Full checkpoints use `base_ts=0` and reset the transaction timeline after reopening.
+`CURRENT` is the sole publication selector. Its content is the selected manifest's decimal ID followed by a single trailing newline (for example `3\n`), written via an atomic rename; operators may inspect or rewrite it manually with a plain text editor. A published manifest has the required fields `v`, `base_ts`, `schema`, and `modules`; it may also contain `scalars`. Module descriptors persist object IDs, not absolute paths. The same ID names the manifest and its WAL epoch. `base_ts` is the highest transaction timestamp already represented by the manifest, so recovery replays the selected epoch from `base_ts + 1`. Full checkpoints use `base_ts=0` and reset the transaction timeline after reopening.
 
-Checkpoint objects are immutable and may be referenced by several manifests. Runtime files are not checkpoint data: each database open receives its own `runtime/open-<id>/` directory (the suffix is an opaque unique ID, not a timestamp or manifest ID), and closing that database removes only its own unpinned workspace. Existing `checkpoint-N` directories are unsupported and rejected without modification; this format does not migrate or read them. Recover or rebuild such a database with a version that supports the legacy format first.
+Checkpoint objects are immutable and may be referenced by several manifests. Runtime files are not checkpoint data: each database open receives its own `runtime/open-<id>/` directory (the suffix is an opaque unique ID, not a timestamp or manifest ID), and closing that database removes only its own unpinned workspace.
+
+### Upgrading legacy checkpoint directories
+
+When `CURRENT` is absent, the first read-write open automatically upgrades the newest valid released v1 `checkpoint-N` generation. NeuG imports its immutable snapshot files into `checkpoint/objects/`, preserves its generation as the new manifest and WAL epoch ID, and publishes a v2 manifest with `base_ts=0`; normal recovery then replays every legacy WAL record. Files are hardlinked when safe and copied otherwise.
+
+The old directories are not changed before the new `CURRENT` is durably published. A crash before publication leaves the legacy checkpoint usable and the next read-write open retries. After the database has opened and recovered successfully, normal garbage collection removes the old `checkpoint-N` and `checkpoint-N.next` directories, making the upgrade one-way. A legacy-only database cannot be opened read-only: open it once in read-write mode to perform the upgrade. Legacy `meta` versions other than v1 are rejected rather than guessed.
 
 ## What a checkpoint does
 
@@ -162,7 +168,7 @@ persistence succeeded. If you set `checkpoint_on_close=False`:
 
 ## Failure and recovery
 
-On startup, NeuG opens only the manifest named by `CURRENT`; it does not scan for the newest directory. An incomplete staging manifest or object is unreachable until `CURRENT` changes and is therefore never selected. In Service mode, NeuG validates the selected WAL epoch and replays only records with timestamps greater than that manifest's `base_ts`.
+On startup, NeuG opens only the manifest named by `CURRENT`; it never falls back to a legacy directory when that selector exists. If `CURRENT` is absent, a read-write open may perform the one-time v1 migration described above. An incomplete staging manifest or object is unreachable until `CURRENT` changes and is therefore never selected. In Service mode, NeuG validates the selected WAL epoch and replays only records with timestamps greater than that manifest's `base_ts`.
 
 A **manual** `CHECKPOINT` fails in one of two ways:
 

--- a/doc/source/transaction/checkpoint.md
+++ b/doc/source/transaction/checkpoint.md
@@ -103,16 +103,17 @@ A persistent database uses one manifest selector, immutable objects shared by ma
 ```text
 data_dir/
 ├── checkpoint/
-│   ├── CURRENT                 # decimal ID of the selected manifest
+│   ├── CURRENT                 # decimal manifest ID + trailing newline
 │   ├── manifests/<id>.manifest
 │   └── objects/<object-id>
 ├── wal/<id>/                   # WAL epoch for manifest <id>
-└── runtime/open-<epoch>/       # temporary files for one database open
+└── runtime/open-<id>/          # temporary files for one database open;
+                                # <id> is an opaque unique suffix (a UUID)
 ```
 
-`CURRENT` is the sole publication selector. A published manifest has the required fields `v`, `id`, `base_ts`, `schema`, and `modules`; it may also contain `scalars`. Module descriptors persist object IDs, not absolute paths. The same ID names the manifest and its WAL epoch. `base_ts` is the highest transaction timestamp already represented by the manifest, so recovery replays the selected epoch from `base_ts + 1`. Full checkpoints use `base_ts=0` and reset the transaction timeline after reopening.
+`CURRENT` is the sole publication selector. Its content is the selected manifest's decimal ID followed by a single trailing newline (for example `3\n`), written via an atomic rename; operators may inspect or rewrite it manually with a plain text editor. A published manifest has the required fields `v`, `id`, `base_ts`, `schema`, and `modules`; it may also contain `scalars`. Module descriptors persist object IDs, not absolute paths. The same ID names the manifest and its WAL epoch. `base_ts` is the highest transaction timestamp already represented by the manifest, so recovery replays the selected epoch from `base_ts + 1`. Full checkpoints use `base_ts=0` and reset the transaction timeline after reopening.
 
-Checkpoint objects are immutable and may be referenced by several manifests. Runtime files are not checkpoint data: each database open receives its own `runtime/open-<epoch>/` directory, and closing that database removes only its own unpinned workspace. Existing `checkpoint-N` directories are unsupported and rejected without modification; this format does not migrate or read them. Recover or rebuild such a database with a version that supports the legacy format first.
+Checkpoint objects are immutable and may be referenced by several manifests. Runtime files are not checkpoint data: each database open receives its own `runtime/open-<id>/` directory (the suffix is an opaque unique ID, not a timestamp or manifest ID), and closing that database removes only its own unpinned workspace. Existing `checkpoint-N` directories are unsupported and rejected without modification; this format does not migrate or read them. Recover or rebuild such a database with a version that supports the legacy format first.
 
 ## What a checkpoint does
 
@@ -123,6 +124,12 @@ After publication, NeuG reopens the graph and allocators from the new checkpoint
 Recovery and shutdown checkpoints use the same compacting, destructive dump. Recovery reopens the graph and allocators before the database starts serving; shutdown persists without reopening. Garbage collection removes manifests, WAL epochs, and objects only when they are neither current nor retained by a live checkpoint reference.
 
 "Full" describes the runtime lifecycle boundary; it does not require rewriting every clean immutable object. Checkpoint disk growth is therefore driven by rewritten modules plus objects retained by live references. Schedule checkpoints based on the acceptable replay work after a crash and WAL growth, rather than a fixed tight interval.
+
+### Disk space reclamation
+
+Retired manifests, WAL epochs, immutable objects, and abandoned `runtime/open-<id>/` workspaces are removed by garbage collection, which runs only at three points: read-write database open, a successful manual `CHECKPOINT`, and database close. Deleting rows or dropping tables therefore does not shrink disk usage until one of those points is reached.
+
+Read-only opens never run garbage collection. A pure read-only deployment accumulates the stale `runtime/open-<id>/` workspaces left behind by crashed read-only processes; the next read-write open reclaims them.
 
 ### Concurrency
 

--- a/doc/source/transaction/checkpoint.md
+++ b/doc/source/transaction/checkpoint.md
@@ -9,8 +9,8 @@ plays a different role in each mode:
 | Question | Embedded mode | Service mode |
 |---|---|---|
 | Is `CHECKPOINT` required for durability? | Yes; un-checkpointed changes are lost when the database closes | No; committed changes are already durable in the WAL |
-| What is it for? | Persist changes and create a recovery point | Optional maintenance: fold WAL records into a fresh snapshot |
-| What is recovered after a restart? | The last successful checkpoint | The last checkpoint plus WAL replay |
+| What is it for? | Persist changes and create a recovery point | Optional maintenance: publish a checkpoint that bounds WAL replay |
+| What is recovered after a restart? | The checkpoint selected by `CURRENT` | The `CURRENT` checkpoint plus WAL records after its `base_ts` |
 
 For transaction boundaries and concurrency outside checkpoint operations, see
 [Transaction Management](transaction.md).
@@ -85,7 +85,7 @@ session.execute(
     access_mode="insert",
 )
 
-# Optional maintenance: fold committed WAL records into a fresh snapshot.
+# Optional maintenance: publish a checkpoint that bounds future WAL replay.
 session.execute("CHECKPOINT")
 session.close()
 ```
@@ -96,26 +96,33 @@ closed with `checkpoint_on_close=True`, any outstanding WAL records are
 folded into the final checkpoint; if checkpointing is disabled, the WAL
 remains on disk for replay on the next startup.
 
+## On-disk layout
+
+A persistent database uses one manifest selector, immutable objects shared by manifests, a WAL epoch per manifest ID, and a temporary workspace per database open:
+
+```text
+data_dir/
+├── checkpoint/
+│   ├── CURRENT                 # decimal ID of the selected manifest
+│   ├── manifests/<id>.manifest
+│   └── objects/<object-id>
+├── wal/<id>/                   # WAL epoch for manifest <id>
+└── runtime/open-<epoch>/       # temporary files for one database open
+```
+
+`CURRENT` is the sole publication selector. A published manifest has the required fields `v`, `id`, `base_ts`, `schema`, and `modules`; it may also contain `scalars`. Module descriptors persist object IDs, not absolute paths. The same ID names the manifest and its WAL epoch. `base_ts` is the highest transaction timestamp already represented by the manifest, so recovery replays the selected epoch from `base_ts + 1`. Full checkpoints use `base_ts=0` and reset the transaction timeline after reopening.
+
+Checkpoint objects are immutable and may be referenced by several manifests. Runtime files are not checkpoint data: each database open receives its own `runtime/open-<epoch>/` directory, and closing that database removes only its own unpinned workspace. Existing `checkpoint-N` directories are unsupported and rejected without modification; this format does not migrate or read them. Recover or rebuild such a database with a version that supports the legacy format first.
+
 ## What a checkpoint does
 
-Each successful checkpoint performs the following steps:
+A manual `CHECKPOINT` first takes exclusive checkpoint maintenance control and waits for in-flight work to finish (see [Concurrency](#concurrency)). It preserves the existing full-checkpoint behavior: compact the live graph, destructively dump it, publish a complete manifest, and reopen the graph and allocators. Only dirty graph and index modules need new immutable objects; clean module descriptors may continue to reference existing objects. The manifest and its WAL epoch are made durable before `CURRENT` is atomically replaced.
 
-1. Take exclusive control of the database, waiting for in-flight work to
-   finish (see [Concurrency](#concurrency)).
-2. Write a complete new snapshot generation to disk, alongside the current
-   one.
-3. Publish the new generation atomically. From this point on it is the
-   recovery point; the previous generation is no longer needed for recovery.
-4. Reopen the live database on the new generation and resume normal
-   operation. In Service mode this also starts a fresh, empty WAL.
-5. Remove the retired generation (best effort).
+After publication, NeuG reopens the graph and allocators from the new checkpoint. In Service mode, each execution-slot WAL writer is then rotated onto the new epoch. Finally, the transaction timeline is reset and new transactions are admitted. These steps all run while the checkpoint barrier is still held.
 
-Because step 2 writes a full copy while the current generation still exists,
-peak disk usage during a checkpoint is roughly twice the database size, and
-checkpoint time grows with database size. Disk usage drops back once the
-retired generation is removed in step 5. Schedule checkpoints based on how
-much work you can afford to redo after a crash (your recovery point) and
-how large you want the WAL to grow, rather than on a fixed tight interval.
+Recovery and shutdown checkpoints use the same compacting, destructive dump. Recovery reopens the graph and allocators before the database starts serving; shutdown persists without reopening. Garbage collection removes manifests, WAL epochs, and objects only when they are neither current nor retained by a live checkpoint reference.
+
+"Full" describes the runtime lifecycle boundary; it does not require rewriting every clean immutable object. Checkpoint disk growth is therefore driven by rewritten modules plus objects retained by live references. Schedule checkpoints based on the acceptable replay work after a crash and WAL growth, rather than a fixed tight interval.
 
 ### Concurrency
 
@@ -148,20 +155,18 @@ persistence succeeded. If you set `checkpoint_on_close=False`:
 
 ## Failure and recovery
 
-On startup, NeuG opens the newest completely published checkpoint; an
-incomplete generation is never selected. In Service mode, NeuG then replays
-WAL records created after that checkpoint.
+On startup, NeuG opens only the manifest named by `CURRENT`; it does not scan for the newest directory. An incomplete staging manifest or object is unreachable until `CURRENT` changes and is therefore never selected. In Service mode, NeuG validates the selected WAL epoch and replays only records with timestamps greater than that manifest's `base_ts`.
 
 A **manual** `CHECKPOINT` fails in one of two ways:
 
 - **Before the snapshot build starts** — for example, if the database cannot
   begin maintenance — the statement returns an error and the database keeps
   running normally.
-- **After the snapshot build has started**, a failure can leave the
+- **After the destructive publication boundary**, a failure can leave the
   in-memory state undefined. To avoid operating on a corrupt state, NeuG
   intentionally terminates the database process via `LOG(FATAL)`. This is
   by design, not a crash: restarting the database recovers cleanly from the
-  latest published checkpoint and, in Service mode, the WAL.
+  manifest selected by `CURRENT` and, in Service mode, its WAL epoch.
 
 A **recovery** checkpoint (run automatically on database open) takes a
 different path: if it fails, NeuG does not terminate the process. Instead,
@@ -197,5 +202,5 @@ except Exception:
 ```
 
 For long imports, checkpoint after each batch whose completed work is worth
-preserving. Always leave enough temporary disk space for a new full
-generation.
+preserving. Leave enough temporary disk space for rewritten objects and any
+older objects that remain reachable during publication.

--- a/include/neug/main/checkpoint_coordinator.h
+++ b/include/neug/main/checkpoint_coordinator.h
@@ -32,23 +32,24 @@ class UpdateTimestampLease;
  *
  * NeugDB owns one coordinator for the lifetime of an open database. Manual
  * checkpoint callers transfer an UpdateTimestampLease to
- * PublishManualCheckpoint()
- * for the entire graph and runtime-state rotation. The coordinator promotes
- * that lease to the exclusive commit phase before starting maintenance.
+ * PublishManualCheckpoint() for the entire graph and runtime-state rotation.
+ * The coordinator promotes that lease to the exclusive commit phase before
+ * starting maintenance.
  *
  * Two extension points run after the graph reopens from a published
  * checkpoint, before retired generations are reclaimed and before new
  * transactions are allowed to start:
  *
  * - PostReopenHandler (mandatory): injected at construction by the database
- *   owner and invoked on EVERY reopen (manual and recovery checkpoints). It
- *   carries correctness-critical database state activation such as reopening
- *   allocators and invalidating the compiled-plan cache. It must be infallible:
- *   it runs after the old live graph has been consumed. A manual-path failure
- *   terminates the live process; a recovery-path failure aborts database open.
+ * owner and invoked on every reopen (manual and recovery checkpoints). It
+ * carries
+ * correctness-critical database state activation such as reopening allocators
+ * and invalidating the compiled-plan cache. It must be infallible: it runs
+ * after the old live graph has been consumed. A manual-path failure terminates
+ * the live process; a recovery-path failure aborts database open.
  *
- * - CheckpointActivationHandler (optional): set by the service owner and
- *   invoked on the manual path after the post-reopen handler. It activates
+ * - WalEpochActivationHandler (optional): set by the service owner and
+ *   invoked on the manual path. It activates
  *   service-owned state such as execution-slot WAL rotation for the published
  *   checkpoint.
  *
@@ -63,8 +64,8 @@ class CheckpointCoordinator {
 
   /// Optional service-owned state activation for the manual path.
   /// Invoked with the published checkpoint's WAL directory.
-  using CheckpointActivationHandler =
-      std::function<void(const std::string& checkpoint_wal_uri)>;
+  using WalEpochActivationHandler =
+      std::function<void(const std::string& checkpoint_wal_dir)>;
 
   CheckpointCoordinator(CheckpointManager& checkpoint_manager,
                         GraphSnapshotStore& snapshot_store,
@@ -72,21 +73,22 @@ class CheckpointCoordinator {
                         PostReopenHandler post_reopen_handler);
 
   /// Set the single activation handler invoked by PublishManualCheckpoint()
-  /// after the post-reopen handler and before retired generations are reclaimed
-  /// or the transaction gate is reopened. Setting a second handler without
+  /// before retired checkpoint roots are reclaimed or the transaction gate is
+  /// reopened. Setting a second handler without
   /// first clearing the existing one is an error.
   ///
   /// The service sets the handler at startup and clears it before destroying
-  /// handler-owned state. ClearActivationHandler() waits for an in-flight
-  /// invocation to finish, so no invocation can outlive that call. The handler
-  /// must not call SetActivationHandler() or ClearActivationHandler().
-  void SetActivationHandler(CheckpointActivationHandler handler);
-  void ClearActivationHandler();
+  /// handler-owned state. ClearWalEpochActivationHandler() waits for an
+  /// in-flight invocation to finish, so no invocation can outlive that call.
+  /// The handler must not call SetWalEpochActivationHandler() or
+  /// ClearWalEpochActivationHandler().
+  void SetWalEpochActivationHandler(WalEpochActivationHandler handler);
+  void ClearWalEpochActivationHandler();
 
-  /// Publish a manual checkpoint and activate database- and optional
-  /// service-owned runtime state through the configured handlers. The caller
-  /// transfers an active update lease that has not entered the commit phase
-  /// and must not hold an ordinary snapshot pin.
+  /// Publish a full manual checkpoint, reopen the live graph and allocators,
+  /// rotate the service WAL epoch, and reset the transaction timeline. The
+  /// caller transfers an active update lease that has not entered the commit
+  /// phase and must not hold an ordinary snapshot pin.
   Status PublishManualCheckpoint(UpdateTimestampLease timestamp_lease);
 
   /// Publish a recovery checkpoint and reopen the live graph.
@@ -103,15 +105,15 @@ class CheckpointCoordinator {
   };
 
   Status execute(Reason reason);
-  void invokeActivationHandler(const std::string& checkpoint_wal_uri);
+  void invokeWalEpochActivationHandler(const std::string& checkpoint_wal_dir);
   static const char* reasonName(Reason reason);
 
   CheckpointManager& checkpoint_manager_;
   GraphSnapshotStore& snapshot_store_;
   MemoryLevel memory_level_;
   PostReopenHandler post_reopen_handler_;
-  std::mutex activation_handler_mutex_;
-  CheckpointActivationHandler activation_handler_;
+  std::mutex wal_epoch_activation_handler_mutex_;
+  WalEpochActivationHandler wal_epoch_activation_handler_;
 };
 
 }  // namespace neug

--- a/include/neug/main/neug_db.h
+++ b/include/neug/main/neug_db.h
@@ -126,10 +126,12 @@ class NEUG_API NeugDB {
    * the query processor and planner.
    *
    * **Data Directory Structure:**
-   * The data_dir should contain:
-   * - `graph.yaml`: Schema definition file
-   * - `snapshot/`: Vertex and edge data files
-   * - `wal/`: Write-ahead log files (optional, for recovery)
+   * Checkpointed data is organized as:
+   * - `checkpoint/CURRENT`: atomically published manifest id
+   * - `checkpoint/manifests/`: immutable manifest files
+   * - `checkpoint/objects/`: immutable module objects
+   * - `wal/<id>/`: WAL epoch for each manifest
+   * - `runtime/open-<epoch>/`: mutable allocator workspace for an open process
    *
    * **Usage Example:**
    * @code{.cpp}
@@ -318,7 +320,7 @@ class NEUG_API NeugDB {
     return *snapshot_store_;
   }
 
-  std::string work_dir() const { return checkpoint_mgr_.db_dir(); }
+  std::string work_dir() const { return checkpoint_mgr_.database_dir(); }
 
   inline const NeugDBConfig& config() const { return config_; }
 
@@ -338,7 +340,8 @@ class NEUG_API NeugDB {
   void initAllocators(const std::string& allocator_dir);
   void reopenAllocators(const std::string& allocator_dir);
   timestamp_t openGraphAndIngestWals();
-  timestamp_t ingestWals(IWalParser& parser, PropertyGraph& graph);
+  timestamp_t ingestWals(IWalParser& parser, PropertyGraph& graph,
+                         timestamp_t base_timestamp);
   void initPlanner();
   void initQueryRuntime();
   void clearQueryRuntime() noexcept;

--- a/include/neug/server/tp_execution_slot_pool.h
+++ b/include/neug/server/tp_execution_slot_pool.h
@@ -178,7 +178,7 @@ class TpExecutionSlotPool {
   }
 
   // Runs while checkpoint maintenance has drained all active transactions.
-  // Rotate every stable per-slot WAL writer to the published generation.
+  // Rotate every stable per-slot WAL writer to the published epoch.
   void RotateWalWriters(const std::string& wal_uri);
 
  private:

--- a/include/neug/storages/checkpoint.h
+++ b/include/neug/storages/checkpoint.h
@@ -14,11 +14,9 @@
  */
 #pragma once
 
-#include <cassert>
 #include <cstdint>
 #include <filesystem>
 #include <memory>
-#include <mutex>
 #include <string>
 #include <utility>
 
@@ -29,87 +27,49 @@
 namespace neug {
 
 /**
- * @brief Represents a single numbered checkpoint directory.
+ * @brief A manifest-selected checkpoint root.
  *
- * A checkpoint lives at `db_dir/checkpoint-NNNNN/` and contains:
+ * `CURRENT` selects one immutable-object manifest. Its ID also names the WAL
+ * epoch; the manifest's base timestamp bounds replay from that epoch. Runtime
+ * working files belong to the current database-open epoch instead:
  *
  * ```
- * checkpoint-NNNNN/
- * ├── meta        ← CheckpointManifest JSON
- * ├── snapshot/   ← immutable data files
- * ├── runtime/    ← mutable working files (allocator, tmp, …)
- * └── wal/        ← write-ahead log files
+ * db/
+ * ├── checkpoint/{CURRENT,manifests,objects}
+ * ├── wal/<checkpoint-id>/
+ * └── runtime/<open-epoch>/
  * ```
  *
- * # Thread safety
+ * # Ownership and synchronization
  *
- * All public methods are individually safe to invoke concurrently *except*
- * the meta accessors `GetMeta()` / `MutableMeta()`, which return references
- * into a meta_ slot that `UpdateMeta()` may replace.
+ * `CheckpointManager` owns checkpoint creation and publication. It serializes
+ * staging, manifest persistence, and replacement of `CURRENT`. A
+ * `Checkpoint` holds the selected manifest and delegates runtime-file and
+ * immutable-object operations to `CheckpointFileManager`.
  *
- * Specifically:
- *   * `OpenFile` / `CreateRuntimeContainer` / `Commit` /
- *     `CreateRuntimeFile` / `CommitRuntimeFile` / `LinkToSnapshot` —
- *     internally lock when allocating or publishing runtime files; otherwise
- *     they only read immutable members (`path_`, `id_`).
- *   * `UpdateMeta` — fully serialized: takes the lock for the entire JSON
- *     write + meta swap + orphan cleanup, so concurrent UpdateMeta calls are
- *     safe and won't tear the on-disk meta file.
- *   * `GetMeta` / `MutableMeta` — *not* internally synchronized; the caller
- *     is responsible for ensuring no concurrent UpdateMeta runs while a
- *     reference is held.
- *
- * The constructor and destructor follow standard C++ object-lifetime rules:
- * the instance must not be in use on another thread while either runs.
+ * `SetManifest()` and `manifest()` are not internally synchronized: callers
+ * must keep manifest construction and inspection within the checkpoint
+ * maintenance/publish lifecycle. File operations are synchronized by
+ * `CheckpointFileManager`; this does not make concurrent mutation of the
+ * same `IDataContainer` safe.
  */
 class Checkpoint {
  public:
-  /**
-   * @brief Create and initialize a checkpoint at @p path.
-   *
-   * Creates directories, loads meta JSON, and absolutizes paths. When
-   * @p cleanup_orphan_runtime_files is true, also removes orphaned runtime
-   * files. Read-only database opens disable that cleanup because another
-   * read-only process may own those temporary files.
-   *
-   * Returns nullptr only on unrecoverable errors (currently throws instead).
-   */
-  static std::shared_ptr<Checkpoint> Open(
-      std::string path, uint32_t id, bool cleanup_orphan_runtime_files = true);
-
-  ~Checkpoint();  // defined in .cc where CheckpointManifest is complete
+  ~Checkpoint();
   Checkpoint(const Checkpoint&) = delete;
   Checkpoint& operator=(const Checkpoint&) = delete;
 
-  /// Root path of this checkpoint: `db_dir/checkpoint-NNNNN`.
-  const std::string& path() const { return path_; }
+  /// Canonical manifest path for this root.
+  const std::string& manifest_path() const { return manifest_path_; }
+  uint64_t id() const { return id_; }
 
-  uint32_t id() const { return id_; }
+  /// Temporary workspace belonging to this database-open epoch.
+  const std::string& runtime_dir() const { return *runtime_workspace_; }
 
-  std::string snapshot_dir() const {
-    assert(!IsEmpty());
-    return path_ + "/snapshot";
-  }
+  /// WAL epoch directory whose name is this manifest ID.
+  const std::string& wal_dir() const { return wal_dir_; }
 
-  std::string runtime_dir() const {
-    assert(!IsEmpty());
-    return path_ + "/runtime";
-  }
-
-  std::string wal_dir() const {
-    assert(!IsEmpty());
-    return path_ + "/wal";
-  }
-
-  std::string meta_path() const {
-    assert(!IsEmpty());
-    return path_ + "/meta";
-  }
-
-  std::string allocator_dir() const {
-    assert(!IsEmpty());
-    return path_ + "/allocator";
-  }
+  std::string allocator_dir() const { return runtime_dir() + "/allocator"; }
 
   std::shared_ptr<IDataContainer> OpenFile(const std::string& file_path,
                                            MemoryLevel level) {
@@ -121,55 +81,59 @@ class Checkpoint {
     return file_mgr_->CreateRuntimeContainer(size, level);
   }
 
-  /// Commit a container to the snapshot directory. This consumes and closes the
-  /// container; callers must not access it after Commit() returns.
+  /// Consume @p buffer and publish it as an immutable object.
   std::string Commit(IDataContainer& buffer) {
     return file_mgr_->Commit(buffer);
   }
 
-  void UpdateMeta(CheckpointManifest&& meta);
+  /// Set the complete in-memory manifest. CheckpointManager persists it before
+  /// advancing CURRENT.
+  void SetManifest(CheckpointManifest&& manifest);
 
-  const CheckpointManifest& GetMeta() const {
-    assert(meta_ != nullptr);
-    return *meta_;
-  }
-
-  CheckpointManifest& MutableMeta() {
-    assert(meta_ != nullptr);
-    return *meta_;
-  }
-
-  bool IsEmpty() const { return path_.empty(); }
+  const CheckpointManifest& manifest() const { return manifest_; }
 
   /// Allocate an anonymous runtime file handle (RAII).
   CheckpointFileManager::RuntimeFileHandle CreateRuntimeFile() {
     return file_mgr_->CreateRuntimeFile();
   }
 
-  /// Move a runtime file into the snapshot directory and return its path.
+  /// Finalize a runtime file as an immutable object and return its path.
   std::string CommitRuntimeFile(
       CheckpointFileManager::RuntimeFileHandle&& file) {
     return file_mgr_->CommitRuntimeFile(std::move(file));
   }
 
-  std::string LinkToSnapshot(const std::string& abs_path) {
-    return file_mgr_->LinkToSnapshot(abs_path);
+  /// Reuse an object already in the object store; runtime files are copied to
+  /// a fresh immutable object.
+  std::string MaterializeObject(const std::string& abs_path) {
+    return file_mgr_->MaterializeObject(abs_path);
   }
 
  private:
-  /// Private constructor — only initializes members. Use Open() to create.
-  Checkpoint(std::string path, uint32_t id);
+  friend class CheckpointManager;
 
-  /// Performs all I/O: create dirs, load meta, absolutize paths, and optionally
-  /// clean orphaned runtime files.
-  void initialize(bool cleanup_orphan_runtime_files);
+  static std::shared_ptr<Checkpoint> OpenPublished(
+      std::string database_dir, uint64_t id,
+      std::shared_ptr<const std::string> runtime_workspace);
+  static std::shared_ptr<Checkpoint> CreateStaging(
+      std::string database_dir, uint64_t id,
+      std::shared_ptr<const std::string> runtime_workspace);
 
+  Checkpoint(std::string database_dir, uint64_t id,
+             std::shared_ptr<const std::string> runtime_workspace);
+
+  void initialize(bool load_manifest);
   void create_dirs() const;
+  void resolve_object_paths();
+  void PersistManifest();
 
-  std::string path_;
-  uint32_t id_;
-  mutable std::mutex mutex_;
-  std::unique_ptr<CheckpointManifest> meta_;
+  std::string database_dir_;
+  std::string manifest_path_;
+  std::string object_dir_;
+  std::shared_ptr<const std::string> runtime_workspace_;
+  std::string wal_dir_;
+  uint64_t id_;
+  CheckpointManifest manifest_;
   std::unique_ptr<CheckpointFileManager> file_mgr_;
 };
 

--- a/include/neug/storages/checkpoint.h
+++ b/include/neug/storages/checkpoint.h
@@ -66,7 +66,7 @@ class Checkpoint {
   uint64_t id() const { return id_; }
 
   /// Temporary workspace belonging to this database-open epoch.
-  const std::string& runtime_dir() const { return *runtime_workspace_; }
+  const std::string& runtime_dir() const;
 
   /// WAL epoch directory whose name is this manifest ID.
   const std::string& wal_dir() const { return wal_dir_; }
@@ -117,13 +117,13 @@ class Checkpoint {
 
   static std::shared_ptr<Checkpoint> OpenPublished(
       std::string database_dir, uint64_t id,
-      std::shared_ptr<const std::string> runtime_workspace);
+      std::shared_ptr<const RuntimeWorkspace> runtime_workspace);
   static std::shared_ptr<Checkpoint> CreateStaging(
       std::string database_dir, uint64_t id,
-      std::shared_ptr<const std::string> runtime_workspace);
+      std::shared_ptr<const RuntimeWorkspace> runtime_workspace);
 
   Checkpoint(std::string database_dir, uint64_t id,
-             std::shared_ptr<const std::string> runtime_workspace);
+             std::shared_ptr<const RuntimeWorkspace> runtime_workspace);
 
   void initialize(bool load_manifest);
   void create_dirs() const;
@@ -133,7 +133,7 @@ class Checkpoint {
   std::string database_dir_;
   std::string manifest_path_;
   std::string object_dir_;
-  std::shared_ptr<const std::string> runtime_workspace_;
+  std::shared_ptr<const RuntimeWorkspace> runtime_workspace_;
   std::string wal_dir_;
   uint64_t id_;
   CheckpointManifest manifest_;

--- a/include/neug/storages/checkpoint.h
+++ b/include/neug/storages/checkpoint.h
@@ -125,7 +125,7 @@ class Checkpoint {
   void initialize(bool load_manifest);
   void create_dirs() const;
   void resolve_object_paths();
-  void PersistManifest();
+  void persist_manifest();
 
   std::string database_dir_;
   std::string manifest_path_;

--- a/include/neug/storages/checkpoint.h
+++ b/include/neug/storages/checkpoint.h
@@ -26,6 +26,8 @@
 
 namespace neug {
 
+class LegacyCheckpointMigrator;
+
 /**
  * @brief A manifest-selected checkpoint root.
  *
@@ -111,6 +113,7 @@ class Checkpoint {
 
  private:
   friend class CheckpointManager;
+  friend class LegacyCheckpointMigrator;
 
   static std::shared_ptr<Checkpoint> OpenPublished(
       std::string database_dir, uint64_t id,

--- a/include/neug/storages/checkpoint_file_manager.h
+++ b/include/neug/storages/checkpoint_file_manager.h
@@ -35,16 +35,14 @@ class RuntimeWorkspace final {
   RuntimeWorkspace(const RuntimeWorkspace&) = delete;
   RuntimeWorkspace& operator=(const RuntimeWorkspace&) = delete;
 
+  const std::string& path() const noexcept { return path_; }
+
  private:
-  friend class Checkpoint;
-  friend class CheckpointFileManager;
   friend class CheckpointManager;
 
   static std::shared_ptr<const RuntimeWorkspace> Create(std::string path);
 
   explicit RuntimeWorkspace(std::string path);
-
-  const std::string& path() const noexcept { return path_; }
 
   std::string path_;
 };

--- a/include/neug/storages/checkpoint_file_manager.h
+++ b/include/neug/storages/checkpoint_file_manager.h
@@ -25,10 +25,10 @@
 namespace neug {
 
 /**
- * @brief Manages file lifecycle within a single checkpoint directory.
+ * @brief Publishes immutable checkpoint objects and owns one runtime epoch.
  *
  * Extracted from Checkpoint to separate file-management concerns (create,
- * commit, link, cleanup) from meta/directory-structure management.
+ * commit, materialize, cleanup) from manifest/directory-structure management.
  *
  * Thread safety: all public methods are safe to call concurrently.
  */
@@ -52,18 +52,17 @@ class CheckpointFileManager {
     friend class CheckpointFileManager;
 
     RuntimeFileHandle(std::shared_ptr<RuntimeFileCleanupContext> cleanup,
-                      std::string uuid, std::string path);
+                      std::string path);
 
     bool valid() const { return cleanup_ != nullptr; }
     void Release();
 
     std::shared_ptr<RuntimeFileCleanupContext> cleanup_;
-    std::string uuid_;
     std::string path_;
   };
 
-  CheckpointFileManager(const std::string& snapshot_dir,
-                        const std::string& runtime_dir);
+  CheckpointFileManager(const std::string& object_dir,
+                        std::shared_ptr<const std::string> runtime_workspace);
   ~CheckpointFileManager();
 
   CheckpointFileManager(const CheckpointFileManager&) = delete;
@@ -77,7 +76,7 @@ class CheckpointFileManager {
   std::shared_ptr<IDataContainer> CreateRuntimeContainer(size_t size,
                                                          MemoryLevel level);
 
-  /// Commit a data container to a persistent snapshot file.
+  /// Commit a data container to a persistent immutable object.
   ///
   /// This is a consuming operation: the container dumps its current contents
   /// and is closed by the call. The caller must not read from or write to the
@@ -90,39 +89,29 @@ class CheckpointFileManager {
   /// it is destroyed before CommitRuntimeFile() consumes it.
   RuntimeFileHandle CreateRuntimeFile();
 
-  /// Finalize a manually-written runtime file into snapshot_dir.
+  /// Finalize a manually-written runtime file into the object store.
   std::string CommitRuntimeFile(RuntimeFileHandle&& file);
 
-  /// Hardlink (or copy) a caller-guaranteed immutable/retired file into
-  /// snapshot_dir. This fast path is valid for files that no legal writer can
-  /// mutate again, such as clean runtime files from a previous checkpoint.
-  ///
-  /// Active MAP_SHARED runtime containers must use Commit(), which consumes and
-  /// closes the container while publishing its current contents.
-  std::string LinkToSnapshot(const std::string& abs_path);
-
-  /// fsync snapshot_dir after snapshot file entries are ready.
-  bool SyncSnapshotDirectory() const;
-
-  /// Make an absolute path relative to the checkpoint root.
-  std::string MakeRelativePath(const std::string& abs_path,
-                               const std::string& checkpoint_root) const;
-
-  /// Resolve a relative path against the checkpoint root.
-  std::string ResolveAbsolutePath(const std::string& rel_path,
-                                  const std::string& checkpoint_root) const;
+  /// Reuse an existing object-store path, or copy a runtime file into a fresh
+  /// immutable object. Active MAP_SHARED files are never hardlinked.
+  std::string MaterializeObject(const std::string& abs_path);
 
  private:
+  friend class Checkpoint;
+
+  /// fsync the object directory after object entries are ready.
+  bool SyncObjectDirectory() const;
+
   std::shared_ptr<IDataContainer> WrapWithRuntimeCleanup(
       std::unique_ptr<IDataContainer> container) const;
 
   std::string CreateRuntimeContainerPath();
   std::string CreateRuntimeObjectNameLocked() const;
-  std::string copyToSnapshotLocked(const std::string& abs_path);
+  std::string materializeObjectLocked(const std::string& abs_path);
   std::string commitRuntimeFileLocked(const std::string& uuid,
                                       const std::string& abs_path);
 
-  std::string snapshot_dir_;
+  std::string object_dir_;
   std::string runtime_dir_;
   mutable std::mutex mutex_;
   std::shared_ptr<RuntimeFileCleanupContext> runtime_cleanup_;

--- a/include/neug/storages/checkpoint_file_manager.h
+++ b/include/neug/storages/checkpoint_file_manager.h
@@ -24,6 +24,31 @@
 
 namespace neug {
 
+class Checkpoint;
+class CheckpointManager;
+
+/** Shared lifetime owner for one database-open runtime directory. */
+class RuntimeWorkspace final {
+ public:
+  ~RuntimeWorkspace();
+
+  RuntimeWorkspace(const RuntimeWorkspace&) = delete;
+  RuntimeWorkspace& operator=(const RuntimeWorkspace&) = delete;
+
+ private:
+  friend class Checkpoint;
+  friend class CheckpointFileManager;
+  friend class CheckpointManager;
+
+  static std::shared_ptr<const RuntimeWorkspace> Create(std::string path);
+
+  explicit RuntimeWorkspace(std::string path);
+
+  const std::string& path() const noexcept { return path_; }
+
+  std::string path_;
+};
+
 /**
  * @brief Publishes immutable checkpoint objects and owns one runtime epoch.
  *
@@ -61,8 +86,6 @@ class CheckpointFileManager {
     std::string path_;
   };
 
-  CheckpointFileManager(const std::string& object_dir,
-                        std::shared_ptr<const std::string> runtime_workspace);
   ~CheckpointFileManager();
 
   CheckpointFileManager(const CheckpointFileManager&) = delete;
@@ -98,6 +121,10 @@ class CheckpointFileManager {
 
  private:
   friend class Checkpoint;
+
+  CheckpointFileManager(
+      const std::string& object_dir,
+      std::shared_ptr<const RuntimeWorkspace> runtime_workspace);
 
   /// fsync the object directory after object entries are ready.
   bool SyncObjectDirectory() const;

--- a/include/neug/storages/checkpoint_manager.h
+++ b/include/neug/storages/checkpoint_manager.h
@@ -18,35 +18,19 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <vector>
 
 #include "neug/storages/checkpoint.h"
 #include "neug/utils/api.h"
 
 namespace neug {
 
-// ---------------------------------------------------------------------------
-
 /**
- * @brief Manages the published checkpoint directories for a database.
+ * @brief Owns the database CURRENT selector and checkpoint publication.
  *
- * Directory layout:
- * ```
- * db_dir/
- * |-- checkpoint-N/       # published checkpoint
- * `-- checkpoint-(N+1).next/  # unpublished staging checkpoint
- * ```
- *
- * `CheckpointManager` does **not** inherit `Module`; it is a directory-level
- * manager, not a data module itself.
- *
- * The current checkpoint is the highest valid published generation. Committing
- * a staging checkpoint publishes the next generation but leaves the retired
- * checkpoint directory on disk until the caller releases graph/container
- * resources that may still reference it.
- *
- * Thread safety: All public methods are individually thread-safe (guarded by
- * an internal mutex). Callers that race CreateStagingCheckpoint() / Close()
- * must coordinate externally.
+ * `checkpoint/CURRENT` is the only normal publication selector. A staging
+ * handle may create unreachable immutable objects, a manifest, and its empty
+ * WAL epoch, but it is not visible until Publish() durably replaces CURRENT.
  */
 class NEUG_API CheckpointManager {
  public:
@@ -59,12 +43,8 @@ class NEUG_API CheckpointManager {
     StagingCheckpoint& operator=(const StagingCheckpoint&) = delete;
 
     std::shared_ptr<Checkpoint> checkpoint() const;
-    /// Publish this staging checkpoint as the current checkpoint. If
-    /// previous_checkpoint_path is non-null, it receives the retired checkpoint
-    /// directory path. The caller decides when that directory is safe to
-    /// delete.
-    std::shared_ptr<Checkpoint> Commit(
-        std::string* previous_checkpoint_path = nullptr);
+    /// Make this manifest visible by durably replacing CURRENT.
+    std::shared_ptr<Checkpoint> Publish();
     void Discard() noexcept;
 
    private:
@@ -78,69 +58,38 @@ class NEUG_API CheckpointManager {
     std::shared_ptr<Checkpoint> checkpoint_;
   };
 
-  /**
-   * @brief Open a database directory.
-   * @param db_dir Path to the database directory.
-   * @param recover_workspace Whether to remove stale staging directories and
-   * invalid published checkpoints while opening.
-   */
-  void Open(const std::string& db_dir, bool recover_workspace = true);
-
-  /**
-   * @brief Close the workspace and release resources.
-   */
+  /// Open @p database_dir. Existing checkpoint-N directories are unsupported
+  /// and rejected without modification. Recover or rebuild them with a
+  /// version that supports the legacy format first.
+  void Open(const std::string& database_dir, bool create_if_missing = true);
+  /// Release manager-owned references. The runtime workspace is reclaimed
+  /// after its last checkpoint, container, or runtime-file handle is released.
   void Close();
 
-  /// Return true if a published checkpoint is currently open.
-  bool HasCurrentCheckpoint() const;
+  /// Return the checkpoint selected by CURRENT, or nullptr before first
+  /// publication.
+  std::shared_ptr<Checkpoint> Current() const;
 
-  /**
-   * @brief Get the current published checkpoint, or nullptr if none exists.
-   */
-  std::shared_ptr<Checkpoint> CurrentCheckpoint() const;
+  /// Create an unpublished staging checkpoint. Destroying its move-only handle
+  /// discards it unless Publish() has made its manifest visible.
+  StagingCheckpoint CreateStaging();
 
-  /**
-   * @brief Create a new unpublished staging checkpoint.
-   * @return Move-only handle that discards the staging checkpoint on scope
-   * exit.
-   */
-  StagingCheckpoint CreateStagingCheckpoint();
+  /// Reclaim manifests, WAL epochs, and immutable objects not held by the
+  /// current checkpoint or a live Checkpoint shared_ptr.
+  void CollectGarbage();
 
-  /**
-   * @brief Point the manager at another already-published checkpoint.
-   *
-   * This is an explicit repair primitive. It does not undo a durable
-   * publication and is not used by the live checkpoint execution protocol.
-   */
-  void RestoreCurrentCheckpoint(std::shared_ptr<Checkpoint> checkpoint);
-
-  /**
-   * @brief Best-effort cleanup of one published checkpoint that is not current.
-   *
-   * This is an explicit repair/maintenance primitive and refuses to remove the
-   * current checkpoint.
-   */
-  void CleanupPublishedCheckpoint(std::shared_ptr<Checkpoint> checkpoint);
-
-  /**
-   * @brief Best-effort cleanup of published checkpoints other than current.
-   *
-   * The caller must only invoke this after all graph/container resources that
-   * might reference retired checkpoint directories have been released.
-   */
-  void CleanupRetiredCheckpoints();
-
-  std::string db_dir() const;
+  std::string database_dir() const;
 
  private:
-  std::shared_ptr<Checkpoint> CommitStagingCheckpoint(
-      StagingCheckpoint& staging, std::string* previous_checkpoint_path);
+  std::shared_ptr<Checkpoint> PublishStagingCheckpoint(
+      StagingCheckpoint& staging);
   void DiscardStagingCheckpoint(StagingCheckpoint& staging) noexcept;
 
-  std::string db_dir_;
+  std::string database_dir_;
+  std::shared_ptr<const std::string> runtime_workspace_;
   std::shared_ptr<Checkpoint> current_checkpoint_;
   std::shared_ptr<Checkpoint> staging_checkpoint_;
-  int32_t current_generation_ = -1;
+  std::vector<std::weak_ptr<Checkpoint>> published_checkpoints_;
   mutable std::mutex mutex_;
 };
 

--- a/include/neug/storages/checkpoint_manager.h
+++ b/include/neug/storages/checkpoint_manager.h
@@ -89,7 +89,7 @@ class NEUG_API CheckpointManager {
   StagingCheckpoint CreateStagingLocked(uint64_t id);
 
   std::string database_dir_;
-  std::shared_ptr<const std::string> runtime_workspace_;
+  std::shared_ptr<const RuntimeWorkspace> runtime_workspace_;
   std::shared_ptr<Checkpoint> current_checkpoint_;
   std::shared_ptr<Checkpoint> staging_checkpoint_;
   std::vector<std::weak_ptr<Checkpoint>> published_checkpoints_;

--- a/include/neug/storages/checkpoint_manager.h
+++ b/include/neug/storages/checkpoint_manager.h
@@ -75,7 +75,9 @@ class NEUG_API CheckpointManager {
   StagingCheckpoint CreateStaging();
 
   /// Reclaim manifests, WAL epochs, and immutable objects not held by the
-  /// current checkpoint or a live Checkpoint shared_ptr.
+  /// current checkpoint or a live Checkpoint shared_ptr, plus runtime
+  /// workspaces abandoned by earlier processes. The caller must hold exclusive
+  /// database-writer ownership; the current open epoch is always preserved.
   void CollectGarbage();
 
   std::string database_dir() const;

--- a/include/neug/storages/checkpoint_manager.h
+++ b/include/neug/storages/checkpoint_manager.h
@@ -58,9 +58,9 @@ class NEUG_API CheckpointManager {
     std::shared_ptr<Checkpoint> checkpoint_;
   };
 
-  /// Open @p database_dir. Existing checkpoint-N directories are unsupported
-  /// and rejected without modification. Recover or rebuild them with a
-  /// version that supports the legacy format first.
+  /// Open @p database_dir. A writer open automatically migrates the newest
+  /// valid legacy checkpoint-N v1 generation when CURRENT is absent. A
+  /// read-only open never migrates legacy data.
   void Open(const std::string& database_dir, bool create_if_missing = true);
   /// Release manager-owned references. The runtime workspace is reclaimed
   /// after its last checkpoint, container, or runtime-file handle is released.
@@ -86,6 +86,7 @@ class NEUG_API CheckpointManager {
   std::shared_ptr<Checkpoint> PublishStagingCheckpoint(
       StagingCheckpoint& staging);
   void DiscardStagingCheckpoint(StagingCheckpoint& staging) noexcept;
+  StagingCheckpoint CreateStagingLocked(uint64_t id);
 
   std::string database_dir_;
   std::shared_ptr<const std::string> runtime_workspace_;

--- a/include/neug/storages/checkpoint_manifest.h
+++ b/include/neug/storages/checkpoint_manifest.h
@@ -42,7 +42,7 @@ class CheckpointManifest {
   /// Bump only on breaking changes to the JSON layout (renamed/removed
   /// fields, changed value semantics).  Additive changes (new optional
   /// fields) do not require a bump.  Readers must reject unknown versions.
-  static constexpr int kFormatVersion = 2;
+  static constexpr int kFormatVersion = 3;
 
   CheckpointManifest() = default;
 
@@ -110,12 +110,6 @@ class CheckpointManifest {
   /// always carries a schema, even when the graph has no tables.
   bool has_schema() const { return has_schema_; }
 
-  /// ID shared by this manifest and its WAL epoch.
-  uint64_t checkpoint_id() const { return checkpoint_id_; }
-  void set_checkpoint_id(uint64_t checkpoint_id) {
-    checkpoint_id_ = checkpoint_id;
-  }
-
   /// Greatest transaction timestamp represented by this manifest. Recovery
   /// starts WAL replay at the next timestamp.
   uint64_t base_timestamp() const { return base_timestamp_; }
@@ -129,7 +123,6 @@ class CheckpointManifest {
 
   Schema schema_;
   bool has_schema_ = false;
-  uint64_t checkpoint_id_ = 0;
   uint64_t base_timestamp_ = 0;
   std::unordered_map<std::string, ModuleDescriptor> modules_;
   std::unordered_map<std::string, std::string> scalars_;

--- a/include/neug/storages/checkpoint_manifest.h
+++ b/include/neug/storages/checkpoint_manifest.h
@@ -43,11 +43,9 @@ class CheckpointManifest {
   /// fields, changed value semantics).  Additive changes (new optional
   /// fields) do not require a bump.  Readers must reject unknown versions.
   ///
-  /// Version 2 was briefly written by an intermediate, never-released
-  /// revision of this format; version 3 is intentionally the next shipped
-  /// number so that any directory produced by those intermediate builds is
-  /// rejected instead of being misread.
-  static constexpr int kFormatVersion = 3;
+  /// Version 1 belongs to the legacy checkpoint-N meta format. This immutable
+  /// objects + complete manifest layout starts at version 2.
+  static constexpr int kFormatVersion = 2;
 
   CheckpointManifest() = default;
 

--- a/include/neug/storages/checkpoint_manifest.h
+++ b/include/neug/storages/checkpoint_manifest.h
@@ -42,6 +42,11 @@ class CheckpointManifest {
   /// Bump only on breaking changes to the JSON layout (renamed/removed
   /// fields, changed value semantics).  Additive changes (new optional
   /// fields) do not require a bump.  Readers must reject unknown versions.
+  ///
+  /// Version 2 was briefly written by an intermediate, never-released
+  /// revision of this format; version 3 is intentionally the next shipped
+  /// number so that any directory produced by those intermediate builds is
+  /// rejected instead of being misread.
   static constexpr int kFormatVersion = 3;
 
   CheckpointManifest() = default;

--- a/include/neug/storages/checkpoint_manifest.h
+++ b/include/neug/storages/checkpoint_manifest.h
@@ -19,6 +19,7 @@
 #include <sstream>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "neug/storages/graph/schema.h"
 #include "neug/storages/module_descriptor.h"
@@ -31,71 +32,45 @@ class Checkpoint;
  * @brief In-memory representation of a checkpoint's module inventory.
  *
  * Maps canonical string keys to ModuleDescriptors for all modules in a
- * checkpoint. Serialized as JSON for persistence inside checkpoint directories.
+ * checkpoint. On disk every descriptor references immutable object IDs; the
+ * Checkpoint root resolves them to local paths after loading.
  */
 class CheckpointManifest {
  public:
-  /// Name of the meta file written inside the checkpoint directory.
-  static constexpr const char* kMetaFileName = "meta";
-
-  /// Current on-disk format version for the meta JSON.
+  /// Current on-disk format version for the manifest JSON.
   ///
   /// Bump only on breaking changes to the JSON layout (renamed/removed
   /// fields, changed value semantics).  Additive changes (new optional
   /// fields) do not require a bump.  Readers must reject unknown versions.
-  static constexpr int kFormatVersion = 1;
+  static constexpr int kFormatVersion = 2;
 
   CheckpointManifest() = default;
 
-  /**
-   * @brief Return the descriptor for @p key, or std::nullopt if absent.
-   */
-  std::optional<ModuleDescriptor> module(const std::string& key) const;
+  /// Return the descriptor for @p key, or nullptr if absent.
+  const ModuleDescriptor* FindModule(const std::string& key) const;
+
+  /// Return the mutable descriptor for @p key, or nullptr if absent.
+  ModuleDescriptor* FindMutableModule(const std::string& key);
 
   /**
    * @brief Insert or replace the descriptor for @p key.
    */
-  void set_module(const std::string& key, ModuleDescriptor desc);
-
-  /**
-   * @brief Remove the descriptor for @p key (no-op if absent).
-   */
-  void remove_module(const std::string& key);
+  void SetModule(const std::string& key, ModuleDescriptor desc);
 
   /**
    * @brief Returns true if @p key is present in the module map.
    */
-  bool has_module(const std::string& key) const;
+  bool HasModule(const std::string& key) const;
 
-  /**
-   * @brief If @p key exists in @p prev, hardlink its paths and the complete
-   * referenced-module dependency closure into @p ckp, then store their
-   * descriptors here.
-   */
-  void LinkModuleFrom(const CheckpointManifest& prev, const std::string& key,
-                      Checkpoint& ckp);
+  /// Copy @p key and its referenced-module dependency closure from @p prev.
+  /// Object references are immutable and therefore reused without file I/O.
+  void ReuseModuleClosureFrom(const CheckpointManifest& prev,
+                              const std::string& key);
 
   /**
    * @brief Read-only access to the full module map.
    */
-  const std::unordered_map<std::string, ModuleDescriptor>& modules() const;
-
-  /**
-   * @brief Mutable access to the module map.  Useful for in-place traversal
-   * (e.g. recursive path rewriting in Checkpoint::UpdateMeta) that would
-   * otherwise require copy-modify-replace cycles.
-   */
-  std::unordered_map<std::string, ModuleDescriptor>& mutable_modules();
-
-  /**
-   * @brief Retrieve a scalar value by key.  Returns std::nullopt if absent.
-   *
-   * Scalars hold shell-owned state that has no Module home of its own —
-   * LFIndexer's num_elements, EdgeTable's row_count, hash policy index, etc.
-   * Convention: namespace the key by owner using `/`, e.g.
-   * "indexer_person/num_elements".
-   */
-  std::optional<std::string> GetScalar(const std::string& key) const;
+  const std::unordered_map<std::string, ModuleDescriptor>& Modules() const;
 
   /// Insert or replace a scalar entry.
   void SetScalar(std::string key, std::string value);
@@ -103,7 +78,7 @@ class CheckpointManifest {
   /**
    * @brief If @p key exists in @p prev, copy its scalar value into this
    * manifest. Scalars have no filesystem payload, so this is a plain copy
-   * (unlike LinkModuleFrom).
+   * (unlike ReuseModuleFrom).
    */
   void CopyScalarFrom(const CheckpointManifest& prev, const std::string& key);
 
@@ -123,29 +98,39 @@ class CheckpointManifest {
     return value;
   }
 
-  /// Read-only access to the full scalar map.
-  const std::unordered_map<std::string, std::string>& scalars() const;
-
   void Load(const std::string& file_path);
 
   void Save(const std::string& file_path) const;
-
-  static void GenerateEmptyMeta(const std::string& file_path);
 
   const Schema& GetSchema() const;
 
   void SetSchema(const Schema& schema);
 
-  /// Returns true if the meta file contained a "schema" field when loaded.
-  /// GenerateEmptyMeta() does not write a schema, so this returns false for
-  /// stub checkpoints created during initial DB creation.  A fully committed
-  /// checkpoint (via Save()) always writes a schema, even if the graph has
-  /// no tables.
+  /// Returns true if the manifest contains a schema. A committed manifest
+  /// always carries a schema, even when the graph has no tables.
   bool has_schema() const { return has_schema_; }
 
+  /// ID shared by this manifest and its WAL epoch.
+  uint64_t checkpoint_id() const { return checkpoint_id_; }
+  void set_checkpoint_id(uint64_t checkpoint_id) {
+    checkpoint_id_ = checkpoint_id;
+  }
+
+  /// Greatest transaction timestamp represented by this manifest. Recovery
+  /// starts WAL replay at the next timestamp.
+  uint64_t base_timestamp() const { return base_timestamp_; }
+
  private:
+  std::optional<std::string> GetScalar(const std::string& key) const;
+
+  void ReuseModuleClosureFromImpl(const CheckpointManifest& prev,
+                                  const std::string& key,
+                                  std::unordered_set<std::string>& visited);
+
   Schema schema_;
   bool has_schema_ = false;
+  uint64_t checkpoint_id_ = 0;
+  uint64_t base_timestamp_ = 0;
   std::unordered_map<std::string, ModuleDescriptor> modules_;
   std::unordered_map<std::string, std::string> scalars_;
 };

--- a/include/neug/storages/csr/mutable_csr.h
+++ b/include/neug/storages/csr/mutable_csr.h
@@ -424,7 +424,7 @@ class EmptyCsr : public TypedCsrBase<EDATA_T> {
             const std::string& key) override {
     ModuleDescriptor desc;
     desc.module_type = type_name();
-    meta.set_module(key, desc);
+    meta.SetModule(key, desc);
   }
 
   void compact() override {}

--- a/include/neug/storages/graph/edge_table.h
+++ b/include/neug/storages/graph/edge_table.h
@@ -87,8 +87,8 @@ class NEUG_API EdgeTable {
 
   /// When this table is clean, re-link prior-snapshot modules/scalars into
   /// @p meta instead of dumping. Links exact keys for this triplet only.
-  void LinkToSnapshot(Checkpoint& ckp, CheckpointManifest& meta,
-                      const CheckpointManifest& prev) const;
+  void ReuseCheckpointModules(Checkpoint& ckp, CheckpointManifest& manifest,
+                              const CheckpointManifest& previous) const;
 
   void SetInCsr(std::unique_ptr<CsrBase> csr);
   void SetOutCsr(std::unique_ptr<CsrBase> csr);

--- a/include/neug/storages/graph/property_graph.h
+++ b/include/neug/storages/graph/property_graph.h
@@ -142,6 +142,12 @@ class NEUG_API PropertyGraph {
   /// Dump this graph into @p ckp and clear all in-memory storage afterwards.
   /// Callers that need a usable graph after dumping must explicitly Open() a
   /// checkpoint and rebuild any GraphView that pointed into this graph.
+  ///
+  /// Precondition: the graph must already be compacted. DumpAndClear never
+  /// compacts implicitly; the production checkpoint path always calls
+  /// Compact() immediately before this (see CheckpointCoordinator). Custom
+  /// StorageIndex implementations that dump via this path should follow the
+  /// same sequence.
   void DumpAndClear(std::shared_ptr<Checkpoint> ckp);
 
   DirtyTracker& dirty_tracker() { return dirty_; }

--- a/include/neug/storages/graph/property_graph.h
+++ b/include/neug/storages/graph/property_graph.h
@@ -84,9 +84,9 @@ class StorageIndexManager;
  * - Level 3: Force hugepages (highest performance, most memory)
  *
  * **Persistence:**
- * - Snapshot-based persistence to work_dir
+ * - Manifest-selected immutable checkpoint objects
  * - Compaction support for removing deleted data
- * - Schema stored in `graph.yaml`
+ * - Schema stored in the checkpoint manifest
  *
  * @note For query execution, use Connection::Query() instead of direct
  * PropertyGraph access.
@@ -159,12 +159,8 @@ class NEUG_API PropertyGraph {
   }
   void MarkSchemaDirty() { dirty_.MarkSchema(); }
   bool IsSchemaDirty() const { return dirty_.IsSchemaDirty(); }
-  /// True if schema or any table has been marked dirty since the last
-  /// ClearAllDirty().
-  bool IsModified() const { return dirty_.IsModified(); }
-  /// Clear all table-level and schema dirty bits. Call only after a checkpoint
-  /// has been successfully published.
-  void ClearAllDirty() { dirty_.ClearAll(); }
+  /// True if schema, any table, or any index has changed since publication.
+  bool IsModified() const;
 
   Checkpoint& checkpoint() {
     assert(ckp_);
@@ -634,8 +630,6 @@ class NEUG_API PropertyGraph {
   }
 
   std::string get_statistics_json() const;
-
-  inline std::string work_dir() const { return ckp_->path(); }
 
   std::shared_ptr<PropertyGraph> Clone() const;
 

--- a/include/neug/storages/graph/vertex_table.h
+++ b/include/neug/storages/graph/vertex_table.h
@@ -172,8 +172,8 @@ class NEUG_API VertexTable {
 
   /// When this table is clean, re-link prior-snapshot modules into @p meta
   /// instead of dumping. Links exact keys for this label only.
-  void LinkToSnapshot(Checkpoint& ckp, CheckpointManifest& meta,
-                      const CheckpointManifest& prev) const;
+  void ReuseCheckpointModules(Checkpoint& ckp, CheckpointManifest& manifest,
+                              const CheckpointManifest& previous) const;
 
   void SetIndexer(std::unique_ptr<IndexerType> indexer) {
     indexer_ = std::move(indexer);

--- a/include/neug/storages/index/storage_index_manager.h
+++ b/include/neug/storages/index/storage_index_manager.h
@@ -119,11 +119,12 @@ class StorageIndexManager {
 
   bool HasPendingIndexes() const { return !pending_indexes_.empty(); }
   bool HasPendingMutations() const { return !pending_mutations_.empty(); }
+  bool HasCatalogChanges() const { return catalog_dirty_; }
 
   /**
-   * @brief Move all indexes into the module broker for persistence.
+   * @brief Move all active indexes into the module broker for persistence.
    */
-  void Dump(ModuleBroker& store, Checkpoint& ckp, CheckpointManifest& meta);
+  void Dump(ModuleBroker& store, CheckpointManifest& meta);
 
   void Clear();
 
@@ -141,6 +142,7 @@ class StorageIndexManager {
   std::unordered_map<std::string, std::unique_ptr<StorageIndex>> indexes_;
   std::unordered_map<std::string, PendingIndex> pending_indexes_;
   std::vector<std::shared_ptr<const PendingIndexMutation>> pending_mutations_;
+  bool catalog_dirty_{false};
 };
 
 }  // namespace neug

--- a/include/neug/storages/loader/abstract_property_graph_loader.h
+++ b/include/neug/storages/loader/abstract_property_graph_loader.h
@@ -33,16 +33,18 @@ class AbstractPropertyGraphLoader : public IFragmentLoader {
         loading_config_(loading_config),
         thread_num_(loading_config_.GetParallelism()) {
     checkpoint_mgr_.Open(work_dir);
-    if (checkpoint_mgr_.HasCurrentCheckpoint()) {
+    if (checkpoint_mgr_.Current() != nullptr) {
       THROW_INVALID_ARGUMENT_EXCEPTION("CheckpointManager is not empty: " +
                                        work_dir);
     }
-    staging_checkpoint_.emplace(checkpoint_mgr_.CreateStagingCheckpoint());
+    staging_checkpoint_.emplace(checkpoint_mgr_.CreateStaging());
     auto ckp = staging_checkpoint_->checkpoint();
-    ckp->MutableMeta().SetSchema(schema_);
+    CheckpointManifest manifest;
+    manifest.SetSchema(schema_);
+    ckp->SetManifest(std::move(manifest));
     graph_.Open(ckp, MemoryLevel::kSyncToFile);
     // Bulk load bypasses Storage*Interface NVI; mark everything dirty so the
-    // final DumpAndClear / Compact treat this as a full first write.
+    // final compacted dump treats this as a full first write.
     graph_.MarkSchemaDirty();
     for (label_t v = 0; v < schema_.vertex_label_frontier(); ++v) {
       if (schema_.is_vertex_label_valid(v)) {

--- a/include/neug/storages/module_descriptor.h
+++ b/include/neug/storages/module_descriptor.h
@@ -90,10 +90,10 @@ struct ModuleDescriptor {
   }
 
   /**
-   * @brief Record a filesystem path under @p name.  Paths live in a separate
-   * map from `extra_` so Checkpoint::UpdateMeta / Checkpoint::Checkpoint can
-   * relativize / absolutize them on persistence without scanning every extras
-   * key by name.  Mirrors set() in chainability.
+   * @brief Record the resolved local path for an immutable checkpoint object.
+   *
+   * In memory this is an absolute path. On disk it is serialized as the
+   * object's stable ID under the `objects` field.
    */
   ModuleDescriptor& set_path(const std::string& name, std::string path) {
     paths_[name] = std::move(path);
@@ -118,8 +118,8 @@ struct ModuleDescriptor {
     return paths_;
   }
 
-  /// Mutable access — useful for in-place rewrites (e.g. absolute ↔ relative
-  /// conversion in Checkpoint).
+  /// Mutable access for Checkpoint's object-ID and resolved-local-path
+  /// conversion.
   std::unordered_map<std::string, std::string>& mutable_paths() {
     return paths_;
   }
@@ -179,22 +179,12 @@ struct ModuleDescriptor {
    */
   std::string ToJsonString() const;
 
-  /**
-   * @brief Copy @p prev and hardlink each non-empty path into @p ckp.
-   *
-   * Used when a clean table reuses the prior snapshot: metadata (type, extras,
-   * refs) is preserved, while filesystem paths are rewritten to hardlinks in
-   * the new checkpoint.
-   */
-  static ModuleDescriptor Link(const ModuleDescriptor& prev, Checkpoint& ckp);
-
  private:
   /// Optional free-form key-value pairs for module-specific metadata.
   std::unordered_map<std::string, std::string> extra_;
 
-  /// Filesystem paths a Module owns, keyed by an arbitrary local name (e.g.
-  /// "nbr_list", "items").  Carved out of `extra_` so checkpoint code can
-  /// rewrite paths without scanning every extras key by suffix.
+  /// Resolved immutable object paths a Module owns, keyed by an arbitrary
+  /// local name (e.g. "nbr_list", "items").
   std::unordered_map<std::string, std::string> paths_;
 
   /// Named references to other flat module entries. For example, ArrayColumn

--- a/include/neug/transaction/README.md
+++ b/include/neug/transaction/README.md
@@ -89,15 +89,17 @@ A manual checkpoint receives an active `UpdateTimestampLease` from
 readers, and runs maintenance only after `GraphSnapshotStore` verifies that no
 ordinary or stale snapshot pins remain.
 
-Maintenance compacts and dumps the live graph, publishes the checkpoint, and
-reopens the graph. The database handler then reopens allocators and invalidates
-the query cache; service mode additionally rotates execution-slot WAL writers.
-New transactions remain blocked until these steps finish. Success resets the
-timestamp timeline (`read_ts = 0`, next `write_ts = 1`) and reopens admission.
+Manual maintenance preserves the full-checkpoint lifecycle: compact and
+destructively dump the live graph, atomically publish the new manifest, reopen
+the graph and allocators, rotate execution-slot WAL writers in service mode,
+and reset the timestamp timeline. New transactions remain blocked until all
+activation finishes. Recovery uses the same full path and reopens runtime state;
+shutdown does not reopen the graph or run activation handlers.
+
+Publication makes the new `checkpoint/CURRENT` selector durable only after its `manifests/<id>.manifest`, immutable objects, and `wal/<id>/` epoch are ready. Dirty modules write new objects while clean descriptors may be reused from the previous manifest; the manager reclaims unreferenced manifests, WAL epochs, and objects only after their checkpoint references are released. Each database open owns a separate `runtime/open-<epoch>/` workspace.
 
 Recovery and shutdown checkpoints rely on database lifecycle quiescence rather
-than a transaction lease. Shutdown does not reopen the graph or run activation
-handlers.
+than a transaction lease.
 
 ## Version Management
 

--- a/include/neug/utils/io/file/file_utils.h
+++ b/include/neug/utils/io/file/file_utils.h
@@ -100,6 +100,11 @@ namespace file_utils {
  */
 class AtomicFileWriter {
  public:
+  enum class CommitResult {
+    kDurable,
+    kCommitUnknown,
+  };
+
   explicit AtomicFileWriter(const std::string& target_path);
   ~AtomicFileWriter();
 
@@ -115,8 +120,10 @@ class AtomicFileWriter {
   std::ostream& stream();
 
   /// Flush + fsync(fd) + close + rename(tmp → target) + fsync(parent dir).
-  /// Throws on any I/O failure.  After Commit() the writer is spent.
-  void Commit();
+  /// Failures before rename throw. A parent-directory fsync failure returns
+  /// kCommitUnknown because the target has already been atomically replaced.
+  /// After Commit() the writer is spent.
+  CommitResult Commit();
 
  private:
   void Abort() noexcept;

--- a/include/neug/utils/property/column.h
+++ b/include/neug/utils/property/column.h
@@ -95,7 +95,7 @@ class TypedColumn : public ColumnBase {
     ModuleDescriptor desc;
     desc.set_path(ModuleDescriptor::kDataPath, ckp.Commit(*buffer_));
     desc.module_type = ModuleTypeName();
-    meta.set_module(key, std::move(desc));
+    meta.SetModule(key, std::move(desc));
   }
 
   size_t size() const override { return size_; }
@@ -207,7 +207,7 @@ class TypedColumn<EmptyType> : public ColumnBase {
             const std::string& key) override {
     ModuleDescriptor desc;
     desc.module_type = ModuleTypeName();
-    meta.set_module(key, std::move(desc));
+    meta.SetModule(key, std::move(desc));
   }
   size_t size() const override { return 0; }
   void resize(size_t size) override {}
@@ -305,10 +305,10 @@ class TypedColumn<std::string_view> : public ColumnBase {
     if (is_data_unmodified()) {
       desc.set("pos", std::to_string(pos_.load()));
       desc.set_path(ModuleDescriptor::kItemsPath,
-                    ckp.LinkToSnapshot(items_buffer_->GetPath()));
+                    ckp.MaterializeObject(items_buffer_->GetPath()));
       desc.set_path(ModuleDescriptor::kDataPath,
-                    ckp.LinkToSnapshot(data_buffer_->GetPath()));
-      meta.set_module(key, std::move(desc));
+                    ckp.MaterializeObject(data_buffer_->GetPath()));
+      meta.SetModule(key, std::move(desc));
       return;
     }
     auto data_runtime_file = ckp.CreateRuntimeFile();
@@ -393,7 +393,7 @@ class TypedColumn<std::string_view> : public ColumnBase {
                   ckp.CommitRuntimeFile(std::move(item_runtime_file)));
     desc.set_path(ModuleDescriptor::kDataPath,
                   ckp.CommitRuntimeFile(std::move(data_runtime_file)));
-    meta.set_module(key, std::move(desc));
+    meta.SetModule(key, std::move(desc));
   }
 
   size_t size() const override { return size_; }

--- a/src/main/checkpoint_coordinator.cc
+++ b/src/main/checkpoint_coordinator.cc
@@ -41,7 +41,7 @@ namespace {
 void cleanup_retired_checkpoints(
     CheckpointManager& checkpoint_manager) noexcept {
   try {
-    checkpoint_manager.CleanupRetiredCheckpoints();
+    checkpoint_manager.CollectGarbage();
   } catch (const std::exception& e) {
     LOG(WARNING) << "Checkpoint GC failed: " << e.what();
   } catch (...) { LOG(WARNING) << "Checkpoint GC failed"; }
@@ -74,29 +74,29 @@ CheckpointCoordinator::CheckpointCoordinator(
   }
 }
 
-void CheckpointCoordinator::SetActivationHandler(
-    CheckpointActivationHandler handler) {
+void CheckpointCoordinator::SetWalEpochActivationHandler(
+    WalEpochActivationHandler handler) {
   if (!handler) {
     THROW_INVALID_ARGUMENT_EXCEPTION(
         "Checkpoint activation handler must not be empty");
   }
-  std::lock_guard<std::mutex> lock(activation_handler_mutex_);
-  if (activation_handler_) {
+  std::lock_guard<std::mutex> lock(wal_epoch_activation_handler_mutex_);
+  if (wal_epoch_activation_handler_) {
     THROW_RUNTIME_ERROR("Checkpoint activation handler is already set");
   }
-  activation_handler_ = std::move(handler);
+  wal_epoch_activation_handler_ = std::move(handler);
 }
 
-void CheckpointCoordinator::ClearActivationHandler() {
-  std::lock_guard<std::mutex> lock(activation_handler_mutex_);
-  activation_handler_ = nullptr;
+void CheckpointCoordinator::ClearWalEpochActivationHandler() {
+  std::lock_guard<std::mutex> lock(wal_epoch_activation_handler_mutex_);
+  wal_epoch_activation_handler_ = nullptr;
 }
 
-void CheckpointCoordinator::invokeActivationHandler(
-    const std::string& checkpoint_wal_uri) {
-  std::lock_guard<std::mutex> lock(activation_handler_mutex_);
-  if (activation_handler_) {
-    activation_handler_(checkpoint_wal_uri);
+void CheckpointCoordinator::invokeWalEpochActivationHandler(
+    const std::string& checkpoint_wal_dir) {
+  std::lock_guard<std::mutex> lock(wal_epoch_activation_handler_mutex_);
+  if (wal_epoch_activation_handler_) {
+    wal_epoch_activation_handler_(checkpoint_wal_dir);
   }
 }
 
@@ -119,9 +119,8 @@ Status CheckpointCoordinator::PublishManualCheckpoint(
     return status;
   }
 
-  // The post-reopen and activation handlers completed every database- and
-  // service-owned state transition while this lease still prevented new
-  // transactions from starting.
+  // The graph, allocators, and WAL writers now reference the newly published
+  // checkpoint while this lease still prevents new transactions from starting.
   timestamp_lease.FinishAndResetTimeline();
   return status;
 }
@@ -142,7 +141,7 @@ Status CheckpointCoordinator::execute(Reason reason) {
   // runtimes, so their callers may still unwind and destroy the consumed graph.
   bool destructive_phase = false;
   try {
-    auto staging_checkpoint = checkpoint_manager_.CreateStagingCheckpoint();
+    auto staging_checkpoint = checkpoint_manager_.CreateStaging();
     return snapshot_store_.WithCheckpointMaintenance(
         [&](GraphSnapshotStore::CheckpointMaintenanceContext& maintenance)
             -> Status {
@@ -163,8 +162,9 @@ Status CheckpointCoordinator::execute(Reason reason) {
           destructive_phase = true;
           live_graph.Compact();
           live_graph.DumpAndClear(staging_checkpoint.checkpoint());
-          auto published_checkpoint = staging_checkpoint.Commit();
-          VLOG(1) << "Finish checkpoint: " << published_checkpoint->path();
+          auto published_checkpoint = staging_checkpoint.Publish();
+          VLOG(1) << "Finish checkpoint: "
+                  << published_checkpoint->manifest_path();
 
           if (reopen_after_checkpoint) {
             // This is the intentional in-place checkpoint reopen path. It is
@@ -174,13 +174,12 @@ Status CheckpointCoordinator::execute(Reason reason) {
             maintenance.ReopenCurrentGraphFromCheckpoint(published_checkpoint,
                                                          memory_level_);
 
-            // Correctness-critical rotation first. Infallible by contract; a
-            // throwing handler fails the live manual path closed or aborts
-            // recovery.
+            // Correctness-critical runtime rotation. This handler is infallible
+            // by contract because the live graph was consumed.
             post_reopen_handler_(published_checkpoint->allocator_dir());
 
             if (reason == Reason::kManual) {
-              invokeActivationHandler(published_checkpoint->wal_dir());
+              invokeWalEpochActivationHandler(published_checkpoint->wal_dir());
             }
 
             cleanup_retired_checkpoints(checkpoint_manager_);

--- a/src/main/neug_db.cc
+++ b/src/main/neug_db.cc
@@ -188,7 +188,7 @@ bool NeugDB::Open(const NeugDBConfig& config) {
     }
 
     checkpoint_mgr_.Open(config_.data_dir, recover_workspace);
-    VLOG(1) << "Opening NeuGDB at " << checkpoint_mgr_.db_dir();
+    VLOG(1) << "Opening NeuGDB at " << checkpoint_mgr_.database_dir();
     neug::execution::PlanParser::get().init();
     timestamp_t initial_visibility_ts = openGraphAndIngestWals();
     checkpoint_coordinator_ = std::make_unique<CheckpointCoordinator>(
@@ -205,7 +205,7 @@ bool NeugDB::Open(const NeugDBConfig& config) {
       }
     }
     if (config_.mode == DBMode::READ_WRITE) {
-      checkpoint_mgr_.CleanupRetiredCheckpoints();
+      checkpoint_mgr_.CollectGarbage();
     }
     initVersionManager(initial_visibility_ts);
     extension_manager_ = std::make_unique<ExtensionManager>();
@@ -499,23 +499,23 @@ void NeugDB::reopenAllocators(const std::string& allocator_dir) {
 timestamp_t NeugDB::openGraphAndIngestWals() {
   max_thread_num_ = config_.max_thread_num;
   try {
-    auto ckp = checkpoint_mgr_.CurrentCheckpoint();
+    auto ckp = checkpoint_mgr_.Current();
     if (ckp == nullptr) {
       if (config_.mode == DBMode::READ_ONLY && !is_pure_memory_) {
         THROW_NO_CHECKPOINT_EXCEPTION(
             "NeugDB::Open: no checkpoint found in read-only database: " +
-            checkpoint_mgr_.db_dir());
+            checkpoint_mgr_.database_dir());
       }
-      auto staging_checkpoint = checkpoint_mgr_.CreateStagingCheckpoint();
+      auto staging_checkpoint = checkpoint_mgr_.CreateStaging();
       ckp = staging_checkpoint.checkpoint();
       CheckpointManifest meta;
       meta.SetSchema(Schema());
-      ckp->UpdateMeta(std::move(meta));
-      ckp = staging_checkpoint.Commit();
+      ckp->SetManifest(std::move(meta));
+      ckp = staging_checkpoint.Publish();
       LOG(INFO) << "No checkpoint found, created initial checkpoint: "
-                << ckp->path();
+                << ckp->manifest_path();
     }
-    LOG(INFO) << "Opening graph from checkpoint " << ckp->path();
+    LOG(INFO) << "Opening graph from checkpoint " << ckp->manifest_path();
     auto graph = std::make_shared<PropertyGraph>();
     graph->Open(ckp, config_.memory_level);
 
@@ -524,9 +524,11 @@ timestamp_t NeugDB::openGraphAndIngestWals() {
 
     neug::WalParserFactory::Init();
     auto wal_parser = WalParserFactory::CreateWalParser(ckp->wal_dir());
-    const timestamp_t recovered_wal_timestamp = ingestWals(*wal_parser, *graph);
+    const timestamp_t recovered_wal_timestamp =
+        ingestWals(*wal_parser, *graph,
+                   static_cast<timestamp_t>(ckp->manifest().base_timestamp()));
 
-    // Create GraphSnapshotStore with the graph at timestamp 0
+    // VersionManager is initialized by the caller with recovered_wal_timestamp.
     snapshot_store_ =
         std::make_unique<GraphSnapshotStore>(config_.storage_slot_num, graph);
     return recovered_wal_timestamp;
@@ -539,8 +541,9 @@ timestamp_t NeugDB::openGraphAndIngestWals() {
   }
 }
 
-timestamp_t NeugDB::ingestWals(IWalParser& parser, PropertyGraph& graph) {
-  uint32_t from_ts = 1;
+timestamp_t NeugDB::ingestWals(IWalParser& parser, PropertyGraph& graph,
+                               timestamp_t base_timestamp) {
+  uint32_t from_ts = base_timestamp + 1;
   LOG(INFO) << "Ingesting update wals size: "
             << parser.get_update_wals().size();
 
@@ -561,7 +564,7 @@ timestamp_t NeugDB::ingestWals(IWalParser& parser, PropertyGraph& graph) {
     IngestWalRange(graph, allocators_, parser, from_ts, parser.last_ts() + 1);
   }
   LOG(INFO) << "Finish ingesting wals up to timestamp: " << parser.last_ts();
-  return parser.last_ts();
+  return std::max(base_timestamp, parser.last_ts());
 }
 
 void NeugDB::initPlanner() {
@@ -665,7 +668,7 @@ void NeugDB::createCheckpointOnClose() {
   checkpoint_coordinator_.reset();
   snapshot_store_.reset();
   allocators_.clear();
-  checkpoint_mgr_.CleanupRetiredCheckpoints();
+  checkpoint_mgr_.CollectGarbage();
 }
 
 }  // namespace neug

--- a/src/server/neug_db_service.cc
+++ b/src/server/neug_db_service.cc
@@ -94,7 +94,7 @@ void NeugDBService::init(const ServiceConfig& config) {
   hdl_mgr_->Init(effective_config);
   service_config_ = effective_config;
 
-  db_.checkpoint_coordinator_->SetActivationHandler(
+  db_.checkpoint_coordinator_->SetWalEpochActivationHandler(
       [pool = execution_slot_pool_.get()](const std::string& wal_uri) {
         pool->RotateWalWriters(wal_uri);
       });
@@ -107,7 +107,7 @@ NeugDBService::~NeugDBService() {
     hdl_mgr_.reset();
   }
   if (db_.checkpoint_coordinator_) {
-    db_.checkpoint_coordinator_->ClearActivationHandler();
+    db_.checkpoint_coordinator_->ClearWalEpochActivationHandler();
   }
   execution_slot_pool_.reset();
   restoreNativeRuntimeWait();

--- a/src/storages/csr/immutable_csr.cc
+++ b/src/storages/csr/immutable_csr.cc
@@ -84,7 +84,7 @@ void ImmutableCsr<EDATA_T>::Dump(Checkpoint& ckp, CheckpointManifest& meta,
   desc.set_path(ModuleDescriptor::kDegreeListPath,
                 ckp.Commit(*degree_list_buffer_));
   desc.set_path(ModuleDescriptor::kNbrListPath, ckp.Commit(*nbr_list_buffer_));
-  meta.set_module(key, desc);
+  meta.SetModule(key, desc);
 }
 
 template <typename EDATA_T>
@@ -403,7 +403,7 @@ void SingleImmutableCsr<EDATA_T>::Dump(Checkpoint& ckp,
   desc.module_type = ModuleTypeName();
   desc.set_path(ModuleDescriptor::kNbrListPath, ckp.Commit(*nbr_list_buffer_));
   desc.set("edge_num", std::to_string(edge_num_.load()));
-  meta.set_module(key, desc);
+  meta.SetModule(key, desc);
 }
 
 template <typename EDATA_T>

--- a/src/storages/csr/mutable_csr.cc
+++ b/src/storages/csr/mutable_csr.cc
@@ -140,7 +140,7 @@ void MutableCsr<EDATA_T>::Dump(Checkpoint& ckp, CheckpointManifest& meta,
                              vnum)) {
     // If the neighbor list is unmodified, we can reuse the existing file.
     descriptor.set_path(ModuleDescriptor::kNbrListPath,
-                        ckp.LinkToSnapshot(nbr_list_->GetPath()));
+                        ckp.MaterializeObject(nbr_list_->GetPath()));
   } else {
     std::string nbr_path_committed;
 
@@ -165,7 +165,7 @@ void MutableCsr<EDATA_T>::Dump(Checkpoint& ckp, CheckpointManifest& meta,
 
   descriptor.set_path(ModuleDescriptor::kCapacityListPath,
                       ckp.Commit(*cap_list_));
-  meta.set_module(key, descriptor);
+  meta.SetModule(key, descriptor);
 }
 
 template <typename EDATA_T>
@@ -552,7 +552,7 @@ void SingleMutableCsr<EDATA_T>::Dump(Checkpoint& ckp, CheckpointManifest& meta,
   descriptor.module_type = ModuleTypeName();
   descriptor.set_path(ModuleDescriptor::kNbrListPath, ckp.Commit(*nbr_list_));
   descriptor.set("edge_num", std::to_string(edge_num_.load()));
-  meta.set_module(key, descriptor);
+  meta.SetModule(key, descriptor);
 }
 
 template <typename EDATA_T>

--- a/src/storages/graph/checkpoint.cc
+++ b/src/storages/graph/checkpoint.cc
@@ -84,15 +84,10 @@ void Checkpoint::initialize(bool load_manifest) {
   file_mgr_ =
       std::make_unique<CheckpointFileManager>(object_dir_, runtime_workspace_);
   if (!load_manifest) {
-    manifest_.set_checkpoint_id(id_);
     return;
   }
 
   manifest_.Load(manifest_path());
-  if (manifest_.checkpoint_id() != id_) {
-    THROW_CHECKPOINT_EXCEPTION("Checkpoint manifest id does not match path: " +
-                               manifest_path());
-  }
   resolve_object_paths();
 }
 
@@ -138,14 +133,13 @@ void Checkpoint::resolve_object_paths() {
 }
 
 void Checkpoint::SetManifest(CheckpointManifest&& manifest) {
-  manifest.set_checkpoint_id(id_);
   manifest_ = std::move(manifest);
 }
 
-void Checkpoint::PersistManifest() {
+void Checkpoint::persist_manifest() {
   if (!file_mgr_->SyncObjectDirectory()) {
-    THROW_IO_EXCEPTION("Checkpoint::PersistManifest: failed to fsync objects " +
-                       object_dir_);
+    THROW_IO_EXCEPTION(
+        "Checkpoint::persist_manifest: failed to fsync objects " + object_dir_);
   }
 
   CheckpointManifest persisted = manifest_;

--- a/src/storages/graph/checkpoint.cc
+++ b/src/storages/graph/checkpoint.cc
@@ -16,168 +16,157 @@
 #include "neug/storages/checkpoint.h"
 
 #include <filesystem>
-#include <regex>
 #include <string>
 
-#include "neug/storages/checkpoint_manifest.h"
 #include "neug/utils/exception/exception.h"
-
-#include <glog/logging.h>
 
 namespace neug {
 
-bool is_valid_uuid(const std::string& uuid) {
-  static const std::regex uuid_regex(
-      "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]"
-      "{12}$");
-  return std::regex_match(uuid, uuid_regex);
-}
-
-static void CollectReferencedFiles(const ModuleDescriptor& desc,
-                                   const std::string& target_dir,
-                                   std::set<std::string>& referenced_files) {
-  for (const auto& [_, p] : desc.paths()) {
-    if (p.empty()) {
-      continue;
-    }
-    auto parent = std::filesystem::path(p).parent_path().string();
-    if (parent == target_dir) {
-      referenced_files.insert(std::filesystem::path(p).filename().string());
-    }
-  }
-}
-
 Checkpoint::~Checkpoint() = default;
 
-Checkpoint::Checkpoint(std::string path, uint32_t id)
-    : path_(std::move(path)), id_(id) {}
+Checkpoint::Checkpoint(std::string database_dir, uint64_t id,
+                       std::shared_ptr<const std::string> runtime_workspace)
+    : database_dir_(
+          std::filesystem::absolute(std::move(database_dir)).string()),
+      manifest_path_((std::filesystem::path(database_dir_) / "checkpoint" /
+                      "manifests" / (std::to_string(id) + ".manifest"))
+                         .string()),
+      object_dir_(
+          (std::filesystem::path(database_dir_) / "checkpoint" / "objects")
+              .string()),
+      runtime_workspace_(std::move(runtime_workspace)),
+      wal_dir_(
+          (std::filesystem::path(database_dir_) / "wal" / std::to_string(id))
+              .string()),
+      id_(id) {}
 
-std::shared_ptr<Checkpoint> Checkpoint::Open(
-    std::string path, uint32_t id, bool cleanup_orphan_runtime_files) {
-  // Can't use make_shared because constructor is private.
-  auto ckp = std::shared_ptr<Checkpoint>(new Checkpoint(std::move(path), id));
-  ckp->initialize(cleanup_orphan_runtime_files);
-  return ckp;
+std::shared_ptr<Checkpoint> Checkpoint::OpenPublished(
+    std::string database_dir, uint64_t id,
+    std::shared_ptr<const std::string> runtime_workspace) {
+  auto checkpoint = std::shared_ptr<Checkpoint>(new Checkpoint(
+      std::move(database_dir), id, std::move(runtime_workspace)));
+  checkpoint->initialize(true);
+  return checkpoint;
 }
 
-void Checkpoint::initialize(bool cleanup_orphan_runtime_files) {
-  create_dirs();
-  file_mgr_ =
-      std::make_unique<CheckpointFileManager>(snapshot_dir(), runtime_dir());
-  meta_ = std::make_unique<CheckpointManifest>();
-  meta_->Load(meta_path());
+std::shared_ptr<Checkpoint> Checkpoint::CreateStaging(
+    std::string database_dir, uint64_t id,
+    std::shared_ptr<const std::string> runtime_workspace) {
+  auto checkpoint = std::shared_ptr<Checkpoint>(new Checkpoint(
+      std::move(database_dir), id, std::move(runtime_workspace)));
+  checkpoint->initialize(false);
+  return checkpoint;
+}
 
-  for (const auto& [key, desc] : meta_->modules()) {
-    ModuleDescriptor absolute_desc = desc;
-    for (auto& [_, v] : absolute_desc.mutable_paths()) {
-      v = file_mgr_->ResolveAbsolutePath(v, path_);
+void Checkpoint::initialize(bool load_manifest) {
+  if (load_manifest) {
+    if (!std::filesystem::is_regular_file(manifest_path())) {
+      THROW_CHECKPOINT_EXCEPTION("Checkpoint manifest is missing: " +
+                                 manifest_path());
     }
-    meta_->set_module(key, std::move(absolute_desc));
+    if (!std::filesystem::is_directory(object_dir_)) {
+      THROW_CHECKPOINT_EXCEPTION("Checkpoint object directory is missing: " +
+                                 object_dir_);
+    }
+    const auto create_runtime_dir = [](const std::string& path) {
+      std::error_code ec;
+      std::filesystem::create_directories(path, ec);
+      if (ec) {
+        THROW_IO_EXCEPTION("Checkpoint: failed to create " + path + ": " +
+                           ec.message());
+      }
+    };
+    create_runtime_dir(runtime_dir());
+    create_runtime_dir(allocator_dir());
+  } else {
+    create_dirs();
   }
-
-  if (!cleanup_orphan_runtime_files) {
+  file_mgr_ =
+      std::make_unique<CheckpointFileManager>(object_dir_, runtime_workspace_);
+  if (!load_manifest) {
+    manifest_.set_checkpoint_id(id_);
     return;
   }
 
-  // Clean orphaned runtime files not referenced by meta. This is only safe for
-  // a writer holding the exclusive database lock: a shared read-only process
-  // may otherwise delete another reader's active temporary backing file.
-  std::set<std::string> referenced_runtime_files;
-  for (auto& [key, desc] : meta_->modules()) {
-    CollectReferencedFiles(desc, runtime_dir(), referenced_runtime_files);
+  manifest_.Load(manifest_path());
+  if (manifest_.checkpoint_id() != id_) {
+    THROW_CHECKPOINT_EXCEPTION("Checkpoint manifest id does not match path: " +
+                               manifest_path());
   }
-
-  try {
-    for (const auto& entry :
-         std::filesystem::directory_iterator(runtime_dir())) {
-      if (entry.is_regular_file()) {
-        std::string name = entry.path().filename().string();
-        // Everything under runtime/ is temporary working state. In addition to
-        // UUID reservations, remove copy staging files left by a process that
-        // exited before its exception/RAII cleanup ran.
-        if (referenced_runtime_files.count(name) == 0) {
-          std::filesystem::remove(entry.path());
-          VLOG(1) << "Checkpoint::initialize: cleaned orphan file " << name;
-        }
-      }
-    }
-  } catch (const std::filesystem::filesystem_error& e) {
-    LOG(WARNING) << "Checkpoint::initialize: error during cleanup: "
-                 << e.what();
-  }
+  resolve_object_paths();
 }
 
 void Checkpoint::create_dirs() const {
-  assert(!IsEmpty());
-#define CREATE_DIR(dir)                                                   \
-  do {                                                                    \
-    std::error_code ec;                                                   \
-    std::filesystem::create_directories(dir(), ec);                       \
-    if (ec) {                                                             \
-      LOG(ERROR) << "Checkpoint::create_dirs: failed to create " << dir() \
-                 << ": " << ec.message();                                 \
-    }                                                                     \
-  } while (0)
-  CREATE_DIR(snapshot_dir);
-  CREATE_DIR(runtime_dir);
-  CREATE_DIR(wal_dir);
-  CREATE_DIR(allocator_dir);
-#undef CREATE_DIR
+  const auto create = [](const std::string& path) {
+    std::error_code ec;
+    std::filesystem::create_directories(path, ec);
+    if (ec) {
+      THROW_IO_EXCEPTION("Checkpoint: failed to create " + path + ": " +
+                         ec.message());
+    }
+  };
+  create(object_dir_);
+  create(std::filesystem::path(manifest_path()).parent_path().string());
+  create(runtime_dir());
+  create(allocator_dir());
 }
 
-void Checkpoint::UpdateMeta(CheckpointManifest&& meta) {
-  assert(!IsEmpty());
-  std::lock_guard<std::mutex> lock(mutex_);
-  auto old_meta = std::move(meta_);
-  try {
-    // Persist a copy with paths rewritten relative to the checkpoint root, so
-    // the directory remains relocatable on disk.
-    CheckpointManifest meta_with_relative_paths = meta;
-    for (const auto& [key, desc] : meta.modules()) {
-      ModuleDescriptor relative_desc = desc;
-      for (auto& [_, v] : relative_desc.mutable_paths()) {
-        v = file_mgr_->MakeRelativePath(v, path_);
+void Checkpoint::resolve_object_paths() {
+  for (const auto& [key, desc] : manifest_.Modules()) {
+    ModuleDescriptor resolved = desc;
+    for (auto& [_, object_id] : resolved.mutable_paths()) {
+      if (object_id.empty()) {
+        continue;
       }
-      meta_with_relative_paths.set_module(key, std::move(relative_desc));
-    }
-    if (!file_mgr_->SyncSnapshotDirectory()) {
-      THROW_IO_EXCEPTION(
-          "Checkpoint::UpdateMeta: failed to fsync snapshot_dir " +
-          snapshot_dir());
-    }
-    meta_with_relative_paths.Save(meta_path());
-
-    // Keep the in-memory meta_ in absolute-path form so downstream consumers
-    // (CollectReferencedFiles for orphan cleanup, Module::Open, …) can keep
-    // operating on usable paths without knowing the checkpoint root.
-    meta_ = std::make_unique<CheckpointManifest>(std::move(meta));
-
-    std::set<std::string> referenced_snapshot_files;
-    for (const auto& [key, desc] : meta_->modules()) {
-      CollectReferencedFiles(desc, snapshot_dir(), referenced_snapshot_files);
-    }
-    try {
-      for (const auto& entry :
-           std::filesystem::directory_iterator(snapshot_dir())) {
-        if (!entry.is_regular_file()) {
-          continue;
-        }
-        std::string name = entry.path().filename().string();
-        if (is_valid_uuid(name) && referenced_snapshot_files.count(name) == 0) {
-          std::filesystem::remove(entry.path());
-          VLOG(1) << "UpdateMeta: removed orphan from snapshot_dir: " << name;
-        }
+      const std::filesystem::path relative(object_id);
+      if (relative.is_absolute() || relative.has_parent_path()) {
+        THROW_CHECKPOINT_EXCEPTION(
+            "Checkpoint manifest contains invalid "
+            "object id: " +
+            object_id);
       }
-    } catch (const std::filesystem::filesystem_error& e) {
-      LOG(WARNING) << "UpdateMeta: error cleaning snapshot_dir: " << e.what();
+      object_id = (std::filesystem::path(object_dir_) / relative).string();
+      if (!std::filesystem::exists(object_id)) {
+        THROW_CHECKPOINT_EXCEPTION(
+            "Checkpoint manifest references missing "
+            "object: " +
+            object_id);
+      }
     }
-    return;
-  } catch (...) {
-    LOG(ERROR) << "Checkpoint::UpdateMeta: failed to persist meta to "
-               << meta_path();
-    meta_ = std::move(old_meta);
-    throw;
+    manifest_.SetModule(key, std::move(resolved));
   }
+}
+
+void Checkpoint::SetManifest(CheckpointManifest&& manifest) {
+  manifest.set_checkpoint_id(id_);
+  manifest_ = std::move(manifest);
+}
+
+void Checkpoint::PersistManifest() {
+  if (!file_mgr_->SyncObjectDirectory()) {
+    THROW_IO_EXCEPTION("Checkpoint::PersistManifest: failed to fsync objects " +
+                       object_dir_);
+  }
+
+  CheckpointManifest persisted = manifest_;
+  for (const auto& [key, desc] : manifest_.Modules()) {
+    ModuleDescriptor object_desc = desc;
+    for (auto& [_, path] : object_desc.mutable_paths()) {
+      if (path.empty()) {
+        continue;
+      }
+      if (std::filesystem::path(path).parent_path() !=
+          std::filesystem::path(object_dir_)) {
+        THROW_CHECKPOINT_EXCEPTION(
+            "Checkpoint manifest object is outside "
+            "the object store: " +
+            path);
+      }
+      path = std::filesystem::path(path).filename().string();
+    }
+    persisted.SetModule(key, std::move(object_desc));
+  }
+  persisted.Save(manifest_path());
 }
 
 }  // namespace neug

--- a/src/storages/graph/checkpoint.cc
+++ b/src/storages/graph/checkpoint.cc
@@ -24,8 +24,9 @@ namespace neug {
 
 Checkpoint::~Checkpoint() = default;
 
-Checkpoint::Checkpoint(std::string database_dir, uint64_t id,
-                       std::shared_ptr<const std::string> runtime_workspace)
+Checkpoint::Checkpoint(
+    std::string database_dir, uint64_t id,
+    std::shared_ptr<const RuntimeWorkspace> runtime_workspace)
     : database_dir_(
           std::filesystem::absolute(std::move(database_dir)).string()),
       manifest_path_((std::filesystem::path(database_dir_) / "checkpoint" /
@@ -42,7 +43,7 @@ Checkpoint::Checkpoint(std::string database_dir, uint64_t id,
 
 std::shared_ptr<Checkpoint> Checkpoint::OpenPublished(
     std::string database_dir, uint64_t id,
-    std::shared_ptr<const std::string> runtime_workspace) {
+    std::shared_ptr<const RuntimeWorkspace> runtime_workspace) {
   auto checkpoint = std::shared_ptr<Checkpoint>(new Checkpoint(
       std::move(database_dir), id, std::move(runtime_workspace)));
   checkpoint->initialize(true);
@@ -51,11 +52,15 @@ std::shared_ptr<Checkpoint> Checkpoint::OpenPublished(
 
 std::shared_ptr<Checkpoint> Checkpoint::CreateStaging(
     std::string database_dir, uint64_t id,
-    std::shared_ptr<const std::string> runtime_workspace) {
+    std::shared_ptr<const RuntimeWorkspace> runtime_workspace) {
   auto checkpoint = std::shared_ptr<Checkpoint>(new Checkpoint(
       std::move(database_dir), id, std::move(runtime_workspace)));
   checkpoint->initialize(false);
   return checkpoint;
+}
+
+const std::string& Checkpoint::runtime_dir() const {
+  return runtime_workspace_->path();
 }
 
 void Checkpoint::initialize(bool load_manifest) {
@@ -81,8 +86,7 @@ void Checkpoint::initialize(bool load_manifest) {
   } else {
     create_dirs();
   }
-  file_mgr_ =
-      std::make_unique<CheckpointFileManager>(object_dir_, runtime_workspace_);
+  file_mgr_.reset(new CheckpointFileManager(object_dir_, runtime_workspace_));
   if (!load_manifest) {
     return;
   }

--- a/src/storages/graph/checkpoint_file_manager.cc
+++ b/src/storages/graph/checkpoint_file_manager.cc
@@ -36,6 +36,30 @@
 
 namespace neug {
 
+std::shared_ptr<const RuntimeWorkspace> RuntimeWorkspace::Create(
+    std::string path) {
+  auto workspace =
+      std::shared_ptr<RuntimeWorkspace>(new RuntimeWorkspace(std::move(path)));
+  std::error_code ec;
+  std::filesystem::create_directories(workspace->path_, ec);
+  if (ec) {
+    THROW_IO_EXCEPTION("RuntimeWorkspace: failed to create " +
+                       workspace->path_ + ": " + ec.message());
+  }
+  return workspace;
+}
+
+RuntimeWorkspace::RuntimeWorkspace(std::string path) : path_(std::move(path)) {}
+
+RuntimeWorkspace::~RuntimeWorkspace() {
+  std::error_code ec;
+  std::filesystem::remove_all(path_, ec);
+  if (ec) {
+    LOG(WARNING) << "RuntimeWorkspace: failed to remove " << path_ << ": "
+                 << ec.message();
+  }
+}
+
 namespace {
 
 void sync_file(const std::string& path) {
@@ -65,16 +89,15 @@ void sync_file(const std::string& path) {
 
 struct CheckpointFileManager::RuntimeFileCleanupContext {
   explicit RuntimeFileCleanupContext(
-      std::shared_ptr<const std::string> runtime_workspace)
-      : runtime_workspace(std::move(runtime_workspace)),
-        runtime_dir(*this->runtime_workspace) {}
+      std::shared_ptr<const RuntimeWorkspace> runtime_workspace)
+      : runtime_workspace(std::move(runtime_workspace)) {}
 
   bool IsRuntimeFile(const std::string& path) const {
     if (path.empty()) {
       return false;
     }
     auto parent = std::filesystem::path(path).parent_path().string();
-    return parent == runtime_dir;
+    return parent == runtime_workspace->path();
   }
 
   void RemoveIfRuntimeFile(const std::string& path) {
@@ -89,8 +112,7 @@ struct CheckpointFileManager::RuntimeFileCleanupContext {
     }
   }
 
-  std::shared_ptr<const std::string> runtime_workspace;
-  std::string runtime_dir;
+  std::shared_ptr<const RuntimeWorkspace> runtime_workspace;
 };
 
 CheckpointFileManager::RuntimeFileHandle::RuntimeFileHandle(
@@ -114,9 +136,9 @@ void CheckpointFileManager::RuntimeFileHandle::Release() {
 
 CheckpointFileManager::CheckpointFileManager(
     const std::string& object_dir,
-    std::shared_ptr<const std::string> runtime_workspace)
+    std::shared_ptr<const RuntimeWorkspace> runtime_workspace)
     : object_dir_(object_dir),
-      runtime_dir_(*runtime_workspace),
+      runtime_dir_(runtime_workspace->path()),
       runtime_cleanup_(std::make_shared<RuntimeFileCleanupContext>(
           std::move(runtime_workspace))) {}
 

--- a/src/storages/graph/checkpoint_file_manager.cc
+++ b/src/storages/graph/checkpoint_file_manager.cc
@@ -25,6 +25,7 @@
 #endif
 
 #include <cerrno>
+#include <cstring>
 #include <filesystem>
 #include <system_error>
 #include <utility>
@@ -35,9 +36,29 @@
 
 namespace neug {
 
+namespace {
+
+void sync_file(const std::string& path) {
+  const int fd = ::open(path.c_str(), O_RDONLY);
+  if (fd < 0) {
+    THROW_IO_EXCEPTION("Checkpoint object open failed: " + path);
+  }
+  if (::fsync(fd) != 0) {
+    const auto message = std::string(std::strerror(errno));
+    ::close(fd);
+    THROW_IO_EXCEPTION("Checkpoint object fsync failed: " + path + ": " +
+                       message);
+  }
+  ::close(fd);
+}
+
+}  // namespace
+
 struct CheckpointFileManager::RuntimeFileCleanupContext {
-  explicit RuntimeFileCleanupContext(std::string runtime_dir)
-      : runtime_dir(std::move(runtime_dir)) {}
+  explicit RuntimeFileCleanupContext(
+      std::shared_ptr<const std::string> runtime_workspace)
+      : runtime_workspace(std::move(runtime_workspace)),
+        runtime_dir(*this->runtime_workspace) {}
 
   bool IsRuntimeFile(const std::string& path) const {
     if (path.empty()) {
@@ -59,15 +80,13 @@ struct CheckpointFileManager::RuntimeFileCleanupContext {
     }
   }
 
+  std::shared_ptr<const std::string> runtime_workspace;
   std::string runtime_dir;
 };
 
 CheckpointFileManager::RuntimeFileHandle::RuntimeFileHandle(
-    std::shared_ptr<RuntimeFileCleanupContext> cleanup, std::string uuid,
-    std::string path)
-    : cleanup_(std::move(cleanup)),
-      uuid_(std::move(uuid)),
-      path_(std::move(path)) {}
+    std::shared_ptr<RuntimeFileCleanupContext> cleanup, std::string path)
+    : cleanup_(std::move(cleanup)), path_(std::move(path)) {}
 
 CheckpointFileManager::RuntimeFileHandle::~RuntimeFileHandle() {
   if (cleanup_) {
@@ -77,22 +96,20 @@ CheckpointFileManager::RuntimeFileHandle::~RuntimeFileHandle() {
 
 CheckpointFileManager::RuntimeFileHandle::RuntimeFileHandle(
     RuntimeFileHandle&& other) noexcept
-    : cleanup_(std::move(other.cleanup_)),
-      uuid_(std::move(other.uuid_)),
-      path_(std::move(other.path_)) {}
+    : cleanup_(std::move(other.cleanup_)), path_(std::move(other.path_)) {}
 
 void CheckpointFileManager::RuntimeFileHandle::Release() {
   cleanup_.reset();
-  uuid_.clear();
   path_.clear();
 }
 
-CheckpointFileManager::CheckpointFileManager(const std::string& snapshot_dir,
-                                             const std::string& runtime_dir)
-    : snapshot_dir_(snapshot_dir),
-      runtime_dir_(runtime_dir),
-      runtime_cleanup_(
-          std::make_shared<RuntimeFileCleanupContext>(runtime_dir_)) {}
+CheckpointFileManager::CheckpointFileManager(
+    const std::string& object_dir,
+    std::shared_ptr<const std::string> runtime_workspace)
+    : object_dir_(object_dir),
+      runtime_dir_(*runtime_workspace),
+      runtime_cleanup_(std::make_shared<RuntimeFileCleanupContext>(
+          std::move(runtime_workspace))) {}
 
 CheckpointFileManager::~CheckpointFileManager() = default;
 
@@ -164,7 +181,7 @@ static bool is_file_in_dir(const std::string& path, const std::string& dir) {
 
 std::string CheckpointFileManager::Commit(IDataContainer& buffer) {
   auto original_path = buffer.GetPath();
-  if (!buffer.IsDirty() && is_file_in_dir(original_path, snapshot_dir_)) {
+  if (!buffer.IsDirty() && is_file_in_dir(original_path, object_dir_)) {
     buffer.Close();
     return original_path;
   }
@@ -178,8 +195,7 @@ std::string CheckpointFileManager::Commit(IDataContainer& buffer) {
 CheckpointFileManager::RuntimeFileHandle
 CheckpointFileManager::CreateRuntimeFile() {
   auto path = CreateRuntimeContainerPath();
-  auto uuid = std::filesystem::path(path).filename().string();
-  return RuntimeFileHandle(runtime_cleanup_, std::move(uuid), std::move(path));
+  return RuntimeFileHandle(runtime_cleanup_, std::move(path));
 }
 
 std::string CheckpointFileManager::CreateRuntimeContainerPath() {
@@ -187,8 +203,8 @@ std::string CheckpointFileManager::CreateRuntimeContainerPath() {
   while (true) {
     auto uuid = UUIDGenerator::Generate();
     auto runtime_path = runtime_dir_ + "/" + uuid;
-    auto snapshot_path = snapshot_dir_ + "/" + uuid;
-    if (std::filesystem::exists(snapshot_path)) {
+    auto object_path = object_dir_ + "/" + uuid;
+    if (std::filesystem::exists(object_path)) {
       continue;
     }
 
@@ -212,9 +228,9 @@ std::string CheckpointFileManager::CreateRuntimeObjectNameLocked() const {
   while (true) {
     std::string uuid = UUIDGenerator::Generate();
     auto runtime_path = runtime_dir_ + "/" + uuid;
-    auto snapshot_path = snapshot_dir_ + "/" + uuid;
+    auto object_path = object_dir_ + "/" + uuid;
     if (!std::filesystem::exists(runtime_path) &&
-        !std::filesystem::exists(snapshot_path)) {
+        !std::filesystem::exists(object_path)) {
       return uuid;
     }
   }
@@ -226,15 +242,16 @@ std::string CheckpointFileManager::CommitRuntimeFile(RuntimeFileHandle&& file) {
         "CheckpointFileManager::CommitRuntimeFile: invalid runtime file");
   }
   std::lock_guard<std::mutex> lock(mutex_);
-  auto dst = commitRuntimeFileLocked(file.uuid_, file.path_);
+  const auto uuid = std::filesystem::path(file.path_).filename().string();
+  auto dst = commitRuntimeFileLocked(uuid, file.path_);
   file.Release();
   return dst;
 }
 
-std::string CheckpointFileManager::copyToSnapshotLocked(
+std::string CheckpointFileManager::materializeObjectLocked(
     const std::string& abs_path) {
   auto parent = std::filesystem::path(abs_path).parent_path().string();
-  if (parent == snapshot_dir_) {
+  if (parent == object_dir_) {
     return abs_path;
   }
 
@@ -244,10 +261,10 @@ std::string CheckpointFileManager::copyToSnapshotLocked(
   }
 
   std::string new_uuid = CreateRuntimeObjectNameLocked();
-  auto dst = snapshot_dir_ + "/" + new_uuid;
+  auto dst = object_dir_ + "/" + new_uuid;
   file_utils::copy_file(abs_path, dst, false);
-  VLOG(1) << "CopyToSnapshot: " << abs_path
-          << " copied to snapshot_dir: " << dst;
+  sync_file(dst);
+  VLOG(1) << "CopyToSnapshot: " << abs_path << " copied to object_dir: " << dst;
   return dst;
 }
 
@@ -264,13 +281,14 @@ std::string CheckpointFileManager::commitRuntimeFileLocked(
                        abs_path);
   }
 
-  auto dst = snapshot_dir_ + "/" + uuid;
+  auto dst = object_dir_ + "/" + uuid;
   while (std::filesystem::exists(dst)) {
-    dst = snapshot_dir_ + "/" + CreateRuntimeObjectNameLocked();
+    dst = object_dir_ + "/" + CreateRuntimeObjectNameLocked();
   }
   std::error_code ec;
   std::filesystem::rename(abs_path, dst, ec);
   if (!ec) {
+    sync_file(dst);
     VLOG(1) << "CommitRuntimeFile: " << abs_path << " moved to " << dst;
     return dst;
   }
@@ -278,6 +296,7 @@ std::string CheckpointFileManager::commitRuntimeFileLocked(
   VLOG(1) << "CommitRuntimeFile: rename failed (" << ec.message()
           << "), falling back to copy for " << abs_path;
   file_utils::copy_file(abs_path, dst, false);
+  sync_file(dst);
   std::filesystem::remove(abs_path, ec);
   if (ec) {
     LOG(WARNING) << "CommitRuntimeFile: failed to remove " << abs_path
@@ -286,77 +305,18 @@ std::string CheckpointFileManager::commitRuntimeFileLocked(
   return dst;
 }
 
-std::string CheckpointFileManager::LinkToSnapshot(const std::string& abs_path) {
+std::string CheckpointFileManager::MaterializeObject(
+    const std::string& abs_path) {
   std::lock_guard<std::mutex> lock(mutex_);
-  auto parent = std::filesystem::path(abs_path).parent_path().string();
-  if (parent == snapshot_dir_) {
-    return abs_path;
-  }
-  if (parent == runtime_dir_) {
-    // The current checkpoint runtime file can still be backed by a live
-    // MAP_SHARED container. Materialize an independent snapshot instead of
-    // aliasing future writes through a hardlink. Retired runtime files from
-    // older checkpoints are allowed to use the hardlink path below by caller
-    // contract.
-    return copyToSnapshotLocked(abs_path);
-  }
-  std::string new_uuid = CreateRuntimeObjectNameLocked();
-  auto dst = snapshot_dir_ + "/" + new_uuid;
-  std::error_code ec;
-  std::filesystem::create_hard_link(abs_path, dst, ec);
-  if (ec) {
-    VLOG(1) << "LinkToSnapshot: hardlink failed (" << ec.message()
-            << "), falling back to copy for " << abs_path;
-    file_utils::copy_file(abs_path, dst, /*overwrite=*/false);
-  } else {
-    VLOG(1) << "LinkToSnapshot: hardlinked " << abs_path << " -> " << dst;
-  }
-  return dst;
+  // Runtime files may be backed by a live MAP_SHARED container. Materialize a
+  // new immutable object instead of aliasing future writes. External paths use
+  // the same safe copy path.
+  return materializeObjectLocked(abs_path);
 }
 
-bool CheckpointFileManager::SyncSnapshotDirectory() const {
+bool CheckpointFileManager::SyncObjectDirectory() const {
   std::lock_guard<std::mutex> lock(mutex_);
-  return file_utils::fsync_directory(snapshot_dir_);
-}
-
-// True iff the first path component of @p p is exactly "..".  A path escapes
-// its root only when normalization leaves a leading parent-dir component;
-// filenames that merely *contain* ".." (e.g. "..hidden", "foo..bar") are safe.
-bool escapes_root(const std::filesystem::path& p) {
-  static const std::filesystem::path kParent("..");
-  auto it = p.begin();
-  return it != p.end() && *it == kParent;
-}
-
-std::string CheckpointFileManager::MakeRelativePath(
-    const std::string& abs_path, const std::string& checkpoint_root) const {
-  if (abs_path.empty() || checkpoint_root.empty()) {
-    return abs_path;
-  }
-  try {
-    auto rel_path =
-        std::filesystem::relative(std::filesystem::path(abs_path),
-                                  std::filesystem::path(checkpoint_root))
-            .lexically_normal();
-    if (rel_path.empty() || escapes_root(rel_path)) {
-      return abs_path;
-    }
-    return rel_path.string();
-  } catch (...) { return abs_path; }
-}
-
-std::string CheckpointFileManager::ResolveAbsolutePath(
-    const std::string& rel_path, const std::string& checkpoint_root) const {
-  if (rel_path.empty() || checkpoint_root.empty()) {
-    return rel_path;
-  }
-  std::filesystem::path rel_fs(rel_path);
-  if (rel_fs.is_absolute() || escapes_root(rel_fs.lexically_normal())) {
-    return rel_path;
-  }
-  try {
-    return (std::filesystem::path(checkpoint_root) / rel_fs).string();
-  } catch (...) { return rel_path; }
+  return file_utils::fsync_directory(object_dir_);
 }
 
 }  // namespace neug

--- a/src/storages/graph/checkpoint_file_manager.cc
+++ b/src/storages/graph/checkpoint_file_manager.cc
@@ -39,11 +39,20 @@ namespace neug {
 namespace {
 
 void sync_file(const std::string& path) {
+#ifdef _WIN32
+  const int fd = ::_open(path.c_str(), _O_RDWR);
+#else
   const int fd = ::open(path.c_str(), O_RDONLY);
+#endif
   if (fd < 0) {
     THROW_IO_EXCEPTION("Checkpoint object open failed: " + path);
   }
-  if (::fsync(fd) != 0) {
+#ifdef _WIN32
+  const int sync_result = ::_commit(fd);
+#else
+  const int sync_result = ::fsync(fd);
+#endif
+  if (sync_result != 0) {
     const auto message = std::string(std::strerror(errno));
     ::close(fd);
     THROW_IO_EXCEPTION("Checkpoint object fsync failed: " + path + ": " +

--- a/src/storages/graph/checkpoint_manager.cc
+++ b/src/storages/graph/checkpoint_manager.cc
@@ -116,20 +116,6 @@ void ensure_directory(const std::filesystem::path& path,
   }
 }
 
-std::shared_ptr<const std::string> create_runtime_workspace(
-    std::string runtime_dir) {
-  return std::shared_ptr<const std::string>(
-      new std::string(std::move(runtime_dir)), [](const std::string* path) {
-        std::error_code ec;
-        std::filesystem::remove_all(*path, ec);
-        if (ec) {
-          LOG(WARNING) << "CheckpointManager: failed to remove runtime "
-                       << "workspace " << *path << ": " << ec.message();
-        }
-        delete path;
-      });
-}
-
 std::optional<uint64_t> checkpoint_id_from_name(
     const std::filesystem::path& path, std::string_view suffix) {
   const auto name = path.filename().string();
@@ -222,14 +208,11 @@ void CheckpointManager::Open(const std::string& database_dir,
   }
   const auto runtime =
       absolute_db_dir / "runtime" / ("open-" + UUIDGenerator::Generate());
-  ensure_directory(runtime, "CheckpointManager::Open");
-
-  std::shared_ptr<const std::string> runtime_workspace;
+  auto runtime_workspace = RuntimeWorkspace::Create(runtime.string());
   {
     std::lock_guard<std::mutex> lock(mutex_);
     database_dir_ = absolute_db_dir.string();
-    runtime_workspace_ = create_runtime_workspace(runtime.string());
-    runtime_workspace = runtime_workspace_;
+    runtime_workspace_ = runtime_workspace;
     current_checkpoint_.reset();
     staging_checkpoint_.reset();
     published_checkpoints_.clear();
@@ -465,7 +448,7 @@ void CheckpointManager::CollectGarbage() {
 
   bool removed_runtime_workspace = false;
   const auto runtime_root = std::filesystem::path(database_dir_) / "runtime";
-  const auto active_runtime = std::filesystem::path(*runtime_workspace_);
+  const auto active_runtime = std::filesystem::path(runtime_workspace_->path());
   if (std::filesystem::is_directory(runtime_root)) {
     for (const auto& entry :
          std::filesystem::directory_iterator(runtime_root)) {

--- a/src/storages/graph/checkpoint_manager.cc
+++ b/src/storages/graph/checkpoint_manager.cc
@@ -14,337 +14,151 @@
  */
 
 #include "neug/storages/checkpoint_manager.h"
-#include "neug/storages/checkpoint_manifest.h"
-#include "neug/storages/module/module_factory.h"
-#include "neug/utils/exception/exception.h"
-#include "neug/utils/io/file/file_utils.h"
 
-#include <algorithm>
 #include <charconv>
-#include <exception>
 #include <filesystem>
+#include <fstream>
 #include <string>
 #include <string_view>
 #include <system_error>
+#include <unordered_set>
 #include <utility>
-#include <vector>
 
 #include <glog/logging.h>
+
+#include "neug/utils/exception/exception.h"
+#include "neug/utils/io/file/file_utils.h"
+#include "neug/utils/uuid.h"
 
 namespace neug {
 
 namespace {
-constexpr std::string_view kCheckpointPrefix = "checkpoint-";
-constexpr std::string_view kNextSuffix = ".next";
-constexpr int32_t kInvalidCheckpointGeneration = -1;
 
-struct ParsedCheckpointDir {
-  int32_t id;
-  std::filesystem::path path;
-};
-
-struct CheckpointOpenResult {
-  std::shared_ptr<Checkpoint> current_checkpoint;
-  int32_t current_generation = kInvalidCheckpointGeneration;
-};
-
-std::string checkpoint_name(int32_t id) {
-  return std::string(kCheckpointPrefix) + std::to_string(id);
+std::filesystem::path checkpoint_dir(const std::string& db_dir) {
+  return std::filesystem::path(db_dir) / "checkpoint";
 }
 
-std::string staging_checkpoint_name(int32_t id) {
-  return checkpoint_name(id) + std::string(kNextSuffix);
+std::filesystem::path current_path(const std::string& db_dir) {
+  return checkpoint_dir(db_dir) / "CURRENT";
 }
 
-void remove_checkpoint_dir_best_effort(const std::filesystem::path& path,
-                                       std::string_view context) {
-  if (path.empty()) {
-    return;
-  }
-  std::error_code ec;
-  std::filesystem::remove_all(path, ec);
-  if (ec) {
-    LOG(WARNING) << context << ": failed to remove checkpoint " << path << ": "
-                 << ec.message();
-  }
-}
-
-bool parse_checkpoint_name(const std::string& name, int32_t& id) {
-  if (name.size() <= kCheckpointPrefix.size() ||
-      std::string_view(name).substr(0, kCheckpointPrefix.size()) !=
-          kCheckpointPrefix) {
-    return false;
-  }
-  const char* first = name.data() + kCheckpointPrefix.size();
-  const char* last = name.data() + name.size();
-  auto [ptr, ec] = std::from_chars(first, last, id);
-  return ec == std::errc{} && ptr == last && id >= 0;
-}
-
-bool parse_checkpoint_path(const std::filesystem::path& path, int32_t& id) {
-  if (!std::filesystem::is_directory(path)) {
-    return false;
-  }
-  return parse_checkpoint_name(path.filename().string(), id);
-}
-
-bool parse_staging_checkpoint_path(const std::filesystem::path& path,
-                                   int32_t& id) {
-  if (!std::filesystem::is_directory(path)) {
-    return false;
-  }
-  std::string name = path.filename().string();
-  if (name.size() <= kNextSuffix.size() ||
-      std::string_view(name).substr(name.size() - kNextSuffix.size()) !=
-          kNextSuffix) {
-    return false;
-  }
-  name.resize(name.size() - kNextSuffix.size());
-  return parse_checkpoint_name(name, id);
-}
-
-std::vector<ParsedCheckpointDir> discover_published_checkpoints(
-    const std::string& db_dir) {
-  std::vector<ParsedCheckpointDir> dirs;
-  for (const auto& entry : std::filesystem::directory_iterator(db_dir)) {
-    int32_t id;
-    if (entry.is_directory() && parse_checkpoint_path(entry.path(), id)) {
-      dirs.push_back({id, entry.path()});
-    }
-  }
-  std::sort(dirs.begin(), dirs.end(),
-            [](const auto& lhs, const auto& rhs) { return lhs.id > rhs.id; });
-  return dirs;
-}
-
-void cleanup_staging_checkpoints(const std::string& db_dir,
-                                 std::string_view context) {
-  if (db_dir.empty() || !std::filesystem::is_directory(db_dir)) {
-    return;
-  }
-  for (const auto& entry : std::filesystem::directory_iterator(db_dir)) {
-    int32_t id;
-    if (entry.is_directory() &&
-        parse_staging_checkpoint_path(entry.path(), id)) {
-      remove_checkpoint_dir_best_effort(entry.path(), context);
-    }
-  }
-}
-
-std::shared_ptr<Checkpoint> open_checkpoint_checked(
-    const std::filesystem::path& path, int32_t id,
-    bool cleanup_orphan_runtime_files) {
-  auto checkpoint =
-      Checkpoint::Open(path.string(), id, cleanup_orphan_runtime_files);
-  if (!checkpoint->GetMeta().has_schema()) {
-    THROW_CHECKPOINT_EXCEPTION("Checkpoint " + path.string() +
-                               " is incomplete");
-  }
-  for (const auto& [module_name, desc] : checkpoint->GetMeta().modules()) {
-    if (!desc.module_type.empty() &&
-        ModuleFactory::instance().Create(desc.module_type) == nullptr &&
-        desc.required) {
-      THROW_CHECKPOINT_EXCEPTION(
-          "Checkpoint " + path.string() + " references unknown module type " +
-          desc.module_type + " from module " + module_name);
-    }
-    for (const auto& [path_name, file_path] : desc.paths()) {
-      if (file_path.empty()) {
-        continue;
-      }
-      std::error_code ec;
-      if (!std::filesystem::exists(file_path, ec) || ec) {
-        THROW_CHECKPOINT_EXCEPTION(
-            "Checkpoint " + path.string() + " references missing file " +
-            file_path + " from module " + module_name + "/" + path_name);
-      }
-    }
-  }
-  return checkpoint;
-}
-
-void cleanup_non_current_checkpoints(
-    const std::vector<ParsedCheckpointDir>& dirs, int32_t current_generation,
-    std::string_view context) {
-  for (const auto& dir : dirs) {
-    if (dir.id == current_generation) {
-      continue;
-    }
-    remove_checkpoint_dir_best_effort(dir.path, context);
-  }
-}
-
-CheckpointOpenResult open_current_checkpoint(const std::string& db_dir,
-                                             bool recover_workspace) {
-  CheckpointOpenResult result;
+bool has_legacy_checkpoint(const std::filesystem::path& db_dir) {
   if (!std::filesystem::is_directory(db_dir)) {
-    if (!recover_workspace) {
-      return result;
-    }
-    std::filesystem::create_directories(db_dir);
+    return false;
   }
-
-  if (recover_workspace) {
-    cleanup_staging_checkpoints(db_dir, "CheckpointManager::Open");
-  }
-
-  auto dirs = discover_published_checkpoints(db_dir);
-  for (const auto& dir : dirs) {
-    try {
-      result.current_checkpoint =
-          open_checkpoint_checked(dir.path, dir.id, recover_workspace);
-      result.current_generation = dir.id;
-      break;
-    } catch (const std::exception& e) {
-      LOG(WARNING) << "CheckpointManager::Open: "
-                   << (recover_workspace ? "removing" : "skipping")
-                   << " invalid checkpoint " << dir.path << ": " << e.what();
-      if (recover_workspace) {
-        remove_checkpoint_dir_best_effort(dir.path, "CheckpointManager::Open");
-      }
-    } catch (...) {
-      LOG(WARNING) << "CheckpointManager::Open: "
-                   << (recover_workspace ? "removing" : "skipping")
-                   << " invalid checkpoint " << dir.path;
-      if (recover_workspace) {
-        remove_checkpoint_dir_best_effort(dir.path, "CheckpointManager::Open");
-      }
+  for (const auto& entry : std::filesystem::directory_iterator(db_dir)) {
+    const auto name = entry.path().filename().string();
+    if (entry.is_directory() && name.starts_with("checkpoint-")) {
+      return true;
     }
   }
-
-  return result;
+  return false;
 }
 
-std::shared_ptr<Checkpoint> create_staging_checkpoint(const std::string& db_dir,
-                                                      int32_t generation) {
-  auto path =
-      std::filesystem::path(db_dir) / staging_checkpoint_name(generation);
+uint64_t read_current(const std::filesystem::path& path) {
+  std::ifstream input(path);
+  std::string value;
+  std::getline(input, value);
+  if (!input || value.empty()) {
+    THROW_CHECKPOINT_EXCEPTION("Invalid CURRENT selector: " + path.string());
+  }
 
+  uint64_t id = 0;
+  const char* first = value.data();
+  const char* last = first + value.size();
+  const auto [ptr, ec] = std::from_chars(first, last, id);
+  if (ec != std::errc{} || ptr != last) {
+    THROW_CHECKPOINT_EXCEPTION("Invalid CURRENT selector: " + path.string());
+  }
+  return id;
+}
+
+std::optional<uint64_t> try_read_current(
+    const std::filesystem::path& path) noexcept {
+  try {
+    if (!std::filesystem::exists(path)) {
+      return std::nullopt;
+    }
+    return read_current(path);
+  } catch (...) { return std::nullopt; }
+}
+
+bool current_matches(const std::filesystem::path& path,
+                     std::optional<uint64_t> expected) noexcept {
   std::error_code ec;
-  std::filesystem::remove_all(path, ec);
+  const bool exists = std::filesystem::exists(path, ec);
   if (ec) {
-    THROW_IO_EXCEPTION(
-        "CheckpointManager::CreateStagingCheckpoint: failed to clean " +
-        path.string() + ": " + ec.message());
+    return false;
   }
-
-  try {
-    std::filesystem::create_directories(path);
-    CheckpointManifest::GenerateEmptyMeta((path / "meta").string());
-    return Checkpoint::Open(path.string(), generation);
-  } catch (...) {
-    remove_checkpoint_dir_best_effort(
-        path, "CheckpointManager::CreateStagingCheckpoint");
-    throw;
+  if (!expected.has_value()) {
+    return !exists;
   }
+  return exists && try_read_current(path) == expected;
 }
 
-std::shared_ptr<Checkpoint> publish_staging_checkpoint(
-    const std::string& db_dir,
-    const std::shared_ptr<Checkpoint>& staging_checkpoint,
-    const std::shared_ptr<Checkpoint>& current_checkpoint,
-    int32_t current_generation, std::string* previous_checkpoint_path) {
-  const int32_t generation = static_cast<int32_t>(staging_checkpoint->id());
-  if (current_generation != kInvalidCheckpointGeneration &&
-      generation <= current_generation) {
-    THROW_CHECKPOINT_EXCEPTION(
-        "CheckpointManager::CommitStagingCheckpoint: refusing to commit "
-        "non-increasing checkpoint generation " +
-        std::to_string(generation) + " over current generation " +
-        std::to_string(current_generation));
-  }
+bool restore_current(const std::filesystem::path& path,
+                     std::optional<uint64_t> previous_id) noexcept {
+  try {
+    if (previous_id.has_value()) {
+      file_utils::AtomicFileWriter writer(path.string());
+      writer.stream() << *previous_id << '\n';
+      if (writer.Commit() !=
+          file_utils::AtomicFileWriter::CommitResult::kDurable) {
+        return false;
+      }
+    } else {
+      std::error_code ec;
+      std::filesystem::remove(path, ec);
+      if (ec || !file_utils::fsync_directory(path.parent_path().string())) {
+        return false;
+      }
+    }
+    return current_matches(path, previous_id);
+  } catch (...) { return false; }
+}
 
-  auto staging_path = std::filesystem::path(staging_checkpoint->path());
-  int32_t parsed_generation;
-  if (staging_path.filename().string() != staging_checkpoint_name(generation) ||
-      !parse_staging_checkpoint_path(staging_path, parsed_generation) ||
-      parsed_generation != generation) {
-    THROW_CHECKPOINT_EXCEPTION(
-        "CheckpointManager::CommitStagingCheckpoint: invalid staging "
-        "checkpoint path: " +
-        staging_path.string());
-  }
-
-  if (!staging_checkpoint->GetMeta().has_schema()) {
-    THROW_CHECKPOINT_EXCEPTION(
-        "CheckpointManager::CommitStagingCheckpoint: checkpoint has no "
-        "schema: " +
-        staging_path.string());
-  }
-
-  const auto final_path =
-      std::filesystem::path(db_dir) / checkpoint_name(generation);
-  if (std::filesystem::exists(final_path)) {
-    THROW_CHECKPOINT_EXCEPTION(
-        "CheckpointManager::CommitStagingCheckpoint: published checkpoint "
-        "already exists: " +
-        final_path.string());
-  }
-
+void ensure_directory(const std::filesystem::path& path,
+                      std::string_view context) {
   std::error_code ec;
-  std::filesystem::rename(staging_path, final_path, ec);
+  std::filesystem::create_directories(path, ec);
   if (ec) {
-    THROW_IO_EXCEPTION("CheckpointManager::CommitStagingCheckpoint: rename " +
-                       staging_path.string() + " -> " + final_path.string() +
-                       " failed: " + ec.message());
+    THROW_IO_EXCEPTION(std::string(context) + ": failed to create " +
+                       path.string() + ": " + ec.message());
   }
-  if (!file_utils::fsync_directory(db_dir)) {
-    LOG(WARNING)
-        << "CheckpointManager::CommitStagingCheckpoint: failed to fsync "
-        << db_dir;
-  }
-
-  std::shared_ptr<Checkpoint> final_checkpoint;
-  try {
-    final_checkpoint = Checkpoint::Open(final_path.string(), generation);
-  } catch (...) {
-    // rename is the durable commit point. Keep the published generation even
-    // if opening its handle fails; the next database Open will validate it.
-    throw;
-  }
-
-  if (previous_checkpoint_path != nullptr && current_checkpoint != nullptr) {
-    *previous_checkpoint_path = current_checkpoint->path();
-  }
-  return final_checkpoint;
 }
 
-void discard_staging_checkpoint(
-    const std::shared_ptr<Checkpoint>& staging_checkpoint) {
-  if (staging_checkpoint == nullptr) {
-    return;
-  }
-
-  const int32_t generation = static_cast<int32_t>(staging_checkpoint->id());
-  const auto path = std::filesystem::path(staging_checkpoint->path());
-  int32_t staging_generation;
-  if (!parse_staging_checkpoint_path(path, staging_generation) ||
-      staging_generation != generation) {
-    THROW_CHECKPOINT_EXCEPTION(
-        "CheckpointManager::DiscardStagingCheckpoint: checkpoint is not "
-        "staging: " +
-        path.string());
-  }
-
-  remove_checkpoint_dir_best_effort(
-      path, "CheckpointManager::DiscardStagingCheckpoint");
+std::shared_ptr<const std::string> create_runtime_workspace(
+    std::string runtime_dir) {
+  return std::shared_ptr<const std::string>(
+      new std::string(std::move(runtime_dir)), [](const std::string* path) {
+        std::error_code ec;
+        std::filesystem::remove_all(*path, ec);
+        if (ec) {
+          LOG(WARNING) << "CheckpointManager: failed to remove runtime "
+                       << "workspace " << *path << ": " << ec.message();
+        }
+        delete path;
+      });
 }
 
-void discard_staging_checkpoint_best_effort(
-    const std::shared_ptr<Checkpoint>& staging_checkpoint,
-    std::string_view context) {
-  if (staging_checkpoint == nullptr) {
-    return;
+std::optional<uint64_t> checkpoint_id_from_name(
+    const std::filesystem::path& path, std::string_view suffix) {
+  const auto name = path.filename().string();
+  if (!name.ends_with(suffix)) {
+    return std::nullopt;
   }
-  try {
-    discard_staging_checkpoint(staging_checkpoint);
-  } catch (const std::exception& e) {
-    LOG(WARNING) << context << ": failed to discard staging "
-                 << staging_checkpoint->path() << ": " << e.what();
-  } catch (...) {
-    LOG(WARNING) << context << ": failed to discard staging "
-                 << staging_checkpoint->path();
+  const auto id_text =
+      std::string_view(name).substr(0, name.size() - suffix.size());
+  if (id_text.empty()) {
+    return std::nullopt;
   }
+  uint64_t id = 0;
+  const auto [ptr, ec] =
+      std::from_chars(id_text.data(), id_text.data() + id_text.size(), id);
+  if (ec != std::errc{} || ptr != id_text.data() + id_text.size()) {
+    return std::nullopt;
+  }
+  return id;
 }
 
 }  // namespace
@@ -364,266 +178,273 @@ CheckpointManager::StagingCheckpoint::StagingCheckpoint(
 std::shared_ptr<Checkpoint> CheckpointManager::StagingCheckpoint::checkpoint()
     const {
   if (checkpoint_ == nullptr) {
-    THROW_CHECKPOINT_EXCEPTION("Staging checkpoint handle is inactive.");
+    THROW_CHECKPOINT_EXCEPTION("Staging checkpoint handle is inactive");
   }
   return checkpoint_;
 }
 
-std::shared_ptr<Checkpoint> CheckpointManager::StagingCheckpoint::Commit(
-    std::string* previous_checkpoint_path) {
+std::shared_ptr<Checkpoint> CheckpointManager::StagingCheckpoint::Publish() {
   if (checkpoint_ == nullptr) {
-    THROW_CHECKPOINT_EXCEPTION("Staging checkpoint handle is inactive.");
+    THROW_CHECKPOINT_EXCEPTION("Staging checkpoint handle is inactive");
   }
-  return manager_.CommitStagingCheckpoint(*this, previous_checkpoint_path);
+  return manager_.PublishStagingCheckpoint(*this);
 }
 
 void CheckpointManager::StagingCheckpoint::Discard() noexcept {
   if (checkpoint_ != nullptr) {
     manager_.DiscardStagingCheckpoint(*this);
-    return;
   }
-  release();
 }
 
 void CheckpointManager::StagingCheckpoint::release() { checkpoint_.reset(); }
 
-void CheckpointManager::Open(const std::string& db_dir,
-                             bool recover_workspace) {
-  if (db_dir.empty()) {
-    THROW_INVALID_ARGUMENT_EXCEPTION("db_dir cannot be empty");
+void CheckpointManager::Open(const std::string& database_dir,
+                             bool create_if_missing) {
+  if (database_dir.empty()) {
+    THROW_INVALID_ARGUMENT_EXCEPTION("database_dir cannot be empty");
   }
 
-  std::shared_ptr<Checkpoint> stale_staging_checkpoint;
-  try {
-    {
-      std::lock_guard<std::mutex> lock(mutex_);
-      if (!db_dir_.empty()) {
-        LOG(WARNING)
-            << "CheckpointManager::Open called on already-open workspace: "
-            << db_dir_ << ", reopening to: " << db_dir;
-      }
-
-      stale_staging_checkpoint = staging_checkpoint_;
-      db_dir_ = std::filesystem::absolute(db_dir).string();
-      current_checkpoint_.reset();
-      staging_checkpoint_.reset();
-      current_generation_ = kInvalidCheckpointGeneration;
-
-      auto result = open_current_checkpoint(db_dir_, recover_workspace);
-      current_checkpoint_ = std::move(result.current_checkpoint);
-      current_generation_ = result.current_generation;
+  const auto absolute_db_dir = std::filesystem::absolute(database_dir);
+  if (!std::filesystem::exists(absolute_db_dir)) {
+    if (!create_if_missing) {
+      return;
     }
-    discard_staging_checkpoint_best_effort(stale_staging_checkpoint,
-                                           "CheckpointManager::Open");
-  } catch (const std::filesystem::filesystem_error& e) {
-    {
-      std::lock_guard<std::mutex> lock(mutex_);
-      db_dir_.clear();
-      current_checkpoint_.reset();
-      staging_checkpoint_.reset();
-      current_generation_ = kInvalidCheckpointGeneration;
-    }
-    discard_staging_checkpoint_best_effort(stale_staging_checkpoint,
-                                           "CheckpointManager::Open");
-    if (e.code() == std::errc::permission_denied) {
-      THROW_PERMISSION_DENIED("CheckpointManager::Open: cannot access " +
-                              std::string(db_dir) + ": " + e.what());
-    }
-    THROW_IO_EXCEPTION("CheckpointManager::Open: failed to open " +
-                       std::string(db_dir) + ": " + e.what());
+    ensure_directory(absolute_db_dir, "CheckpointManager::Open");
   }
+  if (has_legacy_checkpoint(absolute_db_dir)) {
+    THROW_NOT_SUPPORTED_EXCEPTION(
+        "Legacy checkpoint-N directories are unsupported; this release does "
+        "not read or migrate them. Recover or rebuild the database with a "
+        "version that supports the legacy format first");
+  }
+
+  const auto root = checkpoint_dir(absolute_db_dir.string());
+  const bool has_current = std::filesystem::exists(root / "CURRENT");
+  if (create_if_missing && !has_current) {
+    ensure_directory(root / "manifests", "CheckpointManager::Open");
+    ensure_directory(root / "objects", "CheckpointManager::Open");
+    ensure_directory(absolute_db_dir / "wal", "CheckpointManager::Open");
+  }
+  const auto runtime =
+      absolute_db_dir / "runtime" / ("open-" + UUIDGenerator::Generate());
+  ensure_directory(runtime, "CheckpointManager::Open");
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  database_dir_ = absolute_db_dir.string();
+  runtime_workspace_ = create_runtime_workspace(runtime.string());
+  current_checkpoint_.reset();
+  staging_checkpoint_.reset();
+  published_checkpoints_.clear();
+
+  const auto current = current_path(database_dir_);
+  if (!has_current) {
+    return;
+  }
+
+  const uint64_t id = read_current(current);
+  auto checkpoint =
+      Checkpoint::OpenPublished(database_dir_, id, runtime_workspace_);
+  if (!checkpoint->manifest().has_schema()) {
+    THROW_CHECKPOINT_EXCEPTION("CURRENT manifest has no schema: " +
+                               checkpoint->manifest_path());
+  }
+  if (!std::filesystem::is_directory(checkpoint->wal_dir())) {
+    THROW_CHECKPOINT_EXCEPTION("CURRENT manifest WAL epoch is missing: " +
+                               checkpoint->wal_dir());
+  }
+  current_checkpoint_ = std::move(checkpoint);
+  published_checkpoints_.push_back(current_checkpoint_);
 }
 
 void CheckpointManager::Close() {
-  std::shared_ptr<Checkpoint> staging_checkpoint;
-  {
-    std::lock_guard<std::mutex> lock(mutex_);
-    staging_checkpoint = staging_checkpoint_;
-    db_dir_.clear();
-    current_checkpoint_.reset();
-    staging_checkpoint_.reset();
-    current_generation_ = kInvalidCheckpointGeneration;
-  }
-  discard_staging_checkpoint_best_effort(staging_checkpoint,
-                                         "CheckpointManager::Close");
-}
-
-bool CheckpointManager::HasCurrentCheckpoint() const {
   std::lock_guard<std::mutex> lock(mutex_);
-  return current_checkpoint_ != nullptr;
+  current_checkpoint_.reset();
+  staging_checkpoint_.reset();
+  runtime_workspace_.reset();
+  database_dir_.clear();
+  published_checkpoints_.clear();
 }
 
-std::shared_ptr<Checkpoint> CheckpointManager::CurrentCheckpoint() const {
+std::shared_ptr<Checkpoint> CheckpointManager::Current() const {
   std::lock_guard<std::mutex> lock(mutex_);
   return current_checkpoint_;
 }
 
-CheckpointManager::StagingCheckpoint
-CheckpointManager::CreateStagingCheckpoint() {
+CheckpointManager::StagingCheckpoint CheckpointManager::CreateStaging() {
   std::lock_guard<std::mutex> lock(mutex_);
-  if (db_dir_.empty()) {
-    THROW_CHECKPOINT_EXCEPTION(
-        "CheckpointManager::CreateStagingCheckpoint: manager is not open");
+  if (database_dir_.empty()) {
+    THROW_CHECKPOINT_EXCEPTION("CheckpointManager is not open");
   }
   if (staging_checkpoint_ != nullptr) {
-    THROW_CHECKPOINT_EXCEPTION(
-        "CheckpointManager::CreateStagingCheckpoint: active staging "
-        "checkpoint already exists: " +
-        std::to_string(staging_checkpoint_->id()));
+    THROW_CHECKPOINT_EXCEPTION("A staging checkpoint is already active");
   }
 
-  const int32_t generation = current_generation_ == kInvalidCheckpointGeneration
-                                 ? 0
-                                 : current_generation_ + 1;
-  staging_checkpoint_ = create_staging_checkpoint(db_dir_, generation);
+  const uint64_t id =
+      current_checkpoint_ == nullptr ? 0 : current_checkpoint_->id() + 1;
+  staging_checkpoint_ =
+      Checkpoint::CreateStaging(database_dir_, id, runtime_workspace_);
   return StagingCheckpoint(*this, staging_checkpoint_);
 }
 
-std::shared_ptr<Checkpoint> CheckpointManager::CommitStagingCheckpoint(
-    StagingCheckpoint& staging, std::string* previous_checkpoint_path) {
-  if (previous_checkpoint_path != nullptr) {
-    previous_checkpoint_path->clear();
-  }
-
-  std::shared_ptr<Checkpoint> checkpoint;
-  {
-    std::lock_guard<std::mutex> lock(mutex_);
-    if (&staging.manager_ != this || staging.checkpoint_ == nullptr) {
-      THROW_CHECKPOINT_EXCEPTION(
-          "CheckpointManager::CommitStagingCheckpoint: inactive or foreign "
-          "staging checkpoint");
-    }
-    if (staging_checkpoint_ == nullptr ||
-        staging_checkpoint_ != staging.checkpoint_) {
-      THROW_CHECKPOINT_EXCEPTION(
-          "CheckpointManager::CommitStagingCheckpoint: staging checkpoint is "
-          "not active");
-    }
-
-    current_checkpoint_ = publish_staging_checkpoint(
-        db_dir_, staging_checkpoint_, current_checkpoint_, current_generation_,
-        previous_checkpoint_path);
-    current_generation_ = static_cast<int32_t>(current_checkpoint_->id());
-    staging_checkpoint_.reset();
-    staging.release();
-    checkpoint = current_checkpoint_;
-  }
-
-  return checkpoint;
-}
-
-void CheckpointManager::RestoreCurrentCheckpoint(
-    std::shared_ptr<Checkpoint> checkpoint) {
-  if (checkpoint == nullptr) {
-    THROW_INVALID_ARGUMENT_EXCEPTION(
-        "CheckpointManager::RestoreCurrentCheckpoint: checkpoint is null");
-  }
-
-  const auto checkpoint_path = std::filesystem::path(checkpoint->path());
-  int32_t parsed_generation;
-  if (!parse_checkpoint_path(checkpoint_path, parsed_generation) ||
-      parsed_generation != static_cast<int32_t>(checkpoint->id())) {
-    THROW_CHECKPOINT_EXCEPTION(
-        "CheckpointManager::RestoreCurrentCheckpoint: invalid checkpoint "
-        "path: " +
-        checkpoint->path());
-  }
-
+std::shared_ptr<Checkpoint> CheckpointManager::PublishStagingCheckpoint(
+    StagingCheckpoint& staging) {
   std::lock_guard<std::mutex> lock(mutex_);
-  current_generation_ = static_cast<int32_t>(checkpoint->id());
-  current_checkpoint_ = std::move(checkpoint);
-  staging_checkpoint_.reset();
-}
-
-void CheckpointManager::CleanupPublishedCheckpoint(
-    std::shared_ptr<Checkpoint> checkpoint) {
-  if (checkpoint == nullptr) {
-    return;
+  if (&staging.manager_ != this || staging.checkpoint_ == nullptr ||
+      staging.checkpoint_ != staging_checkpoint_) {
+    THROW_CHECKPOINT_EXCEPTION("Inactive or foreign staging checkpoint");
   }
-
-  const int32_t generation = static_cast<int32_t>(checkpoint->id());
-  auto path = std::filesystem::path(checkpoint->path());
-  if (path.filename().string() != checkpoint_name(generation)) {
-    LOG(WARNING)
-        << "CheckpointManager::CleanupPublishedCheckpoint: refusing to "
-        << "remove non-published checkpoint path " << path;
-    return;
+  if (!staging_checkpoint_->manifest().has_schema()) {
+    THROW_CHECKPOINT_EXCEPTION("Cannot publish a checkpoint without schema");
   }
-
-  std::string db_dir;
-  {
-    std::lock_guard<std::mutex> lock(mutex_);
-    db_dir = db_dir_;
-    if (current_checkpoint_ != nullptr && current_generation_ == generation &&
-        current_checkpoint_->path() == checkpoint->path()) {
-      LOG(WARNING)
-          << "CheckpointManager::CleanupPublishedCheckpoint: refusing to "
-          << "remove current checkpoint " << path;
-      return;
-    }
+  const std::optional<uint64_t> previous_id =
+      current_checkpoint_ == nullptr
+          ? std::nullopt
+          : std::optional<uint64_t>(current_checkpoint_->id());
+  if (previous_id.has_value() && staging_checkpoint_->id() <= *previous_id) {
+    THROW_CHECKPOINT_EXCEPTION("Checkpoint id must increase monotonically");
   }
-  if (db_dir.empty() || path.parent_path() != std::filesystem::path(db_dir)) {
-    LOG(WARNING)
-        << "CheckpointManager::CleanupPublishedCheckpoint: refusing to "
-        << "remove checkpoint outside current workspace " << path;
-    return;
+  const auto wal_dir = std::filesystem::path(staging_checkpoint_->wal_dir());
+  ensure_directory(wal_dir, "CheckpointManager::Publish");
+  if (!file_utils::fsync_directory(wal_dir.string()) ||
+      !file_utils::fsync_directory(wal_dir.parent_path().string())) {
+    THROW_IO_EXCEPTION("CheckpointManager::Publish: failed to fsync WAL epoch");
   }
+  staging_checkpoint_->PersistManifest();
 
-  remove_checkpoint_dir_best_effort(
-      path, "CheckpointManager::CleanupPublishedCheckpoint");
-}
-
-void CheckpointManager::CleanupRetiredCheckpoints() {
-  std::string db_dir;
-  int32_t current_generation;
-  {
-    std::lock_guard<std::mutex> lock(mutex_);
-    if (db_dir_.empty() ||
-        current_generation_ == kInvalidCheckpointGeneration) {
-      return;
-    }
-    db_dir = db_dir_;
-    current_generation = current_generation_;
-  }
-
+  const auto selector = current_path(database_dir_);
+  file_utils::AtomicFileWriter::CommitResult publish_result;
   try {
-    cleanup_non_current_checkpoints(
-        discover_published_checkpoints(db_dir), current_generation,
-        "CheckpointManager::CleanupRetiredCheckpoints");
+    file_utils::AtomicFileWriter writer(selector.string());
+    writer.stream() << staging_checkpoint_->id() << '\n';
+    publish_result = writer.Commit();
   } catch (const std::exception& e) {
-    LOG(WARNING) << "CheckpointManager::CleanupRetiredCheckpoints failed for "
-                 << db_dir << ": " << e.what();
-  } catch (...) {
-    LOG(WARNING) << "CheckpointManager::CleanupRetiredCheckpoints failed for "
-                 << db_dir;
+    if (current_matches(selector, previous_id)) {
+      throw;
+    }
+    if (restore_current(selector, previous_id)) {
+      THROW_IO_EXCEPTION(
+          "CheckpointManager::Publish: CURRENT replacement failed and was "
+          "rolled back: " +
+          std::string(e.what()));
+    }
+    THROW_IO_EXCEPTION(
+        "CheckpointManager::Publish: CURRENT replacement failed and rollback "
+        "could not be confirmed: " +
+        std::string(e.what()));
   }
+  if (publish_result != file_utils::AtomicFileWriter::CommitResult::kDurable) {
+    if (restore_current(selector, previous_id)) {
+      THROW_IO_EXCEPTION(
+          "CheckpointManager::Publish: CURRENT replacement durability failed "
+          "and was rolled back");
+    }
+    THROW_IO_EXCEPTION(
+        "CheckpointManager::Publish: CURRENT replacement durability and "
+        "rollback are commit-unknown");
+  }
+
+  current_checkpoint_ = staging_checkpoint_;
+  published_checkpoints_.push_back(current_checkpoint_);
+  staging_checkpoint_.reset();
+  staging.release();
+  return current_checkpoint_;
 }
 
 void CheckpointManager::DiscardStagingCheckpoint(
     StagingCheckpoint& staging) noexcept {
-  std::shared_ptr<Checkpoint> staging_checkpoint;
-  {
-    std::lock_guard<std::mutex> lock(mutex_);
-    if (&staging.manager_ != this || staging.checkpoint_ == nullptr) {
-      staging.release();
-      return;
-    }
-    if (staging_checkpoint_ != staging.checkpoint_) {
-      staging.release();
-      return;
-    }
-    staging_checkpoint = staging_checkpoint_;
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (&staging.manager_ == this && staging.checkpoint_ == staging_checkpoint_) {
     staging_checkpoint_.reset();
   }
-
-  discard_staging_checkpoint_best_effort(
-      staging_checkpoint, "CheckpointManager::DiscardStagingCheckpoint");
   staging.release();
 }
 
-std::string CheckpointManager::db_dir() const {
+void CheckpointManager::CollectGarbage() {
   std::lock_guard<std::mutex> lock(mutex_);
-  return db_dir_;
+  if (database_dir_.empty()) {
+    return;
+  }
+  // A staging checkpoint may already own immutable objects that are not yet
+  // reachable from a published manifest. Do not race GC with its dump.
+  if (staging_checkpoint_ != nullptr) {
+    return;
+  }
+
+  std::unordered_set<uint64_t> retained_ids;
+  std::vector<std::weak_ptr<Checkpoint>> live_checkpoints;
+  for (const auto& weak_checkpoint : published_checkpoints_) {
+    auto checkpoint = weak_checkpoint.lock();
+    if (checkpoint == nullptr) {
+      continue;
+    }
+    retained_ids.insert(checkpoint->id());
+    live_checkpoints.push_back(checkpoint);
+  }
+  published_checkpoints_ = std::move(live_checkpoints);
+
+  std::unordered_set<std::string> retained_objects;
+  for (const auto& weak_checkpoint : published_checkpoints_) {
+    auto checkpoint = weak_checkpoint.lock();
+    if (checkpoint == nullptr) {
+      continue;
+    }
+    for (const auto& [_, desc] : checkpoint->manifest().Modules()) {
+      for (const auto& [__, object_path] : desc.paths()) {
+        if (!object_path.empty()) {
+          retained_objects.insert(
+              std::filesystem::path(object_path).filename().string());
+        }
+      }
+    }
+  }
+
+  std::error_code ec;
+  const auto root = checkpoint_dir(database_dir_);
+  const auto manifests = root / "manifests";
+  for (const auto& entry : std::filesystem::directory_iterator(manifests)) {
+    auto id = checkpoint_id_from_name(entry.path(), ".manifest");
+    if (id.has_value() && !retained_ids.contains(*id)) {
+      std::filesystem::remove(entry.path(), ec);
+      if (ec) {
+        THROW_IO_EXCEPTION("Checkpoint GC: failed to remove manifest " +
+                           entry.path().string() + ": " + ec.message());
+      }
+    }
+  }
+
+  const auto wal_root = std::filesystem::path(database_dir_) / "wal";
+  for (const auto& entry : std::filesystem::directory_iterator(wal_root)) {
+    auto id = checkpoint_id_from_name(entry.path(), "");
+    if (id.has_value() && !retained_ids.contains(*id)) {
+      std::filesystem::remove_all(entry.path(), ec);
+      if (ec) {
+        THROW_IO_EXCEPTION("Checkpoint GC: failed to remove WAL epoch " +
+                           entry.path().string() + ": " + ec.message());
+      }
+    }
+  }
+
+  const auto objects = root / "objects";
+  for (const auto& entry : std::filesystem::directory_iterator(objects)) {
+    if (entry.is_regular_file() &&
+        !retained_objects.contains(entry.path().filename().string())) {
+      std::filesystem::remove(entry.path(), ec);
+      if (ec) {
+        THROW_IO_EXCEPTION("Checkpoint GC: failed to remove object " +
+                           entry.path().string() + ": " + ec.message());
+      }
+    }
+  }
+  if (!file_utils::fsync_directory(manifests.string()) ||
+      !file_utils::fsync_directory(wal_root.string()) ||
+      !file_utils::fsync_directory(objects.string())) {
+    THROW_IO_EXCEPTION("Checkpoint GC: failed to fsync checkpoint directories");
+  }
+}
+
+std::string CheckpointManager::database_dir() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return database_dir_;
 }
 
 }  // namespace neug

--- a/src/storages/graph/checkpoint_manager.cc
+++ b/src/storages/graph/checkpoint_manager.cc
@@ -30,6 +30,8 @@
 #include "neug/utils/io/file/file_utils.h"
 #include "neug/utils/uuid.h"
 
+#include "legacy_checkpoint_migrator.h"
+
 namespace neug {
 
 namespace {
@@ -40,19 +42,6 @@ std::filesystem::path checkpoint_dir(const std::string& db_dir) {
 
 std::filesystem::path current_path(const std::string& db_dir) {
   return checkpoint_dir(db_dir) / "CURRENT";
-}
-
-bool has_legacy_checkpoint(const std::filesystem::path& db_dir) {
-  if (!std::filesystem::is_directory(db_dir)) {
-    return false;
-  }
-  for (const auto& entry : std::filesystem::directory_iterator(db_dir)) {
-    const auto name = entry.path().filename().string();
-    if (entry.is_directory() && name.starts_with("checkpoint-")) {
-      return true;
-    }
-  }
-  return false;
 }
 
 uint64_t read_current(const std::filesystem::path& path) {
@@ -211,49 +200,72 @@ void CheckpointManager::Open(const std::string& database_dir,
     }
     ensure_directory(absolute_db_dir, "CheckpointManager::Open");
   }
-  if (has_legacy_checkpoint(absolute_db_dir)) {
-    THROW_NOT_SUPPORTED_EXCEPTION(
-        "Legacy checkpoint-N directories are unsupported; this release does "
-        "not read or migrate them. Recover or rebuild the database with a "
-        "version that supports the legacy format first");
-  }
 
   const auto root = checkpoint_dir(absolute_db_dir.string());
   const bool has_current = std::filesystem::exists(root / "CURRENT");
+  // CURRENT is authoritative. Do not even inspect residual legacy entries
+  // when it exists; their validity and accessibility must not affect opening
+  // the published v2 checkpoint.
+  if (!has_current && !create_if_missing &&
+      LegacyCheckpointMigrator::HasLegacyDirectories(absolute_db_dir)) {
+    THROW_NOT_SUPPORTED_EXCEPTION(
+        "A legacy checkpoint-N database must be opened once in read-write "
+        "mode before it can be opened read-only");
+  }
+
+  std::optional<LegacyCheckpointCandidate> legacy;
   if (create_if_missing && !has_current) {
     ensure_directory(root / "manifests", "CheckpointManager::Open");
     ensure_directory(root / "objects", "CheckpointManager::Open");
     ensure_directory(absolute_db_dir / "wal", "CheckpointManager::Open");
+    legacy = LegacyCheckpointMigrator::FindLatest(absolute_db_dir);
   }
   const auto runtime =
       absolute_db_dir / "runtime" / ("open-" + UUIDGenerator::Generate());
   ensure_directory(runtime, "CheckpointManager::Open");
 
-  std::lock_guard<std::mutex> lock(mutex_);
-  database_dir_ = absolute_db_dir.string();
-  runtime_workspace_ = create_runtime_workspace(runtime.string());
-  current_checkpoint_.reset();
-  staging_checkpoint_.reset();
-  published_checkpoints_.clear();
+  std::shared_ptr<const std::string> runtime_workspace;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    database_dir_ = absolute_db_dir.string();
+    runtime_workspace_ = create_runtime_workspace(runtime.string());
+    runtime_workspace = runtime_workspace_;
+    current_checkpoint_.reset();
+    staging_checkpoint_.reset();
+    published_checkpoints_.clear();
+  }
 
-  const auto current = current_path(database_dir_);
-  if (!has_current) {
+  if (has_current) {
+    const auto current = current_path(absolute_db_dir.string());
+    const uint64_t id = read_current(current);
+    auto checkpoint = Checkpoint::OpenPublished(absolute_db_dir.string(), id,
+                                                std::move(runtime_workspace));
+    if (!checkpoint->manifest().has_schema()) {
+      THROW_CHECKPOINT_EXCEPTION("CURRENT manifest has no schema: " +
+                                 checkpoint->manifest_path());
+    }
+    if (!std::filesystem::is_directory(checkpoint->wal_dir())) {
+      THROW_CHECKPOINT_EXCEPTION("CURRENT manifest WAL epoch is missing: " +
+                                 checkpoint->wal_dir());
+    }
+    std::lock_guard<std::mutex> lock(mutex_);
+    current_checkpoint_ = std::move(checkpoint);
+    published_checkpoints_.push_back(current_checkpoint_);
     return;
   }
 
-  const uint64_t id = read_current(current);
-  auto checkpoint =
-      Checkpoint::OpenPublished(database_dir_, id, runtime_workspace_);
-  if (!checkpoint->manifest().has_schema()) {
-    THROW_CHECKPOINT_EXCEPTION("CURRENT manifest has no schema: " +
-                               checkpoint->manifest_path());
+  if (!legacy.has_value()) {
+    return;
   }
-  if (!std::filesystem::is_directory(checkpoint->wal_dir())) {
-    THROW_CHECKPOINT_EXCEPTION("CURRENT manifest WAL epoch is missing: " +
-                               checkpoint->wal_dir());
-  }
-  current_checkpoint_ = std::move(checkpoint);
-  published_checkpoints_.push_back(current_checkpoint_);
+
+  auto staging = [&] {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return CreateStagingLocked(legacy->id);
+  }();
+  LegacyCheckpointMigrator::Import(*legacy, *staging.checkpoint());
+  auto migrated = staging.Publish();
+  LOG(INFO) << "Migrated legacy checkpoint " << legacy->root << " to "
+            << migrated->manifest_path();
 }
 
 void CheckpointManager::Close() {
@@ -272,6 +284,13 @@ std::shared_ptr<Checkpoint> CheckpointManager::Current() const {
 
 CheckpointManager::StagingCheckpoint CheckpointManager::CreateStaging() {
   std::lock_guard<std::mutex> lock(mutex_);
+  const uint64_t id =
+      current_checkpoint_ == nullptr ? 0 : current_checkpoint_->id() + 1;
+  return CreateStagingLocked(id);
+}
+
+CheckpointManager::StagingCheckpoint CheckpointManager::CreateStagingLocked(
+    uint64_t id) {
   if (database_dir_.empty()) {
     THROW_CHECKPOINT_EXCEPTION("CheckpointManager is not open");
   }
@@ -279,8 +298,6 @@ CheckpointManager::StagingCheckpoint CheckpointManager::CreateStaging() {
     THROW_CHECKPOINT_EXCEPTION("A staging checkpoint is already active");
   }
 
-  const uint64_t id =
-      current_checkpoint_ == nullptr ? 0 : current_checkpoint_->id() + 1;
   staging_checkpoint_ =
       Checkpoint::CreateStaging(database_dir_, id, runtime_workspace_);
   return StagingCheckpoint(*this, staging_checkpoint_);
@@ -466,12 +483,16 @@ void CheckpointManager::CollectGarbage() {
       removed_runtime_workspace = true;
     }
   }
+
   if (!file_utils::fsync_directory(manifests.string()) ||
       !file_utils::fsync_directory(wal_root.string()) ||
       !file_utils::fsync_directory(objects.string()) ||
       (removed_runtime_workspace &&
        !file_utils::fsync_directory(runtime_root.string()))) {
     THROW_IO_EXCEPTION("Checkpoint GC: failed to fsync checkpoint directories");
+  }
+  if (current_checkpoint_ != nullptr) {
+    LegacyCheckpointMigrator::RemoveLegacyDirectories(database_dir_);
   }
 }
 

--- a/src/storages/graph/checkpoint_manager.cc
+++ b/src/storages/graph/checkpoint_manager.cc
@@ -332,6 +332,16 @@ std::shared_ptr<Checkpoint> CheckpointManager::PublishStagingCheckpoint(
         "could not be confirmed: " +
         std::string(e.what()));
   }
+  // Commit-unknown handling: AtomicFileWriter::Commit() returns kCommitUnknown
+  // only when the rename succeeded but the parent-directory fsync failed, so
+  // CURRENT has already been atomically replaced with the new ID. Rolling
+  // back to the previous ID is attempted first because that rename is
+  // verifiable; if the rollback itself cannot be confirmed, the new CURRENT
+  // is deliberately kept: it names a manifest that was fully persisted
+  // above, which is strictly safer than an unverified rollback. This branch
+  // is review-verified rather than test-covered: no unit-test seam can
+  // inject a parent-directory fsync failure after a successful rename
+  // without a fault-injection hook in AtomicFileWriter.
   if (publish_result != file_utils::AtomicFileWriter::CommitResult::kDurable) {
     if (restore_current(selector, previous_id)) {
       THROW_IO_EXCEPTION(

--- a/src/storages/graph/checkpoint_manager.cc
+++ b/src/storages/graph/checkpoint_manager.cc
@@ -309,7 +309,7 @@ std::shared_ptr<Checkpoint> CheckpointManager::PublishStagingCheckpoint(
       !file_utils::fsync_directory(wal_dir.parent_path().string())) {
     THROW_IO_EXCEPTION("CheckpointManager::Publish: failed to fsync WAL epoch");
   }
-  staging_checkpoint_->PersistManifest();
+  staging_checkpoint_->persist_manifest();
 
   const auto selector = current_path(database_dir_);
   file_utils::AtomicFileWriter::CommitResult publish_result;
@@ -435,9 +435,32 @@ void CheckpointManager::CollectGarbage() {
       }
     }
   }
+
+  bool removed_runtime_workspace = false;
+  const auto runtime_root = std::filesystem::path(database_dir_) / "runtime";
+  const auto active_runtime = std::filesystem::path(*runtime_workspace_);
+  if (std::filesystem::is_directory(runtime_root)) {
+    for (const auto& entry :
+         std::filesystem::directory_iterator(runtime_root)) {
+      if (!entry.is_directory() ||
+          !entry.path().filename().string().starts_with("open-") ||
+          entry.path() == active_runtime) {
+        continue;
+      }
+      std::filesystem::remove_all(entry.path(), ec);
+      if (ec) {
+        THROW_IO_EXCEPTION(
+            "Checkpoint GC: failed to remove runtime workspace " +
+            entry.path().string() + ": " + ec.message());
+      }
+      removed_runtime_workspace = true;
+    }
+  }
   if (!file_utils::fsync_directory(manifests.string()) ||
       !file_utils::fsync_directory(wal_root.string()) ||
-      !file_utils::fsync_directory(objects.string())) {
+      !file_utils::fsync_directory(objects.string()) ||
+      (removed_runtime_workspace &&
+       !file_utils::fsync_directory(runtime_root.string()))) {
     THROW_IO_EXCEPTION("Checkpoint GC: failed to fsync checkpoint directories");
   }
 }

--- a/src/storages/graph/checkpoint_manifest.cc
+++ b/src/storages/graph/checkpoint_manifest.cc
@@ -15,7 +15,6 @@
 
 #include "neug/storages/checkpoint_manifest.h"
 
-#include "neug/storages/checkpoint.h"
 #include "neug/utils/exception/exception.h"
 #include "neug/utils/io/file/file_utils.h"
 
@@ -38,54 +37,58 @@
 #include <rapidjson/ostreamwrapper.h>
 #include <rapidjson/writer.h>
 
-#include "neug/storages/checkpoint_manager.h"
-
 namespace neug {
 
-std::optional<ModuleDescriptor> CheckpointManifest::module(
+const ModuleDescriptor* CheckpointManifest::FindModule(
     const std::string& key) const {
   auto it = modules_.find(key);
   if (it == modules_.end()) {
-    return std::nullopt;
+    return nullptr;
   }
-  return it->second;
+  return &it->second;
 }
 
-void CheckpointManifest::set_module(const std::string& key,
-                                    ModuleDescriptor desc) {
+ModuleDescriptor* CheckpointManifest::FindMutableModule(
+    const std::string& key) {
+  auto it = modules_.find(key);
+  return it == modules_.end() ? nullptr : &it->second;
+}
+
+void CheckpointManifest::SetModule(const std::string& key,
+                                   ModuleDescriptor desc) {
   modules_[key] = std::move(desc);
 }
 
-void CheckpointManifest::remove_module(const std::string& key) {
-  modules_.erase(key);
-}
-
-bool CheckpointManifest::has_module(const std::string& key) const {
+bool CheckpointManifest::HasModule(const std::string& key) const {
   return modules_.count(key) > 0;
 }
 
-void CheckpointManifest::LinkModuleFrom(const CheckpointManifest& prev,
-                                        const std::string& key,
-                                        Checkpoint& ckp) {
-  auto desc = prev.module(key);
-  if (!desc.has_value()) {
+void CheckpointManifest::ReuseModuleClosureFrom(const CheckpointManifest& prev,
+                                                const std::string& key) {
+  std::unordered_set<std::string> visited;
+  ReuseModuleClosureFromImpl(prev, key, visited);
+}
+
+void CheckpointManifest::ReuseModuleClosureFromImpl(
+    const CheckpointManifest& prev, const std::string& key,
+    std::unordered_set<std::string>& visited) {
+  if (!visited.insert(key).second) {
     return;
   }
-  if (!has_module(key)) {
-    set_module(key, ModuleDescriptor::Link(*desc, ckp));
+  const auto* desc = prev.FindModule(key);
+  if (desc == nullptr) {
+    return;
+  }
+  if (!HasModule(key)) {
+    SetModule(key, *desc);
   }
   for (const auto& [_, referenced_key] : desc->refs()) {
-    LinkModuleFrom(prev, referenced_key, ckp);
+    ReuseModuleClosureFromImpl(prev, referenced_key, visited);
   }
 }
 
 const std::unordered_map<std::string, ModuleDescriptor>&
-CheckpointManifest::modules() const {
-  return modules_;
-}
-
-std::unordered_map<std::string, ModuleDescriptor>&
-CheckpointManifest::mutable_modules() {
+CheckpointManifest::Modules() const {
   return modules_;
 }
 
@@ -109,17 +112,12 @@ void CheckpointManifest::CopyScalarFrom(const CheckpointManifest& prev,
   }
 }
 
-const std::unordered_map<std::string, std::string>&
-CheckpointManifest::scalars() const {
-  return scalars_;
-}
-
 void CheckpointManifest::Load(const std::string& file_path) {
-  // CheckpointManifest lives at the canonical checkpoint meta path.
+  // CheckpointManifest lives at the canonical manifest path.
   std::ifstream ifs(file_path);
   if (!ifs.is_open()) {
-    LOG(WARNING) << "CheckpointManifest::Load: cannot open " << file_path;
-    return;
+    THROW_STORAGE_EXCEPTION("CheckpointManifest::Load: cannot open " +
+                            file_path);
   }
 
   rapidjson::IStreamWrapper isw(ifs);
@@ -131,18 +129,32 @@ void CheckpointManifest::Load(const std::string& file_path) {
                             file_path);
   }
 
-  if (!doc.HasMember("version") || !doc["version"].IsInt()) {
+  if (!doc.HasMember("v") || !doc["v"].IsInt()) {
     THROW_STORAGE_EXCEPTION(
-        "CheckpointManifest::Load: missing or non-integer 'version' in " +
-        file_path);
+        "CheckpointManifest::Load: missing or non-integer 'v' in " + file_path);
   }
-  int file_version = doc["version"].GetInt();
+  int file_version = doc["v"].GetInt();
   if (file_version != kFormatVersion) {
     THROW_NOT_SUPPORTED_EXCEPTION(
-        "CheckpointManifest::Load: incompatible meta version " +
+        "CheckpointManifest::Load: incompatible manifest version " +
         std::to_string(file_version) + " (expected " +
         std::to_string(kFormatVersion) + ") in " + file_path);
   }
+
+  if (!doc.HasMember("id") || !doc["id"].IsUint64()) {
+    THROW_STORAGE_EXCEPTION(
+        "CheckpointManifest::Load: missing or invalid "
+        "'id' in " +
+        file_path);
+  }
+  checkpoint_id_ = doc["id"].GetUint64();
+  if (!doc.HasMember("base_ts") || !doc["base_ts"].IsUint64()) {
+    THROW_STORAGE_EXCEPTION(
+        "CheckpointManifest::Load: missing or invalid "
+        "'base_ts' in " +
+        file_path);
+  }
+  base_timestamp_ = doc["base_ts"].GetUint64();
 
   if (doc.HasMember("schema") && doc["schema"].IsObject()) {
     schema_.FromJson(doc["schema"].GetObject());
@@ -177,15 +189,17 @@ void CheckpointManifest::Save(const std::string& file_path) const {
   rapidjson::Document doc;
   doc.SetObject();
   auto& alloc = doc.GetAllocator();
-  doc.AddMember("version", rapidjson::Value(kFormatVersion), alloc);
+  doc.AddMember("v", rapidjson::Value(kFormatVersion), alloc);
+  doc.AddMember("id", rapidjson::Value(checkpoint_id_), alloc);
+  doc.AddMember("base_ts", rapidjson::Value(base_timestamp_), alloc);
 
   auto schema_res = schema_.ToJson();
   if (!schema_res) {
-    LOG(ERROR) << "CheckpointManifest::Save: failed to serialize schema: "
-               << schema_res.error().error_message();
-  } else {
-    doc.AddMember("schema", schema_res.value().Move(), alloc);
+    THROW_STORAGE_EXCEPTION(
+        "CheckpointManifest::Save: failed to serialize schema: " +
+        schema_res.error().error_message());
   }
+  doc.AddMember("schema", schema_res.value().Move(), alloc);
 
   rapidjson::Value modules_obj(rapidjson::kObjectType);
   for (const auto& [key, desc] : modules_) {
@@ -195,39 +209,28 @@ void CheckpointManifest::Save(const std::string& file_path) const {
   }
   doc.AddMember("modules", modules_obj, alloc);
 
-  rapidjson::Value scalars_obj(rapidjson::kObjectType);
-  for (const auto& [key, value] : scalars_) {
-    rapidjson::Value key_val(
-        key.c_str(), static_cast<rapidjson::SizeType>(key.size()), alloc);
-    rapidjson::Value value_val(
-        value.c_str(), static_cast<rapidjson::SizeType>(value.size()), alloc);
-    scalars_obj.AddMember(key_val, value_val, alloc);
+  if (!scalars_.empty()) {
+    rapidjson::Value scalars_obj(rapidjson::kObjectType);
+    for (const auto& [key, value] : scalars_) {
+      rapidjson::Value key_val(
+          key.c_str(), static_cast<rapidjson::SizeType>(key.size()), alloc);
+      rapidjson::Value value_val(
+          value.c_str(), static_cast<rapidjson::SizeType>(value.size()), alloc);
+      scalars_obj.AddMember(key_val, value_val, alloc);
+    }
+    doc.AddMember("scalars", scalars_obj, alloc);
   }
-  doc.AddMember("scalars", scalars_obj, alloc);
 
   rapidjson::OStreamWrapper osw(os);
   rapidjson::Writer<rapidjson::OStreamWrapper> json_writer(osw);
   doc.Accept(json_writer);
 
-  writer.Commit();
-  LOG(INFO) << "CheckpointManifest::Save: dumped meta to " << file_path;
-}
-
-void CheckpointManifest::GenerateEmptyMeta(const std::string& path) {
-  file_utils::AtomicFileWriter writer(path);
-  auto& os = writer.stream();
-
-  rapidjson::OStreamWrapper osw(os);
-  rapidjson::Writer<rapidjson::OStreamWrapper> json_writer(osw);
-  rapidjson::Document doc;
-  doc.SetObject();
-  auto& alloc = doc.GetAllocator();
-  doc.AddMember("version", rapidjson::Value(1), alloc);
-  doc.AddMember("modules", rapidjson::Value(rapidjson::kObjectType), alloc);
-  doc.AddMember("scalars", rapidjson::Value(rapidjson::kObjectType), alloc);
-  doc.Accept(json_writer);
-
-  writer.Commit();
+  if (writer.Commit() != file_utils::AtomicFileWriter::CommitResult::kDurable) {
+    THROW_IO_EXCEPTION(
+        "CheckpointManifest::Save: manifest replacement is commit-unknown: " +
+        file_path);
+  }
+  LOG(INFO) << "CheckpointManifest::Save: wrote " << file_path;
 }
 
 const Schema& CheckpointManifest::GetSchema() const { return schema_; }

--- a/src/storages/graph/checkpoint_manifest.cc
+++ b/src/storages/graph/checkpoint_manifest.cc
@@ -141,13 +141,6 @@ void CheckpointManifest::Load(const std::string& file_path) {
         std::to_string(kFormatVersion) + ") in " + file_path);
   }
 
-  if (!doc.HasMember("id") || !doc["id"].IsUint64()) {
-    THROW_STORAGE_EXCEPTION(
-        "CheckpointManifest::Load: missing or invalid "
-        "'id' in " +
-        file_path);
-  }
-  checkpoint_id_ = doc["id"].GetUint64();
   if (!doc.HasMember("base_ts") || !doc["base_ts"].IsUint64()) {
     THROW_STORAGE_EXCEPTION(
         "CheckpointManifest::Load: missing or invalid "
@@ -190,7 +183,6 @@ void CheckpointManifest::Save(const std::string& file_path) const {
   doc.SetObject();
   auto& alloc = doc.GetAllocator();
   doc.AddMember("v", rapidjson::Value(kFormatVersion), alloc);
-  doc.AddMember("id", rapidjson::Value(checkpoint_id_), alloc);
   doc.AddMember("base_ts", rapidjson::Value(base_timestamp_), alloc);
 
   auto schema_res = schema_.ToJson();

--- a/src/storages/graph/edge_table.cc
+++ b/src/storages/graph/edge_table.cc
@@ -1225,8 +1225,9 @@ void EdgeTable::DisassembleTo(ModuleBroker& store, CheckpointManifest& meta,
                  std::to_string(GetCapacity()));
 }
 
-void EdgeTable::LinkToSnapshot(Checkpoint& ckp, CheckpointManifest& meta,
-                               const CheckpointManifest& prev) const {
+void EdgeTable::ReuseCheckpointModules(Checkpoint& ckp,
+                                       CheckpointManifest& meta,
+                                       const CheckpointManifest& prev) const {
   if (!meta_) {
     return;
   }
@@ -1235,11 +1236,11 @@ void EdgeTable::LinkToSnapshot(Checkpoint& ckp, CheckpointManifest& meta,
   const auto& dst = meta_->dst_label_name;
   // Exact keys only — prefix matching is ambiguous when label names contain
   // underscores.
-  meta.LinkModuleFrom(prev, KeyOutCsr(src, edge, dst), ckp);
-  meta.LinkModuleFrom(prev, KeyInCsr(src, edge, dst), ckp);
+  meta.ReuseModuleClosureFrom(prev, KeyOutCsr(src, edge, dst));
+  meta.ReuseModuleClosureFrom(prev, KeyInCsr(src, edge, dst));
   if (!meta_->is_bundled()) {
     for (size_t i = 0; i < meta_->properties.size(); ++i) {
-      meta.LinkModuleFrom(prev, KeyProperty(src, edge, dst, i), ckp);
+      meta.ReuseModuleClosureFrom(prev, KeyProperty(src, edge, dst, i));
     }
     meta.CopyScalarFrom(prev, ScalarKey(src, edge, dst, "table_idx"));
   }

--- a/src/storages/graph/legacy_checkpoint_migrator.cc
+++ b/src/storages/graph/legacy_checkpoint_migrator.cc
@@ -369,9 +369,10 @@ void LegacyCheckpointMigrator::RemoveLegacyDirectories(
     removed = true;
   }
   if (removed && !file_utils::fsync_directory(database_dir.string())) {
-    THROW_IO_EXCEPTION("Failed to fsync database directory after removing "
-                       "legacy checkpoints: " +
-                       database_dir.string());
+    THROW_IO_EXCEPTION(
+        "Failed to fsync database directory after removing "
+        "legacy checkpoints: " +
+        database_dir.string());
   }
 }
 

--- a/src/storages/graph/legacy_checkpoint_migrator.cc
+++ b/src/storages/graph/legacy_checkpoint_migrator.cc
@@ -1,0 +1,449 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "legacy_checkpoint_migrator.h"
+
+#include <algorithm>
+#include <charconv>
+#include <fstream>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <glog/logging.h>
+
+#ifdef _WIN32
+#ifdef GetObject
+#undef GetObject
+#endif
+#endif
+
+#include <rapidjson/document.h>
+#include <rapidjson/istreamwrapper.h>
+
+#include "neug/storages/checkpoint.h"
+#include "neug/storages/module/module_factory.h"
+#include "neug/utils/exception/exception.h"
+#include "neug/utils/io/file/file_utils.h"
+#include "neug/utils/uuid.h"
+
+namespace neug {
+
+namespace {
+
+constexpr std::string_view kLegacyPrefix = "checkpoint-";
+constexpr std::string_view kLegacyStagingSuffix = ".next";
+
+struct ParsedLegacyName {
+  uint64_t id;
+  bool staging;
+};
+
+std::optional<ParsedLegacyName> parse_legacy_name(
+    const std::filesystem::path& path) {
+  std::error_code status_ec;
+  if (!std::filesystem::is_directory(
+          std::filesystem::symlink_status(path, status_ec)) ||
+      status_ec) {
+    return std::nullopt;
+  }
+  const std::string filename = path.filename().string();
+  std::string_view name = filename;
+  if (!name.starts_with(kLegacyPrefix)) {
+    return std::nullopt;
+  }
+  name.remove_prefix(kLegacyPrefix.size());
+  bool staging = false;
+  if (name.ends_with(kLegacyStagingSuffix)) {
+    staging = true;
+    name.remove_suffix(kLegacyStagingSuffix.size());
+  }
+  if (name.empty()) {
+    return std::nullopt;
+  }
+  uint64_t id = 0;
+  const auto [ptr, ec] =
+      std::from_chars(name.data(), name.data() + name.size(), id);
+  if (ec != std::errc{} || ptr != name.data() + name.size()) {
+    return std::nullopt;
+  }
+  return ParsedLegacyName{id, staging};
+}
+
+bool escapes_root(const std::filesystem::path& path) {
+  const auto normalized = path.lexically_normal();
+  return !normalized.empty() && *normalized.begin() == "..";
+}
+
+std::filesystem::path resolve_legacy_path(
+    const std::filesystem::path& checkpoint_root, const std::string& value) {
+  std::filesystem::path path(value);
+  if (!path.is_absolute()) {
+    if (escapes_root(path)) {
+      THROW_CHECKPOINT_EXCEPTION("Legacy checkpoint path escapes its root: " +
+                                 value);
+    }
+    path = checkpoint_root / path;
+  }
+  path = path.lexically_normal();
+  std::error_code ec;
+  if (!std::filesystem::is_regular_file(path, ec) || ec) {
+    THROW_CHECKPOINT_EXCEPTION("Legacy checkpoint references missing file: " +
+                               path.string());
+  }
+  return std::filesystem::absolute(path);
+}
+
+template <typename AddEntry>
+void parse_string_map(const rapidjson::Value& descriptor, const char* field,
+                      const std::string& module_key, AddEntry&& add_entry) {
+  const auto member = descriptor.FindMember(field);
+  if (member == descriptor.MemberEnd()) {
+    return;
+  }
+  if (!member->value.IsObject()) {
+    THROW_CHECKPOINT_EXCEPTION("Legacy checkpoint module " + module_key +
+                               " has invalid " + std::string(field) +
+                               " metadata");
+  }
+  for (const auto& entry : member->value.GetObject()) {
+    if (!entry.value.IsString()) {
+      THROW_CHECKPOINT_EXCEPTION("Legacy checkpoint module " + module_key +
+                                 " has a non-string " + std::string(field) +
+                                 " value");
+    }
+    add_entry(entry.name.GetString(), entry.value.GetString());
+  }
+}
+
+ModuleDescriptor parse_v1_module_descriptor(const rapidjson::Value& value,
+                                            const std::filesystem::path& root,
+                                            const std::string& key) {
+  if (!value.IsObject()) {
+    THROW_CHECKPOINT_EXCEPTION(
+        "Legacy checkpoint contains an invalid module descriptor: " + key);
+  }
+
+  ModuleDescriptor descriptor;
+  if (!value.HasMember("module_type") || !value["module_type"].IsString()) {
+    THROW_CHECKPOINT_EXCEPTION("Legacy checkpoint module " + key +
+                               " has no string module_type");
+  }
+  descriptor.module_type = value["module_type"].GetString();
+  if (value.HasMember("required")) {
+    if (!value["required"].IsBool()) {
+      THROW_CHECKPOINT_EXCEPTION("Legacy checkpoint module " + key +
+                                 " has a non-boolean required field");
+    }
+    descriptor.required = value["required"].GetBool();
+  }
+  // Some released v1 descriptors are opened directly by their owning graph
+  // component and intentionally have no factory type (for example an
+  // LFIndexer descriptor). Only non-empty required factory types need to be
+  // registered.
+  if (descriptor.required && !descriptor.module_type.empty() &&
+      ModuleFactory::instance().Create(descriptor.module_type) == nullptr) {
+    THROW_CHECKPOINT_EXCEPTION(
+        "Legacy checkpoint references unknown required module type " +
+        descriptor.module_type + " from module " + key);
+  }
+
+  parse_string_map(value, "extra", key,
+                   [&](const char* name, const char* extra) {
+                     descriptor.set(name, extra);
+                   });
+  parse_string_map(value, "paths", key,
+                   [&](const char* name, const char* value) {
+                     std::string path = value;
+                     if (!path.empty()) {
+                       path = resolve_legacy_path(root, path).string();
+                     }
+                     descriptor.set_path(name, std::move(path));
+                   });
+  parse_string_map(value, "refs", key,
+                   [&](const char* name, const char* reference) {
+                     descriptor.set_ref(name, reference);
+                   });
+  if (value.HasMember("referenced_module")) {
+    if (!value["referenced_module"].IsBool()) {
+      THROW_CHECKPOINT_EXCEPTION("Legacy checkpoint module " + key +
+                                 " has invalid referenced_module metadata");
+    }
+    if (value["referenced_module"].GetBool()) {
+      descriptor.mark_as_referenced_module();
+    }
+  }
+  return descriptor;
+}
+
+CheckpointManifest load_v1_manifest(const std::filesystem::path& root) {
+  const auto meta_path = root / "meta";
+  std::ifstream input(meta_path);
+  if (!input.is_open()) {
+    THROW_CHECKPOINT_EXCEPTION("Legacy checkpoint meta is missing: " +
+                               meta_path.string());
+  }
+
+  rapidjson::IStreamWrapper wrapper(input);
+  rapidjson::Document doc;
+  doc.ParseStream(wrapper);
+  if (doc.HasParseError() || !doc.IsObject()) {
+    THROW_CHECKPOINT_EXCEPTION("Legacy checkpoint meta is invalid JSON: " +
+                               meta_path.string());
+  }
+  if (!doc.HasMember("version") || !doc["version"].IsInt()) {
+    THROW_CHECKPOINT_EXCEPTION(
+        "Legacy checkpoint meta has no integer version: " + meta_path.string());
+  }
+  if (doc["version"].GetInt() != 1) {
+    THROW_NOT_SUPPORTED_EXCEPTION(
+        "Unsupported legacy checkpoint meta version " +
+        std::to_string(doc["version"].GetInt()) + " in " + meta_path.string());
+  }
+  if (!doc.HasMember("schema") || !doc["schema"].IsObject()) {
+    THROW_CHECKPOINT_EXCEPTION("Legacy checkpoint has no schema: " +
+                               meta_path.string());
+  }
+
+  CheckpointManifest manifest;
+  Schema schema;
+  schema.FromJson(doc["schema"].GetObject());
+  manifest.SetSchema(schema);
+
+  if (doc.HasMember("modules") && !doc["modules"].IsObject()) {
+    THROW_CHECKPOINT_EXCEPTION("Legacy checkpoint modules are invalid: " +
+                               meta_path.string());
+  }
+  if (doc.HasMember("modules")) {
+    for (const auto& member : doc["modules"].GetObject()) {
+      const std::string key = member.name.GetString();
+      manifest.SetModule(key,
+                         parse_v1_module_descriptor(member.value, root, key));
+    }
+  }
+
+  if (doc.HasMember("scalars") && !doc["scalars"].IsObject()) {
+    THROW_CHECKPOINT_EXCEPTION("Legacy checkpoint scalars are invalid: " +
+                               meta_path.string());
+  }
+  if (doc.HasMember("scalars")) {
+    for (const auto& member : doc["scalars"].GetObject()) {
+      if (!member.value.IsString()) {
+        THROW_CHECKPOINT_EXCEPTION(
+            "Legacy checkpoint contains a non-string scalar: " +
+            std::string(member.name.GetString()));
+      }
+      manifest.SetScalar(member.name.GetString(), member.value.GetString());
+    }
+  }
+  return manifest;
+}
+
+void remove_tree(const std::filesystem::path& path) {
+  std::error_code ec;
+  std::filesystem::remove_all(path, ec);
+  if (ec) {
+    THROW_IO_EXCEPTION("Failed to clean unpublished migration output " +
+                       path.string() + ": " + ec.message());
+  }
+}
+
+void durable_copy(const std::filesystem::path& source,
+                  const std::filesystem::path& destination) {
+  std::ifstream input(source, std::ios::binary);
+  if (!input.is_open()) {
+    THROW_IO_EXCEPTION("Failed to open legacy checkpoint file: " +
+                       source.string());
+  }
+  file_utils::AtomicFileWriter writer(destination.string());
+  writer.stream() << input.rdbuf();
+  if (input.bad()) {
+    THROW_IO_EXCEPTION("Failed to read legacy checkpoint file: " +
+                       source.string());
+  }
+  if (writer.Commit() != file_utils::AtomicFileWriter::CommitResult::kDurable) {
+    THROW_IO_EXCEPTION("Legacy checkpoint file copy is commit-unknown: " +
+                       destination.string());
+  }
+}
+
+void import_file(const std::filesystem::path& source,
+                 const std::filesystem::path& destination) {
+  std::error_code ec;
+  const bool source_is_symlink = std::filesystem::is_symlink(source, ec);
+  if (ec) {
+    THROW_IO_EXCEPTION("Failed to inspect legacy checkpoint file " +
+                       source.string() + ": " + ec.message());
+  }
+  if (!source_is_symlink) {
+    std::filesystem::create_hard_link(source, destination, ec);
+  } else {
+    ec = std::make_error_code(std::errc::operation_not_supported);
+  }
+  if (ec) {
+    VLOG(1) << "Legacy checkpoint hardlink failed (" << ec.message()
+            << "), falling back to copy for " << source;
+    durable_copy(source, destination);
+  }
+}
+
+std::filesystem::path import_object(const std::filesystem::path& source,
+                                    const std::filesystem::path& object_dir) {
+  std::filesystem::path destination;
+  do {
+    destination = object_dir / UUIDGenerator::Generate();
+  } while (std::filesystem::exists(destination));
+  import_file(source, destination);
+  return destination;
+}
+
+void import_wal(const std::filesystem::path& source_dir,
+                const std::filesystem::path& destination_dir) {
+  remove_tree(destination_dir);
+  std::error_code ec;
+  std::filesystem::create_directories(destination_dir, ec);
+  if (ec) {
+    THROW_IO_EXCEPTION("Failed to create migrated WAL epoch " +
+                       destination_dir.string() + ": " + ec.message());
+  }
+  if (!std::filesystem::exists(source_dir)) {
+    return;
+  }
+  if (!std::filesystem::is_directory(source_dir)) {
+    THROW_CHECKPOINT_EXCEPTION("Legacy WAL path is not a directory: " +
+                               source_dir.string());
+  }
+
+  for (const auto& entry : std::filesystem::directory_iterator(source_dir)) {
+    if (!entry.is_regular_file()) {
+      THROW_CHECKPOINT_EXCEPTION("Legacy WAL contains a non-file entry: " +
+                                 entry.path().string());
+    }
+    import_file(entry.path(), destination_dir / entry.path().filename());
+  }
+}
+
+}  // namespace
+
+bool LegacyCheckpointMigrator::HasLegacyDirectories(
+    const std::filesystem::path& database_dir) {
+  if (!std::filesystem::is_directory(database_dir)) {
+    return false;
+  }
+  for (const auto& entry : std::filesystem::directory_iterator(database_dir)) {
+    if (parse_legacy_name(entry.path()).has_value()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void LegacyCheckpointMigrator::RemoveLegacyDirectories(
+    const std::filesystem::path& database_dir) {
+  bool removed = false;
+  for (const auto& entry : std::filesystem::directory_iterator(database_dir)) {
+    if (!parse_legacy_name(entry.path()).has_value()) {
+      continue;
+    }
+    std::error_code ec;
+    std::filesystem::remove_all(entry.path(), ec);
+    if (ec) {
+      THROW_IO_EXCEPTION("Failed to remove legacy checkpoint " +
+                         entry.path().string() + ": " + ec.message());
+    }
+    removed = true;
+  }
+  if (removed && !file_utils::fsync_directory(database_dir.string())) {
+    THROW_IO_EXCEPTION("Failed to fsync database directory after removing "
+                       "legacy checkpoints: " +
+                       database_dir.string());
+  }
+}
+
+std::optional<LegacyCheckpointCandidate> LegacyCheckpointMigrator::FindLatest(
+    const std::filesystem::path& database_dir) {
+  std::vector<std::pair<uint64_t, std::filesystem::path>> candidates;
+  bool has_legacy_entries = false;
+  for (const auto& entry : std::filesystem::directory_iterator(database_dir)) {
+    auto parsed = parse_legacy_name(entry.path());
+    if (!parsed.has_value()) {
+      continue;
+    }
+    has_legacy_entries = true;
+    if (!parsed->staging) {
+      candidates.emplace_back(parsed->id, entry.path());
+    }
+  }
+  if (!has_legacy_entries) {
+    return std::nullopt;
+  }
+  std::sort(
+      candidates.begin(), candidates.end(),
+      [](const auto& lhs, const auto& rhs) { return lhs.first > rhs.first; });
+
+  std::string last_error = "no published checkpoint-N generation found";
+  for (const auto& [id, root] : candidates) {
+    try {
+      return LegacyCheckpointCandidate{id, root, load_v1_manifest(root)};
+    } catch (const std::exception& e) {
+      last_error = e.what();
+      LOG(WARNING) << "Skipping invalid legacy checkpoint " << root << ": "
+                   << e.what();
+    }
+  }
+  THROW_CHECKPOINT_EXCEPTION(
+      "No valid legacy checkpoint-N generation can be migrated: " + last_error);
+}
+
+void LegacyCheckpointMigrator::Import(
+    const LegacyCheckpointCandidate& candidate, Checkpoint& target) {
+  if (candidate.id != target.id()) {
+    THROW_CHECKPOINT_EXCEPTION("Legacy migration target ID does not match");
+  }
+
+  CheckpointManifest manifest = candidate.manifest;
+  std::unordered_map<std::string, std::string> imported_objects;
+  for (const auto& module : manifest.Modules()) {
+    auto* descriptor = manifest.FindMutableModule(module.first);
+    for (auto& path : descriptor->mutable_paths()) {
+      auto& source = path.second;
+      if (source.empty()) {
+        continue;
+      }
+      std::error_code ec;
+      const auto canonical_source =
+          std::filesystem::weakly_canonical(source, ec).string();
+      if (ec) {
+        THROW_IO_EXCEPTION("Failed to canonicalize legacy object " + source +
+                           ": " + ec.message());
+      }
+      auto [it, inserted] = imported_objects.try_emplace(canonical_source);
+      if (inserted) {
+        it->second = import_object(source, target.object_dir_)
+                         .lexically_normal()
+                         .string();
+      }
+      source = it->second;
+    }
+  }
+
+  import_wal(candidate.root / "wal", target.wal_dir());
+  target.SetManifest(std::move(manifest));
+}
+
+}  // namespace neug

--- a/src/storages/graph/legacy_checkpoint_migrator.h
+++ b/src/storages/graph/legacy_checkpoint_migrator.h
@@ -1,0 +1,55 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+
+#include "neug/storages/checkpoint_manifest.h"
+
+namespace neug {
+
+class Checkpoint;
+
+struct LegacyCheckpointCandidate {
+  uint64_t id;
+  std::filesystem::path root;
+  CheckpointManifest manifest;
+};
+
+/** Internal one-shot upgrader for the released checkpoint-N v1 layout. */
+class LegacyCheckpointMigrator {
+ public:
+  static bool HasLegacyDirectories(const std::filesystem::path& database_dir);
+
+  /// Remove strictly named legacy checkpoint-N and checkpoint-N.next
+  /// directories, then durably sync the database root.
+  static void RemoveLegacyDirectories(
+      const std::filesystem::path& database_dir);
+
+  /// Return the highest valid published generation, or nullopt when no legacy
+  /// entries exist. Throws when entries exist but none is a complete v1
+  /// checkpoint.
+  static std::optional<LegacyCheckpointCandidate> FindLatest(
+      const std::filesystem::path& database_dir);
+
+  /// Import candidate files into target and install a complete in-memory v2
+  /// manifest. The caller publishes target through CheckpointManager.
+  static void Import(const LegacyCheckpointCandidate& candidate,
+                     Checkpoint& target);
+};
+
+}  // namespace neug

--- a/src/storages/graph/module_descriptor.cc
+++ b/src/storages/graph/module_descriptor.cc
@@ -18,8 +18,6 @@
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 
-#include "neug/storages/checkpoint.h"
-
 namespace neug {
 
 rapidjson::Value ModuleDescriptor::ToJson(
@@ -52,7 +50,7 @@ rapidjson::Value ModuleDescriptor::ToJson(
           v.c_str(), static_cast<rapidjson::SizeType>(v.size()), alloc);
       paths_obj.AddMember(key_val, val_val, alloc);
     }
-    obj.AddMember("paths", paths_obj, alloc);
+    obj.AddMember("objects", paths_obj, alloc);
   }
   if (!refs_.empty()) {
     rapidjson::Value refs_obj(rapidjson::kObjectType);
@@ -86,8 +84,8 @@ ModuleDescriptor ModuleDescriptor::FromJson(const rapidjson::Value& obj) {
       }
     }
   }
-  if (obj.HasMember("paths") && obj["paths"].IsObject()) {
-    for (auto& m : obj["paths"].GetObject()) {
+  if (obj.HasMember("objects") && obj["objects"].IsObject()) {
+    for (auto& m : obj["objects"].GetObject()) {
       if (m.value.IsString()) {
         desc.paths_[m.name.GetString()] = m.value.GetString();
       }
@@ -115,17 +113,6 @@ std::string ModuleDescriptor::ToJsonString() const {
   rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
   doc.Accept(writer);
   return buf.GetString();
-}
-
-ModuleDescriptor ModuleDescriptor::Link(const ModuleDescriptor& prev,
-                                        Checkpoint& ckp) {
-  ModuleDescriptor linked = prev;
-  for (auto& [_, path] : linked.mutable_paths()) {
-    if (!path.empty()) {
-      path = ckp.LinkToSnapshot(path);
-    }
-  }
-  return linked;
 }
 
 }  // namespace neug

--- a/src/storages/graph/property_graph.cc
+++ b/src/storages/graph/property_graph.cc
@@ -783,7 +783,7 @@ void PropertyGraph::Open(std::shared_ptr<Checkpoint> ckp,
   Clear();
   memory_level_ = memory_level;
 
-  const CheckpointManifest& meta = ckp->GetMeta();
+  const CheckpointManifest& meta = ckp->manifest();
   schema_ = meta.GetSchema();
   vertex_label_total_count_ = schema_.vertex_label_frontier();
   edge_label_total_count_ = schema_.edge_label_frontier();
@@ -974,16 +974,16 @@ void PropertyGraph::Compact() {
 }
 
 void PropertyGraph::DumpAndClear(std::shared_ptr<Checkpoint> ckp) {
-  LOG(INFO) << "Creating checkpoint at " << ckp->path();
+  LOG(INFO) << "Creating checkpoint at " << ckp->manifest_path();
 
   CheckpointManifest meta;
   ModuleBroker store;
 
-  // Clean tables LinkToSnapshot from prev when entries exist; newly empty
+  // Clean tables reuse previous descriptors when entries exist; newly empty
   // tables write nothing (existence is carried by schema).
   const CheckpointManifest* prev =
-      (ckp_ != nullptr && ckp_->GetMeta().has_schema()) ? &ckp_->GetMeta()
-                                                        : nullptr;
+      (ckp_ != nullptr && ckp_->manifest().has_schema()) ? &ckp_->manifest()
+                                                         : nullptr;
 
   std::vector<size_t> vertex_capacity(vertex_label_total_count_, 0);
   // Capacity snapshot for every live table (needed when a dirty edge table
@@ -1008,7 +1008,7 @@ void PropertyGraph::DumpAndClear(std::shared_ptr<Checkpoint> ckp) {
     if (IsVertexTableDirty(i)) {
       vertex_tables_[i].DisassembleTo(store, meta, *ckp);
     } else if (prev != nullptr) {
-      vertex_tables_[i].LinkToSnapshot(*ckp, meta, *prev);
+      vertex_tables_[i].ReuseCheckpointModules(*ckp, meta, *prev);
     }
   }
 
@@ -1048,24 +1048,27 @@ void PropertyGraph::DumpAndClear(std::shared_ptr<Checkpoint> ckp) {
                          vertex_capacity[dst_label_i], new_cap);
           edge_table.DisassembleTo(store, meta, *ckp);
         } else if (prev != nullptr) {
-          edge_table.LinkToSnapshot(*ckp, meta, *prev);
+          edge_table.ReuseCheckpointModules(*ckp, meta, *prev);
         }
       }
     }
   }
 
-  index_manager_->Dump(store, *ckp, meta);
+  index_manager_->Dump(store, meta);
 
   store.Dump(*ckp, meta);
   // Persist a temporary-stripped schema. Temporary labels are session-scoped
   // and must not appear in the checkpoint. StripTemporary() creates a clean
   // copy without any temporary vertex/edge labels.
   meta.SetSchema(schema_.StripTemporary());
-  ckp->UpdateMeta(
-      std::move(meta));  // Persist meta and set checkpoint to use this meta.
-  LOG(INFO) << "Dump graph to checkpoint " << ckp->path();
+  ckp->SetManifest(std::move(meta));
+  LOG(INFO) << "Dump graph to checkpoint " << ckp->manifest_path();
 
   Clear();
+}
+
+bool PropertyGraph::IsModified() const {
+  return dirty_.IsModified() || index_manager_->HasCatalogChanges();
 }
 
 const Schema& PropertyGraph::schema() const { return schema_; }

--- a/src/storages/graph/schema.cc
+++ b/src/storages/graph/schema.cc
@@ -2697,19 +2697,17 @@ result<rapidjson::Document> Schema::ToJson() const {
 
 void Schema::FromJson(const rapidjson::Value& j) {
   if (!j.IsObject()) {
-    LOG(ERROR) << "Schema JSON must be an object";
-    return;
+    THROW_STORAGE_EXCEPTION("Schema JSON must be an object");
   }
   auto yaml_result = config_parsing::json_to_yaml(j);
   if (!yaml_result) {
-    LOG(ERROR) << "Failed to convert JSON to YAML: " << yaml_result.error();
-    return;
+    THROW_STORAGE_EXCEPTION("Failed to convert JSON to YAML: " +
+                            yaml_result.error().ToString());
   }
   auto load_result = LoadFromYamlNode(yaml_result.value());
   if (!load_result) {
-    LOG(ERROR) << "Failed to load schema from JSON: "
-               << load_result.error().ToString();
-    return;
+    THROW_STORAGE_EXCEPTION("Failed to load schema from JSON: " +
+                            load_result.error().ToString());
   }
   *this = std::move(load_result.value());
 }

--- a/src/storages/graph/schema.cc
+++ b/src/storages/graph/schema.cc
@@ -2463,7 +2463,10 @@ Schema Schema::Compact() const {
       THROW_RUNTIME_ERROR("Failed to add vertex label: " + vlabel_name);
     }
     assert(new_label == new_schema.v_schemas_.size());
-    new_schema.v_schemas_.push_back(v_schemas_[v_label]);
+    auto compacted_vertex =
+        std::make_shared<VertexSchema>(*v_schemas_[v_label]);
+    compacted_vertex->label_id = new_label;
+    new_schema.v_schemas_.push_back(std::move(compacted_vertex));
   }
 
   for (label_t e_label = 0; e_label < elabel_indexer_.num_slots(); ++e_label) {
@@ -2504,7 +2507,12 @@ Schema Schema::Compact() const {
     auto new_index =
         new_schema.generate_edge_label(new_src_v, new_dst_v, new_e_label);
     max_e_triplet_index = std::max(max_e_triplet_index, new_index);
-    new_schema.e_schemas_[new_index] = pair.second;
+    auto compacted_edge = std::make_shared<EdgeSchema>(*pair.second);
+    compacted_edge->entry_id = new_index;
+    compacted_edge->src_label_id = new_src_v;
+    compacted_edge->dst_label_id = new_dst_v;
+    compacted_edge->edge_label_id = new_e_label;
+    new_schema.e_schemas_[new_index] = std::move(compacted_edge);
   }
   new_schema.vlabel_tomb_.resize(new_schema.v_schemas_.size());
   new_schema.elabel_tomb_.resize(new_schema.elabel_indexer_.num_slots());

--- a/src/storages/graph/vertex_table.cc
+++ b/src/storages/graph/vertex_table.cc
@@ -360,10 +360,10 @@ VertexTable VertexTable::OpenFrom(std::shared_ptr<Checkpoint> ckp,
 
   // Restore indexer via LFIndexer::Open
   auto& idx = vt.get_indexer();
-  auto indexer_desc = meta.module(KeyIndexer(lbl));
-  CHECK(indexer_desc.has_value())
+  const auto* indexer_desc = meta.FindModule(KeyIndexer(lbl));
+  CHECK(indexer_desc != nullptr)
       << "missing indexer meta entry for vertex " << lbl;
-  idx.Open(*ckp, indexer_desc.value(), level,
+  idx.Open(*ckp, *indexer_desc, level,
            store.TakeModule<ColumnBase>(KeyKeys(lbl)),
            store.TakeModule<TypedColumn<vid_t>>(KeyIndices(lbl)));
 
@@ -389,7 +389,7 @@ void VertexTable::DisassembleTo(ModuleBroker& store, CheckpointManifest& meta,
   // does not clobber it.
   std::unique_ptr<ColumnBase> keys_out;
   std::unique_ptr<TypedColumn<vid_t>> indices_out;
-  meta.set_module(KeyIndexer(lbl), idx.Dump(ckp, keys_out, indices_out));
+  meta.SetModule(KeyIndexer(lbl), idx.Dump(ckp, keys_out, indices_out));
   store.SetModule(KeyKeys(lbl), std::move(keys_out));
   store.SetModule(KeyIndices(lbl), std::move(indices_out));
 
@@ -400,20 +400,21 @@ void VertexTable::DisassembleTo(ModuleBroker& store, CheckpointManifest& meta,
   store.SetModule(KeyVertexTimestamp(lbl), TakeVertexTimestamp());
 }
 
-void VertexTable::LinkToSnapshot(Checkpoint& ckp, CheckpointManifest& meta,
-                                 const CheckpointManifest& prev) const {
+void VertexTable::ReuseCheckpointModules(Checkpoint& ckp,
+                                         CheckpointManifest& meta,
+                                         const CheckpointManifest& prev) const {
   const auto& lbl = vertex_schema_->label_name;
-  if (!prev.has_module(KeyKeys(lbl))) {
+  if (!prev.HasModule(KeyKeys(lbl))) {
     return;
   }
   // Exact keys only — prefix matching is ambiguous when labels contain
   // underscores (e.g. "a" vs "a_b").
-  meta.LinkModuleFrom(prev, KeyKeys(lbl), ckp);
-  meta.LinkModuleFrom(prev, KeyIndices(lbl), ckp);
-  meta.LinkModuleFrom(prev, KeyIndexer(lbl), ckp);
-  meta.LinkModuleFrom(prev, KeyVertexTimestamp(lbl), ckp);
+  meta.ReuseModuleClosureFrom(prev, KeyKeys(lbl));
+  meta.ReuseModuleClosureFrom(prev, KeyIndices(lbl));
+  meta.ReuseModuleClosureFrom(prev, KeyIndexer(lbl));
+  meta.ReuseModuleClosureFrom(prev, KeyVertexTimestamp(lbl));
   for (size_t i = 0; i < vertex_schema_->property_types.size(); ++i) {
-    meta.LinkModuleFrom(prev, KeyProperty(lbl, i), ckp);
+    meta.ReuseModuleClosureFrom(prev, KeyProperty(lbl, i));
   }
 }
 

--- a/src/storages/graph/vertex_timestamp.cc
+++ b/src/storages/graph/vertex_timestamp.cc
@@ -63,7 +63,7 @@ void VertexTimestamp::Dump(Checkpoint& ckp, CheckpointManifest& meta,
   descriptor.set_path(ModuleDescriptor::kDataPath,
                       ckp.CommitRuntimeFile(std::move(runtime_file)));
   descriptor.module_type = ModuleTypeName();
-  meta.set_module(key, descriptor);
+  meta.SetModule(key, descriptor);
 }
 
 void VertexTimestamp::Init(vid_t init_vertex_num, vid_t max_vertex_num) {

--- a/src/storages/index/index_id_accessor.cc
+++ b/src/storages/index/index_id_accessor.cc
@@ -46,7 +46,7 @@ void DefaultIndexIDAccessor::Dump(Checkpoint& ckp, CheckpointManifest& meta,
       std::to_string(next_index_id_->load(std::memory_order_relaxed)));
   descriptor.set_path(ModuleDescriptor::kVidToIndexIdPath,
                       ckp.Commit(*vid_to_index_id_));
-  meta.set_module(key, std::move(descriptor));
+  meta.SetModule(key, std::move(descriptor));
 }
 
 index_id_t DefaultIndexIDAccessor::GetIndexIDByVID(vid_t vid) const {

--- a/src/storages/index/storage_index.cc
+++ b/src/storages/index/storage_index.cc
@@ -210,7 +210,7 @@ void StorageIndex::Dump(Checkpoint& ckp, CheckpointManifest& meta,
   desc.module_type = ModuleTypeName();
   desc.set("index_meta", meta_->ToJsonString());
 
-  meta.set_module(key, std::move(desc));
+  meta.SetModule(key, std::move(desc));
 }
 
 std::string StorageIndex::ModuleTypeName() const {

--- a/src/storages/index/storage_index_manager.cc
+++ b/src/storages/index/storage_index_manager.cc
@@ -87,6 +87,7 @@ neug::result<StorageIndex*> StorageIndexManager::CreateIndex(
 
   auto* raw_ptr = index.get();
   indexes_[name] = std::move(index);
+  catalog_dirty_ = true;
   return raw_ptr;
 }
 
@@ -94,6 +95,7 @@ Status StorageIndexManager::DropIndex(const std::string& name) {
   auto pending_it = pending_indexes_.find(name);
   if (pending_it != pending_indexes_.end()) {
     pending_indexes_.erase(pending_it);
+    catalog_dirty_ = true;
     if (pending_indexes_.empty()) {
       pending_mutations_.clear();
     }
@@ -105,6 +107,7 @@ Status StorageIndexManager::DropIndex(const std::string& name) {
     return Status(StatusCode::ERR_NOT_FOUND, "Index not found: " + name);
   }
   indexes_.erase(it);
+  catalog_dirty_ = true;
   return Status::OK();
 }
 
@@ -274,8 +277,8 @@ void StorageIndexManager::Open(std::shared_ptr<Checkpoint> ckp,
   Clear();
   ckp_ = std::move(ckp);
   memory_level_ = level;
-  const CheckpointManifest& meta = ckp_->GetMeta();
-  for (const auto& [key, desc] : meta.modules()) {
+  const CheckpointManifest& meta = ckp_->manifest();
+  for (const auto& [key, desc] : meta.Modules()) {
     if (!IsIndexModule(key)) {
       continue;
     }
@@ -318,7 +321,7 @@ result<size_t> StorageIndexManager::ActivateIndexes(
           StatusCode::ERR_SCHEMA_MISMATCH,
           "Module is not an index type: " + pending.descriptor.module_type);
     }
-    module->Open(*ckp_, ckp_->GetMeta(), pending.descriptor, memory_level_);
+    module->Open(*ckp_, ckp_->manifest(), pending.descriptor, memory_level_);
     std::unique_ptr<StorageIndex> index(
         static_cast<StorageIndex*>(module.release()));
     const auto& meta = index->GetMeta();
@@ -347,8 +350,7 @@ result<size_t> StorageIndexManager::ActivateIndexes(
   return candidates.size();
 }
 
-void StorageIndexManager::Dump(ModuleBroker& store, Checkpoint& ckp,
-                               CheckpointManifest& meta) {
+void StorageIndexManager::Dump(ModuleBroker& store, CheckpointManifest& meta) {
   if (!pending_mutations_.empty()) {
     THROW_RUNTIME_ERROR(
         "Cannot create a checkpoint while mutations for pending "
@@ -360,12 +362,12 @@ void StorageIndexManager::Dump(ModuleBroker& store, Checkpoint& ckp,
         "Cannot preserve pending indexes without a previous checkpoint");
   }
   for (const auto& [_, pending] : pending_indexes_) {
-    if (!ckp_->GetMeta().has_module(pending.key)) {
+    if (!ckp_->manifest().HasModule(pending.key)) {
       THROW_RUNTIME_ERROR("Cannot preserve pending index module '" +
                           pending.key +
                           "': descriptor is missing from previous checkpoint");
     }
-    meta.LinkModuleFrom(ckp_->GetMeta(), pending.key, ckp);
+    meta.ReuseModuleClosureFrom(ckp_->manifest(), pending.key);
   }
   for (auto& [name, index] : indexes_) {
     if (!index)
@@ -398,6 +400,7 @@ std::unique_ptr<StorageIndexManager> StorageIndexManager::Clone() const {
   }
   forked->pending_indexes_ = pending_indexes_;
   forked->pending_mutations_ = pending_mutations_;
+  forked->catalog_dirty_ = catalog_dirty_;
   return forked;
 }
 
@@ -405,6 +408,7 @@ void StorageIndexManager::Clear() {
   indexes_.clear();
   pending_indexes_.clear();
   pending_mutations_.clear();
+  catalog_dirty_ = false;
   ckp_.reset();
   memory_level_ = MemoryLevel::kInMemory;
 }

--- a/src/storages/loader/abstract_property_graph_loader.cc
+++ b/src/storages/loader/abstract_property_graph_loader.cc
@@ -187,12 +187,12 @@ result<bool> AbstractPropertyGraphLoader::LoadFragment() {
     loadEdges();
     graph_.Compact();
     graph_.DumpAndClear(staging_checkpoint_->checkpoint());
-    staging_checkpoint_->Commit();
+    staging_checkpoint_->Publish();
 
   } catch (const std::exception& e) {
     graph_.Clear();
     staging_checkpoint_.reset();
-    printDiskRemaining(checkpoint_mgr_.db_dir());
+    printDiskRemaining(checkpoint_mgr_.database_dir());
     LOG(ERROR) << "Load fragment failed: " << e.what();
     return result<bool>(false);
   }

--- a/src/storages/module/module_broker.cc
+++ b/src/storages/module/module_broker.cc
@@ -22,13 +22,13 @@
 namespace neug {
 
 void ModuleBroker::Open(Checkpoint& checkpoint, MemoryLevel level) {
-  Open(checkpoint, checkpoint.GetMeta(), level);
+  Open(checkpoint, checkpoint.manifest(), level);
 }
 
 void ModuleBroker::Open(Checkpoint& checkpoint, const CheckpointManifest& meta,
                         MemoryLevel level) {
   auto& factory = ModuleFactory::instance();
-  for (const auto& [name, desc] : meta.modules()) {
+  for (const auto& [name, desc] : meta.Modules()) {
     if (desc.is_referenced_module()) {
       continue;
     }

--- a/src/transaction/update_transaction.cc
+++ b/src/transaction/update_transaction.cc
@@ -255,8 +255,9 @@ static Status updateVertexIndexData(
     return Status::OK();
   }
 
-  auto indexes = graph.mutable_index_manager().GetIndex(
-      label, v_schema->property_names[col_id]);
+  auto& index_manager = graph.mutable_index_manager();
+  auto indexes =
+      index_manager.GetIndex(label, v_schema->property_names[col_id]);
   if (!indexes) {
     return indexes.error();
   }

--- a/src/transaction/update_transaction.cc
+++ b/src/transaction/update_transaction.cc
@@ -255,9 +255,8 @@ static Status updateVertexIndexData(
     return Status::OK();
   }
 
-  auto& index_manager = graph.mutable_index_manager();
-  auto indexes =
-      index_manager.GetIndex(label, v_schema->property_names[col_id]);
+  auto indexes = graph.mutable_index_manager().GetIndex(
+      label, v_schema->property_names[col_id]);
   if (!indexes) {
     return indexes.error();
   }

--- a/src/utils/io/file/file_utils.cc
+++ b/src/utils/io/file/file_utils.cc
@@ -633,13 +633,30 @@ AtomicFileWriter::CommitResult AtomicFileWriter::Commit() {
   }
   fd_ = -1;
 
-  // Step 4: Atomic rename — POSIX guarantees this is atomic on the same FS.
+  // Step 4: atomically replace the target. MSVC's filesystem::rename does not
+  // provide the replacement semantics required by the CURRENT selector, so
+  // use the native write-through operation on Windows.
+#ifdef _WIN32
+  const auto tmp_path = std::filesystem::path(tmp_path_).wstring();
+  const auto target_path = std::filesystem::path(target_path_).wstring();
+  if (!MoveFileExW(tmp_path.c_str(), target_path.c_str(),
+                   MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+    const auto error = std::error_code(static_cast<int>(GetLastError()),
+                                       std::system_category());
+    std::error_code remove_ec;
+    std::filesystem::remove(tmp_path_, remove_ec);
+    THROW_IO_EXCEPTION("AtomicFileWriter::Commit: replace " + tmp_path_ +
+                       " -> " + target_path_ + " failed: " + error.message());
+  }
+  return CommitResult::kDurable;
+#else
   std::error_code ec;
   std::filesystem::rename(tmp_path_, target_path_, ec);
   if (ec) {
+    const auto message = ec.message();
     std::filesystem::remove(tmp_path_, ec);
     THROW_IO_EXCEPTION("AtomicFileWriter::Commit: rename " + tmp_path_ +
-                       " -> " + target_path_ + " failed: " + ec.message());
+                       " -> " + target_path_ + " failed: " + message);
   }
 
   // Step 5: fsync the parent directory so the directory entry is durable.
@@ -651,6 +668,7 @@ AtomicFileWriter::CommitResult AtomicFileWriter::Commit() {
   const bool durable = ::fsync(dir_fd) == 0;
   ::close(dir_fd);
   return durable ? CommitResult::kDurable : CommitResult::kCommitUnknown;
+#endif
 }
 
 void AtomicFileWriter::Abort() noexcept {

--- a/src/utils/io/file/file_utils.cc
+++ b/src/utils/io/file/file_utils.cc
@@ -581,7 +581,7 @@ std::ostream& AtomicFileWriter::stream() {
   return *ostream_;
 }
 
-void AtomicFileWriter::Commit() {
+AtomicFileWriter::CommitResult AtomicFileWriter::Commit() {
   if (committed_) {
     THROW_IO_EXCEPTION("AtomicFileWriter::Commit: already committed");
   }
@@ -645,10 +645,12 @@ void AtomicFileWriter::Commit() {
   // Step 5: fsync the parent directory so the directory entry is durable.
   auto parent_dir = std::filesystem::path(target_path_).parent_path().string();
   int dir_fd = ::open(parent_dir.c_str(), O_RDONLY);
-  if (dir_fd >= 0) {
-    ::fsync(dir_fd);
-    ::close(dir_fd);
+  if (dir_fd < 0) {
+    return CommitResult::kCommitUnknown;
   }
+  const bool durable = ::fsync(dir_fd) == 0;
+  ::close(dir_fd);
+  return durable ? CommitResult::kDurable : CommitResult::kCommitUnknown;
 }
 
 void AtomicFileWriter::Abort() noexcept {

--- a/src/utils/property/array_column.cc
+++ b/src/utils/property/array_column.cc
@@ -93,14 +93,14 @@ void ArrayColumn::openInternal(Checkpoint& ckp,
   if (child_ref.has_value()) {
     const auto* resolver = manifest;
     if (!resolver) {
-      resolver = &ckp.GetMeta();
+      resolver = &ckp.manifest();
     }
-    auto child_desc = resolver->module(*child_ref);
-    if (!child_desc.has_value()) {
+    const auto* child_desc = resolver->FindModule(*child_ref);
+    if (child_desc == nullptr) {
       THROW_RUNTIME_ERROR("ArrayColumn::Open: missing element module '" +
                           *child_ref + "'");
     }
-    child_column_->Open(ckp, *resolver, child_desc.value(), level);
+    child_column_->Open(ckp, *resolver, *child_desc, level);
     return;
   }
 
@@ -135,15 +135,15 @@ void ArrayColumn::Dump(Checkpoint& ckp, CheckpointManifest& meta,
   auto desc = dumpSelfDescriptor();
   auto child_key = MakeChildModuleKey(key, kElementRef);
   child_column_->Dump(ckp, meta, child_key);
-  auto child_it = meta.mutable_modules().find(child_key);
-  if (child_it == meta.mutable_modules().end()) {
+  auto* child_desc = meta.FindMutableModule(child_key);
+  if (child_desc == nullptr) {
     THROW_RUNTIME_ERROR(
         "ArrayColumn::Dump: element column did not write module '" + child_key +
         "'");
   }
-  child_it->second.mark_as_referenced_module();
+  child_desc->mark_as_referenced_module();
   desc.set_ref(kElementRef, std::move(child_key));
-  meta.set_module(key, desc);
+  meta.SetModule(key, desc);
 }
 
 void ArrayColumn::resize(size_t size) {

--- a/src/utils/property/list_property_column.cc
+++ b/src/utils/property/list_property_column.cc
@@ -38,31 +38,30 @@ std::string ChildModuleKey(const std::string& parent, const std::string& role) {
 }
 
 void MarkReferenced(CheckpointManifest& meta, const std::string& key) {
-  auto it = meta.mutable_modules().find(key);
-  if (it == meta.mutable_modules().end()) {
+  auto* desc = meta.FindMutableModule(key);
+  if (desc == nullptr) {
     THROW_RUNTIME_ERROR(
         "ListPropertyColumn::Dump: child column did not write "
         "module '" +
         key + "'");
   }
-  it->second.mark_as_referenced_module();
+  desc->mark_as_referenced_module();
 }
 
 const ModuleDescriptor& ResolveChild(const CheckpointManifest& manifest,
                                      const ModuleDescriptor& parent,
-                                     const char* role,
-                                     std::optional<ModuleDescriptor>& storage) {
+                                     const char* role) {
   auto ref = parent.get_ref(role);
   if (!ref.has_value()) {
     THROW_RUNTIME_ERROR("ListPropertyColumn::Open: missing '" +
                         std::string(role) + "' ref");
   }
-  storage = manifest.module(*ref);
-  if (!storage.has_value()) {
+  const auto* child = manifest.FindModule(*ref);
+  if (child == nullptr) {
     THROW_RUNTIME_ERROR("ListPropertyColumn::Open: missing child module '" +
                         *ref + "'");
   }
-  return *storage;
+  return *child;
 }
 
 }  // namespace
@@ -123,12 +122,9 @@ void ListPropertyColumn::openInternal(Checkpoint& ckp,
   }
   const size_t expected_rows = std::stoull(*row_count);
 
-  const auto& resolver = manifest ? *manifest : ckp.GetMeta();
-  std::optional<ModuleDescriptor> items_desc;
-  std::optional<ModuleDescriptor> elements_desc;
-  items_->Open(ckp, ResolveChild(resolver, desc, kItemsRef, items_desc), level);
-  elements_->Open(ckp, resolver,
-                  ResolveChild(resolver, desc, kElementsRef, elements_desc),
+  const auto& resolver = manifest ? *manifest : ckp.manifest();
+  items_->Open(ckp, ResolveChild(resolver, desc, kItemsRef), level);
+  elements_->Open(ckp, resolver, ResolveChild(resolver, desc, kElementsRef),
                   level);
   // After loading from a checkpoint, elements_tail_ equals elements_->size(),
   // meaning there is zero spare capacity in the elements column.  Any
@@ -246,7 +242,7 @@ void ListPropertyColumn::Dump(Checkpoint& ckp, CheckpointManifest& meta,
   auto desc = dumpSelfDescriptor();
   desc.set_ref(kItemsRef, std::move(items_key));
   desc.set_ref(kElementsRef, std::move(elements_key));
-  meta.set_module(key, std::move(desc));
+  meta.SetModule(key, std::move(desc));
 }
 
 void ListPropertyColumn::resize(size_t size) {

--- a/src/utils/property/vec_column.cc
+++ b/src/utils/property/vec_column.cc
@@ -226,7 +226,7 @@ VecColumn::VecColumn(std::shared_ptr<IDataContainer> buffer,
 
 void VecColumn::Open(Checkpoint& ckp, const ModuleDescriptor& desc,
                      MemoryLevel level) {
-  openInternal(ckp, &ckp.GetMeta(), desc, level);
+  openInternal(ckp, &ckp.manifest(), desc, level);
 }
 
 void VecColumn::Open(Checkpoint& ckp, const CheckpointManifest& manifest,
@@ -262,8 +262,8 @@ void VecColumn::openInternal(Checkpoint& ckp,
   if (!accessor_ref) {
     offset_accessor_->Open(ckp, ModuleDescriptor{}, level);
   } else {
-    const auto* resolver = manifest ? manifest : &ckp.GetMeta();
-    auto accessor_desc = resolver->module(*accessor_ref);
+    const auto* resolver = manifest ? manifest : &ckp.manifest();
+    const auto* accessor_desc = resolver->FindModule(*accessor_ref);
     if (!accessor_desc) {
       THROW_RUNTIME_ERROR("VecColumn::Open: missing offset accessor module");
     }
@@ -287,9 +287,14 @@ void VecColumn::Dump(Checkpoint& ckp, CheckpointManifest& meta,
   desc.set_path(ModuleDescriptor::kDataPath, ckp.Commit(*buffer_));
   auto accessor_key = key + "/" + kAccessorRef;
   offset_accessor_->Dump(ckp, meta, accessor_key);
-  meta.mutable_modules().at(accessor_key).mark_as_referenced_module();
+  auto* accessor_desc = meta.FindMutableModule(accessor_key);
+  if (accessor_desc == nullptr) {
+    THROW_RUNTIME_ERROR(
+        "VecColumn::Dump: offset accessor did not write module");
+  }
+  accessor_desc->mark_as_referenced_module();
   desc.set_ref(kAccessorRef, accessor_key);
-  meta.set_module(key, std::move(desc));
+  meta.SetModule(key, std::move(desc));
 }
 
 size_t VecColumn::size() const { return size_; }

--- a/tests/extension/vec_index/vec_index.h
+++ b/tests/extension/vec_index/vec_index.h
@@ -85,7 +85,7 @@ class VecIndex final : public StorageIndex {
   void Dump(Checkpoint& ckp, CheckpointManifest& manifest,
             const std::string& key) override {
     StorageIndex::Dump(ckp, manifest, key);
-    manifest.mutable_modules().at(key).required = false;
+    manifest.FindMutableModule(key)->required = false;
   }
 
   void Detach(Checkpoint&, MemoryLevel) override {}

--- a/tests/storage/test_ap_index.cc
+++ b/tests/storage/test_ap_index.cc
@@ -180,11 +180,11 @@ class APIndexTest : public ::testing::Test {
 
   void OpenFreshGraph() {
     checkpoint_mgr_.Open(work_dir_);
-    auto staging = checkpoint_mgr_.CreateStagingCheckpoint();
+    auto staging = checkpoint_mgr_.CreateStaging();
     CheckpointManifest meta;
     meta.SetSchema(Schema());
-    staging.checkpoint()->UpdateMeta(std::move(meta));
-    auto ckp = staging.Commit();
+    staging.checkpoint()->SetManifest(std::move(meta));
+    auto ckp = staging.Publish();
     graph_ = std::make_unique<PropertyGraph>();
     graph_->Open(ckp, MemoryLevel::kInMemory);
     view_ = std::make_unique<GraphView>(*graph_);
@@ -203,9 +203,9 @@ class APIndexTest : public ::testing::Test {
     graph_.reset();
     checkpoint_mgr_.Close();
     checkpoint_mgr_.Open(work_dir_);
-    ASSERT_TRUE(checkpoint_mgr_.HasCurrentCheckpoint());
+    ASSERT_NE(checkpoint_mgr_.Current(), nullptr);
     graph_ = std::make_unique<PropertyGraph>();
-    graph_->Open(checkpoint_mgr_.CurrentCheckpoint(), MemoryLevel::kInMemory);
+    graph_->Open(checkpoint_mgr_.Current(), MemoryLevel::kInMemory);
     view_ = std::make_unique<GraphView>(*graph_);
     ap_ = std::make_unique<StorageAPUpdateInterface>(
         *graph_, *view_, 0, allocator_, [this]() {
@@ -217,9 +217,10 @@ class APIndexTest : public ::testing::Test {
   }
 
   void CheckpointGraph() {
-    auto staging = checkpoint_mgr_.CreateStagingCheckpoint();
+    auto staging = checkpoint_mgr_.CreateStaging();
+    graph_->Compact();
     graph_->DumpAndClear(staging.checkpoint());
-    staging.Commit();
+    staging.Publish();
   }
 
   void CreatePersonTable() {

--- a/tests/storage/test_checkpoint.cc
+++ b/tests/storage/test_checkpoint.cc
@@ -15,9 +15,11 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <vector>
 
 #include "neug/main/neug_db.h"
 #include "neug/main/query_request.h"
@@ -508,7 +510,103 @@ TEST(CheckpointFormatTest,
   std::filesystem::remove_all(db_dir);
 }
 
-TEST(CheckpointFormatTest, ManualCheckpointPreservesDeletedVertexState) {
+// Restores the memory-level coverage of the replaced suite: the core
+// roundtrip and reopen-GC scenarios run at both kInMemory and kSyncToFile,
+// whose object stores differ (hardlink vs copy, mmap'd objects).
+class CheckpointRoundtripTest
+    : public ::testing::TestWithParam<neug::MemoryLevel> {
+ protected:
+  neug::NeugDBConfig Config(const std::string& data_dir) {
+    auto config = ::Config(data_dir);
+    config.memory_level = GetParam();
+    return config;
+  }
+
+  std::string TestDir(const std::string& name) {
+    const auto* suffix =
+        GetParam() == neug::MemoryLevel::kInMemory ? "in_memory" : "sync_file";
+    return ::TestDir(name + "_" + suffix);
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(AllMemoryLevels, CheckpointRoundtripTest,
+                         ::testing::Values(neug::MemoryLevel::kInMemory,
+                                           neug::MemoryLevel::kSyncToFile));
+
+TEST_P(CheckpointRoundtripTest, ReopenReclaimsRetiredCheckpointsAndWalEpochs) {
+  const auto db_dir = TestDir("reopen_reclaims_retired");
+  uint64_t current_id = 0;
+  {
+    neug::NeugDB db;
+    ASSERT_TRUE(db.Open(Config(db_dir)));
+    auto connection = db.Connect();
+    auto result = connection->Query(
+        "CREATE NODE TABLE Person(id INT64, age INT32, PRIMARY KEY(id));");
+    ASSERT_TRUE(result) << result.error().ToString();
+    result = connection->Query("CREATE (:Person {id: 1, age: 30});");
+    ASSERT_TRUE(result) << result.error().ToString();
+    connection->Close();
+    {
+      neug::NeugDBService service(db);
+      CheckpointThroughService(service);
+    }
+
+    // Dirty the vertex module so the second checkpoint cannot reuse the
+    // first checkpoint's objects.
+    connection = db.Connect();
+    result = connection->Query("MATCH (p:Person {id: 1}) SET p.age = 31;");
+    ASSERT_TRUE(result) << result.error().ToString();
+    connection->Close();
+    {
+      neug::NeugDBService service(db);
+      CheckpointThroughService(service);
+      const auto checkpoint = db.graph().checkpoint_ptr();
+      ASSERT_NE(checkpoint, nullptr);
+      current_id = checkpoint->id();
+      EXPECT_GT(current_id, 0u);
+    }
+    db.Close();
+  }
+
+  {
+    neug::NeugDB db;
+    ASSERT_TRUE(db.Open(Config(db_dir)));
+    const auto checkpoint = db.graph().checkpoint_ptr();
+    ASSERT_NE(checkpoint, nullptr);
+    EXPECT_EQ(checkpoint->id(), current_id);
+
+    // The reclaiming reopen (RW open runs GC) leaves only the current
+    // manifest and its WAL epoch behind.
+    std::vector<std::string> manifests;
+    for (const auto& entry : std::filesystem::directory_iterator(
+             std::filesystem::path(db_dir) / "checkpoint" / "manifests")) {
+      manifests.push_back(entry.path().filename().string());
+    }
+    std::sort(manifests.begin(), manifests.end());
+    EXPECT_EQ(manifests, std::vector<std::string>{std::to_string(current_id) +
+                                                  ".manifest"});
+
+    std::vector<std::string> wal_epochs;
+    for (const auto& entry : std::filesystem::directory_iterator(
+             std::filesystem::path(db_dir) / "wal")) {
+      wal_epochs.push_back(entry.path().filename().string());
+    }
+    std::sort(wal_epochs.begin(), wal_epochs.end());
+    EXPECT_EQ(wal_epochs, std::vector<std::string>{std::to_string(current_id)});
+
+    // Rows survive the reclaiming reopen.
+    auto connection = db.Connect();
+    auto result = connection->Query("MATCH (p:Person) RETURN p.age;");
+    ASSERT_TRUE(result) << result.error().ToString();
+    EXPECT_EQ(result.value().response().row_count(), 1);
+    connection->Close();
+    db.Close();
+  }
+
+  std::filesystem::remove_all(db_dir);
+}
+
+TEST_P(CheckpointRoundtripTest, ManualCheckpointPreservesDeletedVertexState) {
   const auto db_dir = TestDir("manual_deleted_vertex");
   {
     neug::NeugDB db;
@@ -554,8 +652,8 @@ TEST(CheckpointFormatTest, ManualCheckpointPreservesDeletedVertexState) {
   std::filesystem::remove_all(db_dir);
 }
 
-TEST(CheckpointFormatTest,
-     ManualCheckpointRoundTripsEvolvedVertexAndEdgeDescriptors) {
+TEST_P(CheckpointRoundtripTest,
+       ManualCheckpointRoundTripsEvolvedVertexAndEdgeDescriptors) {
   const auto db_dir = TestDir("evolved_vertex_edge_descriptors");
   {
     neug::NeugDB db;

--- a/tests/storage/test_checkpoint.cc
+++ b/tests/storage/test_checkpoint.cc
@@ -14,2504 +14,661 @@
  */
 
 #include <gtest/gtest.h>
-#ifndef _WIN32
-#include <poll.h>
-#include <sys/wait.h>
-#include <unistd.h>
-#endif
 
-#include <algorithm>
-#include <array>
-#include <cstring>
 #include <filesystem>
 #include <fstream>
-#include <iostream>
-#include <iterator>
-#include <memory>
 #include <string>
-#include <string_view>
-#include <system_error>
-#include <type_traits>
-#include <utility>
-#include <vector>
-#include "column_assertions.h"
-#include "neug/config.h"
-#include "neug/main/connection.h"
-#include "neug/main/file_lock.h"
+
 #include "neug/main/neug_db.h"
+#include "neug/main/query_request.h"
 #include "neug/server/neug_db_service.h"
-#include "neug/storages/allocators.h"
-#include "neug/storages/checkpoint.h"
-#include "neug/storages/checkpoint_file_manager.h"
 #include "neug/storages/checkpoint_manager.h"
-#include "neug/storages/checkpoint_manifest.h"
-#include "neug/storages/container/file_header.h"
-#include "neug/storages/csr/mutable_csr.h"
 #include "neug/storages/graph/graph_interface.h"
-#include "neug/storages/graph/property_graph.h"
 #include "neug/storages/graph/schema.h"
-#include "neug/storages/module_descriptor.h"
-#include "neug/utils/property/column.h"
-#include "unittest/utils.h"
+#include "neug/storages/graph/vertex_table.h"
+#include "neug/storages/graph_snapshot_store.h"
+#include "neug/storages/index/storage_index_manager.h"
+#include "neug/storages/module/module_factory.h"
+#include "test_index_common.h"
 
 namespace {
 
-// ---------------------------------------------------------------------------
-// Cross-platform helper: returns the current real user id on POSIX and a
-// non-root value on Windows.  Used by permission-based tests that need to
-// skip when running as root.
-inline int GetTestUid() {
-#ifdef _WIN32
-  return 1;
-#else
-  return getuid();
-#endif
-}
-
-// Memory level traits for typed tests.
-// ---------------------------------------------------------------------------
-template <neug::MemoryLevel kLevel>
-struct MemoryLevelTag {
-  static constexpr neug::MemoryLevel value = kLevel;
-};
-
-using InMemoryLevel = MemoryLevelTag<neug::MemoryLevel::kInMemory>;
-using SyncToFileLevel = MemoryLevelTag<neug::MemoryLevel::kSyncToFile>;
-
-using AllMemoryLevels = ::testing::Types<InMemoryLevel, SyncToFileLevel>;
-
-// ---------------------------------------------------------------------------
-// Test data constants
-// ---------------------------------------------------------------------------
-constexpr std::array<int64_t, 4> kPersonIds = {1, 2, 4, 6};
-const std::vector<int64_t> kPersonIdValues(kPersonIds.begin(),
-                                           kPersonIds.end());
-const std::vector<std::string> kPersonNames = {"marko", "vadas", "josh",
-                                               "peter"};
-constexpr std::array<int64_t, 4> kPersonAges = {29, 27, 32, 35};
-const std::vector<int64_t> kPersonAgeValues(kPersonAges.begin(),
-                                            kPersonAges.end());
-
-// ---------------------------------------------------------------------------
-// Assertion helpers
-// ---------------------------------------------------------------------------
-void AssertPersonVertexBasic(const neug::QueryResponse& table) {
-  ASSERT_EQ(table.row_count(), 4);
-  ASSERT_EQ(table.arrays_size(), 3);
-  neug::test::AssertInt64Column(table, 0, kPersonIdValues);
-  neug::test::AssertStringColumn(table, 1, kPersonNames);
-  neug::test::AssertInt64Column(table, 2, kPersonAgeValues);
-}
-
-void AssertPersonVertexWithCreated(
-    const neug::QueryResponse& table,
-    const std::vector<std::string>& created_values) {
-  ASSERT_EQ(table.row_count(), 4);
-  ASSERT_EQ(table.arrays_size(), 4);
-  neug::test::AssertInt64Column(table, 0, kPersonIdValues);
-  neug::test::AssertStringColumn(table, 1, kPersonNames);
-  neug::test::AssertInt64Column(table, 2, kPersonAgeValues);
-  neug::test::AssertStringColumn(table, 3, created_values);
-}
-
-void AssertPersonVertexWithoutAge(const neug::QueryResponse& table) {
-  ASSERT_EQ(table.row_count(), 4);
-  ASSERT_EQ(table.arrays_size(), 2);
-  neug::test::AssertInt64Column(table, 0, kPersonIdValues);
-  neug::test::AssertStringColumn(table, 1, kPersonNames);
-}
-
-void AssertPersonVertexAfterDelete(const neug::QueryResponse& table) {
-  ASSERT_EQ(table.row_count(), 3);
-  ASSERT_EQ(table.arrays_size(), 3);
-  neug::test::AssertInt64Column(table, 0, {2, 4, 6});
-  neug::test::AssertStringColumn(table, 1, {"vadas", "josh", "peter"});
-  neug::test::AssertInt64Column(table, 2, {27, 32, 35});
-}
-
-void AssertKnowsWeight(const neug::QueryResponse& table,
-                       const std::vector<double>& weights) {
-  ASSERT_EQ(table.arrays_size(), 1);
-  neug::test::AssertDoubleColumn(table, 0, weights);
-}
-
-void AssertKnowsWeightAndRegistration(
-    const neug::QueryResponse& table, const std::vector<double>& weights,
-    const std::vector<int64_t>& registrations) {
-  ASSERT_EQ(table.arrays_size(), 2);
-  neug::test::AssertDoubleColumn(table, 0, weights);
-  neug::test::AssertDate32Column(table, 1, registrations);
-}
-
-void AssertKnowsWeightAndDescription(
-    const neug::QueryResponse& table, const std::vector<double>& weights,
-    const std::vector<std::string>& descriptions) {
-  ASSERT_EQ(table.arrays_size(), 2);
-  neug::test::AssertDoubleColumn(table, 0, weights);
-  neug::test::AssertStringColumn(table, 1, descriptions);
-}
-
-void AssertKnowsFullSchema(const neug::QueryResponse& table,
-                           const std::vector<double>& weights,
-                           const std::vector<std::string>& descriptions,
-                           const std::vector<int64_t>& dates) {
-  ASSERT_EQ(table.arrays_size(), 3);
-  neug::test::AssertDoubleColumn(table, 0, weights);
-  neug::test::AssertStringColumn(table, 1, descriptions);
-  neug::test::AssertDate32Column(table, 2, dates);
-}
-
-void AssertMapColumn(const neug::QueryResponse& table, int64_t expected_rows) {
-  ASSERT_EQ(table.arrays_size(), 1);
-  ASSERT_EQ(table.row_count(), expected_rows);
-  auto array = table.arrays(0);
-  ASSERT_TRUE(array.has_vertex_array() || array.has_edge_array() ||
-              array.has_path_array());
-}
-
-void AssertSingleInt64Result(const neug::QueryResponse& table,
-                             int64_t expected) {
-  ASSERT_EQ(table.arrays_size(), 1);
-  ASSERT_EQ(table.row_count(), 1);
-  neug::test::AssertInt64Column(table, 0, {expected});
-}
-
-void InsertItemThroughServiceWal(neug::NeugDB& db, int64_t id) {
-  neug::NeugDBService service(db);
-  auto slot = service.AcquireExecutionSlot();
-  auto txn = slot->GetInsertTransaction();
-  neug::StorageTPInsertInterface interface(txn);
-  const auto item_label = txn.schema().get_vertex_label_id("Item");
-  neug::vid_t vid = 0;
-  ASSERT_TRUE(interface.AddVertex(item_label, neug::Value::INT64(id), {}, vid));
-  ASSERT_TRUE(txn.Commit());
-}
-
-void AssertCreatedEdgesSnapshotResult(
-    const neug::QueryResponse& table, const std::vector<int64_t>& ids,
-    const std::vector<int64_t>& since,
-    const std::vector<int64_t>& software_ids) {
-  ASSERT_EQ(table.arrays_size(), 3);
-  ASSERT_EQ(table.row_count(), ids.size());
-  neug::test::AssertInt64Column(table, 0, ids);
-  neug::test::AssertInt64Column(table, 1, since);
-  neug::test::AssertInt64Column(table, 2, software_ids);
-}
-
-}  // namespace
-
-namespace neug {
-namespace test {
-
-// ===========================================================================
-// Base fixture — shared DB lifecycle helpers for all checkpoint suites.
-// Parameterized by MemoryLevelTag<kLevel> via CRTP so typed tests inherit it.
-// ===========================================================================
-template <typename MemoryLevelT>
-class CheckpointTestBase : public ::testing::Test {
- protected:
-  static constexpr neug::MemoryLevel kMemoryLevel = MemoryLevelT::value;
-
-  // -- Config / open helpers (single source of truth) ----------------------
-
-  static neug::NeugDBConfig MakeConfig(const std::string& data_dir) {
-    neug::NeugDBConfig config;
-    config.data_dir = data_dir;
-    config.memory_level = kMemoryLevel;
-    config.checkpoint_on_close = true;
-    return config;
-  }
-
-  static void OpenDB(neug::NeugDB& db, const std::string& data_dir) {
-    db.Open(MakeConfig(data_dir));
-  }
-
-  // -- Directory lifecycle -------------------------------------------------
-
-  static void CleanDir(const std::string& dir) {
-    if (std::filesystem::exists(dir)) {
-      std::filesystem::remove_all(dir);
-    }
-  }
-
-  static void EnsureCleanDir(const std::string& dir) {
-    CleanDir(dir);
-    std::filesystem::create_directories(dir);
-  }
-
-  // -- Unique per-test directory generation --------------------------------
-
-  static std::string MakeUniqueDir(const std::string& prefix) {
-    const auto* test_info =
-        ::testing::UnitTest::GetInstance()->current_test_info();
-    std::string dir = (std::filesystem::temp_directory_path() /
-                       (prefix + "_" + test_info->test_suite_name() + "_" +
-                        test_info->name()))
-                          .string();
-    EnsureCleanDir(dir);
-    return dir;
-  }
-
-  // -- Query helpers (avoid repetitive boilerplate) ------------------------
-
-  static void ExpectQuery(neug::Connection& conn, const std::string& cypher) {
-    auto res = conn.Query(cypher);
-    EXPECT_TRUE(res) << res.error().ToString();
-  }
-
-  static neug::QueryResponse RunQuery(neug::Connection& conn,
-                                      const std::string& cypher) {
-    auto res = conn.Query(cypher);
-    EXPECT_TRUE(res) << res.error().ToString();
-    return res.value().response();
-  }
-
-  // -- Common assertion combos used across many tests ----------------------
-
-  static void AssertBasicPersonAndKnows(neug::Connection& conn,
-                                        const std::vector<double>& weights) {
-    AssertPersonVertexBasic(RunQuery(conn, "MATCH (v:person) RETURN v.*;"));
-    AssertKnowsWeight(
-        RunQuery(conn, "MATCH (v:person)-[e:knows]->(:person) RETURN e.*;"),
-        weights);
-  }
-};
-
-// ===========================================================================
-// CheckpointTest — modern-graph based checkpoint scenarios
-// ===========================================================================
-template <typename T>
-class CheckpointTest : public CheckpointTestBase<T> {
- protected:
-  std::string db_dir_;
-
-  void SetUp() override {
-    db_dir_ = this->MakeUniqueDir("checkpoint_test");
-    neug::NeugDB db;
-    this->OpenDB(db, db_dir_);
-    auto conn = db.Connect();
-    load_modern_graph(conn);
-    LOG(INFO) << "[CheckPointTest]: Finished loading modern graph";
-    conn->Close();
-    db.Close();
-  }
-
-  void TearDown() override { this->CleanDir(db_dir_); }
-};
-
-TYPED_TEST_SUITE(CheckpointTest, AllMemoryLevels);
-
-TYPED_TEST(CheckpointTest, basic) {
-  neug::NeugDB db;
-  this->OpenDB(db, this->db_dir_);
-  db.Close();
-  this->OpenDB(db, this->db_dir_);
-  auto conn = db.Connect();
-  this->AssertBasicPersonAndKnows(*conn, {0.5, 1.0});
-}
-
-TYPED_TEST(CheckpointTest, after_add_vertex_property) {
-  neug::NeugDB db;
-  this->OpenDB(db, this->db_dir_);
-  auto conn = db.Connect();
-  this->ExpectQuery(*conn, "ALTER TABLE person ADD created STRING;");
-
-  db.Close();
-  this->OpenDB(db, this->db_dir_);
-  conn = db.Connect();
-
-  AssertPersonVertexWithCreated(
-      this->RunQuery(*conn, "MATCH (v:person) RETURN v.*;"), {"", "", "", ""});
-  AssertKnowsWeight(
-      this->RunQuery(*conn,
-                     "MATCH (v:person)-[e:knows]->(:person) RETURN e.*;"),
-      {0.5, 1.0});
-}
-
-TYPED_TEST(CheckpointTest, after_delete_vertex_property) {
-  neug::NeugDB db;
-  this->OpenDB(db, this->db_dir_);
-  auto conn = db.Connect();
-  this->ExpectQuery(*conn, "ALTER TABLE person DROP age;");
-
-  db.Close();
-  this->OpenDB(db, this->db_dir_);
-  conn = db.Connect();
-
-  AssertPersonVertexWithoutAge(
-      this->RunQuery(*conn, "MATCH (v:person) RETURN v.*;"));
-  AssertKnowsWeight(
-      this->RunQuery(*conn,
-                     "MATCH (v:person)-[e:knows]->(:person) RETURN e.*;"),
-      {0.5, 1.0});
-}
-
-TYPED_TEST(CheckpointTest, after_delete_vertex) {
-  neug::NeugDB db;
-  this->OpenDB(db, this->db_dir_);
-  auto conn = db.Connect();
-  this->ExpectQuery(*conn, "MATCH (v:person) WHERE v.id = 1 DELETE v;");
-
-  db.Close();
-  this->OpenDB(db, this->db_dir_);
-  conn = db.Connect();
-
-  AssertPersonVertexAfterDelete(
-      this->RunQuery(*conn, "MATCH (v:person) RETURN v.*;"));
-  AssertKnowsWeight(
-      this->RunQuery(*conn,
-                     "MATCH (v:person)-[e:knows]->(:person) RETURN e.*;"),
-      {});
-}
-
-// ALTER ADD a property, write per-row values, explicit CHECKPOINT, then
-// reopen — the new column must come back via the new module/descriptor flow.
-// add_columns gives the new column a fresh runtime UUID (descriptor.path is
-// empty until the next Dump assigns one), so a Dump-then-reload here is the
-// regression guard for that contract.
-TYPED_TEST(CheckpointTest, alter_add_then_explicit_checkpoint_roundtrip) {
-  neug::NeugDB db;
-  this->OpenDB(db, this->db_dir_);
-  auto conn = db.Connect();
-
-  this->ExpectQuery(*conn, "ALTER TABLE person ADD score INT64;");
-  this->ExpectQuery(*conn, "MATCH (v:person) SET v.score = v.id + 100;");
-  this->ExpectQuery(*conn, "CHECKPOINT;");
-
-  db.Close();
-  this->OpenDB(db, this->db_dir_);
-  conn = db.Connect();
-
-  // Values written before the explicit CHECKPOINT must survive reopen.
-  // load_modern_graph creates persons with id ∈ {1, 2, 4, 6}.
-  auto res = this->RunQuery(
-      *conn, "MATCH (v:person) RETURN v.id, v.score ORDER BY v.id;");
-  neug::test::AssertInt64Column(res, 0, {1, 2, 4, 6});
-  neug::test::AssertInt64Column(res, 1, {101, 102, 104, 106});
-}
-
-TYPED_TEST(CheckpointTest, after_add_edge_property1) {
-  neug::NeugDB db;
-  this->OpenDB(db, this->db_dir_);
-  auto conn = db.Connect();
-  this->ExpectQuery(*conn, "ALTER TABLE knows ADD registration DATE;");
-
-  AssertKnowsWeightAndRegistration(
-      this->RunQuery(*conn,
-                     "MATCH (v:person)-[e:knows]->(:person) RETURN e.*;"),
-      {0.5, 1.0}, {0, 0});
-
-  db.Close();
-  this->OpenDB(db, this->db_dir_);
-  conn = db.Connect();
-
-  AssertPersonVertexBasic(
-      this->RunQuery(*conn, "MATCH (v:person) RETURN v.*;"));
-  AssertKnowsWeightAndRegistration(
-      this->RunQuery(*conn,
-                     "MATCH (v:person)-[e:knows]->(:person) RETURN e.*;"),
-      {0.5, 1.0}, {0, 0});
-}
-
-TYPED_TEST(CheckpointTest, after_add_edge_property2) {
-  neug::NeugDB db;
-  this->OpenDB(db, this->db_dir_);
-  auto conn = db.Connect();
-
-  AssertPersonVertexBasic(
-      this->RunQuery(*conn, "MATCH (v:person) RETURN v.*;"));
-  this->ExpectQuery(*conn, "ALTER TABLE knows ADD description STRING;");
-
-  db.Close();
-  this->OpenDB(db, this->db_dir_);
-  conn = db.Connect();
-
-  AssertKnowsWeightAndDescription(
-      this->RunQuery(*conn,
-                     "MATCH (v:person)-[e:knows]->(:person) RETURN e.*;"),
-      {0.5, 1.0}, {"", ""});
-
-  this->ExpectQuery(*conn, "ALTER TABLE knows ADD date DATE;");
-
-  db.Close();
-  this->OpenDB(db, this->db_dir_);
-  conn = db.Connect();
-
-  AssertPersonVertexBasic(
-      this->RunQuery(*conn, "MATCH (v:person) RETURN v.*;"));
-  AssertKnowsFullSchema(
-      this->RunQuery(*conn,
-                     "MATCH (v:person)-[e:knows]->(:person) RETURN e.*;"),
-      {0.5, 1.0}, {"", ""}, {0, 0});
-}
-
-TYPED_TEST(CheckpointTest, after_delete_edge_property) {
-  neug::NeugDB db;
-  this->OpenDB(db, this->db_dir_);
-  {
-    auto conn = db.Connect();
-    this->ExpectQuery(*conn, "ALTER TABLE knows DROP weight");
-  }
-
-  db.Close();
-  this->OpenDB(db, this->db_dir_);
-  auto conn = db.Connect();
-
-  AssertPersonVertexBasic(
-      this->RunQuery(*conn, "MATCH (v:person) RETURN v.*;"));
-  AssertMapColumn(
-      this->RunQuery(*conn, "MATCH (v:person)-[e:knows]->(:person) RETURN e;"),
-      2);
-}
-
-TYPED_TEST(CheckpointTest, after_delete_edge) {
-  neug::NeugDB db;
-  this->OpenDB(db, this->db_dir_);
-  {
-    auto conn = db.Connect();
-    this->ExpectQuery(
-        *conn,
-        "MATCH (v:person)-[e:knows]->(:person) WHERE v.id = 1 DELETE e;");
-  }
-
-  db.Close();
-  this->OpenDB(db, this->db_dir_);
-  auto conn = db.Connect();
-
-  AssertPersonVertexBasic(
-      this->RunQuery(*conn, "MATCH (v:person) RETURN v.*;"));
-  AssertKnowsWeight(
-      this->RunQuery(*conn,
-                     "MATCH (:person)-[e:knows]->(v:person) RETURN e.*;"),
-      {});
-}
-
-TYPED_TEST(CheckpointTest, compact) {
-  std::string db_path = this->MakeUniqueDir("compact");
-
-  {
-    neug::NeugDB db;
-    this->OpenDB(db, db_path);
-    auto conn = db.Connect();
-    load_modern_graph(conn);
-    conn->Close();
-    auto svc = std::make_shared<neug::NeugDBService>(db);
-    {
-      // The execution-slot lease must be released before the service (and its
-      // TpExecutionSlotPool) is destroyed.
-      auto slot = svc->AcquireExecutionSlot();
-      slot->GetCompactTransaction().Commit();
-    }
-    svc.reset();
-    db.Close();
-  }
-
-  neug::NeugDB db2;
-  this->OpenDB(db2, db_path);
-  auto conn2 = db2.Connect();
-
-  AssertSingleInt64Result(
-      this->RunQuery(*conn2, "MATCH (v:person) RETURN COUNT(v);"), 4);
-  this->ExpectQuery(*conn2, "MATCH (v:person) WHERE v.id <= 2 DELETE v;");
-  conn2->Close();
-
-  auto svc = std::make_shared<neug::NeugDBService>(db2);
-  svc->AcquireExecutionSlot()->GetCompactTransaction().Commit();
-  svc.reset();
-
-  conn2 = db2.Connect();
-  AssertSingleInt64Result(
-      this->RunQuery(*conn2, "MATCH (v:person) RETURN COUNT(v);"), 2);
-  AssertSingleInt64Result(
-      this->RunQuery(*conn2,
-                     "MATCH (v:person)-[e:knows]->(:person) RETURN count(e);"),
-      0);
-
-  conn2->Close();
-  db2.Close();
-  this->CleanDir(db_path);
-}
-
-TYPED_TEST(CheckpointTest, recover_from_checkpoint) {
-  neug::NeugDB db;
-  this->OpenDB(db, this->db_dir_);
-  auto conn = db.Connect();
-
-  AssertSingleInt64Result(
-      this->RunQuery(*conn, "MATCH (v:person) RETURN COUNT(v);"), 4);
-  AssertSingleInt64Result(
-      this->RunQuery(*conn, "MATCH (v)-[e]->(a) RETURN COUNT(e);"), 6);
-  AssertCreatedEdgesSnapshotResult(
-      this->RunQuery(*conn,
-                     "MATCH (v:person)-[e:created]->(f:software) return v.id, "
-                     "e.since, f.id;"),
-      {1, 4, 4, 6}, {2020, 2022, 2021, 2023}, {3, 3, 5, 3});
-
-  this->ExpectQuery(*conn, "MATCH (v:person) WHERE v.id = 1 DELETE v;");
-  this->ExpectQuery(
-      *conn,
-      "MATCH (v:person)-[e:created]->(f:software) WHERE v.id > 4 DELETE e;");
-  conn->Close();
-  db.Close();
-
-  neug::NeugDB db2;
-  this->OpenDB(db2, this->db_dir_);
-  auto conn2 = db2.Connect();
-  AssertSingleInt64Result(
-      this->RunQuery(*conn2, "MATCH (v:person) RETURN COUNT(v);"), 3);
-  AssertSingleInt64Result(
-      this->RunQuery(*conn2, "MATCH (v)-[e]->(a) RETURN COUNT(e);"), 2);
-}
-
-// ---------------------------------------------------------------------------
-// Optimization tests: verify hardlink-based fast path for unchanged dumps.
-// ---------------------------------------------------------------------------
-
-// Helper: return sorted list of checkpoint-NNNNN subdirectories under db_dir.
-static std::vector<std::filesystem::path> list_checkpoint_dirs(
-    const std::string& db_dir) {
-  std::vector<std::filesystem::path> dirs;
-  for (const auto& entry : std::filesystem::directory_iterator(db_dir)) {
-    auto name = entry.path().filename().string();
-    if (entry.is_directory() && name.rfind("checkpoint-", 0) == 0 &&
-        name.find(".next") == std::string::npos) {
-      dirs.push_back(entry.path());
-    }
-  }
-  std::sort(dirs.begin(), dirs.end());
-  return dirs;
-}
-
-static std::filesystem::path create_published_checkpoint_blocker(
-    const std::string& db_dir, int32_t generation) {
-  const auto blocker = std::filesystem::path(db_dir) /
-                       ("checkpoint-" + std::to_string(generation));
-  std::filesystem::create_directories(blocker);
-  std::ofstream(blocker / "blocker") << "not a checkpoint";
-  return blocker;
-}
-
-static size_t count_regular_files(const std::string& dir) {
-  size_t n = 0;
-  for (const auto& e : std::filesystem::directory_iterator(dir)) {
-    if (e.is_regular_file())
-      ++n;
-  }
-  return n;
-}
-
-static size_t count_valid_checkpoint_dirs(const std::string& db_dir) {
-  size_t n = 0;
-  for (const auto& checkpoint_dir : list_checkpoint_dirs(db_dir)) {
-    neug::CheckpointManifest meta;
-    meta.Load((checkpoint_dir / "meta").string());
-    if (meta.has_schema()) {
-      ++n;
-    }
-  }
-  return n;
-}
-
-static std::string make_checkpoint_gc_test_dir(const std::string& prefix) {
-  const auto* test_info =
-      ::testing::UnitTest::GetInstance()->current_test_info();
-  auto dir =
-      std::filesystem::temp_directory_path() /
-      (prefix + "_" + test_info->test_suite_name() + "_" + test_info->name());
+std::string TestDir(const std::string& name) {
+  const auto dir =
+      std::filesystem::temp_directory_path() / ("neug_checkpoint_883_" + name);
   std::error_code ec;
   std::filesystem::remove_all(dir, ec);
   std::filesystem::create_directories(dir);
   return dir.string();
 }
 
-static void write_valid_empty_manifest(std::shared_ptr<neug::Checkpoint> ckp) {
-  neug::CheckpointManifest meta;
-  neug::Schema schema;
-  meta.SetSchema(schema);
-  ckp->UpdateMeta(std::move(meta));
-}
-
-static void create_valid_checkpoint(neug::CheckpointManager& mgr) {
-  auto staging = mgr.CreateStagingCheckpoint();
-  write_valid_empty_manifest(staging.checkpoint());
-  staging.Commit();
-}
-
-static bool has_staging_checkpoint_dirs(const std::string& db_path) {
-  for (const auto& entry : std::filesystem::directory_iterator(db_path)) {
-    auto name = entry.path().filename().string();
-    if (entry.is_directory() && name.rfind("checkpoint-", 0) == 0 &&
-        name.ends_with(".next")) {
-      return true;
-    }
+void WriteManifest(neug::Checkpoint& checkpoint,
+                   const std::string& object_path = {}) {
+  neug::CheckpointManifest manifest;
+  manifest.SetSchema(neug::Schema());
+  if (!object_path.empty()) {
+    neug::ModuleDescriptor descriptor;
+    descriptor.module_type = "test-object";
+    descriptor.set_path(neug::ModuleDescriptor::kDataPath, object_path);
+    manifest.SetModule("test-object", std::move(descriptor));
   }
-  return false;
+  checkpoint.SetManifest(std::move(manifest));
 }
 
-static void AssertSingleCurrentCheckpoint(const std::string& db_path) {
-  auto dirs = list_checkpoint_dirs(db_path);
-  ASSERT_EQ(dirs.size(), 1u);
-  EXPECT_FALSE(has_staging_checkpoint_dirs(db_path));
-}
-
-static std::string read_raw_file(const std::string& path) {
-  std::ifstream input(path, std::ios::binary);
-  EXPECT_TRUE(input.is_open()) << path;
-  return std::string(std::istreambuf_iterator<char>(input),
-                     std::istreambuf_iterator<char>());
-}
-
-static std::string read_container_payload_prefix(const std::string& path,
-                                                 size_t size) {
-  std::ifstream input(path, std::ios::binary);
-  EXPECT_TRUE(input.is_open()) << path;
-  input.seekg(sizeof(neug::FileHeader), std::ios::beg);
-  std::string payload(size, '\0');
-  input.read(payload.data(), static_cast<std::streamsize>(size));
-  EXPECT_EQ(input.gcount(), static_cast<std::streamsize>(size));
-  return payload;
-}
-
-static void write_raw_file(const std::string& path, std::string_view payload) {
-  std::ofstream output(path, std::ios::binary);
-  ASSERT_TRUE(output.is_open()) << path;
-  output.write(payload.data(), static_cast<std::streamsize>(payload.size()));
-  ASSERT_TRUE(output.good()) << path;
-}
-
-static void write_container_payload(neug::IDataContainer& container,
-                                    std::string_view payload) {
-  ASSERT_GE(container.GetDataSize(), payload.size());
-  std::memcpy(container.GetData(), payload.data(), payload.size());
-}
-
-static std::vector<std::filesystem::path> list_regular_files_in_dir(
-    const std::filesystem::path& dir) {
-  std::vector<std::filesystem::path> files;
-  for (const auto& entry : std::filesystem::directory_iterator(dir)) {
-    if (entry.is_regular_file()) {
-      files.push_back(entry.path());
-    }
+std::shared_ptr<neug::Checkpoint> PublishCheckpoint(
+    neug::CheckpointManager& manager, const std::string& object_payload = {}) {
+  auto staging = manager.CreateStaging();
+  std::string object_path;
+  if (!object_payload.empty()) {
+    auto runtime_file = staging.checkpoint()->CreateRuntimeFile();
+    std::ofstream output(runtime_file.path(), std::ios::binary);
+    EXPECT_TRUE(output.is_open());
+    output << object_payload;
+    EXPECT_TRUE(output.good());
+    output.close();
+    object_path =
+        staging.checkpoint()->CommitRuntimeFile(std::move(runtime_file));
   }
-  std::sort(files.begin(), files.end());
-  return files;
+  WriteManifest(*staging.checkpoint(), object_path);
+  return staging.Publish();
 }
 
-static bool is_equivalent_to_any(
-    const std::filesystem::path& path,
-    const std::vector<std::filesystem::path>& candidates) {
-  for (const auto& candidate : candidates) {
-    std::error_code ec;
-    if (std::filesystem::equivalent(path, candidate, ec) && !ec) {
-      return true;
-    }
-  }
-  return false;
+void InsertThroughService(neug::NeugDBService& service, int64_t id) {
+  auto slot = service.AcquireExecutionSlot();
+  auto transaction = slot->GetInsertTransaction();
+  neug::StorageTPInsertInterface storage(transaction);
+  const auto label = transaction.schema().get_vertex_label_id("Item");
+  neug::vid_t vid = 0;
+  ASSERT_TRUE(storage.AddVertex(label, neug::Value::INT64(id), {}, vid));
+  ASSERT_TRUE(transaction.Commit());
 }
 
-static size_t count_mutable_csr_edges(const neug::MutableCsr<int32_t>& csr,
-                                      size_t vertex_count) {
-  size_t edge_count = 0;
-  auto view = csr.get_generic_view(0);
-  for (neug::vid_t src = 0; src < static_cast<neug::vid_t>(vertex_count);
-       ++src) {
-    auto edges = view.get_edges(src);
-    for (auto it = edges.begin(); it != edges.end(); ++it) {
-      ++edge_count;
-    }
-  }
-  return edge_count;
+void CheckpointThroughService(neug::NeugDBService& service) {
+  auto slot = service.AcquireExecutionSlot();
+  auto result = slot->ExecuteTransactionalRequest(
+      neug::RequestSerializer::SerializeRequest("CHECKPOINT;", "update", {}));
+  ASSERT_TRUE(result) << result.error().ToString();
 }
 
-static void open_db_for_checkpoint_test(neug::NeugDB& db,
-                                        const std::string& db_path) {
-  neug::NeugDBConfig config(db_path);
-  config.checkpoint_on_close = true;
-  db.Open(config);
-}
-
-static void seed_checkpoint_opt_graph(std::shared_ptr<neug::Connection> conn) {
-  auto res = conn->Query("CREATE NODE TABLE Item(id INT64, PRIMARY KEY(id));");
-  ASSERT_TRUE(res) << res.error().ToString();
-  res = conn->Query("CREATE (:Item {id: 1});");
-  ASSERT_TRUE(res) << res.error().ToString();
-  res = conn->Query("CREATE (:Item {id: 2});");
-  ASSERT_TRUE(res) << res.error().ToString();
-}
-
-static void assert_checkpoint_opt_graph(neug::NeugDB& db,
-                                        const std::string& db_path) {
-  open_db_for_checkpoint_test(db, db_path);
-  auto conn = db.Connect();
-  auto res = conn->Query("MATCH (v:Item) RETURN COUNT(v);");
-  ASSERT_TRUE(res) << res.error().ToString();
-  AssertSingleInt64Result(res.value().response(), 2);
-  conn->Close();
-  db.Close();
-}
-
-TEST(CheckpointGCTest, commit_staging_checkpoint_publishes_next_generation) {
-  auto db_path = make_checkpoint_gc_test_dir("checkpoint_gc");
-  neug::CheckpointManager mgr;
-  mgr.Open(db_path);
-
-  create_valid_checkpoint(mgr);
-  ASSERT_NE(mgr.CurrentCheckpoint(), nullptr);
-  ASSERT_EQ(mgr.CurrentCheckpoint()->id(), 0);
-
-  auto staging = mgr.CreateStagingCheckpoint();
-  write_valid_empty_manifest(staging.checkpoint());
-  std::string previous_checkpoint_path;
-  auto new_ckp = staging.Commit(&previous_checkpoint_path);
-
-  EXPECT_TRUE(mgr.HasCurrentCheckpoint());
-  EXPECT_EQ(mgr.CurrentCheckpoint(), new_ckp);
-  EXPECT_EQ(new_ckp->id(), 1);
-  EXPECT_EQ(previous_checkpoint_path, db_path + "/checkpoint-0");
-  EXPECT_TRUE(std::filesystem::exists(db_path + "/checkpoint-0"));
-  EXPECT_TRUE(std::filesystem::exists(db_path + "/checkpoint-1"));
-}
-
-TEST(CheckpointGCTest, staging_checkpoint_handle_discards_on_scope_exit) {
-  auto db_path = make_checkpoint_gc_test_dir("checkpoint_gc");
-  neug::CheckpointManager mgr;
-  mgr.Open(db_path);
-
-  std::string staging_path;
-  {
-    auto staging = mgr.CreateStagingCheckpoint();
-    staging_path = staging.checkpoint()->path();
-    ASSERT_TRUE(std::filesystem::exists(staging_path));
-  }
-
-  EXPECT_FALSE(std::filesystem::exists(staging_path));
-  EXPECT_FALSE(has_staging_checkpoint_dirs(db_path));
-}
-
-TEST(CheckpointGCTest, committed_staging_handle_does_not_discard_checkpoint) {
-  auto db_path = make_checkpoint_gc_test_dir("checkpoint_gc");
-  neug::CheckpointManager mgr;
-  mgr.Open(db_path);
-
-  std::string published_path;
-  {
-    auto staging = mgr.CreateStagingCheckpoint();
-    write_valid_empty_manifest(staging.checkpoint());
-    auto published = staging.Commit();
-    published_path = published->path();
-  }
-
-  EXPECT_TRUE(std::filesystem::exists(published_path));
-  EXPECT_FALSE(has_staging_checkpoint_dirs(db_path));
-}
-
-TEST(CheckpointGCTest, create_staging_checkpoint_rejects_active_staging) {
-  auto db_path = make_checkpoint_gc_test_dir("checkpoint_gc");
-  neug::CheckpointManager mgr;
-  mgr.Open(db_path);
-
-  auto staging = mgr.CreateStagingCheckpoint();
-  EXPECT_THROW(mgr.CreateStagingCheckpoint(), std::exception);
-
-  staging.Discard();
-}
-
-TEST(CheckpointGCTest, discard_staging_checkpoint_allows_new_staging) {
-  auto db_path = make_checkpoint_gc_test_dir("checkpoint_gc");
-  neug::CheckpointManager mgr;
-  mgr.Open(db_path);
-
-  auto staging = mgr.CreateStagingCheckpoint();
-  auto path = staging.checkpoint()->path();
-  staging.Discard();
-
-  EXPECT_FALSE(std::filesystem::exists(path));
-  EXPECT_FALSE(mgr.HasCurrentCheckpoint());
-  auto next_staging = mgr.CreateStagingCheckpoint();
-  EXPECT_EQ(next_staging.checkpoint()->path(), path);
-  next_staging.Discard();
-}
-
-TEST(CheckpointGCTest, commit_staging_checkpoint_rejects_missing_schema) {
-  auto db_path = make_checkpoint_gc_test_dir("checkpoint_gc");
-  neug::CheckpointManager mgr;
-  mgr.Open(db_path);
-
-  auto staging = mgr.CreateStagingCheckpoint();
-  EXPECT_THROW(staging.Commit(), std::exception);
-
-  staging.Discard();
-}
-
-TEST(CheckpointGCTest, commit_staging_checkpoint_rejects_inactive_handle) {
-  auto db_path = make_checkpoint_gc_test_dir("checkpoint_gc");
-  neug::CheckpointManager mgr;
-  mgr.Open(db_path);
-
-  auto staging = mgr.CreateStagingCheckpoint();
-  write_valid_empty_manifest(staging.checkpoint());
-  staging.Commit();
-
-  EXPECT_THROW(staging.Commit(), std::exception);
-  ASSERT_NE(mgr.CurrentCheckpoint(), nullptr);
-  EXPECT_EQ(mgr.CurrentCheckpoint()->id(), 0);
-}
-
-TEST(CheckpointGCTest, commit_open_failure_preserves_published_generation) {
-  auto db_path = make_checkpoint_gc_test_dir("checkpoint_gc");
-  neug::CheckpointManager mgr;
-  mgr.Open(db_path);
-
-  auto staging = mgr.CreateStagingCheckpoint();
-  write_valid_empty_manifest(staging.checkpoint());
-  const auto staging_path = std::filesystem::path(staging.checkpoint()->path());
-  const auto published_path = std::filesystem::path(db_path) / "checkpoint-0";
-
-  // Keep the cached manifest valid so commit reaches the durable rename, but
-  // make reopening the renamed checkpoint fail.
-  std::ofstream(staging_path / "meta", std::ios::trunc)
-      << "invalid checkpoint manifest";
-
-  EXPECT_THROW(staging.Commit(), std::exception);
-  EXPECT_FALSE(std::filesystem::exists(staging_path));
-  EXPECT_TRUE(std::filesystem::exists(published_path));
-  EXPECT_EQ(mgr.CurrentCheckpoint(), nullptr);
-
-  staging.Discard();
-}
-
-TEST(CheckpointGCTest, staging_and_session_cleanup_cover_failure_edges) {
-  auto db_path = make_checkpoint_gc_test_dir("checkpoint_gc");
-  std::string closed_staging_path;
-  {
-    neug::CheckpointManager mgr;
-    mgr.Open(db_path);
-    auto staging = mgr.CreateStagingCheckpoint();
-    closed_staging_path = staging.checkpoint()->path();
-    ASSERT_TRUE(std::filesystem::exists(closed_staging_path));
-    mgr.Close();
-    EXPECT_FALSE(std::filesystem::exists(closed_staging_path));
-  }
-  {
-    neug::CheckpointManager mgr;
-    mgr.Open(db_path);
-    auto staging = mgr.CreateStagingCheckpoint();
-    auto reopened_staging_path = staging.checkpoint()->path();
-    ASSERT_TRUE(std::filesystem::exists(reopened_staging_path));
-    mgr.Open(db_path);
-    EXPECT_FALSE(std::filesystem::exists(reopened_staging_path));
-    EXPECT_FALSE(has_staging_checkpoint_dirs(db_path));
-  }
-
-  neug::CheckpointManager mgr;
-  mgr.Open(db_path);
-  create_valid_checkpoint(mgr);
-  auto old_ckp = mgr.CurrentCheckpoint();
-  ASSERT_NE(old_ckp, nullptr);
-  auto old_path = old_ckp->path();
-
-  {
-    auto staging = mgr.CreateStagingCheckpoint();
-    auto staging_path = staging.checkpoint()->path();
-    write_valid_empty_manifest(staging.checkpoint());
-    auto collision = std::filesystem::path(db_path) / "checkpoint-1";
-    std::filesystem::create_directories(collision);
-
-    EXPECT_THROW(staging.Commit(), std::exception);
-    EXPECT_EQ(mgr.CurrentCheckpoint(), old_ckp);
-    EXPECT_TRUE(std::filesystem::exists(old_path));
-    EXPECT_TRUE(std::filesystem::exists(collision));
-
-    staging.Discard();
-    EXPECT_FALSE(std::filesystem::exists(staging_path));
-    std::filesystem::remove_all(collision);
-  }
-
-  auto staging = mgr.CreateStagingCheckpoint();
-  {
-    neug::CheckpointManifest meta;
-    neug::Schema schema;
-    meta.SetSchema(schema);
-    neug::ModuleDescriptor desc;
-    desc.module_type = "missing_module_type_for_checkpoint_gc_test";
-    meta.set_module("bad_module", std::move(desc));
-    staging.checkpoint()->UpdateMeta(std::move(meta));
-  }
-
-  auto published = staging.Commit();
-  auto published_path = published->path();
-  neug::PropertyGraph graph;
-  EXPECT_THROW(graph.Open(published, neug::MemoryLevel::kInMemory),
-               std::exception);
-
-  mgr.RestoreCurrentCheckpoint(old_ckp);
-  mgr.CleanupPublishedCheckpoint(published);
-
-  EXPECT_EQ(mgr.CurrentCheckpoint(), old_ckp);
-  EXPECT_TRUE(std::filesystem::exists(old_path));
-  EXPECT_FALSE(std::filesystem::exists(published_path));
-  EXPECT_FALSE(has_staging_checkpoint_dirs(db_path));
-}
-
-TEST(CheckpointGCTest, open_uses_highest_checkpoint_and_cleanup_is_explicit) {
-  auto db_path = make_checkpoint_gc_test_dir("checkpoint_gc");
-  for (int id = 0; id < 3; ++id) {
-    auto path =
-        std::filesystem::path(db_path) / ("checkpoint-" + std::to_string(id));
-    auto ckp = neug::Checkpoint::Open(path.string(), id);
-    write_valid_empty_manifest(ckp);
-  }
-
-  neug::CheckpointManager mgr;
-  mgr.Open(db_path);
-
-  EXPECT_TRUE(mgr.HasCurrentCheckpoint());
-  ASSERT_NE(mgr.CurrentCheckpoint(), nullptr);
-  EXPECT_EQ(mgr.CurrentCheckpoint()->id(), 2);
-  EXPECT_TRUE(std::filesystem::exists(db_path + "/checkpoint-0"));
-  EXPECT_TRUE(std::filesystem::exists(db_path + "/checkpoint-1"));
-  EXPECT_TRUE(std::filesystem::exists(db_path + "/checkpoint-2"));
-
-  mgr.CleanupRetiredCheckpoints();
-
-  EXPECT_FALSE(std::filesystem::exists(db_path + "/checkpoint-0"));
-  EXPECT_FALSE(std::filesystem::exists(db_path + "/checkpoint-1"));
-  EXPECT_TRUE(std::filesystem::exists(db_path + "/checkpoint-2"));
-}
-
-TEST(CheckpointGCTest, open_skips_highest_checkpoints_with_bad_manifest) {
-  auto db_path = make_checkpoint_gc_test_dir("checkpoint_gc");
-  {
-    neug::CheckpointManager mgr;
-    mgr.Open(db_path);
-    create_valid_checkpoint(mgr);
-    mgr.Close();
-  }
-
-  auto bad_path = std::filesystem::path(db_path) / "checkpoint-1";
-  auto bad_ckp = neug::Checkpoint::Open(bad_path.string(), 1);
-  {
-    neug::CheckpointManifest meta;
-    neug::Schema schema;
-    meta.SetSchema(schema);
-    neug::ModuleDescriptor desc;
-    desc.set_path(neug::ModuleDescriptor::kDataPath,
-                  (bad_path / "snapshot" / "missing-file").string());
-    meta.set_module("bad_module", std::move(desc));
-    bad_ckp->UpdateMeta(std::move(meta));
-  }
-  bad_ckp.reset();
-
-  auto unknown_module_path = std::filesystem::path(db_path) / "checkpoint-2";
-  auto unknown_module_ckp =
-      neug::Checkpoint::Open(unknown_module_path.string(), 2);
-  {
-    neug::CheckpointManifest meta;
-    neug::Schema schema;
-    meta.SetSchema(schema);
-    neug::ModuleDescriptor desc;
-    desc.module_type = "missing_module_type_for_checkpoint_gc_test";
-    meta.set_module("bad_module", std::move(desc));
-    unknown_module_ckp->UpdateMeta(std::move(meta));
-  }
-  unknown_module_ckp.reset();
-
-  neug::CheckpointManager read_only_mgr;
-  read_only_mgr.Open(db_path, false);
-
-  ASSERT_NE(read_only_mgr.CurrentCheckpoint(), nullptr);
-  EXPECT_EQ(read_only_mgr.CurrentCheckpoint()->id(), 0);
-  EXPECT_TRUE(std::filesystem::exists(db_path + "/checkpoint-0"));
-  EXPECT_TRUE(std::filesystem::exists(bad_path));
-  EXPECT_TRUE(std::filesystem::exists(unknown_module_path));
-  read_only_mgr.Close();
-
-  neug::CheckpointManager mgr;
-  mgr.Open(db_path);
-
-  ASSERT_NE(mgr.CurrentCheckpoint(), nullptr);
-  EXPECT_EQ(mgr.CurrentCheckpoint()->id(), 0);
-  EXPECT_TRUE(std::filesystem::exists(db_path + "/checkpoint-0"));
-  EXPECT_FALSE(std::filesystem::exists(bad_path));
-  EXPECT_FALSE(std::filesystem::exists(unknown_module_path));
-  EXPECT_FALSE(has_staging_checkpoint_dirs(db_path));
-}
-
-TEST(CheckpointGCTest, open_cleans_stale_staging_dirs) {
-  auto db_path = make_checkpoint_gc_test_dir("checkpoint_gc");
-  {
-    neug::CheckpointManager mgr;
-    mgr.Open(db_path);
-    create_valid_checkpoint(mgr);
-    mgr.Close();
-  }
-
-  auto staging = std::filesystem::path(db_path) / "checkpoint-999.next";
-  std::filesystem::create_directories(staging);
-  ASSERT_TRUE(std::filesystem::exists(staging));
-
-  neug::CheckpointManager read_only_mgr;
-  read_only_mgr.Open(db_path, false);
-
-  ASSERT_NE(read_only_mgr.CurrentCheckpoint(), nullptr);
-  EXPECT_EQ(read_only_mgr.CurrentCheckpoint()->id(), 0);
-  EXPECT_TRUE(std::filesystem::exists(staging));
-
-  neug::CheckpointManager mgr;
-  mgr.Open(db_path);
-
-  ASSERT_NE(mgr.CurrentCheckpoint(), nullptr);
-  EXPECT_EQ(mgr.CurrentCheckpoint()->id(), 0);
-  EXPECT_FALSE(std::filesystem::exists(staging));
-  EXPECT_TRUE(std::filesystem::exists(db_path + "/checkpoint-0"));
-}
-
-TEST(CheckpointGCTest, neugdb_readonly_open_does_not_recover_workspace) {
-  auto db_path = make_checkpoint_gc_test_dir("checkpoint_gc");
-  {
-    neug::CheckpointManager mgr;
-    mgr.Open(db_path);
-    create_valid_checkpoint(mgr);
-    mgr.Close();
-  }
-  const auto lock_path =
-      std::filesystem::path(db_path) / neug::FileLock::LOCK_FILE_NAME;
-  ASSERT_FALSE(std::filesystem::exists(lock_path));
-
-  auto bad_path = std::filesystem::path(db_path) / "checkpoint-1";
-  auto bad_ckp = neug::Checkpoint::Open(bad_path.string(), 1);
-  {
-    neug::CheckpointManifest meta;
-    neug::Schema schema;
-    meta.SetSchema(schema);
-    neug::ModuleDescriptor desc;
-    desc.module_type = "missing_module_type_for_checkpoint_gc_test";
-    meta.set_module("bad_module", std::move(desc));
-    bad_ckp->UpdateMeta(std::move(meta));
-  }
-  bad_ckp.reset();
-
-  auto staging = std::filesystem::path(db_path) / "checkpoint-999.next";
-  std::filesystem::create_directories(staging);
-
-  const auto orphan_runtime = std::filesystem::path(db_path) / "checkpoint-0" /
-                              "runtime" /
-                              "00000000-0000-0000-0000-000000000001";
-  write_raw_file(orphan_runtime.string(), "reader-owned-runtime");
-  const auto orphan_runtime_copy =
-      std::filesystem::path(orphan_runtime.string() + ".copy-123-0");
-  write_raw_file(orphan_runtime_copy.string(), "interrupted-copy");
-
-  neug::NeugDBConfig config(db_path);
-  config.mode = neug::DBMode::READ_ONLY;
+neug::NeugDBConfig Config(const std::string& data_dir) {
+  neug::NeugDBConfig config(data_dir, 1);
+  config.memory_level = neug::MemoryLevel::kInMemory;
   config.checkpoint_on_close = false;
-
-  neug::NeugDB db;
-  db.Open(config);
-  db.Close();
-
-  EXPECT_TRUE(std::filesystem::exists(lock_path));
-  EXPECT_TRUE(std::filesystem::exists(db_path + "/checkpoint-0"));
-  EXPECT_TRUE(std::filesystem::exists(bad_path));
-  EXPECT_TRUE(std::filesystem::exists(staging));
-  EXPECT_TRUE(std::filesystem::exists(orphan_runtime));
-  EXPECT_TRUE(std::filesystem::exists(orphan_runtime_copy));
-
-  // A writer holds the exclusive database lock, so it can safely recover
-  // runtime files left behind by readers that exited without RAII cleanup.
-  neug::NeugDB writer;
-  neug::NeugDBConfig write_config(db_path);
-  writer.Open(write_config);
-  writer.Close();
-  EXPECT_FALSE(std::filesystem::exists(orphan_runtime));
-  EXPECT_FALSE(std::filesystem::exists(orphan_runtime_copy));
+  config.checkpoint_on_recovery = false;
+  return config;
 }
 
-TEST(CheckpointGCTest,
-     manager_cleanup_removes_old_checkpoint_after_old_refs_release) {
-  auto db_path = make_checkpoint_gc_test_dir("checkpoint_gc");
-  neug::CheckpointManager mgr;
-  mgr.Open(db_path);
-  create_valid_checkpoint(mgr);
-
-  auto old_ckp = mgr.CurrentCheckpoint();
-  ASSERT_NE(old_ckp, nullptr);
-  auto old_path = old_ckp->path();
-  auto old_container =
-      old_ckp->CreateRuntimeContainer(32, neug::MemoryLevel::kSyncToFile);
-  auto old_runtime_path = old_container->GetPath();
-  ASSERT_TRUE(std::filesystem::exists(old_path));
-  ASSERT_TRUE(std::filesystem::exists(old_runtime_path));
-
-  auto staging = mgr.CreateStagingCheckpoint();
-  write_valid_empty_manifest(staging.checkpoint());
-  auto new_ckp = staging.Commit();
-
-  EXPECT_EQ(mgr.CurrentCheckpoint(), new_ckp);
-  EXPECT_TRUE(std::filesystem::exists(old_path));
-  EXPECT_TRUE(std::filesystem::exists(old_runtime_path));
-  EXPECT_TRUE(std::filesystem::exists(new_ckp->path()));
-
-  old_container.reset();
-  old_ckp.reset();
-  mgr.CleanupRetiredCheckpoints();
-  EXPECT_FALSE(std::filesystem::exists(old_path));
-  EXPECT_FALSE(std::filesystem::exists(old_runtime_path));
-  EXPECT_TRUE(std::filesystem::exists(new_ckp->path()));
+neug::NeugDBConfig CheckpointOnCloseConfig(const std::string& data_dir) {
+  auto config = Config(data_dir);
+  config.checkpoint_on_close = true;
+  return config;
 }
 
-TEST(CheckpointGCTest, neugdb_keeps_single_current_checkpoint) {
-  auto db_path = make_checkpoint_gc_test_dir("checkpoint_gc");
-  constexpr size_t kCheckpointRounds = 4;
-  for (size_t i = 0; i < kCheckpointRounds; ++i) {
-    neug::NeugDB db;
-    neug::NeugDBConfig config(db_path);
-    config.checkpoint_on_close = true;
-    db.Open(config);
-    auto conn = db.Connect();
-    auto res = conn->Query(
-        "CREATE NODE TABLE IF NOT EXISTS Item"
-        "(id INT64, PRIMARY KEY(id));");
-    ASSERT_TRUE(res) << res.error().ToString();
-    res = conn->Query("CREATE (:Item {id: " + std::to_string(i) + "});");
-    ASSERT_TRUE(res) << res.error().ToString();
-    conn->Close();
-    db.Close();
-  }
-
-  ASSERT_EQ(count_valid_checkpoint_dirs(db_path), 1u);
-
-  {
-    neug::NeugDB db;
-    neug::NeugDBConfig config(db_path);
-    config.checkpoint_on_close = false;
-
-    db.Open(config);
-    auto conn = db.Connect();
-    auto table = conn->Query("MATCH (v:Item) RETURN count(v);");
-    ASSERT_TRUE(table) << table.error().ToString();
-    AssertSingleInt64Result(table.value().response(), 4);
-    conn->Close();
-    db.Close();
-  }
+void RegisterExampleIndex() {
+  static const bool registered = [] {
+    return neug::ModuleFactory::instance().Register(
+        neug::kExampleIndexType,
+        [] { return std::make_unique<neug::ExampleIndex>(); });
+  }();
+  ASSERT_TRUE(registered);
 }
 
-TEST(CheckpointGCTest,
-     recovery_checkpoint_cleans_retired_checkpoint_after_replay) {
-  auto db_path = make_checkpoint_gc_test_dir("checkpoint_gc");
-  auto make_config = [&](bool checkpoint_on_close,
-                         bool checkpoint_on_recovery) {
-    neug::NeugDBConfig config(db_path);
-    config.checkpoint_on_close = checkpoint_on_close;
-    config.checkpoint_on_recovery = checkpoint_on_recovery;
-    return config;
-  };
-
-  {
-    neug::NeugDB db;
-    db.Open(make_config(true, false));
-    auto conn = db.Connect();
-    auto res = conn->Query(
-        "CREATE NODE TABLE IF NOT EXISTS Item"
-        "(id INT64, PRIMARY KEY(id));");
-    ASSERT_TRUE(res) << res.error().ToString();
-    res = conn->Query("CREATE (:Item {id: 1});");
-    ASSERT_TRUE(res) << res.error().ToString();
-    conn->Close();
-    db.Close();
-  }
-  ASSERT_EQ(count_valid_checkpoint_dirs(db_path), 1u);
-
-  {
-    neug::NeugDB db;
-    db.Open(make_config(false, false));
-    InsertItemThroughServiceWal(db, 2);
-    db.Close();
-  }
-  ASSERT_EQ(count_valid_checkpoint_dirs(db_path), 1u);
-
-  {
-    neug::NeugDB db;
-    db.Open(make_config(false, true));
-    auto conn = db.Connect();
-    auto table = conn->Query("MATCH (v:Item) RETURN count(v);");
-    ASSERT_TRUE(table) << table.error().ToString();
-    AssertSingleInt64Result(table.value().response(), 2);
-    conn->Close();
-    db.Close();
-  }
-
-  EXPECT_EQ(count_valid_checkpoint_dirs(db_path), 1u);
-  EXPECT_FALSE(has_staging_checkpoint_dirs(db_path));
+void CreateExampleAgeIndex(neug::NeugDB& db) {
+  neug::SnapshotGuard guard(db.graph_snapshot_store());
+  auto& graph = *guard.get().mutable_graph();
+  const auto label = graph.schema().get_vertex_label_id("Person");
+  const auto schema = graph.schema().get_vertex_schema(label);
+  const auto property_id = schema->get_property_index("age");
+  auto meta = std::make_unique<neug::IndexMeta>();
+  meta->name = "idx_person_age";
+  meta->type = "example";
+  meta->schema.label_id = label;
+  meta->schema.property_name = "age";
+  meta->schema.property_type = schema->property_types[property_id];
+  auto* column = graph.get_vertex_table(label).GetPropertyColumnBase("age");
+  auto created = graph.mutable_index_manager().CreateIndex(
+      std::move(meta), std::make_unique<neug::DefaultIndexIDAccessor>(), column,
+      graph.GetVertexSet(label));
+  ASSERT_TRUE(created) << created.error().ToString();
 }
 
-TEST(CheckpointFileManagerTest,
-     SyncToFileRuntimeCommitConsumesContainerAndMovesRuntime) {
-  auto db_path = make_checkpoint_gc_test_dir("checkpoint_file_manager");
-  auto snapshot_dir = std::filesystem::path(db_path) / "snapshot";
-  auto runtime_dir = std::filesystem::path(db_path) / "runtime";
-  std::filesystem::create_directories(snapshot_dir);
-  std::filesystem::create_directories(runtime_dir);
-  neug::CheckpointFileManager mgr(snapshot_dir.string(), runtime_dir.string());
+TEST(CheckpointFormatTest, RejectsLegacyCheckpointDirectoriesWithoutMutation) {
+  const auto db_dir = TestDir("legacy_rejected");
+  std::filesystem::create_directories(std::filesystem::path(db_dir) /
+                                      "checkpoint-7");
 
+  neug::CheckpointManager manager;
+  try {
+    manager.Open(db_dir);
+    FAIL() << "Expected legacy checkpoint directory to be rejected";
+  } catch (const neug::exception::NotSupportedException& e) {
+    EXPECT_NE(std::string(e.what()).find("does not read or migrate"),
+              std::string::npos);
+  }
+  EXPECT_FALSE(std::filesystem::exists(std::filesystem::path(db_dir) /
+                                       "checkpoint" / "CURRENT"));
+  EXPECT_TRUE(
+      std::filesystem::exists(std::filesystem::path(db_dir) / "checkpoint-7"));
+
+  std::filesystem::remove_all(db_dir);
+}
+
+TEST(CheckpointFormatTest, RuntimeWorkspaceFollowsLastRuntimeResource) {
+  const auto db_dir = TestDir("runtime_workspace_lifetime");
+  neug::CheckpointManager manager;
+  manager.Open(db_dir);
+
+  auto checkpoint = PublishCheckpoint(manager);
+  const auto runtime_dir = checkpoint->runtime_dir();
   auto container =
-      mgr.CreateRuntimeContainer(64, neug::MemoryLevel::kSyncToFile);
-  auto runtime_path = container->GetPath();
-  ASSERT_TRUE(std::filesystem::exists(runtime_path));
+      checkpoint->CreateRuntimeContainer(64, neug::MemoryLevel::kSyncToFile);
+  ASSERT_NE(container, nullptr);
+  const auto runtime_file = container->GetPath();
+  ASSERT_TRUE(std::filesystem::exists(runtime_file));
 
-  constexpr std::string_view kSnapshotPayload = "snapshot-payload-v1";
-  write_container_payload(*container, kSnapshotPayload);
+  manager.Close();
+  checkpoint.reset();
+  EXPECT_TRUE(std::filesystem::exists(runtime_dir));
+  EXPECT_TRUE(std::filesystem::exists(runtime_file));
 
-  auto snapshot_path = mgr.Commit(*container);
-  ASSERT_TRUE(std::filesystem::exists(snapshot_path));
-  EXPECT_NE(snapshot_path, runtime_path);
-  EXPECT_EQ(
-      read_container_payload_prefix(snapshot_path, kSnapshotPayload.size()),
-      std::string(kSnapshotPayload));
-
-  EXPECT_TRUE(container->GetPath().empty());
-  EXPECT_EQ(container->GetData(), nullptr);
-  EXPECT_EQ(container->GetDataSize(), 0u);
-  EXPECT_FALSE(std::filesystem::exists(runtime_path));
-  EXPECT_TRUE(std::filesystem::exists(snapshot_path));
+  container.reset();
+  EXPECT_FALSE(std::filesystem::exists(runtime_dir));
+  std::filesystem::remove_all(db_dir);
 }
 
-TEST(CheckpointFileManagerTest,
-     CleanSyncToFileOpenFileCommitConsumesRuntimeCopy) {
-  auto db_path = make_checkpoint_gc_test_dir("checkpoint_file_manager");
-  auto snapshot_dir = std::filesystem::path(db_path) / "snapshot";
-  auto runtime_dir = std::filesystem::path(db_path) / "runtime";
-  std::filesystem::create_directories(snapshot_dir);
-  std::filesystem::create_directories(runtime_dir);
-  neug::CheckpointFileManager mgr(snapshot_dir.string(), runtime_dir.string());
+TEST(CheckpointFormatTest, PublishedOpenDoesNotRecreateMissingObjectStore) {
+  const auto db_dir = TestDir("strict_published_open");
+  neug::CheckpointManager manager;
+  manager.Open(db_dir);
+  auto checkpoint = PublishCheckpoint(manager);
+  checkpoint.reset();
+  manager.Close();
 
-  constexpr std::string_view kSnapshotPayload = "clean-snapshot-v1";
-  auto source = mgr.CreateRuntimeContainer(64, neug::MemoryLevel::kSyncToFile);
-  write_container_payload(*source, kSnapshotPayload);
-  auto source_snapshot = mgr.Commit(*source);
-  source.reset();
+  const auto object_dir =
+      std::filesystem::path(db_dir) / "checkpoint" / "objects";
+  std::filesystem::remove_all(object_dir);
+  neug::CheckpointManager reopened;
+  EXPECT_THROW(reopened.Open(db_dir), std::exception);
+  EXPECT_FALSE(std::filesystem::exists(object_dir));
 
-  auto container =
-      mgr.OpenFile(source_snapshot, neug::MemoryLevel::kSyncToFile);
-  auto runtime_path = container->GetPath();
-  ASSERT_TRUE(std::filesystem::exists(runtime_path));
-  EXPECT_FALSE(container->IsDirty());
-
-  auto committed_snapshot = mgr.Commit(*container);
-  ASSERT_TRUE(std::filesystem::exists(committed_snapshot));
-  EXPECT_NE(committed_snapshot, runtime_path);
-  EXPECT_EQ(read_container_payload_prefix(committed_snapshot,
-                                          kSnapshotPayload.size()),
-            std::string(kSnapshotPayload));
-  EXPECT_EQ(
-      read_container_payload_prefix(source_snapshot, kSnapshotPayload.size()),
-      std::string(kSnapshotPayload));
-
-  EXPECT_TRUE(container->GetPath().empty());
-  EXPECT_EQ(container->GetData(), nullptr);
-  EXPECT_EQ(container->GetDataSize(), 0u);
-  EXPECT_FALSE(std::filesystem::exists(runtime_path));
-  EXPECT_TRUE(std::filesystem::exists(committed_snapshot));
+  std::filesystem::remove_all(db_dir);
 }
 
-#ifndef _WIN32
-TEST(CheckpointFileManagerTest,
-     ConcurrentProcessesOpenSnapshotIntoDistinctRuntimeFiles) {
-  auto db_path = make_checkpoint_gc_test_dir("checkpoint_file_manager");
-  auto snapshot_dir = std::filesystem::path(db_path) / "snapshot";
-  auto runtime_dir = std::filesystem::path(db_path) / "runtime";
-  std::filesystem::create_directories(snapshot_dir);
-  std::filesystem::create_directories(runtime_dir);
+TEST(CheckpointFormatTest, StagingHandleOwnsTheSingleActiveStagingCheckpoint) {
+  const auto db_dir = TestDir("staging_lifecycle");
+  neug::CheckpointManager manager;
+  manager.Open(db_dir);
 
-  std::string source_snapshot;
   {
-    neug::CheckpointFileManager mgr(snapshot_dir.string(),
-                                    runtime_dir.string());
-    auto source =
-        mgr.CreateRuntimeContainer(64, neug::MemoryLevel::kSyncToFile);
-    write_container_payload(*source, "concurrent-open");
-    source_snapshot = mgr.Commit(*source);
+    auto staging = manager.CreateStaging();
+    EXPECT_THROW(manager.CreateStaging(), std::exception);
   }
 
-  int start_pipe[2];
-  int release_pipe[2];
-  int first_result_pipe[2];
-  int second_result_pipe[2];
-  ASSERT_EQ(::pipe(start_pipe), 0);
-  ASSERT_EQ(::pipe(release_pipe), 0);
-  ASSERT_EQ(::pipe(first_result_pipe), 0);
-  ASSERT_EQ(::pipe(second_result_pipe), 0);
+  auto replacement = manager.CreateStaging();
+  WriteManifest(*replacement.checkpoint());
+  auto published = replacement.Publish();
+  ASSERT_NE(published, nullptr);
+  EXPECT_EQ(published->id(), 0u);
+  EXPECT_THROW(replacement.checkpoint(), std::exception);
+  EXPECT_THROW(replacement.Publish(), std::exception);
 
-  const auto spawn_reader = [&](int result_pipe[2]) {
-    const pid_t pid = ::fork();
-    if (pid != 0) {
-      ::close(result_pipe[1]);
-      return pid;
-    }
-
-    ::close(start_pipe[1]);
-    ::close(release_pipe[1]);
-    ::close(result_pipe[0]);
-    char signal = 0;
-    if (::read(start_pipe[0], &signal, 1) != 1) {
-      ::_exit(1);
-    }
-
-    std::string runtime_path;
-    std::shared_ptr<neug::IDataContainer> container;
-    try {
-      neug::CheckpointFileManager mgr(snapshot_dir.string(),
-                                      runtime_dir.string());
-      container = mgr.OpenFile(source_snapshot, neug::MemoryLevel::kSyncToFile);
-      runtime_path = container->GetPath();
-    } catch (...) {}
-
-    const uint32_t path_size = static_cast<uint32_t>(runtime_path.size());
-    bool reported =
-        ::write(result_pipe[1], &path_size, sizeof(path_size)) ==
-            sizeof(path_size) &&
-        (path_size == 0 ||
-         ::write(result_pipe[1], runtime_path.data(), path_size) == path_size);
-    if (reported) {
-      (void) ::read(release_pipe[0], &signal, 1);
-    }
-    container.reset();
-    ::_exit(reported && path_size > 0 ? 0 : 1);
-  };
-
-  const pid_t first = spawn_reader(first_result_pipe);
-  ASSERT_GT(first, 0);
-  const pid_t second = spawn_reader(second_result_pipe);
-  ASSERT_GT(second, 0);
-  ::close(start_pipe[0]);
-  ::close(release_pipe[0]);
-  ASSERT_EQ(::write(start_pipe[1], "12", 2), 2);
-  ::close(start_pipe[1]);
-
-  const auto read_path = [](int fd) {
-    pollfd ready{fd, POLLIN, 0};
-    if (::poll(&ready, 1, 5000) != 1) {
-      return std::string{};
-    }
-    uint32_t path_size = 0;
-    if (::read(fd, &path_size, sizeof(path_size)) != sizeof(path_size) ||
-        path_size == 0) {
-      return std::string{};
-    }
-    std::string path(path_size, '\0');
-    size_t offset = 0;
-    while (offset < path.size()) {
-      auto bytes = ::read(fd, path.data() + offset, path.size() - offset);
-      if (bytes <= 0) {
-        return std::string{};
-      }
-      offset += static_cast<size_t>(bytes);
-    }
-    return path;
-  };
-
-  auto first_path = read_path(first_result_pipe[0]);
-  auto second_path = read_path(second_result_pipe[0]);
-  EXPECT_FALSE(first_path.empty());
-  EXPECT_FALSE(second_path.empty());
-  EXPECT_NE(first_path, second_path);
-  EXPECT_TRUE(std::filesystem::exists(first_path));
-  EXPECT_TRUE(std::filesystem::exists(second_path));
-
-  ASSERT_EQ(::write(release_pipe[1], "12", 2), 2);
-  ::close(release_pipe[1]);
-  ::close(first_result_pipe[0]);
-  ::close(second_result_pipe[0]);
-
-  int first_status = 0;
-  int second_status = 0;
-  ASSERT_EQ(::waitpid(first, &first_status, 0), first);
-  ASSERT_EQ(::waitpid(second, &second_status, 0), second);
-  EXPECT_TRUE(WIFEXITED(first_status));
-  EXPECT_EQ(WEXITSTATUS(first_status), 0);
-  EXPECT_TRUE(WIFEXITED(second_status));
-  EXPECT_EQ(WEXITSTATUS(second_status), 0);
-  EXPECT_FALSE(std::filesystem::exists(first_path));
-  EXPECT_FALSE(std::filesystem::exists(second_path));
+  manager.Close();
+  std::filesystem::remove_all(db_dir);
 }
-#endif
 
-TEST(CheckpointFileManagerTest,
-     ManualRuntimeFileHandleCommitAndAbandonCleanup) {
-  auto db_path = make_checkpoint_gc_test_dir("checkpoint_file_manager");
-  auto snapshot_dir = std::filesystem::path(db_path) / "snapshot";
-  auto runtime_dir = std::filesystem::path(db_path) / "runtime";
-  std::filesystem::create_directories(snapshot_dir);
-  std::filesystem::create_directories(runtime_dir);
-  neug::CheckpointFileManager mgr(snapshot_dir.string(), runtime_dir.string());
+TEST(CheckpointFormatTest, PublishRejectsManifestWithoutSchema) {
+  const auto db_dir = TestDir("missing_schema");
+  neug::CheckpointManager manager;
+  manager.Open(db_dir);
 
-  std::string abandoned_path;
-  {
-    auto file = mgr.CreateRuntimeFile();
-    abandoned_path = file.path();
-    ASSERT_TRUE(std::filesystem::exists(abandoned_path));
-    write_raw_file(abandoned_path, "abandoned");
-    ASSERT_TRUE(std::filesystem::exists(abandoned_path));
-  }
-  EXPECT_FALSE(std::filesystem::exists(abandoned_path));
+  auto staging = manager.CreateStaging();
+  EXPECT_THROW(staging.Publish(), std::exception);
+  EXPECT_EQ(manager.Current(), nullptr);
+  staging.Discard();
+
+  manager.Close();
+  std::filesystem::remove_all(db_dir);
+}
+
+TEST(CheckpointFormatTest, RuntimeFileHandleCleansUpAndMaterializesByCopy) {
+  const auto db_dir = TestDir("runtime_file_cleanup");
+  neug::CheckpointManager manager;
+  manager.Open(db_dir);
+  auto staging = manager.CreateStaging();
 
   std::string runtime_path;
-  std::string snapshot_path;
   {
-    auto file = mgr.CreateRuntimeFile();
-    runtime_path = file.path();
-    write_raw_file(runtime_path, "committed-runtime-file");
-    snapshot_path = mgr.CommitRuntimeFile(std::move(file));
-  }
-
-  EXPECT_FALSE(std::filesystem::exists(runtime_path));
-  ASSERT_TRUE(std::filesystem::exists(snapshot_path));
-  EXPECT_EQ(read_raw_file(snapshot_path), "committed-runtime-file");
-}
-
-TEST(CheckpointFileManagerTest,
-     LinkToSnapshotCopiesCurrentRuntimeAndHardlinksRetiredRuntime) {
-  auto db_path = make_checkpoint_gc_test_dir("checkpoint_file_manager");
-  auto old_checkpoint_dir = std::filesystem::path(db_path) / "checkpoint-0";
-  auto old_runtime_dir = old_checkpoint_dir / "runtime";
-  auto new_checkpoint_dir = std::filesystem::path(db_path) / "checkpoint-1";
-  auto new_snapshot_dir = new_checkpoint_dir / "snapshot";
-  auto new_runtime_dir = new_checkpoint_dir / "runtime";
-  std::filesystem::create_directories(old_runtime_dir);
-  std::filesystem::create_directories(new_snapshot_dir);
-  std::filesystem::create_directories(new_runtime_dir);
-  neug::CheckpointFileManager mgr(new_snapshot_dir.string(),
-                                  new_runtime_dir.string());
-
-  auto current_runtime_path = new_runtime_dir / "current-runtime-file";
-  write_raw_file(current_runtime_path.string(), "current-runtime-v1");
-  auto copied_snapshot = mgr.LinkToSnapshot(current_runtime_path.string());
-  ASSERT_TRUE(std::filesystem::exists(copied_snapshot));
-  std::error_code ec;
-  auto copied_from_current =
-      std::filesystem::equivalent(current_runtime_path, copied_snapshot, ec);
-  EXPECT_FALSE(ec);
-  EXPECT_FALSE(copied_from_current);
-  write_raw_file(current_runtime_path.string(), "current-runtime-v2");
-  EXPECT_EQ(read_raw_file(copied_snapshot), "current-runtime-v1");
-
-  // The caller contract for LinkToSnapshot() is that this runtime file belongs
-  // to a retired checkpoint and will never be written again.
-  auto old_runtime_path = old_runtime_dir / "old-runtime-file";
-  write_raw_file(old_runtime_path.string(), "previous-runtime-payload");
-
-  auto linked_snapshot = mgr.LinkToSnapshot(old_runtime_path.string());
-  ASSERT_TRUE(std::filesystem::exists(linked_snapshot));
-  EXPECT_TRUE(std::filesystem::equivalent(old_runtime_path, linked_snapshot));
-  EXPECT_EQ(read_raw_file(linked_snapshot), "previous-runtime-payload");
-
-  std::filesystem::remove_all(old_checkpoint_dir);
-  ASSERT_TRUE(std::filesystem::exists(linked_snapshot));
-  EXPECT_EQ(read_raw_file(linked_snapshot), "previous-runtime-payload");
-}
-
-TEST(CheckpointFileManagerTest,
-     StringColumnFastPathHardlinksRetiredRuntimeFiles) {
-  auto db_path = make_checkpoint_gc_test_dir("checkpoint_file_manager");
-  auto old_ckp = neug::Checkpoint::Open(
-      (std::filesystem::path(db_path) / "checkpoint-0").string(), 0);
-  auto new_ckp = neug::Checkpoint::Open(
-      (std::filesystem::path(db_path) / "checkpoint-1").string(), 1);
-
-  neug::StringColumn original;
-  original.Open(*old_ckp, neug::ModuleDescriptor{},
-                neug::MemoryLevel::kSyncToFile);
-  original.resize(3);
-  original.set_value(0, "alpha");
-  original.set_value(1, "bravo");
-  original.set_value(2, "charlie");
-  neug::CheckpointManifest manifest;
-  original.Dump(*old_ckp, manifest, "test");
-  auto old_desc = *manifest.module("test");
-  original.Close();
-
-  neug::StringColumn clean;
-  clean.Open(*old_ckp, old_desc, neug::MemoryLevel::kSyncToFile);
-  ASSERT_TRUE(clean.is_data_unmodified());
-  auto retired_runtime_files =
-      list_regular_files_in_dir(old_ckp->runtime_dir());
-  ASSERT_GE(retired_runtime_files.size(), 2u);
-
-  neug::CheckpointManifest new_manifest;
-  clean.Dump(*new_ckp, new_manifest, "test");
-  auto new_desc = *new_manifest.module("test");
-  auto new_items = new_desc.get_path(neug::ModuleDescriptor::kItemsPath);
-  auto new_data = new_desc.get_path(neug::ModuleDescriptor::kDataPath);
-  ASSERT_TRUE(new_items.has_value());
-  ASSERT_TRUE(new_data.has_value());
-  EXPECT_TRUE(is_equivalent_to_any(*new_items, retired_runtime_files));
-  EXPECT_TRUE(is_equivalent_to_any(*new_data, retired_runtime_files));
-
-  std::filesystem::remove_all(old_ckp->path());
-  ASSERT_TRUE(std::filesystem::exists(*new_items));
-  ASSERT_TRUE(std::filesystem::exists(*new_data));
-
-  neug::StringColumn reopened;
-  reopened.Open(*new_ckp, new_desc, neug::MemoryLevel::kInMemory);
-  ASSERT_EQ(reopened.size(), 3u);
-  EXPECT_EQ(reopened.get_view(0), "alpha");
-  EXPECT_EQ(reopened.get_view(1), "bravo");
-  EXPECT_EQ(reopened.get_view(2), "charlie");
-}
-
-TEST(CheckpointFileManagerTest,
-     MutableCsrFastPathHardlinksRetiredNbrListRuntimeFile) {
-  auto db_path = make_checkpoint_gc_test_dir("checkpoint_file_manager");
-  auto old_ckp = neug::Checkpoint::Open(
-      (std::filesystem::path(db_path) / "checkpoint-0").string(), 0);
-  auto new_ckp = neug::Checkpoint::Open(
-      (std::filesystem::path(db_path) / "checkpoint-1").string(), 1);
-
-  neug::MutableCsr<int32_t> original;
-  original.Open(*old_ckp, neug::ModuleDescriptor{},
-                neug::MemoryLevel::kSyncToFile);
-  original.resize(4);
-  original.batch_put_edges({0, 1, 1}, {1, 2, 3}, {10, 20, 30}, 0);
-  neug::CheckpointManifest manifest;
-  original.Dump(*old_ckp, manifest, "test");
-  auto old_desc = *manifest.module("test");
-  original.Close();
-
-  neug::MutableCsr<int32_t> clean;
-  clean.Open(*old_ckp, old_desc, neug::MemoryLevel::kSyncToFile);
-  auto retired_runtime_files =
-      list_regular_files_in_dir(old_ckp->runtime_dir());
-  ASSERT_GE(retired_runtime_files.size(), 3u);
-
-  neug::CheckpointManifest new_manifest;
-  clean.Dump(*new_ckp, new_manifest, "test");
-  auto new_desc = *new_manifest.module("test");
-  auto new_nbr_list = new_desc.get_path(neug::ModuleDescriptor::kNbrListPath);
-  ASSERT_TRUE(new_nbr_list.has_value());
-  EXPECT_TRUE(is_equivalent_to_any(*new_nbr_list, retired_runtime_files));
-
-  std::filesystem::remove_all(old_ckp->path());
-  ASSERT_TRUE(std::filesystem::exists(*new_nbr_list));
-
-  neug::MutableCsr<int32_t> reopened;
-  reopened.Open(*new_ckp, new_desc, neug::MemoryLevel::kInMemory);
-  EXPECT_EQ(reopened.edge_num(), 3u);
-  EXPECT_EQ(count_mutable_csr_edges(reopened, 4), 3u);
-}
-
-TEST(CheckpointFileManagerTest,
-     RuntimeContainerOutlivesCheckpointUntilLastRef) {
-  auto db_path = make_checkpoint_gc_test_dir("checkpoint_file_manager");
-  auto checkpoint_path = std::filesystem::path(db_path) / "checkpoint-0";
-  std::shared_ptr<neug::IDataContainer> container;
-  std::string runtime_path;
-
-  {
-    auto checkpoint = neug::Checkpoint::Open(checkpoint_path.string(), 0);
-    container =
-        checkpoint->CreateRuntimeContainer(64, neug::MemoryLevel::kSyncToFile);
-    runtime_path = container->GetPath();
-    write_container_payload(*container, "runtime-survives-checkpoint");
+    auto runtime_file = staging.checkpoint()->CreateRuntimeFile();
+    runtime_path = runtime_file.path();
     ASSERT_TRUE(std::filesystem::exists(runtime_path));
   }
-
-  EXPECT_TRUE(std::filesystem::exists(runtime_path));
-  container->Close();
-  EXPECT_TRUE(container->GetPath().empty());
-  EXPECT_TRUE(std::filesystem::exists(runtime_path));
-  container.reset();
   EXPECT_FALSE(std::filesystem::exists(runtime_path));
-}
 
-TEST(CheckpointFileManagerTest, CheckpointCleansOrphanRuntimeAndSnapshotFiles) {
-  auto db_path = make_checkpoint_gc_test_dir("checkpoint_file_manager");
-  auto checkpoint_path = std::filesystem::path(db_path) / "checkpoint-0";
-  auto checkpoint = neug::Checkpoint::Open(checkpoint_path.string(), 0);
-
-  auto orphan_runtime = std::filesystem::path(checkpoint->runtime_dir()) /
-                        "00000000-0000-0000-0000-000000000001";
-  auto kept_runtime = std::filesystem::path(checkpoint->runtime_dir()) /
-                      "00000000-0000-0000-0000-000000000002";
-  auto orphan_snapshot = std::filesystem::path(checkpoint->snapshot_dir()) /
-                         "00000000-0000-0000-0000-000000000003";
-  auto kept_snapshot = std::filesystem::path(checkpoint->snapshot_dir()) /
-                       "00000000-0000-0000-0000-000000000004";
-  write_raw_file(orphan_runtime.string(), "orphan-runtime");
-  write_raw_file(kept_runtime.string(), "kept-runtime");
-  write_raw_file(orphan_snapshot.string(), "orphan-snapshot");
-  write_raw_file(kept_snapshot.string(), "kept-snapshot");
-
-  neug::CheckpointManifest meta;
-  neug::Schema schema;
-  meta.SetSchema(schema);
-  neug::ModuleDescriptor runtime_desc;
-  runtime_desc.set_path("runtime", kept_runtime.string());
-  meta.set_module("runtime_ref", std::move(runtime_desc));
-  neug::ModuleDescriptor snapshot_desc;
-  snapshot_desc.set_path("snapshot", kept_snapshot.string());
-  meta.set_module("snapshot_ref", std::move(snapshot_desc));
-  checkpoint->UpdateMeta(std::move(meta));
-
-  EXPECT_FALSE(std::filesystem::exists(orphan_snapshot));
-  EXPECT_TRUE(std::filesystem::exists(kept_snapshot));
-  checkpoint.reset();
-
-  auto reopened = neug::Checkpoint::Open(checkpoint_path.string(), 0);
-  ASSERT_NE(reopened, nullptr);
-  EXPECT_FALSE(std::filesystem::exists(orphan_runtime));
-  EXPECT_TRUE(std::filesystem::exists(kept_runtime));
-}
-
-// Verify that dumping an unchanged graph to a new checkpoint keeps the current
-// snapshot file inventory stable under the single-checkpoint layout.
-TEST(CheckpointOptTest, test_no_extra_files_on_unchanged_dump) {
-  std::string db_path = "/tmp/test_unchanged_dump_db";
-  if (std::filesystem::exists(db_path)) {
-    std::filesystem::remove_all(db_path);
-  }
-
-  // Step 1: create a small graph and produce the current checkpoint.
+  std::string materialized_path;
   {
-    neug::NeugDB db;
-    open_db_for_checkpoint_test(db, db_path);
-    auto conn = db.Connect();
-    seed_checkpoint_opt_graph(conn);
-    auto res = conn->Query("CHECKPOINT;");
-    ASSERT_TRUE(res) << res.error().ToString();
-    conn->Close();
-    db.Close();
-  }
-
-  auto dirs1 = list_checkpoint_dirs(db_path);
-  ASSERT_EQ(dirs1.size(), 1u);
-  std::string ckp1_snapshot = dirs1[0].string() + "/snapshot";
-  size_t ckp1_count = count_regular_files(ckp1_snapshot);
-  ASSERT_GT(ckp1_count, 0u);
-
-  // Step 2: reopen, zero changes, another CHECKPOINT.
-  {
-    neug::NeugDB db;
-    open_db_for_checkpoint_test(db, db_path);
-    auto conn = db.Connect();
-    auto res = conn->Query("CHECKPOINT;");
-    ASSERT_TRUE(res) << res.error().ToString();
-    conn->Close();
-    db.Close();
-  }
-
-  auto dirs2 = list_checkpoint_dirs(db_path);
-  ASSERT_EQ(dirs2.size(), 1u);
-  std::string ckp2_snapshot = dirs2[0].string() + "/snapshot";
-
-  size_t ckp2_count = count_regular_files(ckp2_snapshot);
-  EXPECT_EQ(ckp1_count, ckp2_count);
-
-  // Data round-trip correctness.
-  {
-    neug::NeugDB db;
-    assert_checkpoint_opt_graph(db, db_path);
-  }
-}
-
-TEST(
-    CheckpointOptTest,
-    manual_checkpoint_reopens_same_graph_advances_generation_and_preserves_data) {
-  auto db_path = make_checkpoint_gc_test_dir("checkpoint_in_place");
-  neug::NeugDB db;
-  neug::NeugDBConfig config(db_path);
-  config.checkpoint_on_close = false;
-  ASSERT_TRUE(db.Open(config));
-  auto conn = db.Connect();
-  seed_checkpoint_opt_graph(conn);
-
-  const auto* graph_before = &db.graph();
-  auto res = conn->Query("CHECKPOINT;");
-  ASSERT_TRUE(res) << res.error().ToString();
-  EXPECT_EQ(&db.graph(), graph_before);
-  AssertSingleCurrentCheckpoint(db_path);
-  EXPECT_EQ(list_checkpoint_dirs(db_path)[0].filename(), "checkpoint-1");
-
-  res = conn->Query("CHECKPOINT;");
-  ASSERT_TRUE(res) << res.error().ToString();
-  EXPECT_EQ(&db.graph(), graph_before);
-  AssertSingleCurrentCheckpoint(db_path);
-  EXPECT_EQ(list_checkpoint_dirs(db_path)[0].filename(), "checkpoint-2");
-
-  conn->Close();
-  db.Close();
-
-  neug::NeugDB reopened_db;
-  assert_checkpoint_opt_graph(reopened_db, db_path);
-}
-
-TEST(CheckpointOptTest,
-     sync_to_file_checkpoint_reopens_allocator_into_new_generation) {
-  auto db_path = make_checkpoint_gc_test_dir("allocator_reopen");
-  neug::NeugDBConfig config(db_path, 1);
-  config.memory_level = neug::MemoryLevel::kSyncToFile;
-  config.checkpoint_on_close = false;
-
-  {
-    neug::NeugDB db;
-    ASSERT_TRUE(db.Open(config));
-    auto conn = db.Connect();
-    seed_checkpoint_opt_graph(conn);
-    auto res = conn->Query("CREATE REL TABLE Links(FROM Item TO Item);");
-    ASSERT_TRUE(res) << res.error().ToString();
-    res = conn->Query(
-        "MATCH (a:Item), (b:Item) WHERE a.id=1 AND b.id=2 "
-        "CREATE (a)-[:Links]->(b);");
-    ASSERT_TRUE(res) << res.error().ToString();
-
-    auto dirs = list_checkpoint_dirs(db_path);
-    ASSERT_EQ(dirs.size(), 1u);
-    EXPECT_GT(count_regular_files((dirs[0] / "allocator").string()), 0u);
-
-    res = conn->Query("CHECKPOINT;");
-    ASSERT_TRUE(res) << res.error().ToString();
-    AssertSingleCurrentCheckpoint(db_path);
-    dirs = list_checkpoint_dirs(db_path);
-    ASSERT_EQ(dirs[0].filename(), "checkpoint-1");
-
-    res = conn->Query("CREATE (:Item {id: 3});");
-    ASSERT_TRUE(res) << res.error().ToString();
-    res = conn->Query(
-        "MATCH (a:Item), (b:Item) WHERE a.id=3 AND b.id=1 "
-        "CREATE (a)-[:Links]->(b);");
-    ASSERT_TRUE(res) << res.error().ToString();
-    EXPECT_GT(count_regular_files((dirs[0] / "allocator").string()), 0u);
-
-    res = conn->Query("CHECKPOINT;");
-    ASSERT_TRUE(res) << res.error().ToString();
-    AssertSingleCurrentCheckpoint(db_path);
-    dirs = list_checkpoint_dirs(db_path);
-    ASSERT_EQ(dirs[0].filename(), "checkpoint-2");
-
-    conn->Close();
-    db.Close();
-  }
-
-  {
-    neug::NeugDB db;
-    ASSERT_TRUE(db.Open(config));
-    auto conn = db.Connect();
-    auto res = conn->Query("MATCH (:Item)-[e:Links]->(:Item) RETURN COUNT(e);");
-    ASSERT_TRUE(res) << res.error().ToString();
-    AssertSingleInt64Result(res.value().response(), 2);
-    conn->Close();
-    db.Close();
-  }
-}
-
-TEST(CheckpointOptTest, tp_checkpoint_routes_through_execution_slot) {
-  const auto db_path = make_checkpoint_gc_test_dir("tp_checkpoint_execution");
-  neug::NeugDBConfig config(db_path, 1);
-  config.checkpoint_on_close = false;
-
-  neug::NeugDB db;
-  ASSERT_TRUE(db.Open(config));
-  auto conn = db.Connect();
-  seed_checkpoint_opt_graph(conn);
-  conn->Close();
-
-  const auto* graph_before = &db.graph();
-  {
-    neug::NeugDBService service(db);
+    auto runtime_file = staging.checkpoint()->CreateRuntimeFile();
+    runtime_path = runtime_file.path();
     {
-      auto slot = service.AcquireExecutionSlot();
-      auto result = slot->ExecuteTransactionalRequest(
-          R"({"query":"EXPLAIN CHECKPOINT;","parameters":{}})");
-      ASSERT_TRUE(result) << result.error().ToString();
+      std::ofstream output(runtime_path, std::ios::binary);
+      ASSERT_TRUE(output.is_open());
+      output << "runtime-object";
     }
-    EXPECT_EQ(&db.graph(), graph_before);
-    AssertSingleCurrentCheckpoint(db_path);
-    EXPECT_EQ(list_checkpoint_dirs(db_path)[0].filename(), "checkpoint-0");
-
-    {
-      auto slot = service.AcquireExecutionSlot();
-      auto result = slot->ExecuteTransactionalRequest(
-          R"({"query":"CHECKPOINT;","parameters":{}})");
-      ASSERT_TRUE(result) << result.error().ToString();
-    }
-    EXPECT_EQ(&db.graph(), graph_before);
-    AssertSingleCurrentCheckpoint(db_path);
-    EXPECT_EQ(list_checkpoint_dirs(db_path)[0].filename(), "checkpoint-1");
-
-    {
-      auto slot = service.AcquireExecutionSlot();
-      auto result = slot->ExecuteTransactionalRequest(
-          R"({"query":"PROFILE CHECKPOINT;","access_mode":"u","parameters":{}})");
-      ASSERT_TRUE(result) << result.error().ToString();
-      neug::QueryResponse response;
-      ASSERT_TRUE(response.ParseFromString(result.value()));
-      EXPECT_EQ(response.row_count(), 0);
-      ASSERT_TRUE(response.has_profile_result());
-      ASSERT_EQ(response.profile_result().operators_size(), 1);
-      EXPECT_EQ(response.profile_result().operators(0).operator_name(),
-                "Checkpoint");
-    }
-    EXPECT_EQ(&db.graph(), graph_before);
-    AssertSingleCurrentCheckpoint(db_path);
-    EXPECT_EQ(list_checkpoint_dirs(db_path)[0].filename(), "checkpoint-2");
-
-    for (const auto* invalid_mode : {"read", "insert", "schema"}) {
-      auto slot = service.AcquireExecutionSlot();
-      const auto request =
-          std::string(R"({"query":"CHECKPOINT;","access_mode":")") +
-          invalid_mode + R"(","parameters":{}})";
-      auto result = slot->ExecuteTransactionalRequest(request);
-      ASSERT_FALSE(result) << invalid_mode;
-      EXPECT_EQ(result.error().error_code(),
-                neug::StatusCode::ERR_INVALID_ARGUMENT)
-          << invalid_mode;
-    }
+    materialized_path =
+        staging.checkpoint()->MaterializeObject(runtime_file.path());
+    EXPECT_NE(materialized_path, runtime_path);
+    EXPECT_TRUE(std::filesystem::exists(materialized_path));
   }
+  EXPECT_FALSE(std::filesystem::exists(runtime_path));
+  EXPECT_TRUE(std::filesystem::exists(materialized_path));
 
-  db.Close();
+  staging.Discard();
+  manager.Close();
+  std::filesystem::remove_all(db_dir);
 }
 
-TEST(CheckpointOptTest, explain_checkpoint_works_on_read_only_db) {
-  const auto db_path =
-      make_checkpoint_gc_test_dir("explain_checkpoint_read_only");
-  // Step 1: create and checkpoint the database.
-  {
-    neug::NeugDBConfig config(db_path, 1);
-    config.checkpoint_on_close = false;
-    neug::NeugDB db;
-    ASSERT_TRUE(db.Open(config));
-    auto conn = db.Connect();
-    seed_checkpoint_opt_graph(conn);
-    ASSERT_TRUE(conn->Query("CHECKPOINT;"));
-    conn->Close();
-    db.Close();
-  }
+TEST(CheckpointFormatTest, GarbageCollectionSkipsActiveStagingObjects) {
+  const auto db_dir = TestDir("gc_active_staging");
+  neug::CheckpointManager manager;
+  manager.Open(db_dir);
+  auto current = PublishCheckpoint(manager);
 
-  // Step 2: reopen read-only and verify EXPLAIN CHECKPOINT succeeds while
-  // a real CHECKPOINT is still rejected.
+  auto staging = manager.CreateStaging();
+  auto runtime_file = staging.checkpoint()->CreateRuntimeFile();
   {
-    neug::NeugDBConfig config(db_path, 1);
-    config.mode = neug::DBMode::READ_ONLY;
-    config.checkpoint_on_close = false;
+    std::ofstream output(runtime_file.path(), std::ios::binary);
+    ASSERT_TRUE(output.is_open());
+    output << "staging-object";
+  }
+  const auto staging_object =
+      staging.checkpoint()->CommitRuntimeFile(std::move(runtime_file));
+  WriteManifest(*staging.checkpoint(), staging_object);
+
+  manager.CollectGarbage();
+  EXPECT_TRUE(std::filesystem::exists(staging_object));
+  EXPECT_TRUE(std::filesystem::exists(current->manifest_path()));
+
+  staging.Discard();
+  manager.CollectGarbage();
+  EXPECT_FALSE(std::filesystem::exists(staging_object));
+
+  manager.Close();
+  std::filesystem::remove_all(db_dir);
+}
+
+TEST(CheckpointFormatTest, FailedCurrentReplacementKeepsInMemoryCurrent) {
+  const auto db_dir = TestDir("current_replace_failure");
+  neug::CheckpointManager manager;
+  manager.Open(db_dir);
+  auto current = PublishCheckpoint(manager);
+
+  const auto current_path =
+      std::filesystem::path(db_dir) / "checkpoint" / "CURRENT";
+  ASSERT_TRUE(std::filesystem::remove(current_path));
+  ASSERT_TRUE(std::filesystem::create_directory(current_path));
+
+  auto staging = manager.CreateStaging();
+  WriteManifest(*staging.checkpoint());
+  EXPECT_THROW(staging.Publish(), std::exception);
+  EXPECT_EQ(manager.Current(), current);
+  EXPECT_TRUE(std::filesystem::exists(current->manifest_path()));
+  staging.Discard();
+
+  manager.Close();
+  std::filesystem::remove_all(db_dir);
+}
+
+TEST(CheckpointFormatTest, CurrentSelectsManifestAndGcRespectsCheckpointPins) {
+  const auto db_dir = TestDir("manifest_gc_pins");
+  neug::CheckpointManager manager;
+  manager.Open(db_dir);
+
+  auto pinned_checkpoint = PublishCheckpoint(manager, "pinned-object");
+  const auto pinned_manifest = pinned_checkpoint->manifest_path();
+  const auto pinned_object = pinned_checkpoint->manifest()
+                                 .FindModule("test-object")
+                                 ->get_path(neug::ModuleDescriptor::kDataPath)
+                                 .value();
+  ASSERT_TRUE(std::filesystem::exists(pinned_manifest));
+  ASSERT_TRUE(std::filesystem::exists(pinned_object));
+
+  auto current_checkpoint = PublishCheckpoint(manager);
+  EXPECT_EQ(current_checkpoint->id(), 1u);
+  EXPECT_EQ(
+      std::ifstream(std::filesystem::path(db_dir) / "checkpoint" / "CURRENT")
+          .peek(),
+      '1');
+
+  manager.CollectGarbage();
+  EXPECT_TRUE(std::filesystem::exists(pinned_manifest));
+  EXPECT_TRUE(std::filesystem::exists(pinned_object));
+  EXPECT_TRUE(
+      std::filesystem::exists(std::filesystem::path(db_dir) / "wal" / "0"));
+
+  pinned_checkpoint.reset();
+  manager.CollectGarbage();
+  EXPECT_FALSE(std::filesystem::exists(pinned_manifest));
+  EXPECT_FALSE(std::filesystem::exists(pinned_object));
+  EXPECT_FALSE(
+      std::filesystem::exists(std::filesystem::path(db_dir) / "wal" / "0"));
+  EXPECT_TRUE(std::filesystem::exists(current_checkpoint->manifest_path()));
+
+  manager.Close();
+  std::filesystem::remove_all(db_dir);
+}
+
+TEST(CheckpointFormatTest,
+     ManualCheckpointReopensRuntimeAndReplaysOnlyNewWalEpoch) {
+  const auto db_dir = TestDir("manual_wal_epoch");
+  {
     neug::NeugDB db;
-    ASSERT_TRUE(db.Open(config));
+    ASSERT_TRUE(db.Open(Config(db_dir)));
+    auto connection = db.Connect();
+    auto result =
+        connection->Query("CREATE NODE TABLE Item(id INT64, PRIMARY KEY(id));");
+    ASSERT_TRUE(result) << result.error().ToString();
+    result = connection->Query("CREATE (:Item {id: 1});");
+    ASSERT_TRUE(result) << result.error().ToString();
+    connection->Close();
 
     {
       neug::NeugDBService service(db);
-      // EXPLAIN CHECKPOINT is non-mutating; must succeed on a read-only DB.
-      {
-        auto slot = service.AcquireExecutionSlot();
-        auto result = slot->ExecuteTransactionalRequest(
-            R"({"query":"EXPLAIN CHECKPOINT;","parameters":{}})");
-        ASSERT_TRUE(result) << result.error().ToString();
-      }
-      // Also works with an explicit access_mode=read.
-      {
-        auto slot = service.AcquireExecutionSlot();
-        auto result = slot->ExecuteTransactionalRequest(
-            R"({"query":"EXPLAIN CHECKPOINT;","access_mode":"read",)"
-            R"("parameters":{}})");
-        ASSERT_TRUE(result) << result.error().ToString();
-      }
-      // Actual CHECKPOINT must still fail on a read-only DB.
-      {
-        auto slot = service.AcquireExecutionSlot();
-        auto result = slot->ExecuteTransactionalRequest(
-            R"({"query":"CHECKPOINT;","parameters":{}})");
-        ASSERT_FALSE(result);
-        EXPECT_EQ(result.error().error_code(),
-                  neug::StatusCode::ERR_INVALID_ARGUMENT);
-      }
-    }  // service destroyed here
-    db.Close();
-  }
+      InsertThroughService(service, 2);
+      const auto runtime_before = db.graph().checkpoint().runtime_dir();
+      CheckpointThroughService(service);
 
-  // No new checkpoint should have been created.
-  AssertSingleCurrentCheckpoint(db_path);
-  EXPECT_EQ(list_checkpoint_dirs(db_path)[0].filename(), "checkpoint-1");
-}
+      const auto first_checkpoint = db.graph().checkpoint_ptr();
+      ASSERT_NE(first_checkpoint, nullptr);
+      EXPECT_EQ(first_checkpoint->id(), 1u);
+      EXPECT_EQ(first_checkpoint->runtime_dir(), runtime_before);
+      EXPECT_EQ(first_checkpoint->manifest().base_timestamp(), 0u);
+      EXPECT_TRUE(std::filesystem::exists(std::filesystem::path(db_dir) /
+                                          "checkpoint" / "CURRENT"));
+      const auto* first_keys = first_checkpoint->manifest().FindModule(
+          neug::VertexTable::KeyKeys("Item"));
+      ASSERT_TRUE(first_keys);
+      const auto first_keys_json = first_keys->ToJsonString();
 
-template <typename T>
-class CheckpointTestStringProp : public CheckpointTestBase<T> {};
+      // Manual CHECKPOINT keeps its full-checkpoint behavior: compact, publish,
+      // reopen graph and allocator state, and rotate to a new WAL epoch. Clean
+      // immutable objects may still be reused by the new complete manifest.
+      CheckpointThroughService(service);
+      const auto second_checkpoint = db.graph().checkpoint_ptr();
+      ASSERT_NE(second_checkpoint, nullptr);
+      EXPECT_EQ(second_checkpoint->id(), 2u);
+      EXPECT_EQ(second_checkpoint->runtime_dir(), runtime_before);
+      EXPECT_EQ(second_checkpoint->manifest().base_timestamp(), 0u);
+      const auto* second_keys = second_checkpoint->manifest().FindModule(
+          neug::VertexTable::KeyKeys("Item"));
+      ASSERT_TRUE(second_keys);
+      EXPECT_EQ(second_keys->ToJsonString(), first_keys_json);
 
-TYPED_TEST_SUITE(CheckpointTestStringProp, AllMemoryLevels);
-
-TYPED_TEST(CheckpointTestStringProp, test_checkpoint_with_string_edge_prop) {
-  std::string db_path = this->MakeUniqueDir("test_checkpoint_string_edge_prop");
-  {
-    neug::NeugDB db;
-    this->OpenDB(db, db_path);
-    auto conn = db.Connect();
-    this->ExpectQuery(*conn,
-                      "CREATE NODE TABLE A (id STRING, PRIMARY KEY(id));");
-    this->ExpectQuery(*conn,
-                      "CREATE NODE TABLE B (id STRING, PRIMARY KEY(id));");
-    this->ExpectQuery(*conn, "CREATE REL TABLE R (FROM A TO B, prop STRING);");
-    this->ExpectQuery(*conn, "CREATE (a:A {id: 'a1'})");
-    this->ExpectQuery(*conn, "CREATE (b:B {id: 'b1'})");
-    this->ExpectQuery(*conn, "CHECKPOINT;");
-    this->ExpectQuery(
-        *conn,
-        "MATCH (a:A {id: 'a1'}), (b:B {id: 'b1'}) CREATE (a)-[:R {prop: "
-        "'hello'}]->(b)");
-    conn->Close();
-    db.Close();
-  }
-  this->CleanDir(db_path);
-}
-
-// ===========================================================================
-// DropTableCheckpointTest — DROP TABLE checkpoint correctness
-// ===========================================================================
-template <typename T>
-class DropTableCheckpointTest : public CheckpointTestBase<T> {
- protected:
-  std::string db_dir_;
-
-  void SetUp() override { db_dir_ = this->MakeUniqueDir("drop_table_ckpt"); }
-  void TearDown() override { this->CleanDir(db_dir_); }
-
-  void CreateAndCheckpointPerson() {
-    neug::NeugDB db;
-    this->OpenDB(db, db_dir_);
-    auto conn = db.Connect();
-    this->ExpectQuery(*conn,
-                      "CREATE NODE TABLE IF NOT EXISTS Person"
-                      "(id STRING, PRIMARY KEY(id));");
-    this->ExpectQuery(*conn, "CREATE (p:Person {id: 'alice'});");
-    this->ExpectQuery(*conn, "CHECKPOINT;");
-    auto table = this->RunQuery(*conn, "MATCH (p:Person) RETURN p.id;");
-    ASSERT_EQ(table.row_count(), 1);
-    conn->Close();
-    db.Close();
-  }
-
-  // Creates Person + Software vertex tables and a Created edge table,
-  // inserts sample data, and checkpoints.
-  void CreateGraphWithEdgesAndCheckpoint() {
-    neug::NeugDB db;
-    this->OpenDB(db, db_dir_);
-    auto conn = db.Connect();
-    this->ExpectQuery(*conn,
-                      "CREATE NODE TABLE IF NOT EXISTS Person"
-                      "(id STRING, PRIMARY KEY(id));");
-    this->ExpectQuery(*conn,
-                      "CREATE NODE TABLE IF NOT EXISTS Software"
-                      "(id STRING, PRIMARY KEY(id));");
-    this->ExpectQuery(*conn,
-                      "CREATE REL TABLE IF NOT EXISTS Created"
-                      "(FROM Person TO Software, weight DOUBLE);");
-    this->ExpectQuery(*conn, "CREATE (p:Person {id: 'alice'});");
-    this->ExpectQuery(*conn, "CREATE (s:Software {id: 'neug'});");
-    this->ExpectQuery(
-        *conn,
-        "MATCH (p:Person {id: 'alice'}), (s:Software {id: 'neug'}) "
-        "CREATE (p)-[:Created {weight: 1.0}]->(s);");
-    this->ExpectQuery(*conn, "CHECKPOINT;");
-
-    AssertSingleInt64Result(
-        this->RunQuery(
-            *conn,
-            "MATCH (p:Person)-[e:Created]->(s:Software) RETURN count(e);"),
-        1);
-    conn->Close();
-    db.Close();
-  }
-
-  void ReopenAndVerifyPersonEmpty() {
-    neug::NeugDB db;
-    this->OpenDB(db, db_dir_);
-    auto conn = db.Connect();
-    this->ExpectQuery(*conn,
-                      "CREATE NODE TABLE IF NOT EXISTS Person"
-                      "(id STRING, PRIMARY KEY(id));");
-    auto table = this->RunQuery(*conn, "MATCH (p:Person) RETURN p.id;");
-    EXPECT_EQ(table.row_count(), 0);
-    conn->Close();
-    db.Close();
-  }
-};
-
-TYPED_TEST_SUITE(DropTableCheckpointTest, AllMemoryLevels);
-
-TYPED_TEST(DropTableCheckpointTest, drop_and_recreate_clears_stale_data) {
-  this->CreateAndCheckpointPerson();
-
-  neug::NeugDB db;
-  this->OpenDB(db, this->db_dir_);
-  auto conn = db.Connect();
-
-  this->ExpectQuery(*conn, "DROP TABLE IF EXISTS Person;");
-  this->ExpectQuery(
-      *conn,
-      "CREATE NODE TABLE IF NOT EXISTS Person(id STRING, PRIMARY KEY(id));");
-
-  auto table = this->RunQuery(*conn, "MATCH (p:Person) RETURN p.id;");
-  EXPECT_EQ(table.row_count(), 0)
-      << "Stale data visible after DROP TABLE + re-CREATE";
-
-  this->ExpectQuery(*conn, "CREATE (p:Person {id: 'bob'});");
-  auto table2 = this->RunQuery(*conn, "MATCH (p:Person) RETURN p.id;");
-  EXPECT_EQ(table2.row_count(), 1)
-      << "Expected only 'bob', but stale data may be present";
-  neug::test::AssertStringColumn(table2, 0, {"bob"});
-
-  conn->Close();
-  db.Close();
-}
-
-TYPED_TEST(DropTableCheckpointTest, checkpoint_after_drop_succeeds) {
-  this->CreateAndCheckpointPerson();
-
-  {
-    neug::NeugDB db;
-    this->OpenDB(db, this->db_dir_);
-    auto conn = db.Connect();
-    this->ExpectQuery(*conn, "DROP TABLE IF EXISTS Person;");
-    this->ExpectQuery(*conn, "CHECKPOINT;");
-    conn->Close();
-    db.Close();
-  }
-
-  this->ReopenAndVerifyPersonEmpty();
-}
-
-TYPED_TEST(DropTableCheckpointTest,
-           drop_checkpoint_reopen_recreate_has_no_stale_data) {
-  this->CreateAndCheckpointPerson();
-
-  {
-    neug::NeugDB db;
-    this->OpenDB(db, this->db_dir_);
-    auto conn = db.Connect();
-    this->ExpectQuery(*conn, "DROP TABLE IF EXISTS Person;");
-    this->ExpectQuery(*conn, "CHECKPOINT;");
-    conn->Close();
-    db.Close();
-  }
-
-  this->ReopenAndVerifyPersonEmpty();
-}
-
-TYPED_TEST(DropTableCheckpointTest, drop_edge_table_and_checkpoint) {
-  this->CreateGraphWithEdgesAndCheckpoint();
-
-  {
-    neug::NeugDB db;
-    this->OpenDB(db, this->db_dir_);
-    auto conn = db.Connect();
-
-    // Drop the edge table while keeping vertex tables intact
-    this->ExpectQuery(*conn, "DROP TABLE IF EXISTS Created;");
-    this->ExpectQuery(*conn, "CHECKPOINT;");
-
-    conn->Close();
-    db.Close();
-  }
-
-  // Reopen: vertex tables should survive, edge table should be gone
-  {
-    neug::NeugDB db;
-    this->OpenDB(db, this->db_dir_);
-    auto conn = db.Connect();
-
-    // Vertices are still present
-    auto person_table = this->RunQuery(*conn, "MATCH (p:Person) RETURN p.id;");
-    EXPECT_EQ(person_table.row_count(), 1);
-
-    auto software_table =
-        this->RunQuery(*conn, "MATCH (s:Software) RETURN s.id;");
-    EXPECT_EQ(software_table.row_count(), 1);
-
-    // Re-create the edge table — it should be empty
-    this->ExpectQuery(*conn,
-                      "CREATE REL TABLE IF NOT EXISTS Created"
-                      "(FROM Person TO Software, weight DOUBLE);");
-    AssertSingleInt64Result(
-        this->RunQuery(
-            *conn,
-            "MATCH (p:Person)-[e:Created]->(s:Software) RETURN count(e);"),
-        0);
-
-    conn->Close();
-    db.Close();
-  }
-}
-
-TYPED_TEST(DropTableCheckpointTest,
-           drop_edge_table_and_recreate_clears_stale_data) {
-  this->CreateGraphWithEdgesAndCheckpoint();
-
-  neug::NeugDB db;
-  this->OpenDB(db, this->db_dir_);
-  auto conn = db.Connect();
-
-  // Drop + re-create in the same session
-  this->ExpectQuery(*conn, "DROP TABLE IF EXISTS Created;");
-  this->ExpectQuery(*conn,
-                    "CREATE REL TABLE IF NOT EXISTS Created"
-                    "(FROM Person TO Software, weight DOUBLE);");
-
-  // Old edge data must not be visible
-  AssertSingleInt64Result(
-      this->RunQuery(
-          *conn, "MATCH (p:Person)-[e:Created]->(s:Software) RETURN count(e);"),
-      0);
-
-  // Insert fresh edge — only this one should appear
-  this->ExpectQuery(*conn,
-                    "MATCH (p:Person {id: 'alice'}), (s:Software {id: 'neug'}) "
-                    "CREATE (p)-[:Created {weight: 2.0}]->(s);");
-  AssertSingleInt64Result(
-      this->RunQuery(
-          *conn, "MATCH (p:Person)-[e:Created]->(s:Software) RETURN count(e);"),
-      1);
-
-  conn->Close();
-  db.Close();
-}
-
-TYPED_TEST(DropTableCheckpointTest,
-           drop_edge_table_checkpoint_reopen_recreate_has_no_stale_data) {
-  this->CreateGraphWithEdgesAndCheckpoint();
-
-  // Drop edge table + checkpoint
-  {
-    neug::NeugDB db;
-    this->OpenDB(db, this->db_dir_);
-    auto conn = db.Connect();
-    this->ExpectQuery(*conn, "DROP TABLE IF EXISTS Created;");
-    this->ExpectQuery(*conn, "CHECKPOINT;");
-    conn->Close();
-    db.Close();
-  }
-
-  // Reopen, re-create edge table, verify empty
-  {
-    neug::NeugDB db;
-    this->OpenDB(db, this->db_dir_);
-    auto conn = db.Connect();
-    this->ExpectQuery(*conn,
-                      "CREATE REL TABLE IF NOT EXISTS Created"
-                      "(FROM Person TO Software, weight DOUBLE);");
-    AssertSingleInt64Result(
-        this->RunQuery(
-            *conn,
-            "MATCH (p:Person)-[e:Created]->(s:Software) RETURN count(e);"),
-        0);
-    conn->Close();
-    db.Close();
-  }
-}
-
-// Regression: tmp-file cleanup on DROP must key on the full label name, not a
-// bare prefix. Dropping "User" must not wipe files for "UserAccount".
-TYPED_TEST(DropTableCheckpointTest,
-           drop_label_does_not_sweep_sibling_with_shared_prefix) {
-  neug::NeugDB db;
-  this->OpenDB(db, this->db_dir_);
-  auto conn = db.Connect();
-
-  this->ExpectQuery(*conn,
-                    "CREATE NODE TABLE IF NOT EXISTS User"
-                    "(id STRING, PRIMARY KEY(id));");
-  this->ExpectQuery(*conn,
-                    "CREATE NODE TABLE IF NOT EXISTS UserAccount"
-                    "(id STRING, PRIMARY KEY(id));");
-  this->ExpectQuery(*conn, "CREATE (u:User {id: 'u1'});");
-  this->ExpectQuery(*conn, "CREATE (a:UserAccount {id: 'a1'});");
-  this->ExpectQuery(*conn, "CHECKPOINT;");
-
-  // Drop only the shorter-named label. UserAccount data must survive.
-  this->ExpectQuery(*conn, "DROP TABLE IF EXISTS User;");
-
-  auto account_table =
-      this->RunQuery(*conn, "MATCH (a:UserAccount) RETURN a.id;");
-  EXPECT_EQ(account_table.row_count(), 1)
-      << "DROP TABLE User wiped sibling label UserAccount (prefix collision)";
-  neug::test::AssertStringColumn(account_table, 0, {"a1"});
-
-  conn->Close();
-  db.Close();
-}
-
-// ===========================================================================
-// CheckpointSafetyTest — verifies failure handling
-// ===========================================================================
-template <typename T>
-class CheckpointSafetyTest : public CheckpointTestBase<T> {
- protected:
-  std::string db_dir_;
-
-  void SetUp() override { db_dir_ = this->MakeUniqueDir("ckp_safety"); }
-
-  void TearDown() override {
-    // Restore permissions recursively before cleanup.
-    for (const auto& entry : std::filesystem::recursive_directory_iterator(
-             db_dir_,
-             std::filesystem::directory_options::skip_permission_denied)) {
-      std::error_code ec;
-      std::filesystem::permissions(entry.path(),
-                                   std::filesystem::perms::owner_all, ec);
+      InsertThroughService(service, 3);
     }
-    std::error_code ec;
-    std::filesystem::permissions(db_dir_, std::filesystem::perms::owner_all,
-                                 ec);
-    this->CleanDir(db_dir_);
-  }
-
-  neug::NeugDBConfig MakeConfigNoCheckpointOnClose(
-      const std::string& data_dir) {
-    auto config = this->MakeConfig(data_dir);
-    config.checkpoint_on_close = false;
-    return config;
-  }
-};
-
-TYPED_TEST_SUITE(CheckpointSafetyTest, AllMemoryLevels);
-
-// Fix #528: UpdateMeta re-throws on I/O failure and preserves old meta.
-TYPED_TEST(CheckpointSafetyTest, update_meta_rethrows_on_failure) {
-  if (GetTestUid() == 0) {
-    GTEST_SKIP() << "Cannot test permission-based failures as root";
-  }
-  neug::CheckpointManager mgr;
-  mgr.Open(this->db_dir_);
-  auto staging = mgr.CreateStagingCheckpoint();
-  auto ckp = staging.checkpoint();
-
-  ASSERT_TRUE(ckp->GetMeta().modules().empty());
-
-  neug::CheckpointManifest new_meta;
-  neug::ModuleDescriptor desc;
-  desc.set_path("data", "/fake/path");
-  new_meta.set_module("test_module", std::move(desc));
-
-  // Make checkpoint root dir read-only → AtomicFileWriter can't create .tmp.
-  std::filesystem::permissions(
-      ckp->path(),
-      std::filesystem::perms::owner_read | std::filesystem::perms::owner_exec);
-
-  EXPECT_THROW(ckp->UpdateMeta(std::move(new_meta)), std::exception);
-
-  // Old (empty) meta is preserved after the failed update.
-  EXPECT_TRUE(ckp->GetMeta().modules().empty());
-
-  // Restore permissions for cleanup.
-  std::filesystem::permissions(ckp->path(), std::filesystem::perms::owner_all);
-}
-
-// Fix #528 integration: A failed CHECKPOINT does not corrupt on-disk data —
-// recovery on restart succeeds.
-TYPED_TEST(CheckpointSafetyTest,
-           checkpoint_prepare_failure_keeps_database_available) {
-  if (GetTestUid() == 0) {
-    GTEST_SKIP() << "Cannot test permission-based failures as root";
-  }
-  // Phase 1: Create table, insert data, and produce a valid checkpoint.
-  {
-    neug::NeugDB db;
-    this->OpenDB(db, this->db_dir_);
-    auto conn = db.Connect();
-    this->ExpectQuery(*conn,
-                      "CREATE NODE TABLE IF NOT EXISTS Item"
-                      "(id INT64, PRIMARY KEY(id));");
-    this->ExpectQuery(*conn, "CREATE (:Item {id: 100});");
-    this->ExpectQuery(*conn, "CREATE (:Item {id: 200});");
-    auto res = conn->Query("CHECKPOINT;");
-    ASSERT_TRUE(res) << res.error().ToString();
-    conn->Close();
     db.Close();
   }
 
-  // Phase 2: Reopen, mutate so the table is dirty, then trigger a checkpoint
-  // preparation failure before the snapshot build starts. The live graph must
-  // remain usable and retain the uncheckpointed mutation.
   {
     neug::NeugDB db;
-    db.Open(this->MakeConfigNoCheckpointOnClose(this->db_dir_));
-    auto conn = db.Connect();
-    this->ExpectQuery(*conn, "CREATE (:Item {id: 300});");
-
-    std::filesystem::permissions(this->db_dir_,
-                                 std::filesystem::perms::owner_read |
-                                     std::filesystem::perms::owner_exec);
-
-    // CHECKPOINT should fail while creating checkpoint-(N+1).next.
-    auto res = conn->Query("CHECKPOINT;");
-    EXPECT_FALSE(res) << "Expected CHECKPOINT to fail, but it succeeded";
-    EXPECT_FALSE(has_staging_checkpoint_dirs(this->db_dir_));
-
-    auto table = this->RunQuery(*conn, "MATCH (v:Item) RETURN v.id;");
-    EXPECT_EQ(table.row_count(), 3);
-
-    // Restore permissions and verify checkpointing can be retried.
-    std::filesystem::permissions(this->db_dir_,
-                                 std::filesystem::perms::owner_all);
-    res = conn->Query("CHECKPOINT;");
-    ASSERT_TRUE(res) << res.error().ToString();
-    conn->Close();
+    ASSERT_TRUE(db.Open(Config(db_dir)));
+    auto connection = db.Connect();
+    auto result = connection->Query("MATCH (v:Item) RETURN v.id;");
+    ASSERT_TRUE(result) << result.error().ToString();
+    EXPECT_EQ(result.value().response().row_count(), 3);
+    connection->Close();
     db.Close();
   }
 
-  // Phase 3: Reopen and verify data is intact from the valid checkpoint.
-  {
-    neug::NeugDB db;
-    db.Open(this->MakeConfigNoCheckpointOnClose(this->db_dir_));
-    auto conn = db.Connect();
-    auto table = this->RunQuery(*conn, "MATCH (v:Item) RETURN v.id;");
-    EXPECT_EQ(table.row_count(), 3);
-    conn->Close();
-    db.Close();
-  }
+  std::filesystem::remove_all(db_dir);
 }
 
-TYPED_TEST(CheckpointSafetyTest,
-           checkpoint_on_close_failure_is_suppressed_after_cleanup) {
-  auto config = this->MakeConfig(this->db_dir_);
-  neug::NeugDB db;
-  db.Open(config);
-  auto conn = db.Connect();
-  this->ExpectQuery(*conn,
-                    "CREATE NODE TABLE Item(id INT64, PRIMARY KEY(id));");
-  this->ExpectQuery(*conn, "CREATE (:Item {id: 100});");
-  conn->Close();
-
-  // checkpoint-0 is the initial durable generation. Block publication of
-  // checkpoint-1 so the best-effort checkpoint fails after consuming the
-  // live graph.
-  create_published_checkpoint_blocker(this->db_dir_, 1);
-  EXPECT_NO_THROW(db.Close());
-  EXPECT_TRUE(db.IsClosed());
-
-  // Close() must suppress the checkpoint error, release the file lock and all
-  // runtime resources, and let the same object recover through the ordinary
-  // Open path.
-  EXPECT_NO_THROW(db.Open(this->MakeConfigNoCheckpointOnClose(this->db_dir_)));
-  EXPECT_TRUE(db.IsClosed() == false);
-  EXPECT_NO_THROW(db.Close());
-}
-
-TYPED_TEST(CheckpointSafetyTest,
-           destructive_checkpoint_failure_terminates_process) {
+TEST(CheckpointFormatTest, ManualCheckpointPreservesDeletedVertexState) {
+  const auto db_dir = TestDir("manual_deleted_vertex");
   {
     neug::NeugDB db;
-    db.Open(this->MakeConfigNoCheckpointOnClose(this->db_dir_));
-    auto conn = db.Connect();
-    this->ExpectQuery(*conn,
-                      "CREATE NODE TABLE Item(id INT64, PRIMARY KEY(id));");
-    this->ExpectQuery(*conn, "CREATE (:Item {id: 100});");
-    this->ExpectQuery(*conn, "CHECKPOINT;");
+    ASSERT_TRUE(db.Open(Config(db_dir)));
+    auto connection = db.Connect();
+    auto result =
+        connection->Query("CREATE NODE TABLE Item(id INT64, PRIMARY KEY(id));");
+    ASSERT_TRUE(result) << result.error().ToString();
+    result = connection->Query("CREATE (:Item {id: 1}), (:Item {id: 2});");
+    ASSERT_TRUE(result) << result.error().ToString();
+    result = connection->Query("MATCH (v:Item) WHERE v.id = 1 DELETE v;");
+    ASSERT_TRUE(result) << result.error().ToString();
+    connection->Close();
 
-    // A pre-existing final generation makes publish fail after compact/dump,
-    // exercising the destructive fail-stop path with a real filesystem
-    // conflict rather than a product-code test hook.
-    create_published_checkpoint_blocker(this->db_dir_, 2);
-    EXPECT_DEATH({ (void) conn->Query("CHECKPOINT;"); },
-                 "terminating to prevent access to an invalid live graph");
+    const auto label = db.graph().schema().get_vertex_label_id("Item");
+    ASSERT_EQ(db.graph().get_vertex_table(label).LidNum(), 2u);
 
-    conn->Close();
-    db.Close();
-  }
-
-  // Restart recovery discards incomplete staging state and uses the last
-  // durable checkpoint as its baseline.
-  {
-    neug::NeugDB db;
-    db.Open(this->MakeConfigNoCheckpointOnClose(this->db_dir_));
-    auto conn = db.Connect();
-    AssertSingleInt64Result(
-        this->RunQuery(*conn, "MATCH (v:Item) RETURN count(v);"), 1);
-    conn->Close();
-    db.Close();
-  }
-}
-
-TYPED_TEST(CheckpointSafetyTest, checkpoint_gc_failure_is_best_effort) {
-  if (GetTestUid() == 0) {
-    GTEST_SKIP() << "Cannot test permission-based failures as root";
-  }
-
-  neug::NeugDB db;
-  db.Open(this->MakeConfigNoCheckpointOnClose(this->db_dir_));
-  auto conn = db.Connect();
-  this->ExpectQuery(*conn,
-                    "CREATE NODE TABLE Item(id INT64, PRIMARY KEY(id));");
-  this->ExpectQuery(*conn, "CREATE (:Item {id: 1});");
-
-  const auto retired_checkpoint =
-      std::filesystem::path(this->db_dir_) / "checkpoint-0";
-  ASSERT_TRUE(std::filesystem::exists(retired_checkpoint));
-  std::filesystem::permissions(
-      retired_checkpoint,
-      std::filesystem::perms::owner_read | std::filesystem::perms::owner_exec);
-  auto result = conn->Query("CHECKPOINT;");
-  ASSERT_TRUE(result) << result.error().ToString();
-  EXPECT_EQ(list_checkpoint_dirs(this->db_dir_).size(), 2u);
-
-  std::filesystem::permissions(retired_checkpoint,
-                               std::filesystem::perms::owner_all);
-  result = conn->Query("CHECKPOINT;");
-  ASSERT_TRUE(result) << result.error().ToString();
-  AssertSingleCurrentCheckpoint(this->db_dir_);
-
-  conn->Close();
-  db.Close();
-}
-
-// Fix #530: Open discards an incomplete (empty-meta) checkpoint and recovers.
-TYPED_TEST(CheckpointSafetyTest,
-           open_discards_incomplete_checkpoint_and_recovers) {
-  // Phase 1: Create a valid DB with data.
-  {
-    neug::NeugDB db;
-    this->OpenDB(db, this->db_dir_);
-    auto conn = db.Connect();
-    this->ExpectQuery(*conn,
-                      "CREATE NODE TABLE IF NOT EXISTS Widget"
-                      "(id INT64, name STRING, PRIMARY KEY(id));");
-    this->ExpectQuery(*conn, "CREATE (:Widget {id: 1, name: 'alpha'});");
-    this->ExpectQuery(*conn, "CREATE (:Widget {id: 2, name: 'beta'});");
-    conn->Close();
-    db.Close();  // checkpoint_on_close creates a valid checkpoint
-  }
-
-  // Phase 2: Simulate a crash that left an incomplete checkpoint directory.
-  std::string bad_ckp_path;
-  {
-    // Find the highest existing checkpoint ID.
-    int32_t max_id = -1;
-    for (const auto& entry :
-         std::filesystem::directory_iterator(this->db_dir_)) {
-      auto name = entry.path().filename().string();
-      if (name.find("checkpoint-") == 0) {
-        auto id_str = name.substr(std::string("checkpoint-").size());
-        int32_t id = std::stoi(id_str);
-        max_id = std::max(max_id, id);
-      }
+    {
+      neug::NeugDBService service(db);
+      CheckpointThroughService(service);
     }
-    ASSERT_GE(max_id, 0);
 
-    // Create a fake incomplete checkpoint with a higher ID.
-    bad_ckp_path = this->db_dir_ + "/checkpoint-" + std::to_string(max_id + 1);
-    std::filesystem::create_directories(bad_ckp_path);
-    neug::CheckpointManifest::GenerateEmptyMeta(bad_ckp_path + "/meta");
-    ASSERT_TRUE(std::filesystem::exists(bad_ckp_path + "/meta"));
-  }
-
-  // Phase 3: Reopen — the incomplete checkpoint should be discarded.
-  {
-    neug::NeugDB db;
-    db.Open(this->MakeConfigNoCheckpointOnClose(this->db_dir_));
-    auto conn = db.Connect();
-    auto table = this->RunQuery(*conn, "MATCH (v:Widget) RETURN v.id, v.name;");
-    EXPECT_EQ(table.row_count(), 2);
-    conn->Close();
+    const auto checkpoint = db.graph().checkpoint_ptr();
+    ASSERT_NE(checkpoint, nullptr);
+    EXPECT_EQ(checkpoint->manifest().base_timestamp(), 0u);
+    EXPECT_EQ(db.graph().get_vertex_table(label).LidNum(), 2u);
     db.Close();
   }
 
-  EXPECT_FALSE(std::filesystem::exists(bad_ckp_path))
-      << "Incomplete checkpoint directory should have been removed on Open";
+  {
+    neug::NeugDB db;
+    ASSERT_TRUE(db.Open(Config(db_dir)));
+    const auto label = db.graph().schema().get_vertex_label_id("Item");
+    EXPECT_EQ(db.graph().get_vertex_table(label).LidNum(), 2u);
+    auto connection = db.Connect();
+    auto result = connection->Query("MATCH (v:Item) RETURN v.id;");
+    ASSERT_TRUE(result) << result.error().ToString();
+    EXPECT_EQ(result.value().response().row_count(), 1);
+    connection->Close();
+    db.Close();
+  }
+
+  std::filesystem::remove_all(db_dir);
 }
 
-}  // namespace test
-}  // namespace neug
+TEST(CheckpointFormatTest,
+     ManualCheckpointReplacesDirtyIndexAndReusesCleanIndexObject) {
+  RegisterExampleIndex();
+  const auto db_dir = TestDir("manual_index_object_reuse");
+  {
+    neug::NeugDB db;
+    ASSERT_TRUE(db.Open(Config(db_dir)));
+    auto connection = db.Connect();
+    auto result = connection->Query(
+        "CREATE NODE TABLE Person(id INT64, age INT32, PRIMARY KEY(id));");
+    ASSERT_TRUE(result) << result.error().ToString();
+    result = connection->Query("CREATE (:Person {id: 1, age: 30});");
+    ASSERT_TRUE(result) << result.error().ToString();
+    connection->Close();
+
+    CreateExampleAgeIndex(db);
+    std::string first_index_object;
+    {
+      neug::NeugDBService service(db);
+      CheckpointThroughService(service);
+      auto checkpoint = db.graph().checkpoint_ptr();
+      ASSERT_NE(checkpoint, nullptr);
+      const auto* descriptor = checkpoint->manifest().FindModule(
+          neug::StorageIndexManager::GetKey("idx_person_age"));
+      ASSERT_TRUE(descriptor);
+      const auto object = descriptor->get_path(neug::kIndexBufferPath);
+      ASSERT_TRUE(object);
+      first_index_object = *object;
+    }
+
+    connection = db.Connect();
+    result = connection->Query("MATCH (p:Person {id: 1}) SET p.age = 31;");
+    ASSERT_TRUE(result) << result.error().ToString();
+    connection->Close();
+
+    std::string second_index_object;
+    {
+      neug::NeugDBService service(db);
+      CheckpointThroughService(service);
+      auto checkpoint = db.graph().checkpoint_ptr();
+      ASSERT_NE(checkpoint, nullptr);
+      const auto* descriptor = checkpoint->manifest().FindModule(
+          neug::StorageIndexManager::GetKey("idx_person_age"));
+      ASSERT_TRUE(descriptor);
+      const auto object = descriptor->get_path(neug::kIndexBufferPath);
+      ASSERT_TRUE(object);
+      second_index_object = *object;
+      EXPECT_NE(second_index_object, first_index_object);
+
+      CheckpointThroughService(service);
+      checkpoint = db.graph().checkpoint_ptr();
+      ASSERT_NE(checkpoint, nullptr);
+      const auto* reused_descriptor = checkpoint->manifest().FindModule(
+          neug::StorageIndexManager::GetKey("idx_person_age"));
+      ASSERT_TRUE(reused_descriptor);
+      EXPECT_EQ(reused_descriptor->get_path(neug::kIndexBufferPath),
+                std::optional<std::string>(second_index_object));
+    }
+    db.Close();
+  }
+
+  {
+    neug::NeugDB db;
+    ASSERT_TRUE(db.Open(Config(db_dir)));
+    auto* index = dynamic_cast<neug::ExampleIndex*>(
+        db.graph().index_manager().GetIndexByName("idx_person_age").value());
+    ASSERT_NE(index, nullptr);
+    neug::ExampleIndexQueryParams query(31);
+    auto matches = index->Search(query);
+    ASSERT_TRUE(matches) << matches.error().ToString();
+    EXPECT_EQ(matches->size(), 1u);
+    db.Close();
+  }
+
+  std::filesystem::remove_all(db_dir);
+}
+
+TEST(CheckpointFormatTest, IndexCatalogChangesTriggerCheckpointOnClose) {
+  RegisterExampleIndex();
+  const auto db_dir = TestDir("index_catalog_checkpoint_on_close");
+
+  {
+    neug::NeugDB db;
+    ASSERT_TRUE(db.Open(CheckpointOnCloseConfig(db_dir)));
+    auto connection = db.Connect();
+    auto result = connection->Query(
+        "CREATE NODE TABLE Person(id INT64, age INT32, PRIMARY KEY(id));");
+    ASSERT_TRUE(result) << result.error().ToString();
+    result = connection->Query("CREATE (:Person {id: 1, age: 30});");
+    ASSERT_TRUE(result) << result.error().ToString();
+    connection->Close();
+
+    {
+      neug::NeugDBService service(db);
+      CheckpointThroughService(service);
+    }
+    EXPECT_FALSE(db.graph().IsModified());
+
+    CreateExampleAgeIndex(db);
+    EXPECT_TRUE(db.graph().IsModified());
+    db.Close();
+  }
+
+  {
+    neug::NeugDB db;
+    ASSERT_TRUE(db.Open(CheckpointOnCloseConfig(db_dir)));
+    auto index = db.graph().index_manager().GetIndexByName("idx_person_age");
+    ASSERT_TRUE(index) << index.error().ToString();
+    EXPECT_FALSE(db.graph().IsModified());
+
+    {
+      neug::SnapshotGuard guard(db.graph_snapshot_store());
+      ASSERT_TRUE(guard.get()
+                      .mutable_graph()
+                      ->mutable_index_manager()
+                      .DropIndex("idx_person_age")
+                      .ok());
+    }
+    EXPECT_TRUE(db.graph().IsModified());
+    db.Close();
+  }
+
+  {
+    neug::NeugDB db;
+    ASSERT_TRUE(db.Open(Config(db_dir)));
+    EXPECT_FALSE(db.graph()
+                     .index_manager()
+                     .GetIndexByName("idx_person_age")
+                     .has_value());
+    db.Close();
+  }
+
+  std::filesystem::remove_all(db_dir);
+}
+
+TEST(CheckpointFormatTest,
+     DropCheckpointRecreateDoesNotResurrectStaleLabelObjects) {
+  const auto db_dir = TestDir("drop_recreate");
+  {
+    neug::NeugDB db;
+    ASSERT_TRUE(db.Open(Config(db_dir)));
+    auto connection = db.Connect();
+    auto result = connection->Query(
+        "CREATE NODE TABLE Person(id STRING, PRIMARY KEY(id));");
+    ASSERT_TRUE(result) << result.error().ToString();
+    result = connection->Query("CREATE (:Person {id: 'alice'});");
+    ASSERT_TRUE(result) << result.error().ToString();
+    connection->Close();
+
+    {
+      neug::NeugDBService service(db);
+      CheckpointThroughService(service);
+    }
+
+    connection = db.Connect();
+    result = connection->Query("DROP TABLE IF EXISTS Person;");
+    ASSERT_TRUE(result) << result.error().ToString();
+    connection->Close();
+
+    {
+      neug::NeugDBService service(db);
+      CheckpointThroughService(service);
+    }
+    db.Close();
+  }
+
+  {
+    neug::NeugDB db;
+    ASSERT_TRUE(db.Open(Config(db_dir)));
+    auto connection = db.Connect();
+    auto result = connection->Query(
+        "CREATE NODE TABLE Person(id STRING, PRIMARY KEY(id));");
+    ASSERT_TRUE(result) << result.error().ToString();
+    result = connection->Query("MATCH (p:Person) RETURN p.id;");
+    ASSERT_TRUE(result) << result.error().ToString();
+    EXPECT_EQ(result.value().response().row_count(), 0);
+
+    result = connection->Query("CREATE (:Person {id: 'bob'});");
+    ASSERT_TRUE(result) << result.error().ToString();
+    connection->Close();
+    {
+      neug::NeugDBService service(db);
+      CheckpointThroughService(service);
+    }
+    db.Close();
+  }
+
+  {
+    neug::NeugDB db;
+    ASSERT_TRUE(db.Open(Config(db_dir)));
+    auto connection = db.Connect();
+    auto result = connection->Query("MATCH (p:Person) RETURN p.id;");
+    ASSERT_TRUE(result) << result.error().ToString();
+    const auto& response = result.value().response();
+    ASSERT_EQ(response.row_count(), 1);
+    ASSERT_EQ(response.arrays_size(), 1);
+    EXPECT_EQ(response.arrays(0).string_array().values(0), "bob");
+    connection->Close();
+    db.Close();
+  }
+
+  std::filesystem::remove_all(db_dir);
+}
+
+}  // namespace

--- a/tests/storage/test_checkpoint.cc
+++ b/tests/storage/test_checkpoint.cc
@@ -104,6 +104,12 @@ neug::NeugDBConfig CheckpointOnCloseConfig(const std::string& data_dir) {
   return config;
 }
 
+neug::NeugDBConfig SyncToFileConfig(const std::string& data_dir) {
+  auto config = Config(data_dir);
+  config.memory_level = neug::MemoryLevel::kSyncToFile;
+  return config;
+}
+
 void RegisterExampleIndex() {
   static const bool registered = [] {
     return neug::ModuleFactory::instance().Register(
@@ -356,6 +362,87 @@ TEST(CheckpointFormatTest, CurrentSelectsManifestAndGcRespectsCheckpointPins) {
   std::filesystem::remove_all(db_dir);
 }
 
+TEST(CheckpointFormatTest, CurrentIsAuthoritativeAndDoesNotFallback) {
+  const auto db_dir = TestDir("current_is_authoritative");
+  neug::CheckpointManager manager;
+  manager.Open(db_dir);
+  auto first = PublishCheckpoint(manager, "first");
+  auto second = PublishCheckpoint(manager, "second");
+  const auto second_manifest = second->manifest_path();
+  manager.Close();
+
+  const auto current_path =
+      std::filesystem::path(db_dir) / "checkpoint" / "CURRENT";
+  {
+    std::ofstream current(current_path, std::ios::trunc);
+    ASSERT_TRUE(current.is_open());
+    current << "99\n";
+  }
+
+  neug::CheckpointManager reopened;
+  EXPECT_THROW(reopened.Open(db_dir), std::exception);
+  EXPECT_TRUE(std::filesystem::exists(second_manifest));
+  EXPECT_EQ(std::ifstream(current_path).peek(), '9');
+  reopened.Close();
+
+  std::filesystem::remove_all(db_dir);
+}
+
+TEST(CheckpointFormatTest,
+     OpenEpochWorkspacesAreDistinctAndIndependentlyOwned) {
+  const auto db_dir = TestDir("distinct_open_epoch_workspaces");
+  neug::CheckpointManager first;
+  neug::CheckpointManager second;
+  first.Open(db_dir);
+  const auto first_runtime = first.CreateStaging().checkpoint()->runtime_dir();
+  second.Open(db_dir);
+  const auto second_runtime =
+      second.CreateStaging().checkpoint()->runtime_dir();
+
+  EXPECT_NE(first_runtime, second_runtime);
+  EXPECT_TRUE(std::filesystem::exists(first_runtime));
+  EXPECT_TRUE(std::filesystem::exists(second_runtime));
+  first.Close();
+  EXPECT_FALSE(std::filesystem::exists(first_runtime));
+  EXPECT_TRUE(std::filesystem::exists(second_runtime));
+  second.Close();
+  EXPECT_FALSE(std::filesystem::exists(second_runtime));
+
+  std::filesystem::remove_all(db_dir);
+}
+
+TEST(CheckpointFormatTest, GarbageCollectionReclaimsAbandonedOpenEpochs) {
+  const auto db_dir = TestDir("abandoned_open_epochs");
+  const auto runtime_root = std::filesystem::path(db_dir) / "runtime";
+  const auto abandoned = runtime_root / "open-abandoned";
+  const auto unrelated = runtime_root / "keep-this-directory";
+  std::filesystem::create_directories(abandoned / "allocator");
+  std::filesystem::create_directories(unrelated);
+  {
+    std::ofstream payload(abandoned / "allocator" / "data");
+    ASSERT_TRUE(payload.is_open());
+    payload << "stale runtime data";
+  }
+
+  neug::CheckpointManager manager;
+  manager.Open(db_dir);
+  auto current = PublishCheckpoint(manager);
+  const auto active_runtime = current->runtime_dir();
+  ASSERT_TRUE(std::filesystem::exists(active_runtime));
+
+  manager.CollectGarbage();
+  EXPECT_FALSE(std::filesystem::exists(abandoned));
+  EXPECT_TRUE(std::filesystem::exists(active_runtime));
+  EXPECT_TRUE(std::filesystem::exists(unrelated));
+
+  current.reset();
+  manager.Close();
+  EXPECT_FALSE(std::filesystem::exists(active_runtime));
+  EXPECT_TRUE(std::filesystem::exists(unrelated));
+
+  std::filesystem::remove_all(db_dir);
+}
+
 TEST(CheckpointFormatTest,
      ManualCheckpointReopensRuntimeAndReplaysOnlyNewWalEpoch) {
   const auto db_dir = TestDir("manual_wal_epoch");
@@ -460,6 +547,239 @@ TEST(CheckpointFormatTest, ManualCheckpointPreservesDeletedVertexState) {
     auto result = connection->Query("MATCH (v:Item) RETURN v.id;");
     ASSERT_TRUE(result) << result.error().ToString();
     EXPECT_EQ(result.value().response().row_count(), 1);
+    connection->Close();
+    db.Close();
+  }
+
+  std::filesystem::remove_all(db_dir);
+}
+
+TEST(CheckpointFormatTest,
+     ManualCheckpointRoundTripsEvolvedVertexAndEdgeDescriptors) {
+  const auto db_dir = TestDir("evolved_vertex_edge_descriptors");
+  {
+    neug::NeugDB db;
+    ASSERT_TRUE(db.Open(Config(db_dir)));
+    auto connection = db.Connect();
+    auto result = connection->Query(
+        "CREATE NODE TABLE Person(id STRING, PRIMARY KEY(id));");
+    ASSERT_TRUE(result) << result.error().ToString();
+    result = connection->Query(
+        "CREATE NODE TABLE Software(id STRING, PRIMARY KEY(id));");
+    ASSERT_TRUE(result) << result.error().ToString();
+    result = connection->Query(
+        "CREATE REL TABLE Uses(FROM Person TO Software, weight DOUBLE);");
+    ASSERT_TRUE(result) << result.error().ToString();
+    result = connection->Query("CREATE (:Person {id: 'alice'});");
+    ASSERT_TRUE(result) << result.error().ToString();
+    result = connection->Query("CREATE (:Software {id: 'neug'});");
+    ASSERT_TRUE(result) << result.error().ToString();
+    result = connection->Query(
+        "MATCH (p:Person {id: 'alice'}), (s:Software {id: 'neug'}) "
+        "CREATE (p)-[:Uses {weight: 1.5}]->(s);");
+    ASSERT_TRUE(result) << result.error().ToString();
+    connection->Close();
+    {
+      neug::NeugDBService service(db);
+      CheckpointThroughService(service);
+    }
+
+    connection = db.Connect();
+    result = connection->Query("ALTER TABLE Person ADD score INT64;");
+    ASSERT_TRUE(result) << result.error().ToString();
+    result =
+        connection->Query("MATCH (p:Person {id: 'alice'}) SET p.score = 42;");
+    ASSERT_TRUE(result) << result.error().ToString();
+    result = connection->Query("ALTER TABLE Uses ADD description STRING;");
+    ASSERT_TRUE(result) << result.error().ToString();
+    result = connection->Query(
+        "MATCH (:Person)-[e:Uses]->(:Software) SET e.description = 'core';");
+    ASSERT_TRUE(result) << result.error().ToString();
+    connection->Close();
+    {
+      neug::NeugDBService service(db);
+      CheckpointThroughService(service);
+    }
+    db.Close();
+  }
+
+  {
+    neug::NeugDB db;
+    ASSERT_TRUE(db.Open(Config(db_dir)));
+    auto connection = db.Connect();
+    auto result = connection->Query(
+        "MATCH (p:Person)-[e:Uses]->(:Software) "
+        "RETURN p.score, e.weight, e.description;");
+    ASSERT_TRUE(result) << result.error().ToString();
+    const auto& response = result.value().response();
+    ASSERT_EQ(response.row_count(), 1);
+    ASSERT_EQ(response.arrays_size(), 3);
+    EXPECT_EQ(response.arrays(0).int64_array().values(0), 42);
+    EXPECT_DOUBLE_EQ(response.arrays(1).double_array().values(0), 1.5);
+    EXPECT_EQ(response.arrays(2).string_array().values(0), "core");
+    connection->Close();
+    db.Close();
+  }
+
+  std::filesystem::remove_all(db_dir);
+}
+
+TEST(CheckpointFormatTest,
+     DropEdgeTableCheckpointReopenRecreateHasNoStaleData) {
+  const auto db_dir = TestDir("drop_edge_recreate");
+  {
+    neug::NeugDB db;
+    ASSERT_TRUE(db.Open(Config(db_dir)));
+    auto connection = db.Connect();
+    auto result = connection->Query(
+        "CREATE NODE TABLE Person(id STRING, PRIMARY KEY(id));");
+    ASSERT_TRUE(result) << result.error().ToString();
+    result = connection->Query(
+        "CREATE NODE TABLE Software(id STRING, PRIMARY KEY(id));");
+    ASSERT_TRUE(result) << result.error().ToString();
+    result = connection->Query(
+        "CREATE REL TABLE Created(FROM Person TO Software, weight DOUBLE);");
+    ASSERT_TRUE(result) << result.error().ToString();
+    result = connection->Query("CREATE (:Person {id: 'alice'});");
+    ASSERT_TRUE(result) << result.error().ToString();
+    result = connection->Query("CREATE (:Software {id: 'neug'});");
+    ASSERT_TRUE(result) << result.error().ToString();
+    result = connection->Query(
+        "MATCH (p:Person), (s:Software) CREATE (p)-[:Created {weight: "
+        "1.0}]->(s);");
+    ASSERT_TRUE(result) << result.error().ToString();
+    connection->Close();
+    {
+      neug::NeugDBService service(db);
+      CheckpointThroughService(service);
+    }
+
+    connection = db.Connect();
+    result = connection->Query("DROP TABLE Created;");
+    ASSERT_TRUE(result) << result.error().ToString();
+    connection->Close();
+    {
+      neug::NeugDBService service(db);
+      CheckpointThroughService(service);
+    }
+    db.Close();
+  }
+
+  {
+    neug::NeugDB db;
+    ASSERT_TRUE(db.Open(Config(db_dir)));
+    auto connection = db.Connect();
+    auto result = connection->Query(
+        "CREATE REL TABLE Created(FROM Person TO Software, weight DOUBLE);");
+    ASSERT_TRUE(result) << result.error().ToString();
+    result =
+        connection->Query("MATCH (:Person)-[e:Created]->(:Software) RETURN e;");
+    ASSERT_TRUE(result) << result.error().ToString();
+    EXPECT_EQ(result.value().response().row_count(), 0);
+    result = connection->Query(
+        "MATCH (p:Person), (s:Software) CREATE (p)-[:Created {weight: "
+        "2.0}]->(s);");
+    ASSERT_TRUE(result) << result.error().ToString();
+    connection->Close();
+    {
+      neug::NeugDBService service(db);
+      CheckpointThroughService(service);
+    }
+    db.Close();
+  }
+
+  {
+    neug::NeugDB db;
+    ASSERT_TRUE(db.Open(Config(db_dir)));
+    auto connection = db.Connect();
+    auto result = connection->Query(
+        "MATCH (:Person)-[e:Created]->(:Software) RETURN e.weight;");
+    ASSERT_TRUE(result) << result.error().ToString();
+    const auto& response = result.value().response();
+    ASSERT_EQ(response.row_count(), 1);
+    EXPECT_DOUBLE_EQ(response.arrays(0).double_array().values(0), 2.0);
+    connection->Close();
+    db.Close();
+  }
+
+  std::filesystem::remove_all(db_dir);
+}
+
+TEST(CheckpointFormatTest, DropLabelDoesNotSweepSiblingWithSharedPrefix) {
+  const auto db_dir = TestDir("drop_sibling_prefix");
+  {
+    neug::NeugDB db;
+    ASSERT_TRUE(db.Open(Config(db_dir)));
+    auto connection = db.Connect();
+    auto result = connection->Query(
+        "CREATE NODE TABLE User(id STRING, PRIMARY KEY(id));");
+    ASSERT_TRUE(result) << result.error().ToString();
+    result = connection->Query(
+        "CREATE NODE TABLE UserAccount(id STRING, PRIMARY KEY(id));");
+    ASSERT_TRUE(result) << result.error().ToString();
+    result = connection->Query("CREATE (:User {id: 'u1'});");
+    ASSERT_TRUE(result) << result.error().ToString();
+    result = connection->Query("CREATE (:UserAccount {id: 'a1'});");
+    ASSERT_TRUE(result) << result.error().ToString();
+    connection->Close();
+    {
+      neug::NeugDBService service(db);
+      CheckpointThroughService(service);
+    }
+
+    connection = db.Connect();
+    result = connection->Query("DROP TABLE User;");
+    ASSERT_TRUE(result) << result.error().ToString();
+    connection->Close();
+    {
+      neug::NeugDBService service(db);
+      CheckpointThroughService(service);
+    }
+    db.Close();
+  }
+
+  {
+    neug::NeugDB db;
+    ASSERT_TRUE(db.Open(Config(db_dir)));
+    auto connection = db.Connect();
+    auto result = connection->Query("MATCH (u:UserAccount) RETURN u.id;");
+    ASSERT_TRUE(result) << result.error().ToString();
+    const auto& response = result.value().response();
+    ASSERT_EQ(response.row_count(), 1);
+    EXPECT_EQ(response.arrays(0).string_array().values(0), "a1");
+    connection->Close();
+    db.Close();
+  }
+
+  std::filesystem::remove_all(db_dir);
+}
+
+TEST(CheckpointFormatTest, SyncToFileCheckpointRecoversAcrossOpenEpochs) {
+  const auto db_dir = TestDir("sync_to_file_reopen");
+  {
+    neug::NeugDB db;
+    ASSERT_TRUE(db.Open(SyncToFileConfig(db_dir)));
+    auto connection = db.Connect();
+    auto result =
+        connection->Query("CREATE NODE TABLE Item(id INT64, PRIMARY KEY(id));");
+    ASSERT_TRUE(result) << result.error().ToString();
+    result = connection->Query("CREATE (:Item {id: 1}), (:Item {id: 2});");
+    ASSERT_TRUE(result) << result.error().ToString();
+    connection->Close();
+    {
+      neug::NeugDBService service(db);
+      CheckpointThroughService(service);
+    }
+    db.Close();
+  }
+
+  {
+    neug::NeugDB db;
+    ASSERT_TRUE(db.Open(SyncToFileConfig(db_dir)));
+    auto connection = db.Connect();
+    auto result = connection->Query("MATCH (v:Item) RETURN v.id;");
+    ASSERT_TRUE(result) << result.error().ToString();
+    EXPECT_EQ(result.value().response().row_count(), 2);
     connection->Close();
     db.Close();
   }

--- a/tests/storage/test_checkpoint.cc
+++ b/tests/storage/test_checkpoint.cc
@@ -16,10 +16,18 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <charconv>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
+#include <stdexcept>
 #include <string>
 #include <vector>
+
+#include <rapidjson/document.h>
+#include <rapidjson/istreamwrapper.h>
+#include <rapidjson/ostreamwrapper.h>
+#include <rapidjson/writer.h>
 
 #include "neug/main/neug_db.h"
 #include "neug/main/query_request.h"
@@ -42,6 +50,191 @@ std::string TestDir(const std::string& name) {
   std::filesystem::remove_all(dir, ec);
   std::filesystem::create_directories(dir);
   return dir.string();
+}
+
+uint64_t ReadCurrentId(const std::string& db_dir) {
+  std::ifstream input(std::filesystem::path(db_dir) / "checkpoint" / "CURRENT");
+  std::string value;
+  std::getline(input, value);
+  if (!input && !input.eof()) {
+    throw std::runtime_error("failed to read CURRENT");
+  }
+  uint64_t id = 0;
+  const auto [ptr, ec] =
+      std::from_chars(value.data(), value.data() + value.size(), id);
+  if (ec != std::errc{} || ptr != value.data() + value.size()) {
+    throw std::runtime_error("invalid CURRENT");
+  }
+  return id;
+}
+
+void LinkOrCopy(const std::filesystem::path& source,
+                const std::filesystem::path& destination) {
+  if (std::filesystem::exists(destination)) {
+    return;
+  }
+  std::error_code ec;
+  std::filesystem::create_hard_link(source, destination, ec);
+  if (ec) {
+    ec.clear();
+    std::filesystem::copy_file(source, destination, ec);
+  }
+  ASSERT_FALSE(ec) << source << " -> " << destination << ": " << ec.message();
+}
+
+void WriteLegacyEmptyCheckpoint(const std::string& db_dir, uint64_t id,
+                                int version = 1) {
+  const auto root =
+      std::filesystem::path(db_dir) / ("checkpoint-" + std::to_string(id));
+  std::filesystem::create_directories(root / "snapshot");
+  std::filesystem::create_directories(root / "wal");
+
+  rapidjson::Document doc;
+  doc.SetObject();
+  auto& alloc = doc.GetAllocator();
+  doc.AddMember("version", version, alloc);
+  auto schema = neug::Schema().ToJson();
+  ASSERT_TRUE(schema) << schema.error().ToString();
+  doc.AddMember("schema", schema.value().Move(), alloc);
+  doc.AddMember("modules", rapidjson::Value(rapidjson::kObjectType), alloc);
+  doc.AddMember("scalars", rapidjson::Value(rapidjson::kObjectType), alloc);
+
+  std::ofstream output(root / "meta");
+  ASSERT_TRUE(output.is_open());
+  rapidjson::OStreamWrapper wrapper(output);
+  rapidjson::Writer<rapidjson::OStreamWrapper> writer(wrapper);
+  ASSERT_TRUE(doc.Accept(writer));
+}
+
+void WriteLegacyObjectCheckpoint(const std::string& db_dir, uint64_t id,
+                                 bool create_symlink) {
+  const auto root =
+      std::filesystem::path(db_dir) / ("checkpoint-" + std::to_string(id));
+  const auto snapshot = root / "snapshot";
+  std::filesystem::create_directories(snapshot);
+  std::filesystem::create_directories(root / "wal");
+  std::ofstream(snapshot / "shared") << "shared payload";
+  std::ofstream(snapshot / "copy-source") << "copied payload";
+  if (create_symlink) {
+    std::error_code ec;
+    std::filesystem::create_symlink("copy-source", snapshot / "copy-link", ec);
+    ASSERT_FALSE(ec) << ec.message();
+  }
+
+  rapidjson::Document doc;
+  doc.SetObject();
+  auto& alloc = doc.GetAllocator();
+  doc.AddMember("version", 1, alloc);
+  auto schema = neug::Schema().ToJson();
+  ASSERT_TRUE(schema) << schema.error().ToString();
+  doc.AddMember("schema", schema.value().Move(), alloc);
+
+  rapidjson::Value modules(rapidjson::kObjectType);
+  const auto add_module = [&](const char* key, const char* path,
+                              const char* extra_value,
+                              const char* referenced_key) {
+    rapidjson::Value descriptor(rapidjson::kObjectType);
+    descriptor.AddMember("module_type", "", alloc);
+    descriptor.AddMember("required", false, alloc);
+    rapidjson::Value paths(rapidjson::kObjectType);
+    paths.AddMember("data", rapidjson::Value(path, alloc), alloc);
+    descriptor.AddMember("paths", paths, alloc);
+    rapidjson::Value extra(rapidjson::kObjectType);
+    extra.AddMember("marker", rapidjson::Value(extra_value, alloc), alloc);
+    descriptor.AddMember("extra", extra, alloc);
+    if (referenced_key != nullptr) {
+      rapidjson::Value refs(rapidjson::kObjectType);
+      refs.AddMember("child", rapidjson::Value(referenced_key, alloc), alloc);
+      descriptor.AddMember("refs", refs, alloc);
+    }
+    modules.AddMember(rapidjson::Value(key, alloc), descriptor, alloc);
+  };
+  add_module("owner", "snapshot/shared", "owner-extra", "child");
+  add_module("child", "snapshot/shared", "child-extra", nullptr);
+  if (create_symlink) {
+    add_module("symlink", "snapshot/copy-link", "symlink-extra", nullptr);
+  }
+  doc.AddMember("modules", modules, alloc);
+  doc.AddMember("scalars", rapidjson::Value(rapidjson::kObjectType), alloc);
+
+  std::ofstream output(root / "meta");
+  ASSERT_TRUE(output.is_open());
+  rapidjson::OStreamWrapper wrapper(output);
+  rapidjson::Writer<rapidjson::OStreamWrapper> writer(wrapper);
+  ASSERT_TRUE(doc.Accept(writer));
+}
+
+uint64_t ConvertCurrentCheckpointToLegacy(const std::string& db_dir) {
+  const uint64_t id = ReadCurrentId(db_dir);
+  const auto database = std::filesystem::path(db_dir);
+  const auto new_root = database / "checkpoint";
+  const auto legacy_root = database / ("checkpoint-" + std::to_string(id));
+  const auto snapshot = legacy_root / "snapshot";
+  const auto legacy_wal = legacy_root / "wal";
+  std::filesystem::create_directories(snapshot);
+  std::filesystem::create_directories(legacy_wal);
+
+  const auto manifest_path =
+      new_root / "manifests" / (std::to_string(id) + ".manifest");
+  std::ifstream input(manifest_path);
+  if (!input.is_open()) {
+    throw std::runtime_error("failed to open current manifest");
+  }
+  rapidjson::IStreamWrapper input_wrapper(input);
+  rapidjson::Document doc;
+  doc.ParseStream(input_wrapper);
+  if (doc.HasParseError() || !doc.IsObject() || !doc.HasMember("modules")) {
+    throw std::runtime_error("invalid current manifest");
+  }
+
+  auto& alloc = doc.GetAllocator();
+  for (auto& module : doc["modules"].GetObject()) {
+    if (!module.value.HasMember("objects")) {
+      continue;
+    }
+    auto objects = module.value.FindMember("objects");
+    for (auto& object : objects->value.GetObject()) {
+      if (!object.value.IsString()) {
+        throw std::runtime_error("invalid object ID in current manifest");
+      }
+      const std::string object_id = object.value.GetString();
+      LinkOrCopy(new_root / "objects" / object_id, snapshot / object_id);
+      const std::string legacy_path = "snapshot/" + object_id;
+      object.value.SetString(
+          legacy_path.c_str(),
+          static_cast<rapidjson::SizeType>(legacy_path.size()), alloc);
+    }
+    objects->name.SetString("paths", alloc);
+  }
+  doc.RemoveMember("v");
+  doc.RemoveMember("base_ts");
+  doc.AddMember("version", 1, alloc);
+  {
+    std::ofstream output(legacy_root / "meta");
+    if (!output.is_open()) {
+      throw std::runtime_error("failed to create legacy meta");
+    }
+    rapidjson::OStreamWrapper output_wrapper(output);
+    rapidjson::Writer<rapidjson::OStreamWrapper> writer(output_wrapper);
+    if (!doc.Accept(writer)) {
+      throw std::runtime_error("failed to serialize legacy meta");
+    }
+  }
+
+  const auto new_wal = database / "wal" / std::to_string(id);
+  if (std::filesystem::is_directory(new_wal)) {
+    for (const auto& entry : std::filesystem::directory_iterator(new_wal)) {
+      if (!entry.is_regular_file()) {
+        throw std::runtime_error("current WAL contains a non-file entry");
+      }
+      LinkOrCopy(entry.path(), legacy_wal / entry.path().filename());
+    }
+  }
+
+  std::filesystem::remove_all(new_root);
+  std::filesystem::remove_all(database / "wal");
+  std::filesystem::remove_all(database / "runtime");
+  return id;
 }
 
 void WriteManifest(neug::Checkpoint& checkpoint,
@@ -140,26 +333,178 @@ void CreateExampleAgeIndex(neug::NeugDB& db) {
   ASSERT_TRUE(created) << created.error().ToString();
 }
 
-TEST(CheckpointFormatTest, RejectsLegacyCheckpointDirectoriesWithoutMutation) {
-  const auto db_dir = TestDir("legacy_rejected");
+TEST(CheckpointFormatTest, WriterOpenMigratesHighestValidLegacyCheckpoint) {
+  const auto db_dir = TestDir("legacy_migration_selects_latest_valid");
+  WriteLegacyEmptyCheckpoint(db_dir, 7);
   std::filesystem::create_directories(std::filesystem::path(db_dir) /
-                                      "checkpoint-7");
+                                      "checkpoint-8");
+  std::filesystem::create_directories(std::filesystem::path(db_dir) /
+                                      "checkpoint-9.next");
+
+  neug::CheckpointManager manager;
+  manager.Open(db_dir);
+  auto current = manager.Current();
+  ASSERT_NE(current, nullptr);
+  EXPECT_EQ(current->id(), 7u);
+  EXPECT_EQ(ReadCurrentId(db_dir), 7u);
+  EXPECT_EQ(current->manifest().base_timestamp(), 0u);
+  EXPECT_TRUE(std::filesystem::is_regular_file(current->manifest_path()));
+  EXPECT_TRUE(std::filesystem::is_directory(std::filesystem::path(db_dir) /
+                                            "checkpoint" / "objects"));
+  EXPECT_TRUE(std::filesystem::is_directory(current->wal_dir()));
+  EXPECT_TRUE(
+      std::filesystem::exists(std::filesystem::path(db_dir) / "checkpoint-7"));
+
+  {
+    auto next = manager.CreateStaging();
+    EXPECT_EQ(next.checkpoint()->id(), 8u);
+  }
+
+  manager.CollectGarbage();
+  EXPECT_FALSE(
+      std::filesystem::exists(std::filesystem::path(db_dir) / "checkpoint-7"));
+  EXPECT_FALSE(
+      std::filesystem::exists(std::filesystem::path(db_dir) / "checkpoint-8"));
+  EXPECT_FALSE(std::filesystem::exists(std::filesystem::path(db_dir) /
+                                       "checkpoint-9.next"));
+
+  manager.Close();
+  std::filesystem::remove_all(db_dir);
+}
+
+TEST(CheckpointFormatTest, ReadOnlyOpenDoesNotMigrateLegacyCheckpoint) {
+  const auto db_dir = TestDir("legacy_read_only");
+  WriteLegacyEmptyCheckpoint(db_dir, 7);
 
   neug::CheckpointManager manager;
   try {
-    manager.Open(db_dir);
-    FAIL() << "Expected legacy checkpoint directory to be rejected";
+    manager.Open(db_dir, false);
+    FAIL() << "Expected legacy read-only open to require an upgrade";
   } catch (const neug::exception::NotSupportedException& e) {
-    EXPECT_NE(std::string(e.what()).find("does not read or migrate"),
-              std::string::npos);
+    EXPECT_NE(std::string(e.what()).find("read-write"), std::string::npos);
   }
-  EXPECT_FALSE(std::filesystem::exists(std::filesystem::path(db_dir) /
-                                       "checkpoint" / "CURRENT"));
+  EXPECT_FALSE(
+      std::filesystem::exists(std::filesystem::path(db_dir) / "checkpoint"));
   EXPECT_TRUE(
       std::filesystem::exists(std::filesystem::path(db_dir) / "checkpoint-7"));
 
   std::filesystem::remove_all(db_dir);
 }
+
+TEST(CheckpointFormatTest, LegacyMigrationRetriesUnpublishedOutput) {
+  const auto db_dir = TestDir("legacy_migration_retry");
+  WriteLegacyEmptyCheckpoint(db_dir, 7);
+  const auto checkpoint_root = std::filesystem::path(db_dir) / "checkpoint";
+  std::filesystem::create_directories(checkpoint_root / "manifests");
+  std::filesystem::create_directories(checkpoint_root / "objects");
+  std::filesystem::create_directories(std::filesystem::path(db_dir) / "wal" /
+                                      "7");
+  {
+    std::ofstream(checkpoint_root / "manifests" / "7.manifest") << "partial";
+    std::ofstream(checkpoint_root / "objects" / "orphan") << "partial";
+    std::ofstream(std::filesystem::path(db_dir) / "wal" / "7" / "partial.wal")
+        << "partial";
+  }
+
+  neug::CheckpointManager manager;
+  manager.Open(db_dir);
+  ASSERT_NE(manager.Current(), nullptr);
+  EXPECT_EQ(manager.Current()->id(), 7u);
+  EXPECT_FALSE(std::filesystem::exists(std::filesystem::path(db_dir) / "wal" /
+                                       "7" / "partial.wal"));
+
+  manager.CollectGarbage();
+  EXPECT_FALSE(std::filesystem::exists(checkpoint_root / "objects" / "orphan"));
+  manager.Close();
+  std::filesystem::remove_all(db_dir);
+}
+
+TEST(CheckpointFormatTest, UnsupportedLegacyVersionIsNotMigrated) {
+  const auto db_dir = TestDir("legacy_unknown_version");
+  WriteLegacyEmptyCheckpoint(db_dir, 7, 2);
+
+  neug::CheckpointManager manager;
+  EXPECT_THROW(manager.Open(db_dir), std::exception);
+  EXPECT_FALSE(std::filesystem::exists(std::filesystem::path(db_dir) /
+                                       "checkpoint" / "CURRENT"));
+  EXPECT_TRUE(
+      std::filesystem::exists(std::filesystem::path(db_dir) / "checkpoint-7"));
+  manager.Close();
+  std::filesystem::remove_all(db_dir);
+}
+
+TEST(CheckpointFormatTest, RejectsMissingLegacyObjectWithoutPublishing) {
+  const auto db_dir = TestDir("legacy_missing_object");
+  WriteLegacyObjectCheckpoint(db_dir, 7, false);
+  std::filesystem::remove(std::filesystem::path(db_dir) / "checkpoint-7" /
+                          "snapshot" / "shared");
+
+  neug::CheckpointManager manager;
+  EXPECT_THROW(manager.Open(db_dir), std::exception);
+  EXPECT_FALSE(std::filesystem::exists(std::filesystem::path(db_dir) /
+                                       "checkpoint" / "CURRENT"));
+  EXPECT_TRUE(
+      std::filesystem::exists(std::filesystem::path(db_dir) / "checkpoint-7"));
+  manager.Close();
+  std::filesystem::remove_all(db_dir);
+}
+
+TEST(CheckpointFormatTest, RejectsInvalidLegacyWalWithoutPublishing) {
+  const auto db_dir = TestDir("legacy_invalid_wal");
+  WriteLegacyEmptyCheckpoint(db_dir, 7);
+  std::filesystem::create_directories(std::filesystem::path(db_dir) /
+                                      "checkpoint-7" / "wal" / "not-a-file");
+
+  neug::CheckpointManager manager;
+  EXPECT_THROW(manager.Open(db_dir), std::exception);
+  EXPECT_FALSE(std::filesystem::exists(std::filesystem::path(db_dir) /
+                                       "checkpoint" / "CURRENT"));
+  EXPECT_TRUE(std::filesystem::is_directory(
+      std::filesystem::path(db_dir) / "checkpoint-7" / "wal" / "not-a-file"));
+  manager.Close();
+  std::filesystem::remove_all(db_dir);
+}
+
+#ifndef _WIN32
+TEST(CheckpointFormatTest, DeduplicatesObjectsAndCopiesSymlinkSources) {
+  const auto db_dir = TestDir("legacy_object_import");
+  WriteLegacyObjectCheckpoint(db_dir, 7, true);
+  const auto legacy_snapshot =
+      std::filesystem::path(db_dir) / "checkpoint-7" / "snapshot";
+
+  neug::CheckpointManager manager;
+  manager.Open(db_dir);
+  const auto current = manager.Current();
+  ASSERT_NE(current, nullptr);
+  const auto* owner = current->manifest().FindModule("owner");
+  const auto* child = current->manifest().FindModule("child");
+  const auto* symlink = current->manifest().FindModule("symlink");
+  ASSERT_NE(owner, nullptr);
+  ASSERT_NE(child, nullptr);
+  ASSERT_NE(symlink, nullptr);
+  ASSERT_TRUE(owner->get_path("data"));
+  ASSERT_TRUE(child->get_path("data"));
+  ASSERT_TRUE(symlink->get_path("data"));
+  EXPECT_EQ(*owner->get_path("data"), *child->get_path("data"));
+  EXPECT_EQ(owner->get("marker"), "owner-extra");
+  EXPECT_EQ(owner->get_ref("child"), "child");
+  EXPECT_TRUE(std::filesystem::equivalent(legacy_snapshot / "shared",
+                                          *owner->get_path("data")));
+  EXPECT_FALSE(std::filesystem::is_symlink(*symlink->get_path("data")));
+  EXPECT_FALSE(std::filesystem::equivalent(legacy_snapshot / "copy-source",
+                                           *symlink->get_path("data")));
+
+  size_t object_count = 0;
+  for ([[maybe_unused]] const auto& entry : std::filesystem::directory_iterator(
+           std::filesystem::path(db_dir) / "checkpoint" / "objects")) {
+    ++object_count;
+  }
+  EXPECT_EQ(object_count, 2u);
+
+  manager.Close();
+  std::filesystem::remove_all(db_dir);
+}
+#endif
 
 TEST(CheckpointFormatTest, RuntimeWorkspaceFollowsLastRuntimeResource) {
   const auto db_dir = TestDir("runtime_workspace_lifetime");
@@ -390,6 +735,31 @@ TEST(CheckpointFormatTest, CurrentIsAuthoritativeAndDoesNotFallback) {
   std::filesystem::remove_all(db_dir);
 }
 
+TEST(CheckpointFormatTest, CurrentIsAuthoritativeOverResidualLegacyData) {
+  const auto db_dir = TestDir("current_over_legacy");
+  neug::CheckpointManager manager;
+  manager.Open(db_dir);
+  auto current = PublishCheckpoint(manager, "current");
+  const auto current_id = current->id();
+  manager.Close();
+
+  WriteLegacyEmptyCheckpoint(db_dir, current_id + 100);
+  neug::CheckpointManager reopened;
+  reopened.Open(db_dir);
+  ASSERT_NE(reopened.Current(), nullptr);
+  EXPECT_EQ(reopened.Current()->id(), current_id);
+  EXPECT_TRUE(std::filesystem::exists(
+      std::filesystem::path(db_dir) /
+      ("checkpoint-" + std::to_string(current_id + 100))));
+
+  reopened.CollectGarbage();
+  EXPECT_FALSE(std::filesystem::exists(
+      std::filesystem::path(db_dir) /
+      ("checkpoint-" + std::to_string(current_id + 100))));
+  reopened.Close();
+  std::filesystem::remove_all(db_dir);
+}
+
 TEST(CheckpointFormatTest,
      OpenEpochWorkspacesAreDistinctAndIndependentlyOwned) {
   const auto db_dir = TestDir("distinct_open_epoch_workspaces");
@@ -532,6 +902,54 @@ class CheckpointRoundtripTest
 INSTANTIATE_TEST_SUITE_P(AllMemoryLevels, CheckpointRoundtripTest,
                          ::testing::Values(neug::MemoryLevel::kInMemory,
                                            neug::MemoryLevel::kSyncToFile));
+
+TEST_P(CheckpointRoundtripTest, MigratesLegacyGraphAndReplaysItsWalEpoch) {
+  const auto db_dir = TestDir("legacy_graph_and_wal");
+  {
+    neug::NeugDB db;
+    ASSERT_TRUE(db.Open(Config(db_dir)));
+    auto connection = db.Connect();
+    auto result =
+        connection->Query("CREATE NODE TABLE Item(id INT64, PRIMARY KEY(id));");
+    ASSERT_TRUE(result) << result.error().ToString();
+    result = connection->Query("CREATE (:Item {id: 1});");
+    ASSERT_TRUE(result) << result.error().ToString();
+    connection->Close();
+
+    {
+      neug::NeugDBService service(db);
+      CheckpointThroughService(service);
+      InsertThroughService(service, 2);
+    }
+    db.Close();
+  }
+
+  const uint64_t legacy_id = ConvertCurrentCheckpointToLegacy(db_dir);
+  const auto legacy_root = std::filesystem::path(db_dir) /
+                           ("checkpoint-" + std::to_string(legacy_id));
+  ASSERT_TRUE(std::filesystem::exists(legacy_root));
+
+  for (int reopen = 0; reopen < 2; ++reopen) {
+    neug::NeugDB db;
+    ASSERT_TRUE(db.Open(Config(db_dir)));
+    const auto checkpoint = db.graph().checkpoint_ptr();
+    ASSERT_NE(checkpoint, nullptr);
+    EXPECT_EQ(checkpoint->id(), legacy_id);
+    EXPECT_EQ(checkpoint->manifest().base_timestamp(), 0u);
+
+    auto connection = db.Connect();
+    auto result = connection->Query("MATCH (v:Item) RETURN v.id;");
+    ASSERT_TRUE(result) << result.error().ToString();
+    EXPECT_EQ(result.value().response().row_count(), 2);
+    connection->Close();
+    EXPECT_FALSE(std::filesystem::exists(legacy_root));
+    db.Close();
+
+    EXPECT_FALSE(std::filesystem::exists(legacy_root));
+  }
+
+  std::filesystem::remove_all(db_dir);
+}
 
 TEST_P(CheckpointRoundtripTest, ReopenReclaimsRetiredCheckpointsAndWalEpochs) {
   const auto db_dir = TestDir("reopen_reclaims_retired");

--- a/tests/storage/test_index_common.h
+++ b/tests/storage/test_index_common.h
@@ -105,13 +105,14 @@ class ExampleIndex : public StorageIndex {
   void Dump(Checkpoint& ckp, CheckpointManifest& meta,
             const std::string& key) override {
     StorageIndex::Dump(ckp, meta, key);
-    auto descriptor = meta.module(key).value_or(ModuleDescriptor{});
+    auto descriptor = meta.FindModule(key) == nullptr ? ModuleDescriptor{}
+                                                      : *meta.FindModule(key);
     descriptor.module_type = ModuleTypeName();
     descriptor.required = true;
     if (index_id_accessor_) {
       CheckpointManifest accessor_meta;
       index_id_accessor_->Dump(ckp, accessor_meta, "index_id_accessor");
-      auto accessor_desc = accessor_meta.module("index_id_accessor");
+      const auto* accessor_desc = accessor_meta.FindModule("index_id_accessor");
       if (auto next_index_id =
               accessor_desc->get(ModuleDescriptor::kNextIndexId)) {
         descriptor.set(ModuleDescriptor::kNextIndexId, *next_index_id);
@@ -125,7 +126,7 @@ class ExampleIndex : public StorageIndex {
     if (index_buffer_) {
       descriptor.set_path(kIndexBufferPath, ckp.Commit(*index_buffer_));
     }
-    meta.set_module(key, std::move(descriptor));
+    meta.SetModule(key, std::move(descriptor));
   }
 
   void Detach(Checkpoint& ckp, MemoryLevel level) override {

--- a/tests/storage/test_temporary_graph.cc
+++ b/tests/storage/test_temporary_graph.cc
@@ -379,6 +379,7 @@ TEST_F(PropertyGraphTemporaryTest, DumpSkipsTemporaryData) {
 
   // Dump (checkpoint)
   auto ckp2 = make_checkpoint(ws_);
+  graph_->Compact();
   graph_->DumpAndClear(ckp2);
 
   // Open a fresh graph from the checkpoint — temp data should not be there
@@ -403,10 +404,12 @@ TEST_F(PropertyGraphTemporaryTest, DumpManifestFileExcludesTemporary) {
   CreatePersistentPerson();
   CreateTemporaryUser();
 
-  auto ckp2 = make_checkpoint(ws_);
-  graph_->DumpAndClear(ckp2);
+  auto staging = ws_.CreateStaging();
+  graph_->Compact();
+  graph_->DumpAndClear(staging.checkpoint());
+  auto ckp2 = staging.Publish();
 
-  std::string meta_file = ckp2->path() + "/meta";
+  const std::string& meta_file = ckp2->manifest_path();
   ASSERT_TRUE(std::filesystem::exists(meta_file)) << meta_file;
 
   std::ifstream ifs(meta_file);

--- a/tests/storage/test_tp_index.cc
+++ b/tests/storage/test_tp_index.cc
@@ -101,11 +101,11 @@ class TPIndexTest : public ::testing::Test {
 
   void OpenFreshGraph() {
     checkpoint_mgr_.Open(work_dir_);
-    auto staging = checkpoint_mgr_.CreateStagingCheckpoint();
+    auto staging = checkpoint_mgr_.CreateStaging();
     CheckpointManifest meta;
     meta.SetSchema(Schema());
-    staging.checkpoint()->UpdateMeta(std::move(meta));
-    auto ckp = staging.Commit();
+    staging.checkpoint()->SetManifest(std::move(meta));
+    auto ckp = staging.Publish();
     graph_ = std::make_shared<PropertyGraph>();
     graph_->Open(ckp, MemoryLevel::kInMemory);
     view_ = std::make_unique<GraphView>(*graph_);
@@ -649,9 +649,10 @@ TEST_F(TPIndexTest, IndexPersistsAfterCheckpointReopen) {
   std::shared_ptr<Checkpoint> published_checkpoint;
   {
     SnapshotGuard guard(*snapshot_store_);
-    auto staging = checkpoint_mgr_.CreateStagingCheckpoint();
+    auto staging = checkpoint_mgr_.CreateStaging();
+    guard.get().mutable_graph()->Compact();
     guard.get().mutable_graph()->DumpAndClear(staging.checkpoint());
-    published_checkpoint = staging.Commit();
+    published_checkpoint = staging.Publish();
   }
 
   auto reopened = std::make_shared<PropertyGraph>();
@@ -687,9 +688,10 @@ TEST_F(TPIndexTest, AutomaticallyDeletedIndexStaysDeletedAfterReopen) {
   std::shared_ptr<Checkpoint> published_checkpoint;
   {
     SnapshotGuard guard(*snapshot_store_);
-    auto staging = checkpoint_mgr_.CreateStagingCheckpoint();
+    auto staging = checkpoint_mgr_.CreateStaging();
+    guard.get().mutable_graph()->Compact();
     guard.get().mutable_graph()->DumpAndClear(staging.checkpoint());
-    published_checkpoint = staging.Commit();
+    published_checkpoint = staging.Publish();
   }
 
   auto reopened = std::make_shared<PropertyGraph>();

--- a/tests/transaction/test_wal_replay.cc
+++ b/tests/transaction/test_wal_replay.cc
@@ -484,7 +484,7 @@ TEST(WalReplayVersionManagerTest,
   EXPECT_EQ(new_reader.get().visibility_ts, 0);
 }
 
-class CheckpointActivationHandlerTest : public ::testing::Test {
+class WalEpochActivationHandlerTest : public ::testing::Test {
  protected:
   void SetUp() override {
     test_dir_ = make_test_dir();
@@ -519,12 +519,12 @@ class CheckpointActivationHandlerTest : public ::testing::Test {
   std::vector<std::string> handler_calls_;
 };
 
-TEST_F(CheckpointActivationHandlerTest,
-       RecoveryAndManualRunOnlyTheirConfiguredHandlers) {
+TEST_F(WalEpochActivationHandlerTest,
+       RecoveryAndManualReopenBeforeWalActivation) {
   size_t activation_calls = 0;
   std::string observed_wal_uri;
-  coordinator_->SetActivationHandler([&](const std::string& wal_uri) {
-    // The mandatory post-reopen handler always runs first.
+  coordinator_->SetWalEpochActivationHandler([&](const std::string& wal_uri) {
+    // The mandatory post-reopen handler runs before service WAL activation.
     EXPECT_EQ(handler_calls_.size(), 2u);
     ++activation_calls;
     observed_wal_uri = wal_uri;
@@ -535,17 +535,21 @@ TEST_F(CheckpointActivationHandlerTest,
   EXPECT_EQ(activation_calls, 0u);
 
   neug::VersionManager version_manager;
-  version_manager.init_ts({0, 0}, 1);
+  version_manager.init_ts({40, 0}, 1);
   neug::UpdateTimestampLease update_lease(version_manager);
   ASSERT_TRUE(
       coordinator_->PublishManualCheckpoint(std::move(update_lease)).ok());
 
   EXPECT_EQ(activation_calls, 1u);
-  const auto current_checkpoint = checkpoint_manager_.CurrentCheckpoint();
+  const auto current_checkpoint = checkpoint_manager_.Current();
   ASSERT_NE(current_checkpoint, nullptr);
   EXPECT_EQ(observed_wal_uri, current_checkpoint->wal_dir());
   ASSERT_EQ(handler_calls_.size(), 2u);
   EXPECT_EQ(handler_calls_[1], current_checkpoint->allocator_dir());
+  {
+    auto read = version_manager.acquire_read_operation();
+    EXPECT_EQ(read.published_view.visibility_ts, 0u);
+  }
 }
 
 TEST(CheckpointCoordinatorTest,
@@ -587,12 +591,12 @@ TEST(CheckpointCoordinatorTest,
   // PublishManualCheckpoint must fail before destructive graph maintenance,
   // release the update lease normally, and leave the existing WAL writer
   // untouched.
-  auto conflicting_staging = checkpoint_manager.CreateStagingCheckpoint();
+  auto conflicting_staging = checkpoint_manager.CreateStaging();
   neug::VersionManager version_manager;
   version_manager.init_ts({40, 0}, 1);
   neug::UpdateTimestampLease update_lease(version_manager);
   const auto update_ts = update_lease.Timestamp();
-  coordinator.SetActivationHandler([&](const std::string& wal_uri) {
+  coordinator.SetWalEpochActivationHandler([&](const std::string& wal_uri) {
     wal_writer->close();
     wal_writer->open(wal_uri);
     cache_invalidated = true;
@@ -615,7 +619,7 @@ TEST(CheckpointCoordinatorTest,
   version_manager.release_insert_timestamp(next_insert_ts);
 
   wal_writer->close();
-  coordinator.ClearActivationHandler();
+  coordinator.ClearWalEpochActivationHandler();
   conflicting_staging.Discard();
   checkpoint_manager.Close();
   std::filesystem::remove_all(test_dir);

--- a/tests/unittest/test_column.cc
+++ b/tests/unittest/test_column.cc
@@ -466,7 +466,7 @@ TEST(ListPropertyColumnTest, RecursiveLifecycle) {
   CheckpointManifest manifest;
   clone->Dump(*ckp, manifest, "list");
   ListPropertyColumn reopened;
-  reopened.Open(*ckp, manifest, *manifest.module("list"),
+  reopened.Open(*ckp, manifest, *manifest.FindModule("list"),
                 MemoryLevel::kInMemory);
   EXPECT_EQ(reopened.list_type(), outer_type);
   EXPECT_EQ(reopened.get_any(0), final_value);
@@ -507,7 +507,7 @@ TEST(ListPropertyColumnTest, DumpCompactsByPhysicalOffset) {
   column.Dump(*ckp, manifest, "list");
 
   ListPropertyColumn reopened;
-  reopened.Open(*ckp, manifest, *manifest.module("list"),
+  reopened.Open(*ckp, manifest, *manifest.FindModule("list"),
                 MemoryLevel::kInMemory);
   EXPECT_EQ(reopened.get_any(0), list({30, 31, 32}));
   EXPECT_EQ(reopened.get_any(1), list({20, 21}));
@@ -706,7 +706,7 @@ TEST(VecColumnTest, AccessResizeCloneAndDumpOpen) {
   CheckpointManifest loaded_manifest;
   loaded_manifest.Load(manifest_path.string());
   VecColumn reopened;
-  reopened.Open(*ckp, loaded_manifest, *loaded_manifest.module("vec"),
+  reopened.Open(*ckp, loaded_manifest, *loaded_manifest.FindModule("vec"),
                 MemoryLevel::kInMemory);
   EXPECT_FLOAT_EQ(
       ArrayValue::GetChildren(reopened.get_any(4096))[1].GetValue<float>(),

--- a/tests/unittest/test_connection.cc
+++ b/tests/unittest/test_connection.cc
@@ -214,8 +214,7 @@ TEST(ConnectionReadOnlyTest, MultipleProcessesShareDatabase) {
     db.Close();
   }
 
-  const auto allocator_marker =
-      db_dir / "checkpoint-1" / "allocator" / "read_only_marker";
+  const auto allocator_marker = db_dir / "runtime" / "read_only_marker";
   ASSERT_TRUE(std::filesystem::is_directory(allocator_marker.parent_path()));
   {
     std::ofstream marker(allocator_marker);
@@ -282,10 +281,17 @@ TEST(ConnectionReadOnlyTest, MultipleProcessesShareDatabase) {
   EXPECT_EQ(first_ready, '1');
 
   std::vector<std::filesystem::path> first_runtime_files;
-  const auto runtime_dir = db_dir / "checkpoint-1" / "runtime";
-  for (const auto& entry : std::filesystem::directory_iterator(runtime_dir)) {
-    if (entry.is_regular_file()) {
-      first_runtime_files.emplace_back(entry.path());
+  const auto runtime_dir = db_dir / "runtime";
+  for (const auto& epoch : std::filesystem::directory_iterator(runtime_dir)) {
+    if (!epoch.is_directory() ||
+        !epoch.path().filename().string().starts_with("open-")) {
+      continue;
+    }
+    for (const auto& entry :
+         std::filesystem::recursive_directory_iterator(epoch.path())) {
+      if (entry.is_regular_file()) {
+        first_runtime_files.emplace_back(entry.path());
+      }
     }
   }
   EXPECT_FALSE(first_runtime_files.empty());
@@ -664,9 +670,9 @@ TEST_F(ConnectionTest, ApMutationCheckpointRoundTripUsesBaselineTimestamp) {
     ASSERT_TRUE(result) << result.error().ToString();
     EXPECT_EQ(result.value().response().row_count(), 1);
 
-    // Explicit AP CHECKPOINT dumps/reopens without advancing a durable WAL
-    // timeline. Both vertex and edge mutations must therefore remain visible
-    // from the baseline timestamp restored on process restart.
+    // Explicit AP CHECKPOINT resets the timeline after publishing a full
+    // snapshot. Both vertex and edge mutations must remain visible from the
+    // new baseline after process restart.
     SnapshotGuard snapshot(reopened.graph_snapshot_store());
     StorageReadInterface storage(snapshot.get().view(), 0);
     const auto person_label = storage.schema().get_vertex_label_id("person");

--- a/tests/unittest/test_indexer.cc
+++ b/tests/unittest/test_indexer.cc
@@ -258,8 +258,8 @@ TEST_F(LFIndexerTest, DumpsAndOpensAcrossBackends) {
     readonly.Close();
 
     // The dumped meta should advertise the two indexer leaves.
-    EXPECT_TRUE(desc.has_module(kIndexerKeys));
-    EXPECT_TRUE(desc.has_module(kIndexerIndices));
+    EXPECT_TRUE(desc.HasModule(kIndexerKeys));
+    EXPECT_TRUE(desc.HasModule(kIndexerIndices));
   }
 
   {
@@ -290,7 +290,7 @@ TEST_F(LFIndexerTest, SupportsBuildEmptySwapAndVarcharKeys) {
   EXPECT_EQ(empty_indexer.get_index(neug::Value::INT64(42)),
             std::numeric_limits<uint32_t>::max());
   CheckpointManifest empty_dump = DumpIndexerLegacy(empty_indexer, *ckp);
-  EXPECT_TRUE(empty_dump.has_module(kIndexerIndices));
+  EXPECT_TRUE(empty_dump.HasModule(kIndexerIndices));
   empty_indexer.Close();
 
   DataType varchar_type(DataTypeId::kVarchar);

--- a/tests/unittest/utils.h
+++ b/tests/unittest/utils.h
@@ -17,7 +17,6 @@
 
 #include <gtest/gtest.h>
 
-#include <atomic>
 #include <cstdlib>
 #include <filesystem>
 #include <random>
@@ -248,22 +247,18 @@ generate_random_edges(neug::vid_t src_num, neug::vid_t dst_num, size_t len,
   return edges;
 }
 
-// Allocates a fresh standalone checkpoint for storage module round-trip tests.
-//
-// These tests only need a Checkpoint with snapshot/runtime directories; they
-// are not exercising CheckpointManager's publish/GC state machine. Keeping the
-// helper independent from CreateStagingCheckpoint() avoids consuming the single
-// production staging slot when a test needs multiple temporary checkpoints.
+// Allocates a fresh unpublished checkpoint for storage module round-trip tests.
+// These tests do not exercise publication, but use the same CheckpointManager
+// staging, manifest, and object-store representation as production checkpoints.
 inline std::shared_ptr<neug::Checkpoint> make_checkpoint(
     neug::CheckpointManager& ws) {
-  static std::atomic<uint32_t> next_checkpoint_id{0};
-  auto id = next_checkpoint_id.fetch_add(1, std::memory_order_relaxed);
-  auto checkpoint_path = std::filesystem::path(ws.db_dir()) /
-                         ".test-checkpoints" / std::to_string(id);
-  std::filesystem::create_directories(checkpoint_path);
-  neug::CheckpointManifest::GenerateEmptyMeta(
-      (checkpoint_path / neug::CheckpointManifest::kMetaFileName).string());
-  return neug::Checkpoint::Open(checkpoint_path.string(), id);
+  auto staging = ws.CreateStaging();
+  auto checkpoint = staging.checkpoint();
+  neug::CheckpointManifest meta;
+  meta.SetSchema(neug::Schema());
+  checkpoint->SetManifest(std::move(meta));
+  staging.Discard();
+  return checkpoint;
 }
 
 template <typename ModuleT>
@@ -272,11 +267,11 @@ neug::ModuleDescriptor dump_module_descriptor(ModuleT& module,
                                               const std::string& key) {
   neug::CheckpointManifest meta;
   module.Dump(ckp, meta, key);
-  auto desc = meta.module(key);
-  if (!desc.has_value()) {
+  const auto* desc = meta.FindModule(key);
+  if (desc == nullptr) {
     throw std::runtime_error("Module did not write descriptor for key: " + key);
   }
-  return std::move(desc.value());
+  return *desc;
 }
 
 // Test fixtures used to round-trip storage objects through encoded paths in a
@@ -318,7 +313,7 @@ inline void OpenIndexerLegacy(neug::LFIndexer<INDEX_T>& idx,
     neug::LFIndexer<INDEX_T> fresh(key_type);
     idx.swap(fresh);
   }
-  if (!meta.has_module(kIndexerKeys)) {
+  if (!meta.HasModule(kIndexerKeys)) {
     auto keys = CreateColumn(key_type);
     keys->Open(ckp, neug::ModuleDescriptor{}, level);
     auto indices = std::make_unique<neug::TypedColumn<INDEX_T>>();
@@ -374,7 +369,7 @@ inline void OpenVertexTableLegacy(neug::VertexTable& vt,
                                   const neug::CheckpointManifest& meta,
                                   neug::MemoryLevel level) {
   vt.SetMemoryLevel(level);
-  if (!meta.has_module(kVertexIndexerKeys)) {
+  if (!meta.HasModule(kVertexIndexerKeys)) {
     vt.Init(ckp, level);
     return;
   }
@@ -438,7 +433,7 @@ inline void OpenEdgeTableLegacy(neug::EdgeTable& et,
                                 const neug::CheckpointManifest& meta,
                                 neug::MemoryLevel level) {
   et.SetMemoryLevel(level);
-  if (!meta.has_module(kEdgeOutCsr)) {
+  if (!meta.HasModule(kEdgeOutCsr)) {
     et.Init(ckp, level);
     return;
   }

--- a/tests/utils/test_table.cc
+++ b/tests/utils/test_table.cc
@@ -79,7 +79,7 @@ inline std::string TablePropKey(size_t i) {
 static void OpenTableLegacy(Table& t, Checkpoint& ckp,
                             const CheckpointManifest& meta, MemoryLevel level,
                             const std::vector<DataType>& types) {
-  if (!meta.has_module(TablePropKey(0))) {
+  if (!meta.HasModule(TablePropKey(0))) {
     t.Init(ckp, level);
     return;
   }
@@ -145,8 +145,8 @@ TEST_F(TableTest, ModuleBrokerDoesNotSkipUnmarkedReferencedTopLevelModule) {
   owner_desc.set_ref("borrowed", "top_level");
 
   CheckpointManifest meta;
-  meta.set_module("top_level", top_level_desc);
-  meta.set_module("owner", owner_desc);
+  meta.SetModule("top_level", top_level_desc);
+  meta.SetModule("owner", owner_desc);
 
   ModuleBroker store;
   store.Open(*ckp, meta, MemoryLevel::kInMemory);
@@ -163,7 +163,7 @@ TEST_F(TableTest, ModuleBrokerSkipsMarkedReferencedModule) {
   child_desc.mark_as_referenced_module();
 
   CheckpointManifest meta;
-  meta.set_module("child", child_desc);
+  meta.SetModule("child", child_desc);
 
   ModuleBroker store;
   store.Open(*ckp, meta, MemoryLevel::kInMemory);
@@ -458,10 +458,10 @@ TEST_F(TableTest, StringColumnDistinguishesUnsetFromEmptyString) {
             "new value new value new value");
   CheckpointManifest meta;
   string_column->Dump(*ckp, meta, TablePropKey(0));
-  auto desc = meta.module(TablePropKey(0));
-  ASSERT_TRUE(desc.has_value());
+  const auto* desc = meta.FindModule(TablePropKey(0));
+  ASSERT_NE(desc, nullptr);
   StringColumn new_string_column;
-  new_string_column.Open(*ckp, desc.value(), MemoryLevel::kInMemory);
+  new_string_column.Open(*ckp, *desc, MemoryLevel::kInMemory);
   EXPECT_EQ(new_string_column.get_any(0).GetValue<std::string>(),
             "default_value");
   EXPECT_EQ(new_string_column.get_any(1).GetValue<std::string>(),

--- a/tools/python_bind/tests/test_persistence.py
+++ b/tools/python_bind/tests/test_persistence.py
@@ -44,22 +44,21 @@ def _scalar(executor, query):
     return records[0][0]
 
 
-def _published_checkpoint_dirs(db_dir):
-    return sorted(
-        path
-        for path in db_dir.iterdir()
-        if path.is_dir()
-        and path.name.startswith("checkpoint-")
-        and not path.name.endswith(".next")
-    )
+def _published_checkpoint_ids(db_dir):
+    checkpoint_dir = db_dir / "checkpoint"
+    current = checkpoint_dir / "CURRENT"
+    if not current.is_file():
+        return []
+    checkpoint_id = current.read_text().strip()
+    assert (checkpoint_dir / "manifests" / f"{checkpoint_id}.manifest").is_file()
+    return [checkpoint_id]
 
 
 def _assert_single_published_checkpoint(db_dir, expected_generation=None):
-    checkpoints = _published_checkpoint_dirs(db_dir)
+    checkpoints = _published_checkpoint_ids(db_dir)
     assert len(checkpoints) == 1
-    assert not any(path.name.endswith(".next") for path in db_dir.iterdir())
     if expected_generation is not None:
-        assert checkpoints[0].name == f"checkpoint-{expected_generation}"
+        assert checkpoints[0] == str(expected_generation)
 
 
 def _create_issue_651_schema(executor):
@@ -236,10 +235,10 @@ def test_ap_checkpoint_access_modes_and_explain_profile(tmp_path):
     db = Database(db_path=str(db_dir), mode="w", checkpoint_on_close=False)
     conn = db.connect()
     try:
-        before_explain = _published_checkpoint_dirs(db_dir)
+        before_explain = _published_checkpoint_ids(db_dir)
         explain = conn.execute("EXPLAIN CHECKPOINT;")
         assert explain.has_profile_result()
-        assert _published_checkpoint_dirs(db_dir) == before_explain
+        assert _published_checkpoint_ids(db_dir) == before_explain
 
         conn.execute("CHECKPOINT;", access_mode="update")
         conn.execute("CHECKPOINT;", access_mode="u")

--- a/tools/python_bind/tests/test_tp_service.py
+++ b/tools/python_bind/tests/test_tp_service.py
@@ -1227,17 +1227,11 @@ def test_checkpoint(tmp_path):
     db.close()
 
 
-def _single_checkpoint_dir(db_dir, expected_generation):
-    checkpoints = sorted(
-        path
-        for path in db_dir.iterdir()
-        if path.is_dir()
-        and path.name.startswith("checkpoint-")
-        and not path.name.endswith(".next")
-    )
-    assert [path.name for path in checkpoints] == [f"checkpoint-{expected_generation}"]
-    assert not any(path.name.endswith(".next") for path in db_dir.iterdir())
-    return checkpoints[0]
+def _current_checkpoint_wal_dir(db_dir, expected_id):
+    checkpoint_dir = db_dir / "checkpoint"
+    assert (checkpoint_dir / "CURRENT").read_text() == f"{expected_id}\n"
+    assert (checkpoint_dir / "manifests" / f"{expected_id}.manifest").is_file()
+    return db_dir / "wal" / str(expected_id)
 
 
 def test_tp_checkpoint_rotates_wal_and_resets_timeline(tmp_path, unused_tcp_port):
@@ -1266,8 +1260,8 @@ def test_tp_checkpoint_rotates_wal_and_resets_timeline(tmp_path, unused_tcp_port
         session.execute("CREATE NODE TABLE Person(id INT64, PRIMARY KEY(id));")
         session.execute("CREATE (:Person {id: 1});")
         session.execute("CHECKPOINT;")
-        first_checkpoint = _single_checkpoint_dir(db_dir, 1)
-        first_timeline_wals = sorted((first_checkpoint / "wal").glob("*.wal"))
+        first_timeline_wal_dir = _current_checkpoint_wal_dir(db_dir, 1)
+        first_timeline_wals = sorted(first_timeline_wal_dir.glob("*.wal"))
         assert len(first_timeline_wals) == expected_slots
         for wal_path in first_timeline_wals:
             with wal_path.open("rb") as wal_file:
@@ -1277,11 +1271,10 @@ def test_tp_checkpoint_rotates_wal_and_resets_timeline(tmp_path, unused_tcp_port
         session.execute("MATCH (p:Person {id: 1}) SET p.name = 'one';")
         session.execute("CREATE (:Person {id: 2, name: 'two'});")
 
-        assert sorted((first_checkpoint / "wal").glob("*.wal")) == first_timeline_wals
+        assert sorted(first_timeline_wal_dir.glob("*.wal")) == first_timeline_wals
 
         session.execute("CHECKPOINT;")
-        current_checkpoint = _single_checkpoint_dir(db_dir, 2)
-        current_wals = sorted((current_checkpoint / "wal").glob("*.wal"))
+        current_wals = sorted(_current_checkpoint_wal_dir(db_dir, 2).glob("*.wal"))
         assert len(current_wals) == expected_slots
         for wal_path in current_wals:
             with wal_path.open("rb") as wal_file:
@@ -1351,16 +1344,19 @@ def test_tp_checkpoint_invalidates_cached_plans_after_label_compaction(
 
         session.execute("CREATE NODE TABLE A(id INT64, PRIMARY KEY(id));")
         session.execute("CREATE NODE TABLE B(id INT64, name STRING, PRIMARY KEY(id));")
+        session.execute("CREATE NODE TABLE C(id INT64, name STRING, PRIMARY KEY(id));")
+        session.execute("CREATE REL TABLE E(FROM B TO C);")
         session.execute("CREATE (:B {id: 1, name: 'before'});")
+        session.execute("CREATE (:C {id: 2, name: 'after'});")
+        session.execute("MATCH (b:B {id: 1}), (c:C {id: 2}) CREATE (b)-[:E]->(c);")
         session.execute("DROP TABLE A;")
 
-        query = "MATCH (b:B {id: 1}) RETURN b.name;"
-        assert list(session.execute(query)) == [["before"]]
+        query = "MATCH (b:B {id: 1})-[:E]->(c:C) RETURN b.name, c.name;"
+        assert list(session.execute(query)) == [["before", "after"]]
 
-        # Compacting the schema removes A's tombstone and renumbers B from
-        # label 1 to label 0. The cached plan must be rebuilt for that schema.
+        # Compacting the schema removes A's tombstone and renumbers B/C and E.
         session.execute("CHECKPOINT;")
-        assert list(session.execute(query)) == [["before"]]
+        assert list(session.execute(query)) == [["before", "after"]]
     finally:
         if session is not None:
             session.close()


### PR DESCRIPTION
## What do these changes do?

This PR refactors checkpoint storage and publication around immutable objects and complete, versioned manifests. It does **not** add an incremental-checkpoint entry point; manual `CHECKPOINT` keeps the existing full-checkpoint lifecycle.

- Replace numbered `checkpoint-N` directories with:
  - `checkpoint/CURRENT` as the sole publication selector;
  - immutable `checkpoint/objects/<object-id>` files;
  - complete `checkpoint/manifests/<id>.manifest` files;
  - per-checkpoint `wal/<id>` epochs;
  - per-open `runtime/open-<epoch>` workspaces.
- Publish through one staging protocol: persist new objects, initialize and sync the WAL epoch, persist the complete manifest, and only then atomically replace `CURRENT`.
- Attempt to restore the previous `CURRENT` selector when replacement durability cannot be confirmed. If the selector cannot be confirmed or restored, publication is commit-unknown.
- Keep manual, recovery, and shutdown checkpoints on the compacting, destructive `DumpAndClear` path.
- Preserve manual `CHECKPOINT` behavior: reopen the graph and allocator, rotate Service-mode WAL writers, and reset the transaction timeline before admitting new transactions.
- Let dirty graph/index modules create new immutable objects while clean module descriptors reuse existing object references. “Full checkpoint” describes the runtime lifecycle boundary; it does not require rewriting every clean object.
- Reclaim manifests, objects, WAL epochs, and runtime workspaces independently using reachability and live checkpoint pins. GC is skipped while a staging checkpoint owns unpublished objects.
- Narrow and unify checkpoint APIs and naming, centralize graph dump logic, and validate published manifests and referenced objects strictly.
- Reject the legacy `checkpoint-N` layout without modifying it; migration is not included in this PR.

### Checkpoint behavior

| Path | Compact + destructive dump | Reopen graph / allocator | WAL / timeline |
|---|---|---|---|
| Manual `CHECKPOINT` | Yes | Yes | Rotate Service WAL epoch and reset timeline |
| Recovery checkpoint | Yes | Yes | Recover, publish a full baseline, then initialize the timeline |
| Shutdown checkpoint | Yes | No | Persist and close; no online reset |

The manifest format retains `base_ts` for future incremental checkpoint support, but all checkpoint entry points in this PR publish full baselines with `base_ts=0`. A future explicit-transaction bulk-load path can add incremental publication on top of this storage protocol without changing the on-disk ownership model.

## API migration notes for out-of-tree extensions

Checkpoint APIs were renamed to match the new publication model. Out-of-tree extensions that touch checkpoint or manifest APIs need the following mechanical renames:

`CheckpointManager` / `StagingCheckpoint` (`neug/storages/checkpoint_manager.h`):

| Old | New |
|---|---|
| `CreateStagingCheckpoint()` | `CreateStaging()` |
| `StagingCheckpoint::Commit()` | `StagingCheckpoint::Publish()` |
| `CurrentCheckpoint()` | `Current()` |
| `HasCurrentCheckpoint()` | removed; use `Current() != nullptr` |
| `RestoreCurrentCheckpoint(...)` | removed; `CURRENT` is replaced atomically by `Publish` only |
| `CleanupPublishedCheckpoint(...)` / `CleanupRetiredCheckpoints()` | removed; superseded by `CollectGarbage()` reachability |
| `CommitStagingCheckpoint(...)` | `PublishStagingCheckpoint(...)` |
| `db_dir()` | `database_dir()` |
| `Open(db_dir, recover_workspace)` | `Open(database_dir, create_if_missing)` |

`CheckpointManifest` (`neug/storages/checkpoint_manifest.h`):

| Old | New |
|---|---|
| `module(key)` returning `std::optional` | `FindModule(key)` returning a pointer |
| `set_module(...)` | `SetModule(...)` |
| `has_module(key)` | `HasModule(key)` |
| `remove_module(key)` | removed |
| `LinkModuleFrom(...)` | `ReuseModuleClosureFrom(...)` |
| `modules()` | `Modules()` |
| `mutable_modules()` | removed; use `FindMutableModule(key)` |

`Checkpoint` (`neug/storages/checkpoint.h`):

| Old | New |
|---|---|
| `UpdateMeta(meta)` | `SetManifest(manifest)` |
| `GetMeta()` | `manifest()` |
| `path()` | `manifest_path()` |

The in-tree adaptation in `tests/extension/vec_index` (`mutable_modules().at(key)` to `FindMutableModule(key)`) shows the typical migration.

## Related issue

Related to #883

## Testing

- `cmake --build build --target storage_test transaction_test -j4`
- `build/tests/storage/storage_test '--gtest_filter=CheckpointFormatTest.*'` (13 tests passed)
- Focused coordinator/WAL recovery tests (6 tests passed)
- `git diff --check`
- `graphify . --code-only`

