### PR TITLE
fix: port tests/utils/test_output_stream.cc to Windows

### DIFF
--- a/tests/utils/test_output_stream.cc
+++ b/tests/utils/test_output_stream.cc
@@ -17,7 +17,12 @@
 
 #include <gtest/gtest.h>
 
+#ifdef _WIN32
+#include <process.h>
+#define getpid _getpid
+#else
 #include <unistd.h>
+#endif
 
 #include <filesystem>
 #include <fstream>


### PR DESCRIPTION
Fixes

