### PR TITLE
fix: prevent internal graph type leakage in comparison errors

### DIFF
--- a/src/compiler/binder/bind_expression/bind_comparison_expression.cpp
+++ b/src/compiler/binder/bind_expression/bind_comparison_expression.cpp
@@ -36,6 +36,18 @@ using namespace neug::function;
 namespace neug {
 namespace binder {
 
+static std::string getUserFacingComparisonTypeName(const DataType& type) {
+  switch (type.id()) {
+  case DataTypeId::kVarchar:
+  case DataTypeId::kVertex:
+  case DataTypeId::kEdge:
+  case DataTypeId::kPath:
+    return LogicalTypeUtils::toString(type.id());
+  default:
+    return type.ToString();
+  }
+}
+
 std::shared_ptr<Expression> ExpressionBinder::bindComparisonExpression(
     const ParsedExpression& parsedExpression) {
   expression_vector children;
@@ -54,9 +66,10 @@ std::shared_ptr<Expression> ExpressionBinder::bindComparisonExpression(
   auto functionName = ExpressionTypeUtil::toString(expressionType);
   DataType combinedType(DataTypeId::kUnknown);
   if (!ExpressionUtil::tryCombineDataType(children, combinedType)) {
-    THROW_BINDER_EXCEPTION(stringFormat(
-        "Type Mismatch: Cannot compare types {} and {}",
-        children[0]->dataType.ToString(), children[1]->dataType.ToString()));
+    THROW_BINDER_EXCEPTION(
+        stringFormat("Type Mismatch: Cannot compare types {} and {}",
+                     getUserFacingComparisonTypeName(children[0]->dataType),
+                     getUserFacingComparisonTypeName(children[1]->dataType)));
   }
   if (combinedType.id() == DataTypeId::kUnknown) {
     combinedType = DataType(DataTypeId::kInt8);

--- a/src/compiler/common/types/types.cpp
+++ b/src/compiler/common/types/types.cpp
@@ -915,8 +915,27 @@ static bool canAlwaysCast(DataTypeId typeID) {
   }
 }
 
+static bool isGraphEntityType(DataTypeId typeID) {
+  switch (typeID) {
+  case DataTypeId::kVertex:
+  case DataTypeId::kEdge:
+  case DataTypeId::kPath:
+    return true;
+  default:
+    return false;
+  }
+}
+
+static bool isStringGraphEntityPair(DataTypeId left, DataTypeId right) {
+  return (left == DataTypeId::kVarchar && isGraphEntityType(right)) ||
+         (right == DataTypeId::kVarchar && isGraphEntityType(left));
+}
+
 bool LogicalTypeUtils::tryGetMaxDataTypeId(DataTypeId left, DataTypeId right,
                                            DataTypeId& result) {
+  if (isStringGraphEntityPair(left, right)) {
+    return false;
+  }
   if (canAlwaysCast(left) && canAlwaysCast(right)) {
     if (alwaysCastOrder(left) > alwaysCastOrder(right)) {
       result = left;
@@ -975,6 +994,9 @@ static inline bool isSemanticallyNested(DataTypeId ID) {
 bool LogicalTypeUtils::tryGetMaxLogicalType(const DataType& left,
                                             const DataType& right,
                                             DataType& result) {
+  if (isStringGraphEntityPair(left.id(), right.id())) {
+    return false;
+  }
   if (canAlwaysCast(left.id()) && canAlwaysCast(right.id())) {
     if (alwaysCastOrder(left.id()) > alwaysCastOrder(right.id())) {
       result = left.copy();

--- a/tools/python_bind/tests/test_query.py
+++ b/tools/python_bind/tests/test_query.py
@@ -26,6 +26,8 @@ from conftest import ensure_result_cnt_gt_zero
 from conftest import submit_cypher_query
 
 from neug.database import Database
+from neug.proto.error_pb2 import ERR_COMPILATION
+from neug.proto.error_pb2 import ERR_INVALID_SCHEMA
 from neug.proto.error_pb2 import ERR_NOT_SUPPORTED
 from neug.proto.error_pb2 import ERR_QUERY_SYNTAX
 
@@ -170,6 +172,42 @@ def test_filtering(tinysnb):
     )
     records = list(result)
     assert records == [["Alice"], ["Bob"], ["Dan"]]
+
+
+@pytest.mark.parametrize(
+    "predicate, expected_types",
+    [
+        ("r0.id = b", "STRING and NODE"),
+        ("b = r0.id", "NODE and STRING"),
+    ],
+)
+def test_string_property_cannot_be_compared_with_node(
+    empty_db, predicate, expected_types
+):
+    _, conn = empty_db
+    conn.execute(
+        "CREATE NODE TABLE L2(id STRING, PRIMARY KEY(id));",
+        access_mode="schema",
+    )
+    conn.execute(
+        "CREATE REL TABLE T0(FROM L2 TO L2, id STRING);",
+        access_mode="schema",
+    )
+
+    query = (
+        "MATCH (a:L2)-[r0:T0]->(b:L2) "
+        f"WHERE {predicate} "
+        "RETURN toString('x') AS value"
+    )
+    with pytest.raises(Exception) as excinfo:
+        conn.execute(query, access_mode="read")
+
+    message = str(excinfo.value)
+    assert str(ERR_COMPILATION) in message
+    assert f"Type Mismatch: Cannot compare types {expected_types}" in message
+    assert str(ERR_INVALID_SCHEMA) not in message
+    assert "Catalog exception" not in message
+    assert "LABELS(" not in message
 
 
 # DB-003-03


### PR DESCRIPTION
## Summary

Fix type-mismatched comparisons between STRING values and graph entities.

A predicate such as:

```cypher
MATCH (a:L2)-[r:T0]->(b:L2)
WHERE r.id = b
RETURN 1
```

previously inferred NODE as the common type and attempted to cast the STRING property to an internal graph type. This caused the internal representation NODE(LABELS(...)) to be parsed as a catalog type and produced an ERR_INVALID_SCHEMA error.

## Changes

- Reject STRING and graph entity (`NODE`, `REL`, or `PATH`) combinations during common-type inference.
- Apply the check to both the `DataType` and `DataTypeId` inference paths.
- Report graph types using user-facing names such as `NODE`, without internal label metadata.
- Add Python regression coverage for both operand orders:
  - `r.id = b`
  - `b = r.id`
- Verify that the error is an `ERR_COMPILATION` type mismatch and does not contain catalog or `LABELS(...)` details.

## Result

The query now reports:

```text
ERR_COMPILATION: Binder exception:
Type Mismatch: Cannot compare types STRING and NODE
```

Automated regression tests were added to `tools/python_bind/tests/test_query.py` but were not run locally.