### PR TITLE
fix: "invalid oe offset" when creating a relationship after edge deletion (#922)

### DIFF
--- a/src/storages/graph/edge_table.cc
+++ b/src/storages/graph/edge_table.cc
@@ -634,9 +634,6 @@ namespace {
 // tombstone so a stale offset can never overwrite another edge's data.
 bool position_iter_at_raw_slot(NbrIterator& iter, const NbrList& edges,
                                int32_t offset) {
-  if (offset < 0 || edges.start_ptr == nullptr || edges.cfg.stride <= 0) {
-    return false;
-  }
   const auto* start = static_cast<const char*>(edges.start_ptr);
   const auto* end = static_cast<const char*>(edges.end_ptr);
   const auto slot_num =
@@ -645,8 +642,8 @@ bool position_iter_at_raw_slot(NbrIterator& iter, const NbrList& edges,
     return false;
   }
   iter.cur = start + static_cast<size_t>(offset) * edges.cfg.stride;
-  // A tombstone slot holds no visible edge; writing through it would corrupt
-  // the storage of the deleted edge.
+  // A tombstone slot holds no visible edge; set_data would rewrite its
+  // timestamp and silently resurrect the deleted edge.
   return iter.cfg.ts_offset == 0 || iter.get_timestamp() <= iter.timestamp;
 }
 

--- a/src/storages/graph/edge_table.cc
+++ b/src/storages/graph/edge_table.cc
@@ -621,6 +621,37 @@ void EdgeTable::DeleteVertex(bool is_src, vid_t vid, timestamp_t ts) {
   }
 }
 
+namespace {
+
+// Offsets consumed by EdgeTable::UpdateEdgeProperty (produced by
+// CsrBase::put_edge, record_to_csr_offset_pair, or WAL records) are raw
+// adjacency-list slot indices, not visible-edge ordinals.
+// NbrIterator::operator+= advances over visible edges only — it skips
+// tombstones of edges deleted before the view timestamp — so once a vertex
+// has a deleted edge the two notions diverge and `iter += offset` lands past
+// the end of the list (issue #922). Position the iterator by raw slot
+// instead, and reject offsets that fall outside the adjacency list or onto a
+// tombstone so a stale offset can never overwrite another edge's data.
+bool position_iter_at_raw_slot(NbrIterator& iter, const NbrList& edges,
+                               int32_t offset) {
+  if (offset < 0 || edges.start_ptr == nullptr || edges.cfg.stride <= 0) {
+    return false;
+  }
+  const auto* start = static_cast<const char*>(edges.start_ptr);
+  const auto* end = static_cast<const char*>(edges.end_ptr);
+  const auto slot_num =
+      static_cast<size_t>(end - start) / static_cast<size_t>(edges.cfg.stride);
+  if (static_cast<size_t>(offset) >= slot_num) {
+    return false;
+  }
+  iter.cur = start + static_cast<size_t>(offset) * edges.cfg.stride;
+  // A tombstone slot holds no visible edge; writing through it would corrupt
+  // the storage of the deleted edge.
+  return iter.cfg.ts_offset == 0 || iter.get_timestamp() <= iter.timestamp;
+}
+
+}  // namespace
+
 void EdgeTable::UpdateEdgeProperty(vid_t src_lid, vid_t dst_lid,
                                    int32_t oe_offset, int32_t ie_offset,
                                    int32_t col_id, const Value& prop,
@@ -628,16 +659,14 @@ void EdgeTable::UpdateEdgeProperty(vid_t src_lid, vid_t dst_lid,
   auto accessor = get_edge_data_accessor(col_id);
   auto oe_edges = out_csr_->get_generic_view(ts).get_edges(src_lid);
   auto oe_iter = oe_edges.begin();
-  oe_iter += oe_offset;
-  if (oe_iter == oe_edges.end()) {
+  if (!position_iter_at_raw_slot(oe_iter, oe_edges, oe_offset)) {
     THROW_INVALID_ARGUMENT_EXCEPTION("invalid oe offset ");
   }
   accessor.set_data(oe_iter, prop, ts);
   if (meta_->is_bundled()) {
     auto ie_edges = in_csr_->get_generic_view(ts).get_edges(dst_lid);
     auto ie_iter = ie_edges.begin();
-    ie_iter += ie_offset;
-    if (ie_iter == ie_edges.end()) {
+    if (!position_iter_at_raw_slot(ie_iter, ie_edges, ie_offset)) {
       THROW_INVALID_ARGUMENT_EXCEPTION("invalid ie offset ");
     }
     accessor.set_data(ie_iter, prop, ts);

--- a/tests/storage/test_edge_table.cc
+++ b/tests/storage/test_edge_table.cc
@@ -1109,6 +1109,137 @@ TEST_F(EdgeTableTest, TestUpdateEdgeData) {
   }
 }
 
+TEST_F(EdgeTableTest, TestUpdateEdgePropertyAfterDeletion) {
+  // Regression test for issue #922: updating a freshly inserted edge whose
+  // source vertex already has a deleted (tombstoned) outgoing edge must
+  // resolve the raw adjacency-list slot offset, not a visible-edge ordinal.
+  auto ckp = make_checkpoint(workspace());
+  int64_t src_num = 2;
+  int64_t dst_num = 2;
+  this->InitIndexers(*ckp, src_num, dst_num);
+  this->ConstructEdgeTable(src_label_, dst_label_, edge_label_str_int_);
+  this->OpenEdgeTableInMemory(ckp, neug::CheckpointManifest(), src_num,
+                              dst_num);
+  this->edge_table->EnsureCapacity(this->src_indexer.size(),
+                                   this->dst_indexer.size());
+  this->ExpectUnbundledStats(0, 0);
+  this->edge_table->EnsureCapacity(8);
+  neug::Allocator allocator(neug::MemoryLevel::kInMemory, allocator_dir_);
+
+  const neug::vid_t src = 0;
+  const neug::vid_t dst = 1;
+  // Edge e1 occupies raw slot 0; deleting it leaves a tombstone there.
+  auto e1 = this->edge_table->AddEdge(
+      src, dst, {neug::Value::STRING("e1"), neug::Value::INT32(1)}, 1,
+      allocator, false);
+  EXPECT_EQ(e1.first, 0);
+  this->edge_table->DeleteEdge(src, dst, 0, 0, 2);
+
+  // Edge e2 lands at raw slot 1, right after the tombstone.
+  auto e2 = this->edge_table->AddEdge(
+      src, dst, {neug::Value::STRING("e2"), neug::Value::INT32(2)}, 3,
+      allocator, false);
+  EXPECT_EQ(e2.first, 1);
+
+  // Updating through the raw slot offset must succeed. Previously this threw
+  // "invalid oe offset": `iter += 1` skipped the tombstone at slot 0, landed
+  // on slot 2 (past the end) and failed the end() check.
+  this->edge_table->UpdateEdgeProperty(src, dst, e2.first, 0, 0,
+                                       neug::Value::STRING("updated"), 3);
+  this->edge_table->UpdateEdgeProperty(src, dst, e2.first, 0, 1,
+                                       neug::Value::INT32(42), 3);
+
+  // Only e2 remains visible, with the updated properties.
+  std::vector<int64_t> srcs, dsts;
+  this->OutputOutgoingEndpoints(srcs, dsts, 3);
+  ASSERT_EQ(srcs.size(), 1);
+  ASSERT_EQ(dsts.size(), 1);
+
+  auto oe_view = this->edge_table->get_outgoing_view(3);
+  auto es = oe_view.get_edges(src);
+  auto accessor0 = this->edge_table->get_edge_data_accessor(0);
+  auto accessor1 = this->edge_table->get_edge_data_accessor(1);
+  int visible = 0;
+  for (auto it = es.begin(); it != es.end(); ++it) {
+    ++visible;
+    EXPECT_EQ(accessor0.get_data(it).GetValue<std::string>(), "updated");
+    EXPECT_EQ(accessor1.get_data(it).GetValue<int32_t>(), 42);
+  }
+  EXPECT_EQ(visible, 1);
+}
+
+TEST_F(EdgeTableTest, TestUpdateEdgePropertyAfterDeletionBundled) {
+  // Bundled counterpart of the issue #922 regression: the update also
+  // resolves the incoming-side offset, so both CSR sides must be updated.
+  auto ckp = make_checkpoint(workspace());
+  int64_t src_num = 2;
+  int64_t dst_num = 2;
+  this->InitIndexers(*ckp, src_num, dst_num);
+  this->ConstructEdgeTable(src_label_, dst_label_, edge_label_int_);
+  this->OpenEdgeTableInMemory(ckp, neug::CheckpointManifest(), src_num,
+                              dst_num);
+  this->edge_table->EnsureCapacity(this->src_indexer.size(),
+                                   this->dst_indexer.size());
+  this->ExpectBundledStats(0);
+  neug::Allocator allocator(neug::MemoryLevel::kInMemory, allocator_dir_);
+
+  const neug::vid_t src = 0;
+  const neug::vid_t dst = 1;
+  auto e1 = this->edge_table->AddEdge(src, dst, {neug::Value::INT32(1)}, 1,
+                                      allocator, false);
+  EXPECT_EQ(e1.first, 0);
+
+  // Resolve both offsets of e1, then delete it.
+  auto oe_view = this->edge_table->get_outgoing_view(neug::MAX_TIMESTAMP);
+  auto ie_view = this->edge_table->get_incoming_view(neug::MAX_TIMESTAMP);
+  auto oes = oe_view.get_edges(src);
+  auto ies = ie_view.get_edges(dst);
+  int32_t e1_oe = -1;
+  int32_t e1_ie = -1;
+  for (auto it = oes.begin(); it != oes.end(); ++it) {
+    if (it.get_timestamp() == 1) {
+      e1_oe = static_cast<int32_t>(
+          (reinterpret_cast<const char*>(it.get_nbr_ptr()) -
+           reinterpret_cast<const char*>(oes.start_ptr)) /
+          oes.cfg.stride);
+      e1_ie = neug::fuzzy_search_offset_from_nbr_list(
+          ies, src, it.get_data_ptr(), DataTypeId::kInt32);
+    }
+  }
+  ASSERT_GE(e1_oe, 0);
+  ASSERT_GE(e1_ie, 0);
+  this->edge_table->DeleteEdge(src, dst, e1_oe, e1_ie, 2);
+
+  // e2 lands at raw slot 1 on both sides.
+  auto e2 = this->edge_table->AddEdge(src, dst, {neug::Value::INT32(7)}, 3,
+                                      allocator, false);
+  EXPECT_EQ(e2.first, 1);
+
+  // Resolve e2's incoming offset the same way the execution layer does.
+  auto ies3 = this->edge_table->get_incoming_view(3).get_edges(dst);
+  auto e2_ie = neug::fuzzy_search_offset_from_nbr_list(ies3, src, e2.second,
+                                                       DataTypeId::kInt32);
+  ASSERT_NE(e2_ie, std::numeric_limits<int32_t>::max());
+
+  this->edge_table->UpdateEdgeProperty(src, dst, e2.first, e2_ie, 0,
+                                       neug::Value::INT32(99), 3);
+
+  // Both sides see exactly e2 with the updated data.
+  auto oes3 = this->edge_table->get_outgoing_view(3).get_edges(src);
+  int visible = 0;
+  for (auto it = oes3.begin(); it != oes3.end(); ++it) {
+    ++visible;
+    EXPECT_EQ(*reinterpret_cast<const int32_t*>(it.get_data_ptr()), 99);
+  }
+  EXPECT_EQ(visible, 1);
+  visible = 0;
+  for (auto it = ies3.begin(); it != ies3.end(); ++it) {
+    ++visible;
+    EXPECT_EQ(*reinterpret_cast<const int32_t*>(it.get_data_ptr()), 99);
+  }
+  EXPECT_EQ(visible, 1);
+}
+
 TEST_F(EdgeTableTest, TestAddPropertiesTransitionFromEmptyToBundledUnbundled) {
   auto ckp = make_checkpoint(workspace());
   this->InitIndexers(*ckp, 4, 4);

--- a/tools/python_bind/tests/test_dml.py
+++ b/tools/python_bind/tests/test_dml.py
@@ -566,6 +566,187 @@ def test_insert_many_edges(tmp_path):
     db.close()
 
 
+# Regression test for issue #922: creating a relationship failed with
+# "invalid oe offset" whenever the source node previously had an outgoing
+# edge deleted. EdgeTable::UpdateEdgeProperty positioned the CSR iterator
+# with `iter += offset`, but `+=` advances over visible edges only (skipping
+# tombstones), while the offsets it consumes are raw adjacency-list slot
+# indices. The two notions diverge once a vertex has a deleted edge.
+def test_merge_edge_after_deletion(tmp_path):
+    db_dir = tmp_path / "test_merge_edge_after_deletion"
+    shutil.rmtree(db_dir, ignore_errors=True)
+    db_dir.mkdir()
+    db = Database(db_path=str(db_dir), mode="w")
+    conn = db.connect()
+    try:
+        conn.execute("CREATE NODE TABLE person(uuid STRING, PRIMARY KEY(uuid));")
+        conn.execute(
+            "CREATE REL TABLE knows(FROM person TO person, uuid STRING, name STRING);"
+        )
+        conn.execute("CREATE (p: person {uuid: 'a'});")
+        conn.execute("CREATE (p: person {uuid: 'b'});")
+
+        def save_edge(uuid, name):
+            # Graphiti-style edge save: MERGE the edge, then SET its properties.
+            conn.execute(
+                """
+                MATCH (source:person {uuid: $source_uuid})
+                MATCH (target:person {uuid: $target_uuid})
+                MERGE (source)-[e:knows {uuid: $uuid}]->(target)
+                SET e.uuid = $uuid, e.name = $name
+                RETURN e.uuid AS uuid
+                """,
+                "",
+                {
+                    "uuid": uuid,
+                    "name": name,
+                    "source_uuid": "a",
+                    "target_uuid": "b",
+                },
+            )
+
+        save_edge("e1", "edge-e1")
+        conn.execute(
+            "MATCH (a:person {uuid: 'a'})-[e:knows]->(b:person {uuid: 'b'}) DELETE e;"
+        )
+        # Previously raised: ERR_INVALID_ARGUMENT: invalid oe offset
+        save_edge("e2", "edge-e2")
+
+        res = conn.execute("MATCH ()-[e:knows]->() RETURN e.uuid, e.name;")
+        assert list(res) == [["e2", "edge-e2"]]
+    finally:
+        conn.close()
+        db.close()
+
+
+def test_merge_edge_after_repeated_delete_cycles(tmp_path):
+    db_dir = tmp_path / "test_merge_edge_delete_cycles"
+    shutil.rmtree(db_dir, ignore_errors=True)
+    db_dir.mkdir()
+    db = Database(db_path=str(db_dir), mode="w")
+    conn = db.connect()
+    try:
+        conn.execute("CREATE NODE TABLE person(uuid STRING, PRIMARY KEY(uuid));")
+        conn.execute(
+            "CREATE REL TABLE knows(FROM person TO person, uuid STRING, name STRING);"
+        )
+        conn.execute("CREATE (p: person {uuid: 'a'});")
+        conn.execute("CREATE (p: person {uuid: 'b'});")
+
+        for i in range(5):
+            conn.execute(
+                f"MATCH (a:person {{uuid: 'a'}}), (b:person {{uuid: 'b'}}) "
+                f"MERGE (a)-[e:knows {{uuid: 'e{i}'}}]->(b) "
+                f"SET e.uuid = 'e{i}', e.name = 'edge-e{i}';"
+            )
+            conn.execute(
+                "MATCH (a:person {uuid: 'a'})-[e:knows]->(b:person {uuid: 'b'}) "
+                "DELETE e;"
+            )
+        conn.execute(
+            "MATCH (a:person {uuid: 'a'}), (b:person {uuid: 'b'}) "
+            "MERGE (a)-[e:knows {uuid: 'final'}]->(b) "
+            "SET e.uuid = 'final', e.name = 'edge-final';"
+        )
+
+        res = conn.execute("MATCH ()-[e:knows]->() RETURN e.uuid, e.name;")
+        assert list(res) == [["final", "edge-final"]]
+    finally:
+        conn.close()
+        db.close()
+
+
+def test_set_surviving_edge_after_mid_list_deletion(tmp_path):
+    # The deleted edge leaves a tombstone at slot 0; edges e2/e3 live at raw
+    # slots 1/2 while their visible ordinals are 0/1. Property updates must
+    # resolve through raw slot offsets, not visible ordinals.
+    db_dir = tmp_path / "test_set_edge_after_mid_deletion"
+    shutil.rmtree(db_dir, ignore_errors=True)
+    db_dir.mkdir()
+    db = Database(db_path=str(db_dir), mode="w")
+    conn = db.connect()
+    try:
+        conn.execute("CREATE NODE TABLE person(uuid STRING, PRIMARY KEY(uuid));")
+        conn.execute(
+            "CREATE REL TABLE knows(FROM person TO person, uuid STRING, name STRING);"
+        )
+        for v in ("a", "b", "c", "d"):
+            conn.execute(f"CREATE (p: person {{uuid: '{v}'}});")
+
+        for uuid, dst in (("e1", "b"), ("e2", "c"), ("e3", "d")):
+            conn.execute(
+                f"MATCH (a:person {{uuid: 'a'}}), (b:person {{uuid: '{dst}'}}) "
+                f"CREATE (a)-[:knows {{uuid: '{uuid}', name: 'edge-{uuid}'}}]->(b);"
+            )
+
+        # Delete e1, leaving a tombstone at raw slot 0 of a's adjacency list.
+        conn.execute("MATCH (:person {uuid: 'a'})-[e:knows {uuid: 'e1'}]->() DELETE e;")
+        # SET on surviving edges located after the tombstone must hit the
+        # right edge.
+        conn.execute(
+            "MATCH (:person {uuid: 'a'})-[e:knows {uuid: 'e2'}]->() "
+            "SET e.name = 'updated-e2';"
+        )
+        conn.execute(
+            "MATCH (:person {uuid: 'a'})-[e:knows {uuid: 'e3'}]->() "
+            "SET e.name = 'updated-e3';"
+        )
+        res = conn.execute("MATCH ()-[e:knows]->() RETURN e.uuid, e.name;")
+        assert sorted(list(res)) == [
+            ["e2", "updated-e2"],
+            ["e3", "updated-e3"],
+        ]
+
+        # A fresh edge from the same source lands after the tombstones.
+        conn.execute(
+            "MATCH (a:person {uuid: 'a'}), (b:person {uuid: 'b'}) "
+            "CREATE (a)-[:knows {uuid: 'e4', name: 'edge-e4'}]->(b);"
+        )
+        res = conn.execute("MATCH ()-[e:knows]->() RETURN e.uuid;")
+        assert sorted(r[0] for r in res) == ["e2", "e3", "e4"]
+    finally:
+        conn.close()
+        db.close()
+
+
+def test_bundled_edge_recreate_and_set_after_deletion(tmp_path):
+    # Bundled edges (single non-varchar property) exercise both the outgoing
+    # and incoming offset paths in EdgeTable::UpdateEdgeProperty.
+    db_dir = tmp_path / "test_bundled_edge_recreate_after_delete"
+    shutil.rmtree(db_dir, ignore_errors=True)
+    db_dir.mkdir()
+    db = Database(db_path=str(db_dir), mode="w")
+    conn = db.connect()
+    try:
+        conn.execute("CREATE NODE TABLE person(uuid STRING, PRIMARY KEY(uuid));")
+        conn.execute("CREATE REL TABLE knows(FROM person TO person, weight DOUBLE);")
+        conn.execute("CREATE (p: person {uuid: 'a'});")
+        conn.execute("CREATE (p: person {uuid: 'b'});")
+
+        conn.execute(
+            "MATCH (a:person {uuid: 'a'}), (b:person {uuid: 'b'}) "
+            "CREATE (a)-[:knows {weight: 1.5}]->(b);"
+        )
+        conn.execute(
+            "MATCH (:person {uuid: 'a'})-[e:knows]->(:person {uuid: 'b'}) DELETE e;"
+        )
+        conn.execute(
+            "MATCH (a:person {uuid: 'a'}), (b:person {uuid: 'b'}) "
+            "CREATE (a)-[:knows {weight: 2.5}]->(b);"
+        )
+        # Previously raised: ERR_INVALID_ARGUMENT: invalid oe offset
+        conn.execute(
+            "MATCH (:person {uuid: 'a'})-[e:knows]->(:person {uuid: 'b'}) "
+            "SET e.weight = 9.5;"
+        )
+
+        res = conn.execute("MATCH ()-[e:knows]->() RETURN e.weight;")
+        assert list(res) == [[9.5]]
+    finally:
+        conn.close()
+        db.close()
+
+
 def test_copy_from(tmp_path):
     db_dir = tmp_path / "test_copy_from"
     shutil.rmtree(str(db_dir), ignore_errors=True)


### PR DESCRIPTION
## What do these changes do?

Fixes the `ERR_INVALID_ARGUMENT: invalid oe offset` failure when creating a relationship from a node whose previous outgoing edge had been deleted (issue #922).

### Root cause

`EdgeTable::UpdateEdgeProperty` positioned the CSR iterator with `iter += offset`, but the two sides of that expression use different offset semantics:

- **Producers** of the offsets — `MutableCsr::put_edge`'s return value, `record_to_csr_offset_pair`, `search_other_offset_with_cur_offset`, `delete_edge`, and WAL records — all use **raw adjacency-list slot indices**.
- **`NbrIterator::operator+=`** advances over **visible edges only** — `operator++` skips tombstones of edges deleted before the view timestamp.

With no deletions the two notions coincide. Once a vertex has a deleted edge, its adjacency list keeps the tombstone slot (degree is not shrunk), so a newly appended edge sits at raw slot *N* while its visible ordinal is *N-1*. `iter += offset` then lands past the end of the list and the `end()` check throws `invalid oe offset`.

### Fix

Position the iterator by raw slot (`iter.cur = start_ptr + offset * stride`, the same approach documented in `csr_view_utils.cc`), for both the outgoing and incoming sides. Offsets that fall outside the adjacency list **or onto a tombstone** are rejected, so a stale offset can never silently overwrite another edge's data.

### Test plan

- New C++ regression tests: `EdgeTableTest.TestUpdateEdgePropertyAfterDeletion{,Bundled}` (unbundled + bundled, the latter exercises both oe and ie offset paths) — both fail on the unfixed code and pass with the fix.
- New Python regression tests in `tools/python_bind/tests/test_dml.py`: exact issue repro (MERGE + SET after DELETE), 5x delete/re-create cycles, SET on surviving edges after a mid-list deletion, and bundled-edge re-create + SET — all fail on the unfixed code and pass with the fix.
- Existing suites: `transaction_test` 124 passed (incl. `test_update_transaction`, `test_acid`, WAL replay), `csr_test` 370 passed, `edge_table_test` EdgeTableTest 18 passed, Python `test_dml.py` 20 passed, full Python suite shows no new failures vs. baseline.

## Related issue number

Fixes #922
