### PR TITLE
fix(nodejs): bundle linked shared libraries

### DIFF
--- a/.github/workflows/npm-build-test.yml
+++ b/.github/workflows/npm-build-test.yml
@@ -66,8 +66,9 @@ jobs:
             mkdir -p /home/neug/.local
             curl -fsSL https://nodejs.org/dist/v20.0.0/node-v20.0.0-linux-x64.tar.xz \
               | tar -xJ -C /home/neug/.local --strip-components=1
+            curl -fsSL https://github.com/NixOS/patchelf/releases/download/0.19.1/patchelf-0.19.1-x86_64.tar.gz \
+              | tar -xz -C /home/neug/.local
             export PATH=/home/neug/.local/bin:$PATH
-            python3 -m pip install --user patchelf==0.17.2.4
             cp /root/.neug_env /home/neug/.neug_env 2>/dev/null || true
             git config --global --add safe.directory /project
             . /home/neug/.neug_env
@@ -159,8 +160,9 @@ jobs:
             mkdir -p /home/neug/.local
             curl -fsSL https://nodejs.org/dist/v20.0.0/node-v20.0.0-linux-arm64.tar.xz \
               | tar -xJ -C /home/neug/.local --strip-components=1
+            curl -fsSL https://github.com/NixOS/patchelf/releases/download/0.19.1/patchelf-0.19.1-aarch64.tar.gz \
+              | tar -xz -C /home/neug/.local
             export PATH=/home/neug/.local/bin:$PATH
-            python3 -m pip install --user patchelf==0.17.2.4
             cp /root/.neug_env /home/neug/.neug_env 2>/dev/null || true
             git config --global --add safe.directory /project
             . /home/neug/.neug_env

--- a/.github/workflows/npm-build-test.yml
+++ b/.github/workflows/npm-build-test.yml
@@ -66,7 +66,7 @@ jobs:
             mkdir -p /home/neug/.local
             curl -fsSL https://nodejs.org/dist/v20.0.0/node-v20.0.0-linux-x64.tar.xz \
               | tar -xJ -C /home/neug/.local --strip-components=1
-            curl -fsSL https://github.com/NixOS/patchelf/releases/download/0.19.1/patchelf-0.19.1-x86_64.tar.gz \
+            curl -fsSL https://github.com/NixOS/patchelf/releases/download/0.18.0/patchelf-0.18.0-x86_64.tar.gz \
               | tar -xz -C /home/neug/.local
             export PATH=/home/neug/.local/bin:$PATH
             cp /root/.neug_env /home/neug/.neug_env 2>/dev/null || true
@@ -160,7 +160,7 @@ jobs:
             mkdir -p /home/neug/.local
             curl -fsSL https://nodejs.org/dist/v20.0.0/node-v20.0.0-linux-arm64.tar.xz \
               | tar -xJ -C /home/neug/.local --strip-components=1
-            curl -fsSL https://github.com/NixOS/patchelf/releases/download/0.19.1/patchelf-0.19.1-aarch64.tar.gz \
+            curl -fsSL https://github.com/NixOS/patchelf/releases/download/0.18.0/patchelf-0.18.0-aarch64.tar.gz \
               | tar -xz -C /home/neug/.local
             export PATH=/home/neug/.local/bin:$PATH
             cp /root/.neug_env /home/neug/.neug_env 2>/dev/null || true

--- a/.github/workflows/npm-build-test.yml
+++ b/.github/workflows/npm-build-test.yml
@@ -66,7 +66,7 @@ jobs:
             mkdir -p /home/neug/.local
             curl -fsSL https://nodejs.org/dist/v20.0.0/node-v20.0.0-linux-x64.tar.xz \
               | tar -xJ -C /home/neug/.local --strip-components=1
-            curl -fsSL https://github.com/NixOS/patchelf/releases/download/0.18.0/patchelf-0.18.0-x86_64.tar.gz \
+            curl -fsSL https://github.com/NixOS/patchelf/releases/download/0.19.1/patchelf-0.19.1-x86_64.tar.gz \
               | tar -xz -C /home/neug/.local
             export PATH=/home/neug/.local/bin:$PATH
             cp /root/.neug_env /home/neug/.neug_env 2>/dev/null || true
@@ -160,7 +160,7 @@ jobs:
             mkdir -p /home/neug/.local
             curl -fsSL https://nodejs.org/dist/v20.0.0/node-v20.0.0-linux-arm64.tar.xz \
               | tar -xJ -C /home/neug/.local --strip-components=1
-            curl -fsSL https://github.com/NixOS/patchelf/releases/download/0.18.0/patchelf-0.18.0-aarch64.tar.gz \
+            curl -fsSL https://github.com/NixOS/patchelf/releases/download/0.19.1/patchelf-0.19.1-aarch64.tar.gz \
               | tar -xz -C /home/neug/.local
             export PATH=/home/neug/.local/bin:$PATH
             cp /root/.neug_env /home/neug/.neug_env 2>/dev/null || true

--- a/.github/workflows/npm-build-test.yml
+++ b/.github/workflows/npm-build-test.yml
@@ -66,7 +66,7 @@ jobs:
             mkdir -p /home/neug/.local
             curl -fsSL https://nodejs.org/dist/v20.0.0/node-v20.0.0-linux-x64.tar.xz \
               | tar -xJ -C /home/neug/.local --strip-components=1
-            curl -fsSL https://github.com/NixOS/patchelf/releases/download/0.19.1/patchelf-0.19.1-x86_64.tar.gz \
+            curl -fsSL https://github.com/NixOS/patchelf/releases/download/0.19.0/patchelf-0.19.0-x86_64.tar.gz \
               | tar -xz -C /home/neug/.local
             export PATH=/home/neug/.local/bin:$PATH
             cp /root/.neug_env /home/neug/.neug_env 2>/dev/null || true
@@ -160,7 +160,7 @@ jobs:
             mkdir -p /home/neug/.local
             curl -fsSL https://nodejs.org/dist/v20.0.0/node-v20.0.0-linux-arm64.tar.xz \
               | tar -xJ -C /home/neug/.local --strip-components=1
-            curl -fsSL https://github.com/NixOS/patchelf/releases/download/0.19.1/patchelf-0.19.1-aarch64.tar.gz \
+            curl -fsSL https://github.com/NixOS/patchelf/releases/download/0.19.0/patchelf-0.19.0-aarch64.tar.gz \
               | tar -xz -C /home/neug/.local
             export PATH=/home/neug/.local/bin:$PATH
             cp /root/.neug_env /home/neug/.neug_env 2>/dev/null || true

--- a/.github/workflows/npm-build-test.yml
+++ b/.github/workflows/npm-build-test.yml
@@ -67,6 +67,7 @@ jobs:
             curl -fsSL https://nodejs.org/dist/v20.0.0/node-v20.0.0-linux-x64.tar.xz \
               | tar -xJ -C /home/neug/.local --strip-components=1
             export PATH=/home/neug/.local/bin:$PATH
+            python3 -m pip install --user patchelf==0.17.2.4
             cp /root/.neug_env /home/neug/.neug_env 2>/dev/null || true
             git config --global --add safe.directory /project
             . /home/neug/.neug_env
@@ -159,6 +160,7 @@ jobs:
             curl -fsSL https://nodejs.org/dist/v20.0.0/node-v20.0.0-linux-arm64.tar.xz \
               | tar -xJ -C /home/neug/.local --strip-components=1
             export PATH=/home/neug/.local/bin:$PATH
+            python3 -m pip install --user patchelf==0.17.2.4
             cp /root/.neug_env /home/neug/.neug_env 2>/dev/null || true
             git config --global --add safe.directory /project
             . /home/neug/.neug_env
@@ -244,6 +246,12 @@ jobs:
           echo "MACOSX_DEPLOYMENT_TARGET=11.0"
           source ~/.neug_env
           echo "CMAKE_BUILD_PARALLEL_LEVEL=$(sysctl -n hw.ncpu)" >> $GITHUB_ENV
+
+      - name: Install macOS dependency bundling tool
+        run: |
+          python3 -m venv "${RUNNER_TEMP}/delocate-venv"
+          "${RUNNER_TEMP}/delocate-venv/bin/python" -m pip install delocate==0.13.0
+          echo "${RUNNER_TEMP}/delocate-venv/bin" >> "$GITHUB_PATH"
 
       - name: Build
         run: |

--- a/tools/nodejs_bind/CMakeLists.txt
+++ b/tools/nodejs_bind/CMakeLists.txt
@@ -93,8 +93,10 @@ if (APPLE)
 endif()
 
 # Set RPATH so neug_node_bind.node can find libneug.so / libneug.dylib
-# in the same directory (build/Release/<platform>/). This is essential for
-# npm-distributed packages where the shared lib is bundled alongside the .node file.
+# in the same directory (build/Release/<platform>/). Package builds retain
+# CMake's build-tree RPATHs until dependencies are bundled. Those paths identify
+# the exact libraries selected by the linker; the platform bundle step copies them
+# into the package and replaces non-portable RPATHs before npm pack runs.
 if(APPLE)
   set(_neug_node_rpath "@loader_path")
 else()
@@ -102,7 +104,8 @@ else()
 endif()
 
 set_target_properties(neug_node_bind PROPERTIES
+  BUILD_RPATH "${_neug_node_rpath}"
   INSTALL_RPATH "${_neug_node_rpath}"
-  BUILD_WITH_INSTALL_RPATH TRUE
+  BUILD_WITH_INSTALL_RPATH FALSE
 )
 set_property(TARGET neug APPEND PROPERTY BUILD_RPATH "${_neug_node_rpath}")

--- a/tools/nodejs_bind/Makefile
+++ b/tools/nodejs_bind/Makefile
@@ -43,16 +43,14 @@ JOBS   ?= $(NPROC)
 # Platform-specific shared library name
 ifeq ($(UNAME_S),Darwin)
   NEUG_SHARED_LIB := libneug.dylib
-  MIMALLOC_SHARED_LIB := libmimalloc.2.dylib
 else
   NEUG_SHARED_LIB := libneug.so
-  MIMALLOC_SHARED_LIB := libmimalloc.so.2
 endif
 
 # Local staging directory for the addon and its shared-library dependencies
 PLATFORM_DIR := build/$(BUILD_TYPE)/$(PREBUILD_PLATFORM)
 
-.PHONY: help dev build stage pack proto clean
+.PHONY: help dev build stage bundle pack proto clean
 
 .DEFAULT_GOAL := help
 
@@ -69,20 +67,47 @@ dev:  ## Build neug_node_bind (auto-bootstrap if needed)
 
 build: dev  ## Alias for dev
 
-# Stage .node + libneug into PLATFORM_DIR so @loader_path/$ORIGIN resolves.
+# Stage the Node.js addon and core NeuG shared library.
 stage:
+	@rm -rf "$(PLATFORM_DIR)"
 	@mkdir -p $(PLATFORM_DIR)
 	@find $(ROOT_BUILD) -name "neug_node_bind.node" -exec cp {} $(PLATFORM_DIR)/ \;
 	@cp $(ROOT_BUILD)/src/$(NEUG_SHARED_LIB) $(PLATFORM_DIR)/
-	@cp $(ROOT_BUILD)/third_party/mimalloc/$(MIMALLOC_SHARED_LIB) $(PLATFORM_DIR)/
 	@echo "Artifacts staged in $(PLATFORM_DIR):"
 	@ls -lh $(PLATFORM_DIR)/
+
+bundle:  ## Collect linked third-party libraries and replace build-machine RPATHs
+ifeq ($(UNAME_S),Darwin)
+	delocate-path --sanitize-rpaths -v -L .dylibs "$(PLATFORM_DIR)"
+	@find "$(PLATFORM_DIR)" -type f \( -name '*.node' -o -name '*.dylib' \) \
+		-exec otool -L {} \;
+else
+	@set -e; \
+	lib_dir="$(PLATFORM_DIR)/.libs"; \
+	mkdir -p "$$lib_dir"; \
+	for binary in "$(PLATFORM_DIR)/neug_node_bind.node" "$(PLATFORM_DIR)/libneug.so"; do \
+		ldd "$$binary"; \
+	done | awk '$$2 == "=>" && $$3 ~ /^\// { print $$1 "|" $$3 }' | sort -u | \
+	while IFS='|' read -r soname source; do \
+		case "$$soname" in \
+			linux-vdso.so.*|ld-linux*.so.*|libc.so.*|libm.so.*|libpthread.so.*|libdl.so.*|librt.so.*|libgcc_s.so.*|libstdc++.so.*|libutil.so.*|libresolv.so.*|libnsl.so.*) continue ;; \
+		esac; \
+		echo "Copying $$source -> $$lib_dir/$$soname"; \
+		cp -L "$$source" "$$lib_dir/$$soname"; \
+	done; \
+	patchelf --set-rpath '$$ORIGIN:$$ORIGIN/.libs' "$(PLATFORM_DIR)/neug_node_bind.node"; \
+	patchelf --set-rpath '$$ORIGIN:$$ORIGIN/.libs' "$(PLATFORM_DIR)/libneug.so"; \
+	find "$$lib_dir" -type f -exec patchelf --set-rpath '$$ORIGIN' {} \;; \
+	find "$(PLATFORM_DIR)" -type f \( -name '*.node' -o -name '*.so' -o -name '*.so.*' \) \
+		-exec sh -c 'echo "$$1:"; patchelf --print-rpath "$$1"; ldd "$$1"' sh {} \;
+endif
 
 proto:  ## Regenerate lib/proto/error_pb.js from proto/error.proto
 	node scripts/generate_proto.js
 
 pack:  ## Create per-platform npm tarball
 	@$(MAKE) dev NEUG_NATIVE_ARCH=OFF EXTRA_CMAKE_FLAGS="$(EXTRA_CMAKE_FLAGS) $(PACK_CMAKE_FLAGS)"
+	@$(MAKE) bundle
 	@echo "Packing npm package for platform: $(PREBUILD_PLATFORM)"
 	@cp package.json package.json.orig
 	@node -e 'const fs=require("fs"); const p=JSON.parse(fs.readFileSync("package.json")); p.name="@graphscope-neug/$(OS_TAG)-$(ARCH_TAG)"; p.os=[process.platform]; p.cpu=[process.arch]; fs.writeFileSync("package.json", JSON.stringify(p,null,2)+"\n")'

--- a/tools/nodejs_bind/README.md
+++ b/tools/nodejs_bind/README.md
@@ -6,7 +6,7 @@ Same system dependencies as NeuG (CMake >= 3.16, C++20 compiler), plus:
 
 - Node.js >= 20.0.0
 - macOS package builds only: `delocate==0.13.0`
-- Linux package builds only: `ldd` and `patchelf==0.17.2.4`
+- Linux package builds only: `ldd` and `patchelf >= 0.18.0`
 
 Install the macOS packaging dependency with:
 
@@ -14,10 +14,11 @@ Install the macOS packaging dependency with:
 python3 -m pip install delocate==0.13.0
 ```
 
-On Linux, install `patchelf` from the system package manager or with:
+On Linux, install `patchelf >= 0.18.0` from the system package manager or the
+[official releases](https://github.com/NixOS/patchelf/releases):
 
 ```bash
-python3 -m pip install patchelf==0.17.2.4
+patchelf --version
 ```
 
 ### Installing Node.js

--- a/tools/nodejs_bind/README.md
+++ b/tools/nodejs_bind/README.md
@@ -6,7 +6,7 @@ Same system dependencies as NeuG (CMake >= 3.16, C++20 compiler), plus:
 
 - Node.js >= 20.0.0
 - macOS package builds only: `delocate==0.13.0`
-- Linux package builds only: `ldd` and `patchelf==0.19.1`
+- Linux package builds only: `ldd` and `patchelf==0.19.0`
 
 Install the macOS packaging dependency with:
 
@@ -14,7 +14,7 @@ Install the macOS packaging dependency with:
 python3 -m pip install delocate==0.13.0
 ```
 
-On Linux, install `patchelf==0.19.1` from the system package manager or the
+On Linux, install `patchelf==0.19.0` from the system package manager or the
 [official releases](https://github.com/NixOS/patchelf/releases):
 
 ```bash

--- a/tools/nodejs_bind/README.md
+++ b/tools/nodejs_bind/README.md
@@ -6,7 +6,7 @@ Same system dependencies as NeuG (CMake >= 3.16, C++20 compiler), plus:
 
 - Node.js >= 20.0.0
 - macOS package builds only: `delocate==0.13.0`
-- Linux package builds only: `ldd` and `patchelf >= 0.18.0`
+- Linux package builds only: `ldd` and `patchelf==0.19.1`
 
 Install the macOS packaging dependency with:
 
@@ -14,7 +14,7 @@ Install the macOS packaging dependency with:
 python3 -m pip install delocate==0.13.0
 ```
 
-On Linux, install `patchelf >= 0.18.0` from the system package manager or the
+On Linux, install `patchelf==0.19.1` from the system package manager or the
 [official releases](https://github.com/NixOS/patchelf/releases):
 
 ```bash

--- a/tools/nodejs_bind/README.md
+++ b/tools/nodejs_bind/README.md
@@ -5,6 +5,20 @@
 Same system dependencies as NeuG (CMake >= 3.16, C++20 compiler), plus:
 
 - Node.js >= 20.0.0
+- macOS package builds only: `delocate==0.13.0`
+- Linux package builds only: `ldd` and `patchelf==0.17.2.4`
+
+Install the macOS packaging dependency with:
+
+```bash
+python3 -m pip install delocate==0.13.0
+```
+
+On Linux, install `patchelf` from the system package manager or with:
+
+```bash
+python3 -m pip install patchelf==0.17.2.4
+```
 
 ### Installing Node.js
 
@@ -52,11 +66,17 @@ make pack
 Create a self-contained, distributable npm package tarball (`.tgz`). This will:
 
 1. Build the native addon (same as `make build`)
-2. Copy prebuilt binaries into `build/Release/<platform>/`:
+2. Copy NeuG's first-party binaries into `build/Release/<platform>/`:
    - `neug_node_bind.node` — the native addon
    - `libneug.so` / `libneug.dylib` — core shared library
-   - `libmimalloc.so.2` / `libmimalloc.2.dylib` — memory allocator
-3. Run `npm pack` to produce `neug-<version>.tgz`
+3. Collect the third-party libraries actually selected at link time:
+   - macOS uses `delocate-path` to copy them into `.dylibs/` and rewrite their
+     install names.
+   - Linux uses `ldd` to resolve the dependency closure, copies non-system
+     libraries into `.libs/`, and uses `patchelf` to set package-relative
+     `$ORIGIN` RPATHs.
+4. Print the bundled native dependencies for inspection.
+5. Run `npm pack` to produce `neug-<version>.tgz`
 
 Npm package builds always force `NEUG_PACKAGE_BUILD=ON` and
 `NEUG_NATIVE_ARCH=OFF`.


### PR DESCRIPTION
## What do these changes do?

The Node.js package previously copied only `libneug` and `mimalloc`. Other dependencies remained attached to build-machine paths:

```text
neug_node_bind.node:
    @rpath/libneug.dylib
    /opt/homebrew/opt/openssl@3/lib/libssl.3.dylib
    /opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib
    @rpath/libmimalloc.2.dylib

LC_RPATH:
    @loader_path
    /Users/<builder>/neug/build/src
    /Users/<builder>/neug/build/third_party/mimalloc
```

This makes the package depend on fixed local paths and exposes build-directory information.

This PR stages only the Node addon and `libneug`, then bundles dependencies from the binaries actual link results:

- macOS uses `delocate-path` to copy non-system dylibs into `.dylibs`, rewrite install names, and sanitize RPATHs.
- Linux uses `ldd` and `patchelf` to copy non-system libraries into `.libs` and set package-relative `$ORIGIN` RPATHs.

Expected macOS result:

```text
neug_node_bind.node:
    @loader_path/libneug.dylib
    @loader_path/.dylibs/libssl.3.dylib
    @loader_path/.dylibs/libcrypto.3.dylib
    @loader_path/.dylibs/libmimalloc.2.0.dylib
    /System/Library/Frameworks/...
    /usr/lib/...
```

Validation:

- macOS dependency collection copied OpenSSL and mimalloc into `.dylibs`
- build-tree RPATHs were removed
- the staged native addon loaded successfully from Node.js
- `npm pack --dry-run` included the bundled libraries
- Linux bundle commands were expanded and syntax-checked; x86_64 and arm64 run in CI

## Related issue number

Fixes #940