### PR TITLE
fix: validate zvec ANTLR patch state

### DIFF
--- a/.github/workflows/neug-extension-test.yml
+++ b/.github/workflows/neug-extension-test.yml
@@ -52,6 +52,11 @@ jobs:
         git config --global --add safe.directory "$GITHUB_WORKSPACE/third_party/parallel-hashmap"
         git config --global --add safe.directory "$GITHUB_WORKSPACE/third_party/pybind11"
 
+    - name: Clean ZVec state from self-hosted runner
+      run: |
+        git submodule deinit --force third_party/zvec
+        git submodule update --init --force --recursive third_party/zvec
+
     - name: Clean the tool directory for self-hosted runner
       run: |
         rm -rf /__w/_tool/Python

--- a/cmake/BuildZVecAsThirdParty.cmake
+++ b/cmake/BuildZVecAsThirdParty.cmake
@@ -14,6 +14,68 @@
 
 include_guard(GLOBAL)
 
+function(_neug_apply_patch source_dir patch_file patch_name)
+    execute_process(
+        COMMAND git rev-parse --show-toplevel
+        WORKING_DIRECTORY "${source_dir}"
+        RESULT_VARIABLE _git_check
+        OUTPUT_VARIABLE _git_root
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET)
+    file(REAL_PATH "${source_dir}" _source_real_path)
+    if(_git_check EQUAL 0)
+        file(REAL_PATH "${_git_root}" _git_real_path)
+    endif()
+
+    if(_git_check EQUAL 0 AND _git_real_path STREQUAL _source_real_path)
+        set(_patch_check_command git apply --check "${patch_file}")
+        set(_patch_apply_command git apply "${patch_file}")
+        set(_patch_reverse_check_command
+            git apply --reverse --check "${patch_file}")
+    else()
+        find_program(_patch_executable patch REQUIRED)
+        set(_patch_check_command
+            "${_patch_executable}" -p1 -f --dry-run -i "${patch_file}")
+        set(_patch_apply_command
+            "${_patch_executable}" -p1 -f -i "${patch_file}")
+        set(_patch_reverse_check_command
+            "${_patch_executable}" -p1 -f -R --dry-run -i "${patch_file}")
+    endif()
+
+    execute_process(
+        COMMAND ${_patch_check_command}
+        WORKING_DIRECTORY "${source_dir}"
+        RESULT_VARIABLE _patch_check
+        ERROR_VARIABLE _patch_error)
+    if(_patch_check EQUAL 0)
+        execute_process(
+            COMMAND ${_patch_apply_command}
+            WORKING_DIRECTORY "${source_dir}"
+            RESULT_VARIABLE _patch_result
+            ERROR_VARIABLE _patch_error)
+        if(NOT _patch_result EQUAL 0)
+            message(FATAL_ERROR
+                "Failed to apply ${patch_name}: ${_patch_error}")
+        endif()
+        message(STATUS "Applied ${patch_name}.")
+        return()
+    endif()
+
+    execute_process(
+        COMMAND ${_patch_reverse_check_command}
+        WORKING_DIRECTORY "${source_dir}"
+        RESULT_VARIABLE _patch_applied
+        ERROR_VARIABLE _patch_reverse_error)
+    if(_patch_applied EQUAL 0)
+        message(STATUS "${patch_name} is already applied.")
+    else()
+        message(FATAL_ERROR
+            "${patch_name} neither applies nor appears already applied. "
+            "Apply error: ${_patch_error} "
+            "Reverse-check error: ${_patch_reverse_error}")
+    endif()
+endfunction()
+
 function(build_zvec_as_third_party)
     set(ZVEC_SOURCE_DIR
         "${CMAKE_SOURCE_DIR}/third_party/zvec"
@@ -29,67 +91,32 @@ function(build_zvec_as_third_party)
 
     set(_zvec_patch "${CMAKE_SOURCE_DIR}/third_party/zvec.patch")
     if(EXISTS "${_zvec_patch}")
-        execute_process(
-            COMMAND git rev-parse --show-toplevel
-            WORKING_DIRECTORY "${ZVEC_SOURCE_DIR}"
-            RESULT_VARIABLE _zvec_git_check
-            OUTPUT_VARIABLE _zvec_git_root
-            OUTPUT_STRIP_TRAILING_WHITESPACE
-            ERROR_QUIET)
-        file(REAL_PATH "${ZVEC_SOURCE_DIR}" _zvec_source_real_path)
-        if(_zvec_git_check EQUAL 0)
-            file(REAL_PATH "${_zvec_git_root}" _zvec_git_real_path)
-        endif()
-
-        if(_zvec_git_check EQUAL 0
-           AND _zvec_git_real_path STREQUAL _zvec_source_real_path)
-            set(_zvec_patch_check_command
-                git apply --check "${_zvec_patch}")
-            set(_zvec_patch_apply_command git apply "${_zvec_patch}")
-            set(_zvec_patch_reverse_check_command
-                git apply --reverse --check "${_zvec_patch}")
-        else()
-            find_program(_zvec_patch_executable patch REQUIRED)
-            set(_zvec_patch_check_command
-                "${_zvec_patch_executable}" -p1 -f --dry-run
-                -i "${_zvec_patch}")
-            set(_zvec_patch_apply_command
-                "${_zvec_patch_executable}" -p1 -f -i "${_zvec_patch}")
-            set(_zvec_patch_reverse_check_command
-                "${_zvec_patch_executable}" -p1 -f -R --dry-run
-                -i "${_zvec_patch}")
-        endif()
-
-        execute_process(
-            COMMAND ${_zvec_patch_check_command}
-            WORKING_DIRECTORY "${ZVEC_SOURCE_DIR}"
-            RESULT_VARIABLE _zvec_patch_check
-            ERROR_VARIABLE _zvec_patch_error)
-        if(_zvec_patch_check EQUAL 0)
-            execute_process(
-                COMMAND ${_zvec_patch_apply_command}
-                WORKING_DIRECTORY "${ZVEC_SOURCE_DIR}"
-                RESULT_VARIABLE _zvec_patch_result
-                ERROR_VARIABLE _zvec_patch_error)
-            if(NOT _zvec_patch_result EQUAL 0)
-                message(FATAL_ERROR
-                    "Failed to apply zvec.patch: ${_zvec_patch_error}")
-            endif()
-        else()
-            execute_process(
-                COMMAND ${_zvec_patch_reverse_check_command}
-                WORKING_DIRECTORY "${ZVEC_SOURCE_DIR}"
-                RESULT_VARIABLE _zvec_patch_applied
-                ERROR_VARIABLE _zvec_patch_reverse_error)
-            if(_zvec_patch_applied EQUAL 0)
-                message(STATUS "zvec.patch is already applied.")
-            else()
-                message(FATAL_ERROR
-                    "zvec.patch neither applies nor appears already applied: "
-                    "${_zvec_patch_error}")
-            endif()
-        endif()
+        _neug_apply_patch("${ZVEC_SOURCE_DIR}" "${_zvec_patch}" "zvec.patch")
     endif()
+
+    set(_zvec_antlr_source_dir
+        "${ZVEC_SOURCE_DIR}/thirdparty/antlr/antlr4")
+    set(_zvec_antlr_patch
+        "${ZVEC_SOURCE_DIR}/thirdparty/antlr/antlr4.patch")
+    if(NOT EXISTS "${_zvec_antlr_source_dir}/runtime/Cpp/CMakeLists.txt")
+        message(FATAL_ERROR
+            "ZVec's ANTLR4 source was not found at ${_zvec_antlr_source_dir}. "
+            "Initialize ZVec recursively with: git submodule update --init "
+            "--recursive third_party/zvec")
+    endif()
+    if(NOT EXISTS "${_zvec_antlr_patch}")
+        message(FATAL_ERROR
+            "ZVec's ANTLR4 patch was not found at ${_zvec_antlr_patch}.")
+    endif()
+
+    # ZVec's apply_patch_once() trusts this marker without checking whether a
+    # later submodule checkout reset the tracked files. Verify the real source
+    # state first, then create the marker only after the patch is present.
+    _neug_apply_patch(
+        "${_zvec_antlr_source_dir}"
+        "${_zvec_antlr_patch}"
+        "ZVec ANTLR4 patch")
+    file(WRITE "${_zvec_antlr_source_dir}/.antlr4_fix_patched" "patched")
 
     include(ExternalProject)
 

--- a/cmake/BuildZVecAsThirdParty.cmake
+++ b/cmake/BuildZVecAsThirdParty.cmake
@@ -76,6 +76,25 @@ function(_neug_apply_patch source_dir patch_file patch_name)
     endif()
 endfunction()
 
+function(_neug_apply_zvec_patch source_dir patch_file patch_name marker_name)
+    if(NOT EXISTS "${source_dir}")
+        message(FATAL_ERROR
+            "${patch_name} source was not found at ${source_dir}. "
+            "Initialize ZVec recursively with: git submodule update --init "
+            "--recursive third_party/zvec")
+    endif()
+    if(NOT EXISTS "${patch_file}")
+        message(FATAL_ERROR
+            "${patch_name} file was not found at ${patch_file}.")
+    endif()
+
+    # ZVec's apply_patch_once() trusts its marker even if a later submodule
+    # checkout reset the tracked files. Check the source itself, then recreate
+    # the marker only after the patch is known to be present.
+    _neug_apply_patch("${source_dir}" "${patch_file}" "${patch_name}")
+    file(WRITE "${source_dir}/.${marker_name}_patched" "patched")
+endfunction()
+
 function(build_zvec_as_third_party)
     set(ZVEC_SOURCE_DIR
         "${CMAKE_SOURCE_DIR}/third_party/zvec"
@@ -94,29 +113,24 @@ function(build_zvec_as_third_party)
         _neug_apply_patch("${ZVEC_SOURCE_DIR}" "${_zvec_patch}" "zvec.patch")
     endif()
 
-    set(_zvec_antlr_source_dir
-        "${ZVEC_SOURCE_DIR}/thirdparty/antlr/antlr4")
-    set(_zvec_antlr_patch
-        "${ZVEC_SOURCE_DIR}/thirdparty/antlr/antlr4.patch")
-    if(NOT EXISTS "${_zvec_antlr_source_dir}/runtime/Cpp/CMakeLists.txt")
-        message(FATAL_ERROR
-            "ZVec's ANTLR4 source was not found at ${_zvec_antlr_source_dir}. "
-            "Initialize ZVec recursively with: git submodule update --init "
-            "--recursive third_party/zvec")
-    endif()
-    if(NOT EXISTS "${_zvec_antlr_patch}")
-        message(FATAL_ERROR
-            "ZVec's ANTLR4 patch was not found at ${_zvec_antlr_patch}.")
-    endif()
+    _neug_apply_zvec_patch(
+        "${ZVEC_SOURCE_DIR}/thirdparty/antlr/antlr4"
+        "${ZVEC_SOURCE_DIR}/thirdparty/antlr/antlr4.patch"
+        "ZVec ANTLR4 patch"
+        "antlr4_fix")
 
-    # ZVec's apply_patch_once() trusts this marker without checking whether a
-    # later submodule checkout reset the tracked files. Verify the real source
-    # state first, then create the marker only after the patch is present.
-    _neug_apply_patch(
-        "${_zvec_antlr_source_dir}"
-        "${_zvec_antlr_patch}"
-        "ZVec ANTLR4 patch")
-    file(WRITE "${_zvec_antlr_source_dir}/.antlr4_fix_patched" "patched")
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        _neug_apply_zvec_patch(
+            "${ZVEC_SOURCE_DIR}/thirdparty/glog/glog-0.5.0"
+            "${ZVEC_SOURCE_DIR}/thirdparty/glog/glog.patch"
+            "ZVec glog patch"
+            "glog_fix")
+        _neug_apply_zvec_patch(
+            "${ZVEC_SOURCE_DIR}/thirdparty/arrow/apache-arrow-21.0.0"
+            "${ZVEC_SOURCE_DIR}/thirdparty/arrow/arrow.patch"
+            "ZVec Arrow patch"
+            "arrow_fix")
+    endif()
 
     include(ExternalProject)
 

--- a/extension/vector_search/CMakeLists.txt
+++ b/extension/vector_search/CMakeLists.txt
@@ -52,3 +52,5 @@ else()
         zvec_turbo_static)
 endif()
 add_dependencies(neug_vector_search_extension zvec_external)
+
+# to trigger extension CI workflow

--- a/extension/vector_search/src/hnsw_index.cc
+++ b/extension/vector_search/src/hnsw_index.cc
@@ -264,8 +264,8 @@ void HNSWIndex::Dump(Checkpoint& ckp, CheckpointManifest& manifest,
     THROW_RUNTIME_ERROR("HNSWIndex::Dump: index is not open");
 
   StorageIndex::Dump(ckp, manifest, key);
-  auto descriptor = manifest.mutable_modules().find(key);
-  if (descriptor == manifest.mutable_modules().end()) {
+  auto* descriptor = manifest.FindMutableModule(key);
+  if (descriptor == nullptr) {
     THROW_RUNTIME_ERROR(
         "HNSWIndex::Dump: StorageIndex did not write module descriptor for '" +
         key + "'");
@@ -273,7 +273,7 @@ void HNSWIndex::Dump(Checkpoint& ckp, CheckpointManifest& manifest,
   // HNSW is provided by the vector_search extension. Allow the graph to open
   // before that extension is loaded; the pending index is activated after
   // LOAD vector_search registers the hnsw_index module type.
-  descriptor->second.required = false;
+  descriptor->required = false;
   if (zvec_index_->GetDocCount() == 0) {
     return;
   }
@@ -283,7 +283,7 @@ void HNSWIndex::Dump(Checkpoint& ckp, CheckpointManifest& manifest,
   zvec_runtime_file_.reset();
   zvec_runtime_path_ = persisted_path;
 
-  descriptor->second.set_path(kIndexBufferPath, std::move(persisted_path));
+  descriptor->set_path(kIndexBufferPath, std::move(persisted_path));
 }
 
 Status HNSWIndex::Rebind(const IndexBindContext& context) {


### PR DESCRIPTION
## Summary

- refactor NeuG's third-party patch handling into a reusable state-aware helper
- verify zvec's bundled ANTLR4 patch against the actual tracked files before configuring zvec
- recreate zvec's compatibility marker only after the patch is confirmed present
- fail with actionable diagnostics when a patch is neither applicable nor already applied

## Problem introduced by #851

PR #851 added the HNSW vector search extension and its zvec submodule dependency. zvec patches its bundled ANTLR4 runtime during CMake configure, but its apply_patch_once() implementation trusts an untracked .antlr4_fix_patched marker without validating the patched files.

On reused self-hosted runners, actions/checkout can reset the nested ANTLR4 submodule's tracked files while leaving that untracked marker behind. Subsequent builds then skip the patch even though it is no longer present. The original ANTLR4 CMake logic runs find_package(PkgConfig REQUIRED) on Linux, and the current neug-dev image does not provide pkg-config, so the extension build fails persistently until the runner workspace is cleaned.

This change makes NeuG inspect the real patch state on every configure. If checkout reset ANTLR4 but left the marker behind, NeuG reapplies the patch before zvec sees the marker.

## Validation

- configured vector_search from clean zvec and ANTLR4 sources; both patches were applied
- reproduced the polluted-runner state by retaining .antlr4_fix_patched while reverting the ANTLR4 tracked changes; configure detected and reapplied the patch
- configured again with the patch present; configure recognized it as already applied without applying it twice
- ran cmake -P cmake/BuildZVecAsThirdParty.cmake
- ran git diff --check