### PR TITLE
fix: duplicate predicates in cross-product filter pushdown

### DIFF
--- a/src/compiler/optimizer/filter_push_down_optimizer.cpp
+++ b/src/compiler/optimizer/filter_push_down_optimizer.cpp
@@ -137,6 +137,7 @@ FilterPushDownOptimizer::visitCrossProductReplace(
     }
   }
   if (joinConditions.empty()) {
+    predicateSet = std::move(remainingPSet);
     return finishPushDown(op);
   }
   auto hashJoin = std::make_shared<LogicalHashJoin>(

--- a/src/compiler/optimizer/filter_push_down_optimizer.cpp
+++ b/src/compiler/optimizer/filter_push_down_optimizer.cpp
@@ -137,6 +137,9 @@ FilterPushDownOptimizer::visitCrossProductReplace(
     }
   }
   if (joinConditions.empty()) {
+    // `remainingPSet` is the residual predicate set that must stay above this
+    // cross product; child-local predicates have already been pushed down into
+    // the probe/build children and must not be reintroduced here.
     predicateSet = std::move(remainingPSet);
     return finishPushDown(op);
   }

--- a/tools/python_bind/tests/test_query.py
+++ b/tools/python_bind/tests/test_query.py
@@ -210,6 +210,44 @@ def test_string_property_cannot_be_compared_with_node(
     assert "LABELS(" not in message
 
 
+def test_cross_match_where_followed_by_unwind(empty_db):
+    _, conn = empty_db
+    conn.execute(
+        "CREATE NODE TABLE L0(id STRING, PRIMARY KEY(id));",
+        access_mode="schema",
+    )
+    conn.execute(
+        "CREATE REL TABLE T0(FROM L0 TO L0, id STRING);",
+        access_mode="schema",
+    )
+
+    query = (
+        "MATCH (a:L0)-[r0:T0]->(b:L0) "
+        "MATCH (a0:L0)-[r1:T0]->(b0:L0) "
+        "WHERE b.id STARTS WITH 'a' "
+        "UNWIND [1, 2] AS u "
+        "RETURN 'x' AS value"
+    )
+
+    result = conn.execute(query, access_mode="read")
+    assert result.column_names() == ["value"]
+    assert list(result) == []
+
+    conn.execute(
+        "CREATE (:L0 {id: 'source'}), (:L0 {id: 'alpha'}), " "(:L0 {id: 'beta'});"
+    )
+    conn.execute(
+        "MATCH (source:L0 {id: 'source'}), (target:L0 {id: 'alpha'}) "
+        "CREATE (source)-[:T0 {id: 'to-alpha'}]->(target);"
+    )
+    conn.execute(
+        "MATCH (source:L0 {id: 'source'}), (target:L0 {id: 'beta'}) "
+        "CREATE (source)-[:T0 {id: 'to-beta'}]->(target);"
+    )
+
+    assert list(conn.execute(query, access_mode="read")) == [["x"]] * 4
+
+
 # DB-003-03
 def test_return_expression(modern_graph):
     conn = modern_graph


### PR DESCRIPTION
## Summary

Fix an internal error triggered by valid multi-`MATCH` queries where:

- a later `MATCH ... WHERE` references a variable from an earlier `MATCH`; and
- the query continues with `UNWIND`.

These queries could fail while building the execution pipeline with:

```text
ERR_INTERNAL_ERROR: unordered_map::at: key not found
```

or, with libstdc++:

```text
ERR_INTERNAL_ERROR: _Map_base::at
```

Fixes #320 and #122

## Root cause

When optimizing a filter above a `CROSS_PRODUCT`, `FilterPushDownOptimizer` partitions predicates into:

- predicates evaluable by the probe/left child;
- predicates evaluable by the build/right child; and
- predicates that must remain above the cross product.

Child-local predicates were correctly pushed into their respective branches. However, in the `joinConditions.empty()` path, `finishPushDown()` still used the original `predicateSet`.

As a result, a child-local predicate could be present both inside a child plan and above the `CROSS_PRODUCT`.

Both operators referenced the same shared expression. When `RenameDependentVarOpt` rewrote the predicate embedded in `GET_V` to use the default/current alias, the duplicate parent filter was modified as well. Its physical variable was then emitted without a valid tag.

While building `SelectOpr`, expression parsing attempted to resolve tag `-1` through `ContextMeta`, resulting in the internal `unordered_map::at` exception.

`UNWIND` was not the direct source of the exception. It changed the final plan shape such that the invalid duplicate filter remained visible during execution pipeline construction.

## Fix

After optimizing both cross-product children, replace the current predicate set with `remainingPSet` before calling `finishPushDown()`:

```cpp
predicateSet = std::move(remainingPSet);
return finishPushDown(op);
```

This ensures that:

- predicates pushed into the probe/left child are not duplicated above the cross product;
- predicates pushed into the build/right child are not duplicated;
- predicates that genuinely depend on both sides remain above the cross product.

Added an end-to-end regression test covering both empty and non-empty graphs.
