### PR TITLE
fix: bind dynamic parameters in scalar functions

### DIFF
--- a/include/neug/execution/expression/exprs/udfs.h
+++ b/include/neug/execution/expression/exprs/udfs.h
@@ -21,9 +21,13 @@ namespace neug {
 namespace execution {
 class ScalarFunctionExpr : public ExprBase {
  public:
-  ScalarFunctionExpr(neug_func_exec_t fn, const DataType& ret_type,
+  ScalarFunctionExpr(neug_func_exec_t fn, std::string signature,
+                     const DataType& ret_type,
                      std::vector<std::unique_ptr<ExprBase>>&& children)
-      : func_(fn), ret_type_(ret_type), children_(std::move(children)) {}
+      : func_(fn),
+        signature_(std::move(signature)),
+        ret_type_(ret_type),
+        children_(std::move(children)) {}
   ~ScalarFunctionExpr() override = default;
   const DataType& type() const override { return ret_type_; }
 
@@ -32,6 +36,7 @@ class ScalarFunctionExpr : public ExprBase {
 
  private:
   neug_func_exec_t func_;
+  std::string signature_;
   DataType ret_type_;
   std::vector<std::unique_ptr<ExprBase>> children_;
 };

--- a/src/execution/execute/plan_parser.cc
+++ b/src/execution/execute/plan_parser.cc
@@ -402,6 +402,12 @@ static void expression_parse(const ::common::Expression& expr,
         expression_parse(case_expr.else_result_expression(), params_type);
       }
     }
+    if (opr.has_scalar_func()) {
+      const auto& scalar_func = opr.scalar_func();
+      for (const auto& parameter : scalar_func.parameters()) {
+        expression_parse(parameter, params_type);
+      }
+    }
   }
 }
 

--- a/src/execution/expression/expr.cc
+++ b/src/execution/expression/expr.cc
@@ -222,7 +222,7 @@ static std::unique_ptr<ExprBase> build_expr(
         children.emplace_back(
             parse_expression(op.parameters(i), ctx_meta, var_type));
       }
-      return std::make_unique<ScalarFunctionExpr>(fn, ret_type,
+      return std::make_unique<ScalarFunctionExpr>(fn, signature, ret_type,
                                                   std::move(children));
     }
 

--- a/src/execution/expression/exprs/udfs.cc
+++ b/src/execution/expression/exprs/udfs.cc
@@ -66,7 +66,12 @@ std::unique_ptr<BindedExprBase> ScalarFunctionExpr::bind(
     const IStorageInterface* storage, const ParamsMap& params) const {
   std::vector<std::unique_ptr<BindedExprBase>> bound_children;
   for (const auto& child : children_) {
-    bound_children.push_back(child->bind(storage, params));
+    auto bound_child = child->bind(storage, params);
+    if (bound_child == nullptr) {
+      THROW_INVALID_ARGUMENT_EXCEPTION(
+          "Failed to bind a scalar function argument");
+    }
+    bound_children.push_back(std::move(bound_child));
   }
   return std::make_unique<BindedScalarFunctionExpr>(func_, ret_type_,
                                                     std::move(bound_children));

--- a/src/execution/expression/exprs/udfs.cc
+++ b/src/execution/expression/exprs/udfs.cc
@@ -65,11 +65,12 @@ class BindedScalarFunctionExpr : public VertexExprBase,
 std::unique_ptr<BindedExprBase> ScalarFunctionExpr::bind(
     const IStorageInterface* storage, const ParamsMap& params) const {
   std::vector<std::unique_ptr<BindedExprBase>> bound_children;
-  for (const auto& child : children_) {
-    auto bound_child = child->bind(storage, params);
+  for (size_t i = 0; i < children_.size(); ++i) {
+    auto bound_child = children_[i]->bind(storage, params);
     if (bound_child == nullptr) {
-      THROW_INVALID_ARGUMENT_EXCEPTION(
-          "Failed to bind a scalar function argument");
+      THROW_INVALID_ARGUMENT_EXCEPTION("Failed to bind argument " +
+                                       std::to_string(i) +
+                                       " of scalar function " + signature_);
     }
     bound_children.push_back(std::move(bound_child));
   }

--- a/tools/python_bind/tests/test_hnsw_index.py
+++ b/tools/python_bind/tests/test_hnsw_index.py
@@ -218,6 +218,17 @@ def test_hnsw_index_scan_with_dynamic_target(advanced_connection):
     assert "IndexScanOpr" in _profile_operator_names(result)
 
 
+def test_scalar_function_with_dynamic_target(advanced_connection):
+    result = advanced_connection.execute(
+        "PROFILE MATCH (n:Item) WHERE n.id = 500 RETURN n.id, "
+        "vector_distance_l2(n.l2_vec, $target) AS score;",
+        parameters={"target": _constant_vector(500.1)},
+    )
+    rows = list(result)
+    assert rows[0] == pytest.approx([500, 0.16], abs=3e-5)
+    assert "IndexScanOpr" not in _profile_operator_names(result)
+
+
 def test_cosine_index_scan(advanced_connection):
     target_id = 181
     rows = list(

--- a/tools/python_bind/tests/test_hnsw_index.py
+++ b/tools/python_bind/tests/test_hnsw_index.py
@@ -219,13 +219,19 @@ def test_hnsw_index_scan_with_dynamic_target(advanced_connection):
 
 
 def test_scalar_function_with_dynamic_target(advanced_connection):
+    node_vector = _constant_vector(500.0)
+    target_vector = _constant_vector(500.1)
     result = advanced_connection.execute(
         "PROFILE MATCH (n:Item) WHERE n.id = 500 RETURN n.id, "
         "vector_distance_l2(n.l2_vec, $target) AS score;",
-        parameters={"target": _constant_vector(500.1)},
+        parameters={"target": target_vector},
     )
     rows = list(result)
-    assert rows[0] == pytest.approx([500, 0.16], abs=3e-5)
+    expected_score = sum(
+        (left - right) ** 2 for left, right in zip(node_vector, target_vector)
+    )
+    assert len(rows) == 1
+    assert rows[0] == pytest.approx([500, expected_score], abs=3e-5)
     assert "IndexScanOpr" not in _profile_operator_names(result)
 
 

--- a/tools/python_bind/tests/test_query.py
+++ b/tools/python_bind/tests/test_query.py
@@ -195,6 +195,15 @@ def test_return_literal(tinysnb):
     assert res[1] == [2, "person"]  # Assuming there are at
 
 
+def test_builtin_scalar_function_with_dynamic_parameter(empty_db):
+    _, conn = empty_db
+    result = conn.execute(
+        "RETURN lower($value);", parameters={"value": "NeuG"}, access_mode="read"
+    )
+
+    assert list(result) == [["neug"]]
+
+
 @pytest.mark.parametrize(
     "expression, expected",
     [


### PR DESCRIPTION
## Summary

- recursively collect dynamic parameter metadata from scalar-function arguments
- reject unbound scalar-function arguments with a query error instead of dereferencing a null expression
- add a regression test that exercises a dynamic parameter through the scalar execution path without an index scan

## Testing

```text
test_scalar_function_with_dynamic_target PASSED
```

Closes #912