### PR TITLE
fix: reject unsupported UNION without ALL early

### DIFF
--- a/src/compiler/parser/transform/transform_query.cpp
+++ b/src/compiler/parser/transform/transform_query.cpp
@@ -29,9 +29,21 @@
 #include "neug/compiler/parser/query/query_part.h"
 #include "neug/compiler/parser/query/regular_query.h"
 #include "neug/compiler/parser/transformer.h"
+#include "neug/utils/exception/exception.h"
 
 namespace neug {
 namespace parser {
+
+namespace {
+
+void validateUnionAll(CypherParser::OC_UnionContext& unionClause) {
+  if (!unionClause.ALL()) {
+    THROW_NOT_SUPPORTED_EXCEPTION(
+        "UNION without ALL is not supported. Use UNION ALL instead.");
+  }
+}
+
+}  // namespace
 
 std::unique_ptr<Statement> Transformer::transformQuery(
     CypherParser::OC_QueryContext& ctx) {
@@ -59,6 +71,7 @@ std::unique_ptr<Statement> Transformer::transformCallUnionQuery(
   auto regularQuery = std::make_unique<RegularQuery>(
       transformSingleQuery(*oC_CallUnion->oC_SingleQuery()));
   for (auto unionClause : oC_CallUnion->oC_Union()) {
+    validateUnionAll(*unionClause);
     regularQuery->addSingleQuery(
         transformSingleQuery(*unionClause->oC_SingleQuery()),
         unionClause->ALL());
@@ -92,6 +105,7 @@ std::unique_ptr<Statement> Transformer::transformRegularQuery(
   auto regularQuery = std::make_unique<RegularQuery>(
       transformSingleQuery(*ctx.oC_SingleQuery()));
   for (auto unionClause : ctx.oC_Union()) {
+    validateUnionAll(*unionClause);
     regularQuery->addSingleQuery(
         transformSingleQuery(*unionClause->oC_SingleQuery()),
         unionClause->ALL());

--- a/src/compiler/parser/transform/transform_query.cpp
+++ b/src/compiler/parser/transform/transform_query.cpp
@@ -34,16 +34,12 @@
 namespace neug {
 namespace parser {
 
-namespace {
-
-void validateUnionAll(CypherParser::OC_UnionContext& unionClause) {
+static void validateUnionAll(CypherParser::OC_UnionContext& unionClause) {
   if (!unionClause.ALL()) {
     THROW_NOT_SUPPORTED_EXCEPTION(
         "UNION without ALL is not supported. Use UNION ALL instead.");
   }
 }
-
-}  // namespace
 
 std::unique_ptr<Statement> Transformer::transformQuery(
     CypherParser::OC_QueryContext& ctx) {

--- a/tools/python_bind/tests/test_query.py
+++ b/tools/python_bind/tests/test_query.py
@@ -26,6 +26,7 @@ from conftest import ensure_result_cnt_gt_zero
 from conftest import submit_cypher_query
 
 from neug.database import Database
+from neug.proto.error_pb2 import ERR_NOT_SUPPORTED
 from neug.proto.error_pb2 import ERR_QUERY_SYNTAX
 
 logger = logging.getLogger(__name__)
@@ -271,6 +272,51 @@ def test_query_syntax_error(tmp_path):
     assert str(ERR_QUERY_SYNTAX) in str(excinfo.value)
     conn.close()
     db.close()
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "RETURN 1 AS value UNION RETURN 2 AS value",
+        "WITH 1 AS seed "
+        "CALL (seed) { RETURN 1 AS value UNION RETURN 2 AS value } "
+        "RETURN value",
+    ],
+)
+def test_union_without_all_is_not_supported(empty_db, query):
+    _, conn = empty_db
+
+    with pytest.raises(Exception) as excinfo:
+        conn.execute(query, access_mode="read")
+
+    message = str(excinfo.value)
+    assert str(ERR_NOT_SUPPORTED) in message
+    assert "UNION without ALL is not supported" in message
+
+
+def test_union_all_remains_supported(empty_db):
+    _, conn = empty_db
+    conn.execute(
+        "CREATE NODE TABLE Person("
+        "id STRING, name STRING, PRIMARY KEY(id));",
+        access_mode="schema",
+    )
+    conn.execute(
+        "CREATE (p:Person {id:'p1', name:'Alice'});", access_mode="update"
+    )
+    conn.execute(
+        "CREATE (p:Person {id:'p2', name:'Bob'});", access_mode="update"
+    )
+
+    result = conn.execute(
+        "MATCH (a:Person) RETURN a.name "
+        "UNION ALL "
+        "MATCH (b:Person) RETURN b.name",
+        access_mode="read",
+    )
+
+    assert len(result) == 4
+    assert len(result.column_names()) == 1
 
 
 def test_result(modern_graph):

--- a/tools/python_bind/tests/test_query.py
+++ b/tools/python_bind/tests/test_query.py
@@ -297,21 +297,14 @@ def test_union_without_all_is_not_supported(empty_db, query):
 def test_union_all_remains_supported(empty_db):
     _, conn = empty_db
     conn.execute(
-        "CREATE NODE TABLE Person("
-        "id STRING, name STRING, PRIMARY KEY(id));",
+        "CREATE NODE TABLE Person(" "id STRING, name STRING, PRIMARY KEY(id));",
         access_mode="schema",
     )
-    conn.execute(
-        "CREATE (p:Person {id:'p1', name:'Alice'});", access_mode="update"
-    )
-    conn.execute(
-        "CREATE (p:Person {id:'p2', name:'Bob'});", access_mode="update"
-    )
+    conn.execute("CREATE (p:Person {id:'p1', name:'Alice'});", access_mode="update")
+    conn.execute("CREATE (p:Person {id:'p2', name:'Bob'});", access_mode="update")
 
     result = conn.execute(
-        "MATCH (a:Person) RETURN a.name "
-        "UNION ALL "
-        "MATCH (b:Person) RETURN b.name",
+        "MATCH (a:Person) RETURN a.name " "UNION ALL " "MATCH (b:Person) RETURN b.name",
         access_mode="read",
     )
 


### PR DESCRIPTION
## Summary

NeuG currently supports `UNION ALL` but not bare `UNION`. Previously, a bare `UNION` reached the planning pipeline and failed with `ERR_INTERNAL_ERROR (1012): unordered_map::at: key not found`.

This change rejects bare `UNION` during query transformation and returns a clear `ERR_NOT_SUPPORTED (1011)` error:

> UNION without ALL is not supported. Use UNION ALL instead.

Both standard UNION queries and UNION clauses inside `CALL` are covered. This change does not implement the deduplicating semantics of bare `UNION`.

## Tests

Added regression tests covering:

- Standard bare `UNION`
- Bare `UNION` inside `CALL`
- Existing `UNION ALL` behavior

Targeted test result:

`3 passed, 71 deselected`

Fixes #<issue-number>