### PR TITLE
feat: add TP explicit transaction sessions

### DIFF
--- a/doc/source/transaction/transaction.mdx
+++ b/doc/source/transaction/transaction.mdx
@@ -121,11 +121,10 @@ temporary schema operations.
 #### Explicit Transactions in TP Service Mode
 
 TP service explicit transactions are exposed through supported client APIs.
-Clients begin a read-only or read-write transaction, execute queries or inspect
-the transaction's active schema, then commit or roll it back. This guide
-documents that client-level contract; service URIs, headers, status codes, and
-request or response payloads are transport details rather than public
-transaction semantics.
+Clients begin a read-only or read-write transaction, execute queries, then
+commit or roll it back. This guide documents that client-level contract;
+service URIs, headers, status codes, and request or response payloads are
+transport details rather than public transaction semantics.
 
 A read-only transaction pins one TP read view. A read-write transaction owns
 one private COW view, reads its own successful writes, and appends and publishes

--- a/doc/source/transaction/transaction.mdx
+++ b/doc/source/transaction/transaction.mdx
@@ -118,6 +118,37 @@ service sessions, remote clients, Java bindings, savepoints, transaction
 timeouts, or explicit-transaction `COPY`, batch, index, checkpoint, procedure
 calls, or temporary schema operations.
 
+#### Explicit Transactions in TP Service Mode
+
+The HTTP service exposes transaction sessions without reserving an execution
+slot between requests. Begin a session with `POST /transactions` and a JSON
+body of `{"mode":"read_only"}` or `{"mode":"read_write"}`. The response
+contains an `X-Transaction-Id` header; send that header with subsequent routes:
+
+| Route | Operation |
+|-------|-----------|
+| `POST /transactions/query` | Execute one normal `/cypher` request body in the session. |
+| `POST /transactions/commit` | Commit and end the session. |
+| `POST /transactions/rollback` | Abort and end the session. |
+| `GET /transactions/schema` | Read the session's active schema. |
+
+The service marks transaction responses `Cache-Control: no-store`. A
+read-only session pins one TP read view. A read-write session owns one private
+COW view, reads its own successful writes, and appends and publishes one WAL
+commit only when `POST /transactions/commit` succeeds. While a read-write
+session owns the TP update lease, a competing read-write begin returns HTTP 503
+and ordinary TP inserts and updates wait for that session to finish; TP reads
+remain concurrent.
+
+`ServiceConfig::max_explicit_transactions` limits live sessions (zero uses the
+TP slot count), and `explicit_transaction_timeout_ms` sets an absolute session
+lifetime (default 60 seconds; zero disables expiry). Expired, failed, or
+shutdown sessions are rolled back. A failed ordinary statement leaves the
+session rollback-only; issue `POST /transactions/rollback` before reusing its
+transaction id. A read-write begin is rejected when the database itself is
+read-only. Cypher `BEGIN`, `COMMIT`, and `ROLLBACK` remain unsupported: use the
+HTTP routes instead.
+
 ## Deployment Modes Overview
 
 | Aspect | Embedded Mode | Service Mode |

--- a/doc/source/transaction/transaction.mdx
+++ b/doc/source/transaction/transaction.mdx
@@ -113,41 +113,36 @@ programmatic control calls report a transaction-state error without changing an
 otherwise active transaction.
 
 This API does **not** accept Cypher `BEGIN`, `COMMIT`, or `ROLLBACK`; use the
-programmatic `Connection` methods shown above. It does not yet include TP
-service sessions, remote clients, Java bindings, savepoints, transaction
-timeouts, or explicit-transaction `COPY`, batch, index, checkpoint, procedure
-calls, or temporary schema operations.
+programmatic `Connection` methods shown above. The embedded API does not
+include remote clients, Java bindings, savepoints, transaction timeouts, or
+explicit-transaction `COPY`, batch, index, checkpoint, procedure calls, or
+temporary schema operations.
 
 #### Explicit Transactions in TP Service Mode
 
-The HTTP service exposes transaction sessions without reserving an execution
-slot between requests. Begin a session with `POST /transactions` and a JSON
-body of `{"mode":"read_only"}` or `{"mode":"read_write"}`. The response
-contains an `X-Transaction-Id` header; send that header with subsequent routes:
+TP service explicit transactions are exposed through supported client APIs.
+Clients begin a read-only or read-write transaction, execute queries or inspect
+the transaction's active schema, then commit or roll it back. This guide
+documents that client-level contract; service URIs, headers, status codes, and
+request or response payloads are transport details rather than public
+transaction semantics.
 
-| Route | Operation |
-|-------|-----------|
-| `POST /transactions/query` | Execute one normal `/cypher` request body in the session. |
-| `POST /transactions/commit` | Commit and end the session. |
-| `POST /transactions/rollback` | Abort and end the session. |
-| `GET /transactions/schema` | Read the session's active schema. |
+A read-only transaction pins one TP read view. A read-write transaction owns
+one private COW view, reads its own successful writes, and appends and publishes
+one WAL commit only when `commit` succeeds. While a read-write transaction owns
+the TP update lease, another read-write transaction cannot begin; ordinary TP
+inserts and updates wait for it to finish, while TP reads remain concurrent.
 
-The service marks transaction responses `Cache-Control: no-store`. A
-read-only session pins one TP read view. A read-write session owns one private
-COW view, reads its own successful writes, and appends and publishes one WAL
-commit only when `POST /transactions/commit` succeeds. While a read-write
-session owns the TP update lease, a competing read-write begin returns HTTP 503
-and ordinary TP inserts and updates wait for that session to finish; TP reads
-remain concurrent.
+A failed ordinary statement leaves the transaction rollback-only. `rollback`
+ends that transaction immediately; its handle cannot be reused, so clients
+must begin a new transaction before issuing more queries. Transactions may have
+an absolute service-configured lifetime. Expired, failed, or shutdown
+transactions are rolled back and ended. Clients must reliably finish a
+read-write transaction: an abandoned transaction can keep the TP update lease
+and delay ordinary TP writes until the service releases it.
 
-`ServiceConfig::max_explicit_transactions` limits live sessions (zero uses the
-TP slot count), and `explicit_transaction_timeout_ms` sets an absolute session
-lifetime (default 60 seconds; zero disables expiry). Expired, failed, or
-shutdown sessions are rolled back. A failed ordinary statement leaves the
-session rollback-only; issue `POST /transactions/rollback` before reusing its
-transaction id. A read-write begin is rejected when the database itself is
-read-only. Cypher `BEGIN`, `COMMIT`, and `ROLLBACK` remain unsupported: use the
-HTTP routes instead.
+Cypher `BEGIN`, `COMMIT`, and `ROLLBACK` remain unsupported within transaction
+queries; use the client API's transaction-control methods instead.
 
 ## Deployment Modes Overview
 

--- a/include/neug/main/execution_slot.h
+++ b/include/neug/main/execution_slot.h
@@ -52,6 +52,7 @@ class IVersionManager;
 class NeugDB;
 class Connection;
 class ExecutionSlot;
+class ServiceTransactionManager;
 class TpExecutionSlotPool;
 class TransactionContext;
 class ExtensionManager;
@@ -237,6 +238,7 @@ class ExecutionSlot {
  private:
   friend class NeugDB;
   friend class Connection;
+  friend class ServiceTransactionManager;
   friend class TpExecutionSlotPool;
 
   ExecutionSlot(GraphSnapshotStore& snapshot_store,
@@ -289,8 +291,9 @@ class ExecutionSlot {
       QueryCacheMode cache_mode = QueryCacheMode::kShared);
 
   result<CurrentCowWriteTransaction> BeginCurrentCowWriteTransaction();
+  result<SnapshotCowWriteTransaction> TryBeginSnapshotCowWriteTransaction();
   result<QueryResult> ExecuteQueryInTransaction(
-      const std::string& query_string, const std::string& access_mode,
+      const std::string& query_string, AccessMode requested_mode,
       const rapidjson::Value& parameters, int32_t num_threads,
       TransactionContext& transaction_context);
 

--- a/include/neug/main/transaction_context.h
+++ b/include/neug/main/transaction_context.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include <cstdint>
-#include <type_traits>
 #include <utility>
 #include <variant>
 
@@ -32,7 +31,7 @@ namespace neug {
 enum class TransactionMode : uint8_t {
   /** Pin a published read view and reject writes. */
   kReadOnly,
-  /** Hold a private AP COW view and publish it only at Commit(). */
+  /** Hold a private COW view and publish it only at Commit(). */
   kReadWrite,
 };
 
@@ -102,14 +101,15 @@ class TransactionContext {
     state_ = State::kActive;
   }
 
+ private:
+  friend class ExecutionSlot;
+  friend class ServiceTransactionManager;
+
   void Begin(SnapshotCowWriteTransaction transaction) {
     transaction_.emplace<SnapshotCowWriteTransaction>(std::move(transaction));
     mode_ = TransactionMode::kReadWrite;
     state_ = State::kActive;
   }
-
- private:
-  friend class ExecutionSlot;
 
   SnapshotReadTransaction& ReadTransactionOwner() {
     return std::get<SnapshotReadTransaction>(transaction_);
@@ -129,16 +129,9 @@ class TransactionContext {
       return Status::OK();
     }
 
-    auto status = VisitCowWriteOwner([](auto& transaction) {
-      if constexpr (std::is_same_v<std::decay_t<decltype(transaction)>,
-                                   CurrentCowWriteTransaction>) {
-        return transaction.Commit();
-      } else {
-        return transaction.Commit()
-                   ? Status::OK()
-                   : Status::InternalError("Write transaction commit failed.");
-      }
-    });
+    CHECK(std::holds_alternative<CurrentCowWriteTransaction>(transaction_))
+        << "TP snapshot writes must use the prepared commit path";
+    auto status = std::get<CurrentCowWriteTransaction>(transaction_).Commit();
     if (status.ok()) {
       ResetToIdle();
     } else {
@@ -182,8 +175,6 @@ class TransactionContext {
   }
 
  private:
-  friend class ServiceTransactionManager;
-
   Status PrepareTpSnapshotCommit() {
     CHECK(IsActive() && !IsReadOnly());
     if (!std::holds_alternative<SnapshotCowWriteTransaction>(transaction_)) {

--- a/include/neug/main/transaction_context.h
+++ b/include/neug/main/transaction_context.h
@@ -15,12 +15,14 @@
 #pragma once
 
 #include <cstdint>
+#include <type_traits>
 #include <utility>
 #include <variant>
 
 #include <glog/logging.h>
 
 #include "neug/transaction/current_cow_write_transaction.h"
+#include "neug/transaction/snapshot_cow_write_transaction.h"
 #include "neug/transaction/snapshot_read_transaction.h"
 #include "neug/utils/result.h"
 
@@ -35,12 +37,13 @@ enum class TransactionMode : uint8_t {
 };
 
 /**
- * @brief Connection-owned explicit transaction state and concrete owner.
+ * @brief Explicit transaction state and its concrete owner.
  *
- * ExecutionSlot constructs the concrete owner. Connection keeps it across
- * statements without introducing a common transaction interface. A failed
- * statement aborts the concrete owner and leaves this context rollback-only;
- * after that failure, only Rollback() returns it to idle.
+ * ExecutionSlot constructs the concrete owner. A Connection or service session
+ * keeps it across statements without introducing a common transaction
+ * interface. A failed statement aborts the concrete owner and leaves this
+ * context rollback-only; after that failure, only Rollback() returns it to
+ * idle.
  */
 class TransactionContext {
  public:
@@ -55,6 +58,30 @@ class TransactionContext {
     kRollbackOnly,
   };
 
+ private:
+  template <typename Func>
+  decltype(auto) VisitCowWriteOwner(Func&& func) {
+    CHECK(IsActive() && !IsReadOnly());
+    if (std::holds_alternative<CurrentCowWriteTransaction>(transaction_)) {
+      return std::forward<Func>(func)(
+          std::get<CurrentCowWriteTransaction>(transaction_));
+    }
+    return std::forward<Func>(func)(
+        std::get<SnapshotCowWriteTransaction>(transaction_));
+  }
+
+  template <typename Func>
+  decltype(auto) VisitCowWriteOwner(Func&& func) const {
+    CHECK(IsActive() && !IsReadOnly());
+    if (std::holds_alternative<CurrentCowWriteTransaction>(transaction_)) {
+      return std::forward<Func>(func)(
+          std::get<CurrentCowWriteTransaction>(transaction_));
+    }
+    return std::forward<Func>(func)(
+        std::get<SnapshotCowWriteTransaction>(transaction_));
+  }
+
+ public:
   bool HasActiveTransaction() const noexcept { return state_ != State::kIdle; }
   bool IsActive() const noexcept { return state_ == State::kActive; }
   bool IsRollbackOnly() const noexcept {
@@ -75,19 +102,23 @@ class TransactionContext {
     state_ = State::kActive;
   }
 
+  void Begin(SnapshotCowWriteTransaction transaction) {
+    transaction_.emplace<SnapshotCowWriteTransaction>(std::move(transaction));
+    mode_ = TransactionMode::kReadWrite;
+    state_ = State::kActive;
+  }
+
+ private:
+  friend class ExecutionSlot;
+
   SnapshotReadTransaction& ReadTransactionOwner() {
     return std::get<SnapshotReadTransaction>(transaction_);
   }
   const SnapshotReadTransaction& ReadTransactionOwner() const {
     return std::get<SnapshotReadTransaction>(transaction_);
   }
-  CurrentCowWriteTransaction& WriteTransactionOwner() {
-    return std::get<CurrentCowWriteTransaction>(transaction_);
-  }
-  const CurrentCowWriteTransaction& WriteTransactionOwner() const {
-    return std::get<CurrentCowWriteTransaction>(transaction_);
-  }
 
+ public:
   Status Commit() {
     if (IsReadOnly()) {
       if (!ReadTransactionOwner().Commit()) {
@@ -98,7 +129,16 @@ class TransactionContext {
       return Status::OK();
     }
 
-    auto status = WriteTransactionOwner().Commit();
+    auto status = VisitCowWriteOwner([](auto& transaction) {
+      if constexpr (std::is_same_v<std::decay_t<decltype(transaction)>,
+                                   CurrentCowWriteTransaction>) {
+        return transaction.Commit();
+      } else {
+        return transaction.Commit()
+                   ? Status::OK()
+                   : Status::InternalError("Write transaction commit failed.");
+      }
+    });
     if (status.ok()) {
       ResetToIdle();
     } else {
@@ -112,7 +152,7 @@ class TransactionContext {
       if (IsReadOnly()) {
         ReadTransactionOwner().Abort();
       } else {
-        WriteTransactionOwner().Abort();
+        VisitCowWriteOwner([](auto& transaction) { transaction.Abort(); });
       }
     }
     ResetToIdle();
@@ -123,7 +163,7 @@ class TransactionContext {
       if (IsReadOnly()) {
         ReadTransactionOwner().Abort();
       } else {
-        WriteTransactionOwner().Abort();
+        VisitCowWriteOwner([](auto& transaction) { transaction.Abort(); });
       }
     }
     transaction_.emplace<std::monostate>();
@@ -133,11 +173,36 @@ class TransactionContext {
   const Schema& schema() const {
     CHECK(IsActive())
         << "TransactionContext::schema() requires an active transaction";
-    return IsReadOnly() ? ReadTransactionOwner().schema()
-                        : WriteTransactionOwner().schema();
+    if (IsReadOnly()) {
+      return ReadTransactionOwner().schema();
+    }
+    return VisitCowWriteOwner([](const auto& transaction) -> const Schema& {
+      return transaction.schema();
+    });
   }
 
  private:
+  friend class ServiceTransactionManager;
+
+  Status PrepareTpSnapshotCommit() {
+    CHECK(IsActive() && !IsReadOnly());
+    if (!std::holds_alternative<SnapshotCowWriteTransaction>(transaction_)) {
+      return Status::InternalError(
+          "Only TP snapshot write transactions can be prepared.");
+    }
+    return std::get<SnapshotCowWriteTransaction>(transaction_).PrepareCommit();
+  }
+
+  Status CommitPreparedTpSnapshot() {
+    CHECK(IsActive() && !IsReadOnly());
+    if (!std::get<SnapshotCowWriteTransaction>(transaction_).CommitPrepared()) {
+      AbortAndMarkRollbackOnly();
+      return Status::InternalError("Prepared write transaction commit failed.");
+    }
+    ResetToIdle();
+    return Status::OK();
+  }
+
   void ResetToIdle() noexcept {
     transaction_.emplace<std::monostate>();
     state_ = State::kIdle;
@@ -146,7 +211,7 @@ class TransactionContext {
   State state_{State::kIdle};
   TransactionMode mode_{TransactionMode::kReadOnly};
   std::variant<std::monostate, SnapshotReadTransaction,
-               CurrentCowWriteTransaction>
+               CurrentCowWriteTransaction, SnapshotCowWriteTransaction>
       transaction_;
 };
 

--- a/include/neug/server/brpc_service_mgr.h
+++ b/include/neug/server/brpc_service_mgr.h
@@ -39,6 +39,8 @@
 
 namespace neug {
 
+class ServiceTransactionManager;
+
 int32_t status_code_to_http_code(neug::StatusCode code);
 
 /**
@@ -149,8 +151,10 @@ class UnifiedServiceImpl {
 class HttpServiceImpl : public UnifiedServiceImpl, public neug::HttpService {
  public:
   explicit HttpServiceImpl(neug::NeugDB& neug_db,
-                           TpExecutionSlotPool& execution_slot_pool)
+                           TpExecutionSlotPool& execution_slot_pool,
+                           ServiceTransactionManager& transaction_manager)
       : UnifiedServiceImpl(neug_db, execution_slot_pool),
+        transaction_manager_(transaction_manager),
         protocol_(GetServiceProtocol(brpc::PROTOCOL_HTTP)) {}
   virtual ~HttpServiceImpl() {}
 
@@ -166,14 +170,34 @@ class HttpServiceImpl : public UnifiedServiceImpl, public neug::HttpService {
                         const google::protobuf::Empty*, HttpResponse* response,
                         google::protobuf::Closure* done);
 
+  void BeginTransaction(google::protobuf::RpcController* cntl_base,
+                        const HttpRequest* request, HttpResponse* response,
+                        google::protobuf::Closure* done);
+  void ExecuteTransactionQuery(google::protobuf::RpcController* cntl_base,
+                               const HttpRequest* request,
+                               HttpResponse* response,
+                               google::protobuf::Closure* done);
+  void CommitTransaction(google::protobuf::RpcController* cntl_base,
+                         const HttpRequest* request, HttpResponse* response,
+                         google::protobuf::Closure* done);
+  void RollbackTransaction(google::protobuf::RpcController* cntl_base,
+                           const HttpRequest* request, HttpResponse* response,
+                           google::protobuf::Closure* done);
+  void GetTransactionSchema(google::protobuf::RpcController* cntl_base,
+                            const google::protobuf::Empty*,
+                            HttpResponse* response,
+                            google::protobuf::Closure* done);
+
  private:
+  ServiceTransactionManager& transaction_manager_;
   const BrpcServiceProtocol& protocol_;
 };
 
 class BrpcServiceManager : public IServiceManager {
  public:
   explicit BrpcServiceManager(neug::NeugDB& neug_db,
-                              TpExecutionSlotPool& execution_slot_pool);
+                              TpExecutionSlotPool& execution_slot_pool,
+                              ServiceTransactionManager& transaction_manager);
 
   ~BrpcServiceManager();
   void Init(const ServiceConfig& config) override;
@@ -185,6 +209,7 @@ class BrpcServiceManager : public IServiceManager {
  private:
   neug::NeugDB& neug_db_;
   TpExecutionSlotPool& execution_slot_pool_;
+  ServiceTransactionManager& transaction_manager_;
   uint32_t resolve_num_threads() const;
   brpc::ServerOptions get_server_options() const;
 

--- a/include/neug/server/brpc_service_mgr.h
+++ b/include/neug/server/brpc_service_mgr.h
@@ -183,10 +183,6 @@ class HttpServiceImpl : public UnifiedServiceImpl, public neug::HttpService {
   void RollbackTransaction(google::protobuf::RpcController* cntl_base,
                            const HttpRequest* request, HttpResponse* response,
                            google::protobuf::Closure* done);
-  void GetTransactionSchema(google::protobuf::RpcController* cntl_base,
-                            const google::protobuf::Empty*,
-                            HttpResponse* response,
-                            google::protobuf::Closure* done);
 
  private:
   ServiceTransactionManager& transaction_manager_;

--- a/include/neug/server/neug_db_service.h
+++ b/include/neug/server/neug_db_service.h
@@ -90,7 +90,6 @@ class ServiceTransactionManager;
  * - `GET /status` - Check service status
  * - `POST /transactions` - Begin an explicit TP transaction session
  * - `POST /transactions/{id}/query|commit|rollback` - Operate on a session
- * - `GET /transactions/{id}/schema` - Retrieve a session's active schema
  *
  * **Thread Safety:** All public methods are thread-safe. The service uses
  * a TpExecutionSlotPool internally to handle concurrent requests efficiently.

--- a/include/neug/server/neug_db_service.h
+++ b/include/neug/server/neug_db_service.h
@@ -89,8 +89,8 @@ class ServiceTransactionManager;
  * - `GET /schema` - Retrieve graph schema
  * - `GET /status` - Check service status
  * - `POST /transactions` - Begin an explicit TP transaction session
- * - `POST /transactions/query|commit|rollback` - Operate on a session
- * - `GET /transactions/schema` - Retrieve a session's active schema
+ * - `POST /transactions/{id}/query|commit|rollback` - Operate on a session
+ * - `GET /transactions/{id}/schema` - Retrieve a session's active schema
  *
  * **Thread Safety:** All public methods are thread-safe. The service uses
  * a TpExecutionSlotPool internally to handle concurrent requests efficiently.

--- a/include/neug/server/neug_db_service.h
+++ b/include/neug/server/neug_db_service.h
@@ -41,6 +41,8 @@
 
 namespace neug {
 
+class ServiceTransactionManager;
+
 /**
  * @brief NeuG database HTTP service for high-throughput scenarios.
  *
@@ -86,6 +88,9 @@ namespace neug {
  * - `POST /cypher` - Execute Cypher queries
  * - `GET /schema` - Retrieve graph schema
  * - `GET /status` - Check service status
+ * - `POST /transactions` - Begin an explicit TP transaction session
+ * - `POST /transactions/query|commit|rollback` - Operate on a session
+ * - `GET /transactions/schema` - Retrieve a session's active schema
  *
  * **Thread Safety:** All public methods are thread-safe. The service uses
  * a TpExecutionSlotPool internally to handle concurrent requests efficiently.
@@ -111,20 +116,8 @@ class NeugDBService {
    * @throws neug::exception::RuntimeError If local connections are still open
    * or another NeugDBService is already associated with the database
    */
-  NeugDBService(neug::NeugDB& db, const ServiceConfig& config = ServiceConfig())
-      : db_(db), db_config_(db_.config()) {
-    db_.registerService(this);
-    try {
-      installBthreadRuntimeWait();
-      init(config);
-    } catch (...) {
-      hdl_mgr_.reset();
-      execution_slot_pool_.reset();
-      restoreNativeRuntimeWait();
-      db_.unregisterService(this);
-      throw;
-    }
-  }
+  NeugDBService(neug::NeugDB& db,
+                const ServiceConfig& config = ServiceConfig());
 
   /**
    * @brief Gets direct access to the underlying graph database
@@ -276,6 +269,7 @@ class NeugDBService {
   neug::NeugDB& db_;
   neug::NeugDBConfig db_config_;
   std::unique_ptr<neug::TpExecutionSlotPool> execution_slot_pool_;
+  std::unique_ptr<ServiceTransactionManager> transaction_manager_;
   std::unique_ptr<IServiceManager> hdl_mgr_;
 
   std::thread compact_thread_;

--- a/include/neug/server/tp_execution_slot_pool.h
+++ b/include/neug/server/tp_execution_slot_pool.h
@@ -31,6 +31,7 @@ namespace neug {
 class CheckpointCoordinator;
 class NeugDBService;
 class IWalWriter;
+class ServiceTransactionManager;
 
 /**
  * @brief Pool of database slots for concurrent query execution.
@@ -171,9 +172,12 @@ class TpExecutionSlotPool {
   }
 
  private:
+  /// Returns an empty lease instead of waiting when every TP slot is busy.
+  ExecutionSlotLease TryAcquireExecutionSlot();
   static void releaseExecutionSlot(void* owner, size_t slot_id) noexcept;
 
   friend class NeugDBService;
+  friend class ServiceTransactionManager;
 
   Entry* entries_;
   size_t slot_num_;

--- a/include/neug/transaction/operation_gate.h
+++ b/include/neug/transaction/operation_gate.h
@@ -23,6 +23,8 @@
 
 namespace neug {
 
+class VersionManager;
+
 namespace detail {
 
 enum class AdmissionState : uint8_t { kOpen, kInsertsBlocked, kAllBlocked };
@@ -181,6 +183,13 @@ class OperationGate {
   }
 
  private:
+  friend class VersionManager;
+
+  // One-shot phase acquisition for service admission. It never waits and
+  // leaves the gate unchanged when another writer or maintenance operation is
+  // already active.
+  bool try_enter_phase(detail::AdmissionState desired_phase) noexcept;
+
   std::atomic<uint64_t> state_;
   std::atomic<RuntimeWaitFn> runtime_wait_;
 };

--- a/include/neug/transaction/snapshot_cow_write_transaction.h
+++ b/include/neug/transaction/snapshot_cow_write_transaction.h
@@ -25,6 +25,7 @@
 #include "neug/transaction/cow_graph_storage.h"
 #include "neug/transaction/cow_graph_workspace.h"
 #include "neug/transaction/timestamp_lease.h"
+#include "neug/utils/result.h"
 
 namespace neug {
 
@@ -70,6 +71,7 @@ class SnapshotCowWriteTransaction {
     return GraphStats(workspace_.view(), workspace_.base_planning_generation());
   }
   const Schema& schema() const { return workspace_.view().schema(); }
+  bool PlanningChanged() const { return workspace_.PlanningChanged(); }
 
   Value GetVertexId(label_t label, vid_t lid) const;
   bool GetVertexIndex(label_t label, const Value& id, vid_t& index) const;
@@ -99,6 +101,13 @@ class SnapshotCowWriteTransaction {
   }
 
  private:
+  friend class TransactionContext;
+
+  // ServiceTransactionManager checks its deadline after this fallible prepare
+  // step and before entering the WAL durability boundary.
+  Status PrepareCommit();
+  bool CommitPrepared();
+
   bool active() const noexcept { return timestamp_lease_.active(); }
   void release(std::optional<uint32_t> installed_snapshot_generation) noexcept;
 
@@ -107,6 +116,7 @@ class SnapshotCowWriteTransaction {
   IWalWriter& wal_writer_;
   GraphSnapshotStore& snapshot_store_;
   UpdateTimestampLease timestamp_lease_;
+  std::optional<GraphSnapshotStore::PreparedSnapshot> prepared_snapshot_;
 };
 
 }  // namespace neug

--- a/include/neug/transaction/timestamp_lease.h
+++ b/include/neug/transaction/timestamp_lease.h
@@ -20,6 +20,7 @@
 
 namespace neug {
 
+class ExecutionSlot;
 class IVersionManager;
 
 /**
@@ -53,6 +54,12 @@ class UpdateTimestampLease {
   void FinishAndResetTimeline() noexcept;
 
  private:
+  friend class ExecutionSlot;
+
+  static std::optional<UpdateTimestampLease> TryAcquire(
+      IVersionManager& version_manager);
+  UpdateTimestampLease(IVersionManager& version_manager, uint32_t timestamp)
+      : version_manager_(&version_manager), timestamp_(timestamp) {}
   void reset() noexcept;
 
   static constexpr uint32_t kInactiveTimestamp = UINT32_MAX;

--- a/include/neug/transaction/version_manager.h
+++ b/include/neug/transaction/version_manager.h
@@ -114,9 +114,14 @@ class IVersionManager {
   friend class UpdateTimestampLease;
 
   // Timed acquisition is intentionally lease-only: callers must not receive a
-  // raw timestamp without immediately establishing RAII ownership.
+  // raw timestamp without immediately establishing RAII ownership. It has no
+  // production callers yet, but remains for a future explicit update
+  // transaction that waits for admission until its deadline.
   virtual uint32_t acquire_update_timestamp_until(
       std::chrono::steady_clock::time_point deadline) = 0;
+  // Attempt update admission without waiting. Returns false when no writer can
+  // be admitted immediately.
+  virtual bool try_acquire_update_timestamp(uint32_t&) = 0;
 
   /// Complete an exclusive update after external state has moved to a new
   /// timeline. Preserve the current snapshot generation and publish visibility
@@ -191,6 +196,7 @@ class VersionManager : public IVersionManager {
  private:
   uint32_t acquire_update_timestamp_until(
       std::chrono::steady_clock::time_point deadline) override;
+  bool try_acquire_update_timestamp(uint32_t& timestamp) override;
   void finish_update_and_reset_timeline(uint32_t ts) noexcept override;
 
   int thread_num_;

--- a/include/neug/utils/service_manager.h
+++ b/include/neug/utils/service_manager.h
@@ -55,6 +55,11 @@ struct ServiceConfig {
   static constexpr const uint32_t DEFAULT_THREAD_NUM = 0;
   /// Default HTTP port for query endpoint
   static constexpr const uint32_t DEFAULT_QUERY_PORT = 10000;
+  /// 0 scales the session limit with the TP execution slot count.
+  static constexpr const uint32_t DEFAULT_MAX_EXPLICIT_TRANSACTIONS = 0;
+  /// Default absolute lifetime for an explicit HTTP transaction.
+  static constexpr const uint64_t DEFAULT_EXPLICIT_TRANSACTION_TIMEOUT_MS =
+      60000;
 
   /// HTTP port for the query endpoint (default: 10000)
   uint32_t query_port;
@@ -67,6 +72,10 @@ struct ServiceConfig {
   std::string host_str;
   /// Enable background auto-compaction thread while serving
   bool auto_compaction;
+  /// Maximum active explicit HTTP transactions. 0 follows the slot count.
+  uint32_t max_explicit_transactions;
+  /// Absolute lifetime of an explicit HTTP transaction, in milliseconds.
+  uint64_t explicit_transaction_timeout_ms;
 
   /**
    * @brief Constructs ServiceConfig with default values.
@@ -76,12 +85,17 @@ struct ServiceConfig {
    * - thread_num: 0 (auto-select from database max_thread_num)
    * - host_str: "127.0.0.1" (localhost only)
    * - auto_compaction: true
+   * - max_explicit_transactions: 0 (one session per TP slot)
+   * - explicit_transaction_timeout_ms: 60000
    */
   ServiceConfig()
       : query_port(DEFAULT_QUERY_PORT),
         thread_num(DEFAULT_THREAD_NUM),
         host_str("127.0.0.1"),
-        auto_compaction(true) {}
+        auto_compaction(true),
+        max_explicit_transactions(DEFAULT_MAX_EXPLICIT_TRANSACTIONS),
+        explicit_transaction_timeout_ms(
+            DEFAULT_EXPLICIT_TRANSACTION_TIMEOUT_MS) {}
 };
 
 class IServiceManager {

--- a/proto/http_svc.proto
+++ b/proto/http_svc.proto
@@ -36,5 +36,4 @@ service HttpService {
   rpc ExecuteTransactionQuery(HttpRequest) returns (HttpResponse);
   rpc CommitTransaction(HttpRequest) returns (HttpResponse);
   rpc RollbackTransaction(HttpRequest) returns (HttpResponse);
-  rpc GetTransactionSchema(google.protobuf.Empty) returns (HttpResponse);
 }

--- a/proto/http_svc.proto
+++ b/proto/http_svc.proto
@@ -32,4 +32,9 @@ service HttpService {
       returns (HttpResponse);  // Use a different name to avoid conflict with
                                // the brpc status method
   rpc PostCypherQuery(HttpRequest) returns (HttpResponse);
+  rpc BeginTransaction(HttpRequest) returns (HttpResponse);
+  rpc ExecuteTransactionQuery(HttpRequest) returns (HttpResponse);
+  rpc CommitTransaction(HttpRequest) returns (HttpResponse);
+  rpc RollbackTransaction(HttpRequest) returns (HttpResponse);
+  rpc GetTransactionSchema(google.protobuf.Empty) returns (HttpResponse);
 }

--- a/src/main/connection.cc
+++ b/src/main/connection.cc
@@ -18,6 +18,7 @@
 #include <exception>
 
 #include "neug/main/execution_slot.h"
+#include "neug/utils/access_mode.h"
 #include "neug/utils/exception/exception.h"
 #include "neug/utils/yaml_utils.h"
 
@@ -149,8 +150,15 @@ result<QueryResult> Connection::Query(const std::string& query_string,
                "Transaction is rollback-only; Rollback() is required."));
   }
   if (transaction_context_.IsActive()) {
+    AccessMode requested_mode;
+    try {
+      requested_mode = ParseAccessMode(access_mode);
+    } catch (...) {
+      transaction_context_.AbortAndMarkRollbackOnly();
+      throw;
+    }
     return execution_slot_->ExecuteQueryInTransaction(
-        query_string, access_mode, parameters, /*num_threads=*/0,
+        query_string, requested_mode, parameters, /*num_threads=*/0,
         transaction_context_);
   }
   return execution_slot_->ExecuteQuery(query_string, access_mode, parameters);

--- a/src/main/execution_slot.cc
+++ b/src/main/execution_slot.cc
@@ -226,7 +226,7 @@ ExecutionSlot::TryBeginSnapshotCowWriteTransaction() {
   auto timestamp_lease = UpdateTimestampLease::TryAcquire(version_manager_);
   if (!timestamp_lease) {
     RETURN_ERROR(Status(StatusCode::ERR_SERVICE_UNAVAILABLE,
-                        "A TP write transaction is already active."));
+                        "The TP update lease is unavailable."));
   }
   auto [cow_graph, planning_generation] =
       snapshot_store_.CloneCurrentForUpdate();

--- a/src/main/execution_slot.cc
+++ b/src/main/execution_slot.cc
@@ -216,6 +216,25 @@ SnapshotCowWriteTransaction ExecutionSlot::BeginSnapshotCowWriteTransaction() {
                                      std::move(timestamp_lease));
 }
 
+result<SnapshotCowWriteTransaction>
+ExecutionSlot::TryBeginSnapshotCowWriteTransaction() {
+  if (db_config_.mode == DBMode::READ_ONLY) {
+    RETURN_ERROR(Status(StatusCode::ERR_INVALID_ARGUMENT,
+                        "Write transactions are not allowed on a read-only "
+                        "database."));
+  }
+  auto timestamp_lease = UpdateTimestampLease::TryAcquire(version_manager_);
+  if (!timestamp_lease) {
+    RETURN_ERROR(Status(StatusCode::ERR_SERVICE_UNAVAILABLE,
+                        "A TP write transaction is already active."));
+  }
+  auto [cow_graph, planning_generation] =
+      snapshot_store_.CloneCurrentForUpdate();
+  return SnapshotCowWriteTransaction(std::move(cow_graph), planning_generation,
+                                     alloc_, *wal_writer_, snapshot_store_,
+                                     std::move(*timestamp_lease));
+}
+
 result<CurrentCowWriteTransaction>
 ExecutionSlot::BeginCurrentCowWriteTransaction() {
   if (execution_strategy_ != QueryExecutionStrategy::kDirect) {
@@ -422,7 +441,7 @@ Status ExecutionSlot::executePreparedQuery(
 }
 
 result<QueryResult> ExecutionSlot::ExecuteQueryInTransaction(
-    const std::string& query_string, const std::string& access_mode,
+    const std::string& query_string, AccessMode requested_mode,
     const rapidjson::Value& parameters, int32_t num_threads,
     TransactionContext& transaction_context) {
   CHECK(transaction_context.IsActive());
@@ -435,9 +454,6 @@ result<QueryResult> ExecutionSlot::ExecuteQueryInTransaction(
       RETURN_ERROR(Status(StatusCode::ERR_NOT_SUPPORTED,
                           "COPY is not supported in an explicit transaction."));
     }
-    const auto requested_mode = access_mode.empty()
-                                    ? AccessMode::kUnKnown
-                                    : ParseAccessMode(access_mode);
     const auto resolved_mode = requested_mode == AccessMode::kUnKnown
                                    ? analysis.access_mode
                                    : requested_mode;
@@ -482,13 +498,15 @@ result<QueryResult> ExecutionSlot::ExecuteQueryInTransaction(
       status = prepare_and_execute(transaction.statistic(), storage,
                                    QueryCacheMode::kShared, true);
     } else {
-      auto& transaction = transaction_context.WriteTransactionOwner();
-      auto storage = transaction.OpenStorage();
-      const auto cache_mode = transaction.PlanningChanged()
-                                  ? QueryCacheMode::kBypassShared
-                                  : QueryCacheMode::kShared;
-      status = prepare_and_execute(transaction.statistic(), storage, cache_mode,
-                                   false);
+      status = transaction_context.VisitCowWriteOwner(
+          [&prepare_and_execute](auto& transaction) {
+            auto storage = transaction.OpenStorage();
+            const auto cache_mode = transaction.PlanningChanged()
+                                        ? QueryCacheMode::kBypassShared
+                                        : QueryCacheMode::kShared;
+            return prepare_and_execute(transaction.statistic(), storage,
+                                       cache_mode, false);
+          });
     }
     if (!status.ok()) {
       transaction_context.AbortAndMarkRollbackOnly();

--- a/src/server/brpc_service_mgr.cc
+++ b/src/server/brpc_service_mgr.cc
@@ -15,7 +15,13 @@
 
 #include "neug/server/brpc_service_mgr.h"
 
+#include <chrono>
+#include <cstdio>
+#include <ctime>
 #include <utility>
+
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
 
 #include "service_transaction_manager.h"
 
@@ -116,32 +122,62 @@ void SendHttpStringResponse(brpc::Controller* cntl,
   }
 }
 
-result<std::string_view> TransactionIdFromHeader(brpc::Controller* cntl) {
-  const auto* transaction_id =
-      cntl->http_request().GetHeader("X-Transaction-Id");
-  if (transaction_id == nullptr || transaction_id->empty() ||
-      transaction_id->find(',') != std::string::npos) {
+namespace {
+
+result<std::string_view> TransactionIdFromPath(brpc::Controller* cntl) {
+  const auto& transaction_id = cntl->http_request().unresolved_path();
+  if (transaction_id.empty() || transaction_id.find('/') != std::string::npos) {
     RETURN_ERROR(Status(StatusCode::ERR_INVALID_ARGUMENT,
-                        "A single X-Transaction-Id header is required."));
+                        "A transaction ID is required in the request path."));
   }
-  return std::string_view(*transaction_id);
+  return std::string_view(transaction_id);
 }
 
-Status RejectTransactionIdHeader(brpc::Controller* cntl) {
-  if (cntl->http_request().GetHeader("X-Transaction-Id") != nullptr) {
-    return Status(StatusCode::ERR_INVALID_ARGUMENT,
-                  "X-Transaction-Id is only valid on /transactions routes.");
-  }
-  return Status::OK();
+std::string FormatExpiresAt(std::chrono::system_clock::time_point expires_at) {
+  const auto epoch_milliseconds =
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          expires_at.time_since_epoch());
+  const auto epoch_seconds =
+      std::chrono::duration_cast<std::chrono::seconds>(epoch_milliseconds);
+  const auto milliseconds = epoch_milliseconds - epoch_seconds;
+  const auto time = static_cast<std::time_t>(epoch_seconds.count());
+  std::tm utc_time{};
+#ifdef _WIN32
+  gmtime_s(&utc_time, &time);
+#else
+  gmtime_r(&time, &utc_time);
+#endif
+  char buffer[32];
+  std::snprintf(buffer, sizeof(buffer), "%04d-%02d-%02dT%02d:%02d:%02d.%03dZ",
+                utc_time.tm_year + 1900, utc_time.tm_mon + 1, utc_time.tm_mday,
+                utc_time.tm_hour, utc_time.tm_min, utc_time.tm_sec,
+                static_cast<int>(milliseconds.count()));
+  return buffer;
 }
 
-Status RejectNestedTransactionHeader(brpc::Controller* cntl) {
-  if (cntl->http_request().GetHeader("X-Transaction-Id") != nullptr) {
-    return Status(StatusCode::ERR_TX_STATE_CONFLICT,
-                  "Cannot begin a transaction while another transaction is "
-                  "active.");
+std::string SerializeBeginResponse(
+    const ServiceTransactionManager::BeginResult& transaction,
+    TransactionMode mode) {
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+  writer.StartObject();
+  writer.Key("transaction_id");
+  writer.String(
+      transaction.transaction_id.data(),
+      static_cast<rapidjson::SizeType>(transaction.transaction_id.size()));
+  writer.Key("mode");
+  writer.String(mode == TransactionMode::kReadOnly ? "read_only"
+                                                   : "read_write");
+  writer.Key("expires_at");
+  if (transaction.expires_at) {
+    const auto expires_at = FormatExpiresAt(*transaction.expires_at);
+    writer.String(expires_at.data(),
+                  static_cast<rapidjson::SizeType>(expires_at.size()));
+  } else {
+    writer.Null();
   }
-  return Status::OK();
+  writer.EndObject();
+  return std::string(buffer.GetString(), buffer.GetSize());
 }
 
 result<TransactionMode> ParseTransactionMode(brpc::Controller* cntl) {
@@ -182,7 +218,7 @@ void FinishTransaction(brpc::Controller* cntl,
                        const BrpcServiceProtocol& protocol,
                        Operation&& operation) {
   MarkTransactionResponse(cntl);
-  auto transaction_id = TransactionIdFromHeader(cntl);
+  auto transaction_id = TransactionIdFromPath(cntl);
   Status status =
       transaction_id ? RequireEmptyBody(cntl) : transaction_id.error();
   if (status.ok()) {
@@ -192,6 +228,8 @@ void FinishTransaction(brpc::Controller* cntl,
       status.ok() ? result<std::string>("") : tl::unexpected(status);
   protocol.send_query_response(cntl, response);
 }
+
+}  // namespace
 
 bool BrpcServiceProtocolManager::RegisterProtocol(
     brpc::ProtocolType type, const BrpcServiceProtocol& protocol) {
@@ -314,12 +352,6 @@ void HttpServiceImpl::PostCypherQuery(
     HttpResponse* response, google::protobuf::Closure* done) {
   brpc::ClosureGuard done_guard(done);
   brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
-  auto header_status = RejectTransactionIdHeader(cntl);
-  if (!header_status.ok()) {
-    result<std::string> error = tl::unexpected(header_status);
-    protocol_.send_query_response(cntl, error);
-    return;
-  }
   std::string query_request;
   // 1. Parse query request
   if (!protocol_.parse_query_request(cntl, (void*) request, query_request)) {
@@ -351,12 +383,6 @@ void HttpServiceImpl::GetSchema(google::protobuf::RpcController* cntl_base,
                                 google::protobuf::Closure* done) {
   brpc::ClosureGuard done_guard(done);
   brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
-  auto header_status = RejectTransactionIdHeader(cntl);
-  if (!header_status.ok()) {
-    result<std::string> error = tl::unexpected(header_status);
-    protocol_.send_schema_response(cntl, error);
-    return;
-  }
   // No need to parse request for Schema
   auto ret = GetSchemaImpl(cntl);
 
@@ -369,12 +395,6 @@ void HttpServiceImpl::GetServiceStatus(
     HttpResponse* response, google::protobuf::Closure* done) {
   brpc::ClosureGuard done_guard(done);
   brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
-  auto header_status = RejectTransactionIdHeader(cntl);
-  if (!header_status.ok()) {
-    result<std::string> error = tl::unexpected(header_status);
-    protocol_.send_service_status_response(cntl, error);
-    return;
-  }
   // No need to parse request for ServiceStatus
   auto ret = GetServiceStatusImpl(cntl);
 
@@ -388,23 +408,25 @@ void HttpServiceImpl::BeginTransaction(
   brpc::ClosureGuard done_guard(done);
   auto* cntl = static_cast<brpc::Controller*>(cntl_base);
   MarkTransactionResponse(cntl);
-  auto header_status = RejectNestedTransactionHeader(cntl);
-  if (!header_status.ok()) {
-    result<std::string> error = tl::unexpected(header_status);
-    protocol_.send_query_response(cntl, error);
-    return;
-  }
   auto mode = ParseTransactionMode(cntl);
   if (!mode) {
     result<std::string> error = tl::unexpected(mode.error());
     protocol_.send_query_response(cntl, error);
     return;
   }
-  auto transaction_id = transaction_manager_.Begin(mode.value());
-  if (transaction_id) {
-    cntl->http_response().SetHeader("X-Transaction-Id", transaction_id.value());
+  auto transaction = transaction_manager_.Begin(mode.value());
+  if (!transaction) {
+    result<std::string> error = tl::unexpected(transaction.error());
+    protocol_.send_query_response(cntl, error);
+    return;
   }
-  protocol_.send_query_response(cntl, transaction_id);
+  result<std::string> response =
+      SerializeBeginResponse(transaction.value(), mode.value());
+  protocol_.send_query_response(cntl, response);
+  cntl->http_response().set_status_code(brpc::HTTP_STATUS_CREATED);
+  cntl->http_response().set_content_type("application/json");
+  cntl->http_response().SetHeader(
+      "Location", "/transactions/" + transaction->transaction_id);
 }
 
 void HttpServiceImpl::ExecuteTransactionQuery(
@@ -413,7 +435,7 @@ void HttpServiceImpl::ExecuteTransactionQuery(
   brpc::ClosureGuard done_guard(done);
   auto* cntl = static_cast<brpc::Controller*>(cntl_base);
   MarkTransactionResponse(cntl);
-  auto transaction_id = TransactionIdFromHeader(cntl);
+  auto transaction_id = TransactionIdFromPath(cntl);
   if (!transaction_id) {
     result<std::string> error = tl::unexpected(transaction_id.error());
     protocol_.send_query_response(cntl, error);
@@ -450,7 +472,7 @@ void HttpServiceImpl::GetTransactionSchema(
   brpc::ClosureGuard done_guard(done);
   auto* cntl = static_cast<brpc::Controller*>(cntl_base);
   MarkTransactionResponse(cntl);
-  auto transaction_id = TransactionIdFromHeader(cntl);
+  auto transaction_id = TransactionIdFromPath(cntl);
   if (!transaction_id) {
     result<std::string> error = tl::unexpected(transaction_id.error());
     protocol_.send_schema_response(cntl, error);
@@ -487,10 +509,10 @@ void BrpcServiceManager::Init(const ServiceConfig& config) {
       "/service_status => GetServiceStatus,"
       "/schema => GetSchema,"
       "/transactions => BeginTransaction,"
-      "/transactions/query => ExecuteTransactionQuery,"
-      "/transactions/commit => CommitTransaction,"
-      "/transactions/rollback => RollbackTransaction,"
-      "/transactions/schema => GetTransactionSchema";
+      "/transactions/*/query => ExecuteTransactionQuery,"
+      "/transactions/*/commit => CommitTransaction,"
+      "/transactions/*/rollback => RollbackTransaction,"
+      "/transactions/*/schema => GetTransactionSchema";
 
 #ifdef ENABLE_HTTP_PROTOCOL
   auto http_svc = std::make_unique<HttpServiceImpl>(

--- a/src/server/brpc_service_mgr.cc
+++ b/src/server/brpc_service_mgr.cc
@@ -15,6 +15,10 @@
 
 #include "neug/server/brpc_service_mgr.h"
 
+#include <utility>
+
+#include "service_transaction_manager.h"
+
 #include "neug/compiler/planner/graph_planner.h"
 #include "neug/generated/proto/plan/error.pb.h"
 
@@ -43,7 +47,7 @@ int32_t status_code_to_http_code(neug::StatusCode code) {
   case neug::StatusCode::ERR_INTERNAL_ERROR:
     return brpc::HTTP_STATUS_INTERNAL_SERVER_ERROR;
   case neug::StatusCode::ERR_NOT_FOUND:
-    return brpc::HTTP_STATUS_INTERNAL_SERVER_ERROR;
+    return brpc::HTTP_STATUS_NOT_FOUND;
   case neug::StatusCode::ERR_NO_CHECKPOINT:
     return brpc::HTTP_STATUS_NOT_FOUND;
   case neug::StatusCode::ERR_INVALID_ARGUMENT:
@@ -52,6 +56,9 @@ int32_t status_code_to_http_code(neug::StatusCode code) {
     return brpc::HTTP_STATUS_INTERNAL_SERVER_ERROR;
   case neug::StatusCode::ERR_SERVICE_UNAVAILABLE:
     return brpc::HTTP_STATUS_SERVICE_UNAVAILABLE;
+  case neug::StatusCode::ERR_TX_STATE_CONFLICT:
+  case neug::StatusCode::ERR_TX_TIMEOUT:
+    return brpc::HTTP_STATUS_CONFLICT;
   default:
     return brpc::HTTP_STATUS_INTERNAL_SERVER_ERROR;
   }
@@ -107,6 +114,83 @@ void SendHttpStringResponse(brpc::Controller* cntl,
     cntl->SetFailed(http_code, "%s", error.ToString().c_str());
     cntl->http_response().set_status_code(http_code);
   }
+}
+
+result<std::string_view> TransactionIdFromHeader(brpc::Controller* cntl) {
+  const auto* transaction_id =
+      cntl->http_request().GetHeader("X-Transaction-Id");
+  if (transaction_id == nullptr || transaction_id->empty() ||
+      transaction_id->find(',') != std::string::npos) {
+    RETURN_ERROR(Status(StatusCode::ERR_INVALID_ARGUMENT,
+                        "A single X-Transaction-Id header is required."));
+  }
+  return std::string_view(*transaction_id);
+}
+
+Status RejectTransactionIdHeader(brpc::Controller* cntl) {
+  if (cntl->http_request().GetHeader("X-Transaction-Id") != nullptr) {
+    return Status(StatusCode::ERR_INVALID_ARGUMENT,
+                  "X-Transaction-Id is only valid on /transactions routes.");
+  }
+  return Status::OK();
+}
+
+Status RejectNestedTransactionHeader(brpc::Controller* cntl) {
+  if (cntl->http_request().GetHeader("X-Transaction-Id") != nullptr) {
+    return Status(StatusCode::ERR_TX_STATE_CONFLICT,
+                  "Cannot begin a transaction while another transaction is "
+                  "active.");
+  }
+  return Status::OK();
+}
+
+result<TransactionMode> ParseTransactionMode(brpc::Controller* cntl) {
+  const auto body = cntl->request_attachment().to_string();
+  rapidjson::Document document;
+  document.Parse(body.data(), body.size());
+  if (document.HasParseError() || !document.IsObject() ||
+      !document.HasMember("mode") || !document["mode"].IsString()) {
+    RETURN_ERROR(Status(StatusCode::ERR_INVALID_ARGUMENT,
+                        "Transaction begin requires a JSON mode."));
+  }
+  const std::string_view mode(document["mode"].GetString(),
+                              document["mode"].GetStringLength());
+  if (mode == "read_only") {
+    return TransactionMode::kReadOnly;
+  }
+  if (mode == "read_write") {
+    return TransactionMode::kReadWrite;
+  }
+  RETURN_ERROR(Status(StatusCode::ERR_INVALID_ARGUMENT,
+                      "Transaction mode must be read_only or read_write."));
+}
+
+Status RequireEmptyBody(brpc::Controller* cntl) {
+  if (!cntl->request_attachment().empty()) {
+    return Status(StatusCode::ERR_INVALID_ARGUMENT,
+                  "This transaction operation does not accept a request body.");
+  }
+  return Status::OK();
+}
+
+void MarkTransactionResponse(brpc::Controller* cntl) {
+  cntl->http_response().SetHeader("Cache-Control", "no-store");
+}
+
+template <typename Operation>
+void FinishTransaction(brpc::Controller* cntl,
+                       const BrpcServiceProtocol& protocol,
+                       Operation&& operation) {
+  MarkTransactionResponse(cntl);
+  auto transaction_id = TransactionIdFromHeader(cntl);
+  Status status =
+      transaction_id ? RequireEmptyBody(cntl) : transaction_id.error();
+  if (status.ok()) {
+    status = operation(transaction_id.value());
+  }
+  result<std::string> response =
+      status.ok() ? result<std::string>("") : tl::unexpected(status);
+  protocol.send_query_response(cntl, response);
 }
 
 bool BrpcServiceProtocolManager::RegisterProtocol(
@@ -230,6 +314,12 @@ void HttpServiceImpl::PostCypherQuery(
     HttpResponse* response, google::protobuf::Closure* done) {
   brpc::ClosureGuard done_guard(done);
   brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
+  auto header_status = RejectTransactionIdHeader(cntl);
+  if (!header_status.ok()) {
+    result<std::string> error = tl::unexpected(header_status);
+    protocol_.send_query_response(cntl, error);
+    return;
+  }
   std::string query_request;
   // 1. Parse query request
   if (!protocol_.parse_query_request(cntl, (void*) request, query_request)) {
@@ -261,6 +351,12 @@ void HttpServiceImpl::GetSchema(google::protobuf::RpcController* cntl_base,
                                 google::protobuf::Closure* done) {
   brpc::ClosureGuard done_guard(done);
   brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
+  auto header_status = RejectTransactionIdHeader(cntl);
+  if (!header_status.ok()) {
+    result<std::string> error = tl::unexpected(header_status);
+    protocol_.send_schema_response(cntl, error);
+    return;
+  }
   // No need to parse request for Schema
   auto ret = GetSchemaImpl(cntl);
 
@@ -273,6 +369,12 @@ void HttpServiceImpl::GetServiceStatus(
     HttpResponse* response, google::protobuf::Closure* done) {
   brpc::ClosureGuard done_guard(done);
   brpc::Controller* cntl = static_cast<brpc::Controller*>(cntl_base);
+  auto header_status = RejectTransactionIdHeader(cntl);
+  if (!header_status.ok()) {
+    result<std::string> error = tl::unexpected(header_status);
+    protocol_.send_service_status_response(cntl, error);
+    return;
+  }
   // No need to parse request for ServiceStatus
   auto ret = GetServiceStatusImpl(cntl);
 
@@ -280,9 +382,90 @@ void HttpServiceImpl::GetServiceStatus(
   return;
 }
 
-BrpcServiceManager::BrpcServiceManager(neug::NeugDB& neug_db,
-                                       TpExecutionSlotPool& execution_slot_pool)
-    : neug_db_(neug_db), execution_slot_pool_(execution_slot_pool) {
+void HttpServiceImpl::BeginTransaction(
+    google::protobuf::RpcController* cntl_base, const HttpRequest*,
+    HttpResponse*, google::protobuf::Closure* done) {
+  brpc::ClosureGuard done_guard(done);
+  auto* cntl = static_cast<brpc::Controller*>(cntl_base);
+  MarkTransactionResponse(cntl);
+  auto header_status = RejectNestedTransactionHeader(cntl);
+  if (!header_status.ok()) {
+    result<std::string> error = tl::unexpected(header_status);
+    protocol_.send_query_response(cntl, error);
+    return;
+  }
+  auto mode = ParseTransactionMode(cntl);
+  if (!mode) {
+    result<std::string> error = tl::unexpected(mode.error());
+    protocol_.send_query_response(cntl, error);
+    return;
+  }
+  auto transaction_id = transaction_manager_.Begin(mode.value());
+  if (transaction_id) {
+    cntl->http_response().SetHeader("X-Transaction-Id", transaction_id.value());
+  }
+  protocol_.send_query_response(cntl, transaction_id);
+}
+
+void HttpServiceImpl::ExecuteTransactionQuery(
+    google::protobuf::RpcController* cntl_base, const HttpRequest*,
+    HttpResponse*, google::protobuf::Closure* done) {
+  brpc::ClosureGuard done_guard(done);
+  auto* cntl = static_cast<brpc::Controller*>(cntl_base);
+  MarkTransactionResponse(cntl);
+  auto transaction_id = TransactionIdFromHeader(cntl);
+  if (!transaction_id) {
+    result<std::string> error = tl::unexpected(transaction_id.error());
+    protocol_.send_query_response(cntl, error);
+    return;
+  }
+  auto response = transaction_manager_.Execute(
+      transaction_id.value(), cntl->request_attachment().to_string());
+  protocol_.send_query_response(cntl, response);
+}
+
+void HttpServiceImpl::CommitTransaction(
+    google::protobuf::RpcController* cntl_base, const HttpRequest*,
+    HttpResponse*, google::protobuf::Closure* done) {
+  brpc::ClosureGuard done_guard(done);
+  auto* cntl = static_cast<brpc::Controller*>(cntl_base);
+  FinishTransaction(cntl, protocol_, [this](std::string_view transaction_id) {
+    return transaction_manager_.Commit(transaction_id);
+  });
+}
+
+void HttpServiceImpl::RollbackTransaction(
+    google::protobuf::RpcController* cntl_base, const HttpRequest*,
+    HttpResponse*, google::protobuf::Closure* done) {
+  brpc::ClosureGuard done_guard(done);
+  auto* cntl = static_cast<brpc::Controller*>(cntl_base);
+  FinishTransaction(cntl, protocol_, [this](std::string_view transaction_id) {
+    return transaction_manager_.Rollback(transaction_id);
+  });
+}
+
+void HttpServiceImpl::GetTransactionSchema(
+    google::protobuf::RpcController* cntl_base, const google::protobuf::Empty*,
+    HttpResponse*, google::protobuf::Closure* done) {
+  brpc::ClosureGuard done_guard(done);
+  auto* cntl = static_cast<brpc::Controller*>(cntl_base);
+  MarkTransactionResponse(cntl);
+  auto transaction_id = TransactionIdFromHeader(cntl);
+  if (!transaction_id) {
+    result<std::string> error = tl::unexpected(transaction_id.error());
+    protocol_.send_schema_response(cntl, error);
+    return;
+  }
+  auto response = transaction_manager_.GetSchema(transaction_id.value());
+  protocol_.send_schema_response(cntl, response);
+}
+
+BrpcServiceManager::BrpcServiceManager(
+    neug::NeugDB& neug_db, TpExecutionSlotPool& execution_slot_pool,
+    ServiceTransactionManager& transaction_manager)
+    : neug_db_(neug_db),
+      execution_slot_pool_(execution_slot_pool),
+      transaction_manager_(transaction_manager) {
   brpc_server_ = std::make_unique<brpc::Server>();
 }
 
@@ -302,11 +485,16 @@ void BrpcServiceManager::Init(const ServiceConfig& config) {
   svc_options.restful_mappings =
       "/cypher => PostCypherQuery,"
       "/service_status => GetServiceStatus,"
-      "/schema => GetSchema";
+      "/schema => GetSchema,"
+      "/transactions => BeginTransaction,"
+      "/transactions/query => ExecuteTransactionQuery,"
+      "/transactions/commit => CommitTransaction,"
+      "/transactions/rollback => RollbackTransaction,"
+      "/transactions/schema => GetTransactionSchema";
 
 #ifdef ENABLE_HTTP_PROTOCOL
-  auto http_svc =
-      std::make_unique<HttpServiceImpl>(neug_db_, execution_slot_pool_);
+  auto http_svc = std::make_unique<HttpServiceImpl>(
+      neug_db_, execution_slot_pool_, transaction_manager_);
   if (brpc_server_->AddService(http_svc.get(), svc_options) == -1) {
     LOG(ERROR) << "Failed to add http service to brpc server";
   }
@@ -346,7 +534,10 @@ void BrpcServiceManager::RunAndWaitForExit() {
 
 void BrpcServiceManager::Stop() {
   LOG(INFO) << "Stopping brpc server";
-  brpc_server_->Stop(0);
+  if (brpc_server_->IsRunning()) {
+    brpc_server_->Stop(0);
+    brpc_server_->Join();
+  }
   LOG(INFO) << "Brpc server stopped";
 }
 

--- a/src/server/brpc_service_mgr.cc
+++ b/src/server/brpc_service_mgr.cc
@@ -213,11 +213,26 @@ void MarkTransactionResponse(brpc::Controller* cntl) {
   cntl->http_response().SetHeader("Cache-Control", "no-store");
 }
 
+bool RequireHttpMethod(brpc::Controller* cntl, brpc::HttpMethod expected,
+                       const char* expected_name) {
+  if (cntl->http_request().method() == expected) {
+    return true;
+  }
+  cntl->SetFailed(brpc::HTTP_STATUS_METHOD_NOT_ALLOWED,
+                  "This transaction endpoint requires %s.", expected_name);
+  cntl->http_response().set_status_code(brpc::HTTP_STATUS_METHOD_NOT_ALLOWED);
+  cntl->http_response().SetHeader("Allow", expected_name);
+  return false;
+}
+
 template <typename Operation>
 void FinishTransaction(brpc::Controller* cntl,
                        const BrpcServiceProtocol& protocol,
                        Operation&& operation) {
   MarkTransactionResponse(cntl);
+  if (!RequireHttpMethod(cntl, brpc::HTTP_METHOD_POST, "POST")) {
+    return;
+  }
   auto transaction_id = TransactionIdFromPath(cntl);
   Status status =
       transaction_id ? RequireEmptyBody(cntl) : transaction_id.error();
@@ -408,6 +423,9 @@ void HttpServiceImpl::BeginTransaction(
   brpc::ClosureGuard done_guard(done);
   auto* cntl = static_cast<brpc::Controller*>(cntl_base);
   MarkTransactionResponse(cntl);
+  if (!RequireHttpMethod(cntl, brpc::HTTP_METHOD_POST, "POST")) {
+    return;
+  }
   auto mode = ParseTransactionMode(cntl);
   if (!mode) {
     result<std::string> error = tl::unexpected(mode.error());
@@ -435,6 +453,9 @@ void HttpServiceImpl::ExecuteTransactionQuery(
   brpc::ClosureGuard done_guard(done);
   auto* cntl = static_cast<brpc::Controller*>(cntl_base);
   MarkTransactionResponse(cntl);
+  if (!RequireHttpMethod(cntl, brpc::HTTP_METHOD_POST, "POST")) {
+    return;
+  }
   auto transaction_id = TransactionIdFromPath(cntl);
   if (!transaction_id) {
     result<std::string> error = tl::unexpected(transaction_id.error());
@@ -466,22 +487,6 @@ void HttpServiceImpl::RollbackTransaction(
   });
 }
 
-void HttpServiceImpl::GetTransactionSchema(
-    google::protobuf::RpcController* cntl_base, const google::protobuf::Empty*,
-    HttpResponse*, google::protobuf::Closure* done) {
-  brpc::ClosureGuard done_guard(done);
-  auto* cntl = static_cast<brpc::Controller*>(cntl_base);
-  MarkTransactionResponse(cntl);
-  auto transaction_id = TransactionIdFromPath(cntl);
-  if (!transaction_id) {
-    result<std::string> error = tl::unexpected(transaction_id.error());
-    protocol_.send_schema_response(cntl, error);
-    return;
-  }
-  auto response = transaction_manager_.GetSchema(transaction_id.value());
-  protocol_.send_schema_response(cntl, response);
-}
-
 BrpcServiceManager::BrpcServiceManager(
     neug::NeugDB& neug_db, TpExecutionSlotPool& execution_slot_pool,
     ServiceTransactionManager& transaction_manager)
@@ -511,8 +516,7 @@ void BrpcServiceManager::Init(const ServiceConfig& config) {
       "/transactions => BeginTransaction,"
       "/transactions/*/query => ExecuteTransactionQuery,"
       "/transactions/*/commit => CommitTransaction,"
-      "/transactions/*/rollback => RollbackTransaction,"
-      "/transactions/*/schema => GetTransactionSchema";
+      "/transactions/*/rollback => RollbackTransaction";
 
 #ifdef ENABLE_HTTP_PROTOCOL
   auto http_svc = std::make_unique<HttpServiceImpl>(

--- a/src/server/neug_db_service.cc
+++ b/src/server/neug_db_service.cc
@@ -24,6 +24,7 @@
 #include "neug/server/brpc_service_mgr.h"
 #include "neug/server/bthread_runtime_wait.h"
 #include "neug/transaction/version_manager.h"
+#include "service_transaction_manager.h"
 
 #define STRINGIFY(x) #x
 #define TOSTRING(x) STRINGIFY(x)
@@ -34,6 +35,22 @@ namespace {
 constexpr auto kCompactInterval = std::chrono::seconds(30);
 constexpr size_t kCompactQueryThreshold = 100000;
 }  // namespace
+
+NeugDBService::NeugDBService(neug::NeugDB& db, const ServiceConfig& config)
+    : db_(db), db_config_(db_.config()) {
+  db_.registerService(this);
+  try {
+    installBthreadRuntimeWait();
+    init(config);
+  } catch (...) {
+    hdl_mgr_.reset();
+    transaction_manager_.reset();
+    execution_slot_pool_.reset();
+    restoreNativeRuntimeWait();
+    db_.unregisterService(this);
+    throw;
+  }
+}
 
 void NeugDBService::installBthreadRuntimeWait() {
   CHECK(!bthread_runtime_wait_installed_);
@@ -89,17 +106,30 @@ void NeugDBService::init(const ServiceConfig& config) {
       *db_.version_manager_, *db_.checkpoint_coordinator_,
       db_.extension_manager(), db_.allocators_, *db_.wal_writers_, db_config_);
 
-  hdl_mgr_ = std::make_unique<BrpcServiceManager>(db_, *execution_slot_pool_);
+  transaction_manager_ = std::make_unique<ServiceTransactionManager>(
+      *execution_slot_pool_, effective_config.max_explicit_transactions,
+      effective_config.explicit_transaction_timeout_ms);
+  hdl_mgr_ = std::make_unique<BrpcServiceManager>(db_, *execution_slot_pool_,
+                                                  *transaction_manager_);
   hdl_mgr_->Init(effective_config);
   service_config_ = effective_config;
 }
 
 NeugDBService::~NeugDBService() {
-  stopCompactThread();
+  if (transaction_manager_) {
+    transaction_manager_->CloseAdmission();
+  }
   if (hdl_mgr_) {
     hdl_mgr_->Stop();
-    hdl_mgr_.reset();
   }
+  if (transaction_manager_) {
+    transaction_manager_->Close();
+  }
+  // An auto-compaction task can be waiting for an explicit write session's
+  // update lease. Roll back those sessions before joining the compact thread.
+  stopCompactThread();
+  hdl_mgr_.reset();
+  transaction_manager_.reset();
   execution_slot_pool_.reset();
   restoreNativeRuntimeWait();
   db_.unregisterService(this);
@@ -138,9 +168,14 @@ void NeugDBService::run_and_wait_for_exit() {
   startCompactThread();
   running_.store(true, std::memory_order_relaxed);
   try {
+    transaction_manager_->Open();
     hdl_mgr_->RunAndWaitForExit();
+    transaction_manager_->Close();
     running_.store(false, std::memory_order_relaxed);
   } catch (...) {
+    transaction_manager_->CloseAdmission();
+    hdl_mgr_->Stop();
+    transaction_manager_->Close();
     running_.store(false, std::memory_order_relaxed);
     stopCompactThread();
     throw;
@@ -155,7 +190,9 @@ void NeugDBService::Stop() {
     return;
   }
   if (hdl_mgr_) {
+    transaction_manager_->CloseAdmission();
     hdl_mgr_->Stop();
+    transaction_manager_->Close();
     running_.store(false, std::memory_order_relaxed);
     stopCompactThread();
     return;
@@ -172,10 +209,12 @@ std::string NeugDBService::Start() {
   if (hdl_mgr_) {
     startCompactThread();
     try {
+      transaction_manager_->Open();
       auto ret = hdl_mgr_->Start();
       running_.store(true, std::memory_order_relaxed);
       return ret;
     } catch (...) {
+      transaction_manager_->CloseAdmission();
       stopCompactThread();
       throw;
     }

--- a/src/server/service_transaction_manager.cc
+++ b/src/server/service_transaction_manager.cc
@@ -264,35 +264,6 @@ Status ServiceTransactionManager::Rollback(std::string_view transaction_id) {
   return Status::OK();
 }
 
-result<std::string> ServiceTransactionManager::GetSchema(
-    std::string_view transaction_id) {
-  auto locked_result = LockEntry(transaction_id);
-  if (!locked_result) {
-    RETURN_ERROR(locked_result.error());
-  }
-  auto locked = std::move(locked_result).value();
-  auto& entry = locked.entry;
-  if (!entry->context.IsActive()) {
-    RETURN_ERROR(Status(StatusCode::ERR_TX_STATE_CONFLICT,
-                        "Transaction must be rolled back before reuse."));
-  }
-  auto yaml = entry->context.schema().to_yaml();
-  if (!yaml) {
-    RETURN_ERROR(yaml.error());
-  }
-  auto schema = get_json_string_from_yaml(yaml.value());
-  if (!schema) {
-    RETURN_ERROR(schema.error());
-  }
-  if (Expired(*entry)) {
-    entry->context.Rollback();
-    locked.lock.unlock();
-    Remove(transaction_id, entry);
-    RETURN_ERROR(TransactionExpired());
-  }
-  return schema;
-}
-
 void ServiceTransactionManager::Close() {
   decltype(entries_) entries;
   {

--- a/src/server/service_transaction_manager.cc
+++ b/src/server/service_transaction_manager.cc
@@ -1,0 +1,401 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "service_transaction_manager.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <random>
+#include <utility>
+#include <vector>
+
+#include "neug/main/query_request.h"
+#include "neug/server/tp_execution_slot_pool.h"
+#include "neug/utils/yaml_utils.h"
+
+namespace neug {
+
+namespace {
+
+Status ServiceUnavailable(const std::string& message) {
+  return Status(StatusCode::ERR_SERVICE_UNAVAILABLE, message);
+}
+
+Status TransactionNotFound() {
+  return Status(StatusCode::ERR_NOT_FOUND, "Transaction does not exist.");
+}
+
+Status TransactionExpired() {
+  return Status(StatusCode::ERR_TX_TIMEOUT, "Transaction has expired.");
+}
+
+Status TransactionBusy() {
+  return Status(StatusCode::ERR_TX_STATE_CONFLICT,
+                "Another request is already using this transaction.");
+}
+
+std::string GenerateTransactionId() {
+  static constexpr char kHexDigits[] = "0123456789abcdef";
+  thread_local std::random_device random_device;
+
+  std::string transaction_id(32, '0');
+  for (size_t word_index = 0; word_index < 4; ++word_index) {
+    auto word = static_cast<uint32_t>(random_device());
+    const auto offset = word_index * 8;
+    for (size_t digit_index = 0; digit_index < 8; ++digit_index) {
+      transaction_id[offset + 7 - digit_index] = kHexDigits[word & 0x0F];
+      word >>= 4;
+    }
+  }
+  return transaction_id;
+}
+
+}  // namespace
+
+ServiceTransactionManager::ServiceTransactionManager(
+    TpExecutionSlotPool& execution_slot_pool, size_t max_transactions,
+    uint64_t timeout_ms)
+    : execution_slot_pool_(execution_slot_pool),
+      max_transactions_(max_transactions == 0
+                            ? execution_slot_pool.ExecutionSlotNum()
+                            : max_transactions),
+      timeout_(timeout_ms) {
+  reaper_ = std::thread([this] { ReaperMain(); });
+}
+
+ServiceTransactionManager::~ServiceTransactionManager() {
+  Close();
+  {
+    std::lock_guard lock(mutex_);
+    stop_reaper_ = true;
+  }
+  changed_.notify_all();
+  if (reaper_.joinable()) {
+    reaper_.join();
+  }
+}
+
+result<std::string> ServiceTransactionManager::Begin(TransactionMode mode) {
+  {
+    std::lock_guard lock(mutex_);
+    if (!accepting_) {
+      RETURN_ERROR(ServiceUnavailable("Transaction service is stopping."));
+    }
+    if (entries_.size() + pending_begins_ >= max_transactions_) {
+      RETURN_ERROR(ServiceUnavailable("Too many active transactions."));
+    }
+    ++pending_begins_;
+  }
+
+  const auto finish_pending_begin = [this] {
+    {
+      std::lock_guard lock(mutex_);
+      CHECK_GT(pending_begins_, 0U);
+      --pending_begins_;
+    }
+    changed_.notify_all();
+  };
+
+  try {
+    TransactionContext context;
+    {
+      auto slot = execution_slot_pool_.TryAcquireExecutionSlot();
+      if (!slot) {
+        finish_pending_begin();
+        RETURN_ERROR(ServiceUnavailable("No TP execution slot is available."));
+      }
+      if (mode == TransactionMode::kReadOnly) {
+        context.Begin(slot->BeginSnapshotReadTransaction());
+      } else {
+        auto transaction = slot->TryBeginSnapshotCowWriteTransaction();
+        if (!transaction) {
+          finish_pending_begin();
+          RETURN_ERROR(transaction.error());
+        }
+        context.Begin(std::move(transaction).value());
+      }
+    }
+
+    auto entry = std::make_shared<Entry>(std::move(context), NewDeadline());
+    std::string transaction_id;
+    bool accepted = false;
+    while (!accepted) {
+      transaction_id = GenerateTransactionId();
+      std::lock_guard lock(mutex_);
+      if (!accepting_) {
+        CHECK_GT(pending_begins_, 0U);
+        --pending_begins_;
+        break;
+      }
+      if (!entries_.contains(transaction_id)) {
+        entries_.emplace(transaction_id, entry);
+        CHECK_GT(pending_begins_, 0U);
+        --pending_begins_;
+        accepted = true;
+      }
+    }
+    changed_.notify_all();
+    if (!accepted) {
+      entry->context.Rollback();
+      RETURN_ERROR(ServiceUnavailable("Transaction service is stopping."));
+    }
+    return transaction_id;
+  } catch (const std::exception& e) {
+    finish_pending_begin();
+    RETURN_ERROR(Status::RuntimeError(e.what()));
+  } catch (...) {
+    finish_pending_begin();
+    RETURN_ERROR(Status::InternalError("Failed to begin transaction."));
+  }
+}
+
+result<std::string> ServiceTransactionManager::Execute(
+    std::string_view transaction_id, const std::string& request) {
+  std::string query;
+  AccessMode mode = AccessMode::kUnKnown;
+  rapidjson::Document parameters;
+  try {
+    RETURN_STATUS_ERROR_IF_NOT_OK(
+        RequestParser::ParseFromString(request, query, mode, parameters));
+  } catch (const std::exception& e) {
+    RETURN_ERROR(Status(StatusCode::ERR_INVALID_ARGUMENT, e.what()));
+  }
+
+  auto locked_result = LockEntry(transaction_id);
+  if (!locked_result) {
+    RETURN_ERROR(locked_result.error());
+  }
+  auto locked = std::move(locked_result).value();
+  auto& entry = locked.entry;
+  if (!entry->context.IsActive()) {
+    RETURN_ERROR(Status(StatusCode::ERR_TX_STATE_CONFLICT,
+                        "Transaction must be rolled back before reuse."));
+  }
+
+  result<std::string> response = [&]() -> result<std::string> {
+    try {
+      auto slot = execution_slot_pool_.TryAcquireExecutionSlot();
+      if (!slot) {
+        RETURN_ERROR(ServiceUnavailable("No TP execution slot is available."));
+      }
+      auto query_result = slot->ExecuteQueryInTransaction(
+          query, mode, parameters, /*num_threads=*/0, entry->context);
+      if (!query_result) {
+        RETURN_ERROR(query_result.error());
+      }
+      return query_result.value().Serialize();
+    } catch (const std::exception& e) {
+      RETURN_ERROR(Status::RuntimeError(e.what()));
+    }
+  }();
+  if (!response) {
+    RETURN_ERROR(response.error());
+  }
+  if (Expired(*entry)) {
+    entry->context.Rollback();
+    locked.lock.unlock();
+    Remove(transaction_id, entry);
+    RETURN_ERROR(TransactionExpired());
+  }
+  return response;
+}
+
+Status ServiceTransactionManager::Commit(std::string_view transaction_id) {
+  auto locked_result = LockEntry(transaction_id);
+  if (!locked_result) {
+    return locked_result.error();
+  }
+  auto locked = std::move(locked_result).value();
+  auto& entry = locked.entry;
+  if (!entry->context.IsActive()) {
+    return Status(StatusCode::ERR_TX_STATE_CONFLICT,
+                  "Transaction must be rolled back before commit.");
+  }
+
+  Status status;
+  if (entry->context.IsReadOnly()) {
+    status = entry->context.Commit();
+  } else {
+    status = entry->context.PrepareTpSnapshotCommit();
+    if (status.ok() && Expired(*entry)) {
+      entry->context.Rollback();
+      status = TransactionExpired();
+    }
+    if (status.ok()) {
+      status = entry->context.CommitPreparedTpSnapshot();
+    }
+  }
+  if (!status.ok() && entry->context.IsActive()) {
+    entry->context.Rollback();
+  }
+  locked.lock.unlock();
+  Remove(transaction_id, entry);
+  return status;
+}
+
+Status ServiceTransactionManager::Rollback(std::string_view transaction_id) {
+  auto locked_result = LockEntry(transaction_id);
+  if (!locked_result) {
+    return locked_result.error();
+  }
+  auto locked = std::move(locked_result).value();
+  auto& entry = locked.entry;
+  entry->context.Rollback();
+  locked.lock.unlock();
+  Remove(transaction_id, entry);
+  return Status::OK();
+}
+
+result<std::string> ServiceTransactionManager::GetSchema(
+    std::string_view transaction_id) {
+  auto locked_result = LockEntry(transaction_id);
+  if (!locked_result) {
+    RETURN_ERROR(locked_result.error());
+  }
+  auto locked = std::move(locked_result).value();
+  auto& entry = locked.entry;
+  if (!entry->context.IsActive()) {
+    RETURN_ERROR(Status(StatusCode::ERR_TX_STATE_CONFLICT,
+                        "Transaction must be rolled back before reuse."));
+  }
+  auto yaml = entry->context.schema().to_yaml();
+  if (!yaml) {
+    RETURN_ERROR(yaml.error());
+  }
+  return get_json_string_from_yaml(yaml.value());
+}
+
+void ServiceTransactionManager::Close() {
+  decltype(entries_) entries;
+  {
+    std::unique_lock lock(mutex_);
+    accepting_ = false;
+    changed_.wait(lock, [this] { return pending_begins_ == 0; });
+    entries.swap(entries_);
+  }
+  for (const auto& [_, entry] : entries) {
+    std::lock_guard lock(entry->mutex);
+    entry->context.Rollback();
+  }
+}
+
+void ServiceTransactionManager::CloseAdmission() {
+  std::lock_guard lock(mutex_);
+  accepting_ = false;
+}
+
+void ServiceTransactionManager::Open() {
+  std::lock_guard lock(mutex_);
+  accepting_ = true;
+}
+
+result<ServiceTransactionManager::LockedEntry>
+ServiceTransactionManager::LockEntry(std::string_view transaction_id) {
+  auto entry = Find(transaction_id);
+  if (!entry) {
+    RETURN_ERROR(TransactionNotFound());
+  }
+  std::unique_lock entry_lock(entry->mutex, std::try_to_lock);
+  if (!entry_lock.owns_lock()) {
+    RETURN_ERROR(TransactionBusy());
+  }
+  if (Expired(*entry)) {
+    entry->context.Rollback();
+    entry_lock.unlock();
+    Remove(transaction_id, entry);
+    RETURN_ERROR(TransactionExpired());
+  }
+  return LockedEntry{std::move(entry), std::move(entry_lock)};
+}
+
+ServiceTransactionManager::EntryPtr ServiceTransactionManager::Find(
+    std::string_view transaction_id) const {
+  std::lock_guard lock(mutex_);
+  const auto found = entries_.find(transaction_id);
+  return found == entries_.end() ? nullptr : found->second;
+}
+
+void ServiceTransactionManager::Remove(std::string_view transaction_id,
+                                       const EntryPtr& entry) {
+  {
+    std::lock_guard lock(mutex_);
+    const auto found = entries_.find(transaction_id);
+    if (found != entries_.end() && found->second == entry) {
+      entries_.erase(found);
+    }
+  }
+  changed_.notify_all();
+}
+
+bool ServiceTransactionManager::Expired(const Entry& entry) const noexcept {
+  return std::chrono::steady_clock::now() >= entry.deadline;
+}
+
+std::chrono::steady_clock::time_point ServiceTransactionManager::NewDeadline()
+    const noexcept {
+  return timeout_.count() == 0 ? std::chrono::steady_clock::time_point::max()
+                               : std::chrono::steady_clock::now() + timeout_;
+}
+
+bool ServiceTransactionManager::ReapExpiredTransactions() {
+  std::vector<std::pair<std::string, EntryPtr>> candidates;
+  {
+    std::lock_guard lock(mutex_);
+    candidates.reserve(entries_.size());
+    for (const auto& [transaction_id, entry] : entries_) {
+      if (Expired(*entry)) {
+        candidates.emplace_back(transaction_id, entry);
+      }
+    }
+  }
+  bool busy_expired = false;
+  for (const auto& [transaction_id, entry] : candidates) {
+    std::unique_lock entry_lock(entry->mutex, std::try_to_lock);
+    if (!entry_lock.owns_lock()) {
+      busy_expired = true;
+      continue;
+    }
+    entry->context.Rollback();
+    entry_lock.unlock();
+    Remove(transaction_id, entry);
+  }
+  return busy_expired;
+}
+
+void ServiceTransactionManager::ReaperMain() {
+  std::unique_lock lock(mutex_);
+  while (!stop_reaper_) {
+    auto next_deadline = std::chrono::steady_clock::time_point::max();
+    for (const auto& [_, entry] : entries_) {
+      next_deadline = std::min(next_deadline, entry->deadline);
+    }
+    if (next_deadline == std::chrono::steady_clock::time_point::max()) {
+      changed_.wait(lock);
+    } else {
+      changed_.wait_until(lock, next_deadline);
+    }
+    if (stop_reaper_) {
+      break;
+    }
+    lock.unlock();
+    const bool busy_expired = ReapExpiredTransactions();
+    lock.lock();
+    if (busy_expired && !stop_reaper_) {
+      // Retry without blocking cleanup behind one long-running request.
+      changed_.wait_for(lock, std::chrono::milliseconds(1));
+    }
+  }
+}
+
+}  // namespace neug

--- a/src/server/service_transaction_manager.cc
+++ b/src/server/service_transaction_manager.cc
@@ -86,7 +86,8 @@ ServiceTransactionManager::~ServiceTransactionManager() {
   }
 }
 
-result<std::string> ServiceTransactionManager::Begin(TransactionMode mode) {
+result<ServiceTransactionManager::BeginResult> ServiceTransactionManager::Begin(
+    TransactionMode mode) {
   {
     std::lock_guard lock(mutex_);
     if (!accepting_) {
@@ -127,7 +128,13 @@ result<std::string> ServiceTransactionManager::Begin(TransactionMode mode) {
       }
     }
 
-    auto entry = std::make_shared<Entry>(std::move(context), NewDeadline());
+    auto deadline = std::chrono::steady_clock::time_point::max();
+    std::optional<std::chrono::system_clock::time_point> expires_at;
+    if (timeout_.count() != 0) {
+      deadline = std::chrono::steady_clock::now() + timeout_;
+      expires_at = std::chrono::system_clock::now() + timeout_;
+    }
+    auto entry = std::make_shared<Entry>(std::move(context), deadline);
     std::string transaction_id;
     bool accepted = false;
     while (!accepted) {
@@ -150,7 +157,7 @@ result<std::string> ServiceTransactionManager::Begin(TransactionMode mode) {
       entry->context.Rollback();
       RETURN_ERROR(ServiceUnavailable("Transaction service is stopping."));
     }
-    return transaction_id;
+    return BeginResult{std::move(transaction_id), expires_at};
   } catch (const std::exception& e) {
     finish_pending_begin();
     RETURN_ERROR(Status::RuntimeError(e.what()));
@@ -273,7 +280,17 @@ result<std::string> ServiceTransactionManager::GetSchema(
   if (!yaml) {
     RETURN_ERROR(yaml.error());
   }
-  return get_json_string_from_yaml(yaml.value());
+  auto schema = get_json_string_from_yaml(yaml.value());
+  if (!schema) {
+    RETURN_ERROR(schema.error());
+  }
+  if (Expired(*entry)) {
+    entry->context.Rollback();
+    locked.lock.unlock();
+    Remove(transaction_id, entry);
+    RETURN_ERROR(TransactionExpired());
+  }
+  return schema;
 }
 
 void ServiceTransactionManager::Close() {
@@ -340,12 +357,6 @@ void ServiceTransactionManager::Remove(std::string_view transaction_id,
 
 bool ServiceTransactionManager::Expired(const Entry& entry) const noexcept {
   return std::chrono::steady_clock::now() >= entry.deadline;
-}
-
-std::chrono::steady_clock::time_point ServiceTransactionManager::NewDeadline()
-    const noexcept {
-  return timeout_.count() == 0 ? std::chrono::steady_clock::time_point::max()
-                               : std::chrono::steady_clock::now() + timeout_;
 }
 
 bool ServiceTransactionManager::ReapExpiredTransactions() {

--- a/src/server/service_transaction_manager.cc
+++ b/src/server/service_transaction_manager.cc
@@ -201,7 +201,12 @@ result<std::string> ServiceTransactionManager::Execute(
       if (!query_result) {
         RETURN_ERROR(query_result.error());
       }
-      return query_result.value().Serialize();
+      try {
+        return query_result.value().Serialize();
+      } catch (const std::exception& e) {
+        entry->context.AbortAndMarkRollbackOnly();
+        RETURN_ERROR(Status::RuntimeError(e.what()));
+      }
     } catch (const std::exception& e) {
       RETURN_ERROR(Status::RuntimeError(e.what()));
     }

--- a/src/server/service_transaction_manager.h
+++ b/src/server/service_transaction_manager.h
@@ -21,6 +21,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -37,6 +38,11 @@ class TpExecutionSlotPool;
  */
 class ServiceTransactionManager {
  public:
+  struct BeginResult {
+    std::string transaction_id;
+    std::optional<std::chrono::system_clock::time_point> expires_at;
+  };
+
   ServiceTransactionManager(TpExecutionSlotPool& execution_slot_pool,
                             size_t max_transactions, uint64_t timeout_ms);
   ~ServiceTransactionManager();
@@ -45,7 +51,7 @@ class ServiceTransactionManager {
   ServiceTransactionManager& operator=(const ServiceTransactionManager&) =
       delete;
 
-  result<std::string> Begin(TransactionMode mode);
+  result<BeginResult> Begin(TransactionMode mode);
   result<std::string> Execute(std::string_view transaction_id,
                               const std::string& request);
   Status Commit(std::string_view transaction_id);
@@ -90,7 +96,6 @@ class ServiceTransactionManager {
   EntryPtr Find(std::string_view transaction_id) const;
   void Remove(std::string_view transaction_id, const EntryPtr& entry);
   bool Expired(const Entry& entry) const noexcept;
-  std::chrono::steady_clock::time_point NewDeadline() const noexcept;
   bool ReapExpiredTransactions();
   void ReaperMain();
 

--- a/src/server/service_transaction_manager.h
+++ b/src/server/service_transaction_manager.h
@@ -40,6 +40,10 @@ class ServiceTransactionManager {
  public:
   struct BeginResult {
     std::string transaction_id;
+    // Advisory expiry time derived from the system clock for client display;
+    // the authoritative deadline is tracked with the steady clock, so this
+    // value may drift under system clock adjustments. Nullopt when session
+    // expiry is disabled.
     std::optional<std::chrono::system_clock::time_point> expires_at;
   };
 

--- a/src/server/service_transaction_manager.h
+++ b/src/server/service_transaction_manager.h
@@ -1,0 +1,112 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <unordered_map>
+
+#include "neug/main/transaction_context.h"
+#include "neug/utils/result.h"
+
+namespace neug {
+
+class TpExecutionSlotPool;
+
+/** Owns service-local explicit transactions without retaining execution slots.
+ */
+class ServiceTransactionManager {
+ public:
+  ServiceTransactionManager(TpExecutionSlotPool& execution_slot_pool,
+                            size_t max_transactions, uint64_t timeout_ms);
+  ~ServiceTransactionManager();
+
+  ServiceTransactionManager(const ServiceTransactionManager&) = delete;
+  ServiceTransactionManager& operator=(const ServiceTransactionManager&) =
+      delete;
+
+  result<std::string> Begin(TransactionMode mode);
+  result<std::string> Execute(std::string_view transaction_id,
+                              const std::string& request);
+  Status Commit(std::string_view transaction_id);
+  Status Rollback(std::string_view transaction_id);
+  result<std::string> GetSchema(std::string_view transaction_id);
+
+  void Close();
+  void CloseAdmission();
+  void Open();
+
+ private:
+  struct Entry {
+    Entry(TransactionContext transaction_context,
+          std::chrono::steady_clock::time_point transaction_deadline)
+        : context(std::move(transaction_context)),
+          deadline(transaction_deadline) {}
+
+    std::mutex mutex;
+    TransactionContext context;
+    const std::chrono::steady_clock::time_point deadline;
+  };
+
+  using EntryPtr = std::shared_ptr<Entry>;
+
+  struct LockedEntry {
+    EntryPtr entry;
+    std::unique_lock<std::mutex> lock;
+  };
+
+  struct TransparentStringHash {
+    using is_transparent = void;
+
+    size_t operator()(std::string_view value) const noexcept {
+      return std::hash<std::string_view>{}(value);
+    }
+    size_t operator()(const std::string& value) const noexcept {
+      return operator()(std::string_view(value));
+    }
+  };
+
+  result<LockedEntry> LockEntry(std::string_view transaction_id);
+  EntryPtr Find(std::string_view transaction_id) const;
+  void Remove(std::string_view transaction_id, const EntryPtr& entry);
+  bool Expired(const Entry& entry) const noexcept;
+  std::chrono::steady_clock::time_point NewDeadline() const noexcept;
+  bool ReapExpiredTransactions();
+  void ReaperMain();
+
+  TpExecutionSlotPool& execution_slot_pool_;
+  const size_t max_transactions_;
+  const std::chrono::milliseconds timeout_;
+
+  mutable std::mutex mutex_;
+  std::condition_variable changed_;
+  std::unordered_map<std::string, EntryPtr, TransparentStringHash,
+                     std::equal_to<>>
+      entries_;
+  size_t pending_begins_{0};
+  bool accepting_{true};
+  bool stop_reaper_{false};
+  std::thread reaper_;
+};
+
+}  // namespace neug

--- a/src/server/service_transaction_manager.h
+++ b/src/server/service_transaction_manager.h
@@ -56,7 +56,6 @@ class ServiceTransactionManager {
                               const std::string& request);
   Status Commit(std::string_view transaction_id);
   Status Rollback(std::string_view transaction_id);
-  result<std::string> GetSchema(std::string_view transaction_id);
 
   void Close();
   void CloseAdmission();

--- a/src/server/tp_execution_slot_pool.cc
+++ b/src/server/tp_execution_slot_pool.cc
@@ -31,6 +31,20 @@ ExecutionSlotLease TpExecutionSlotPool::AcquireExecutionSlot() {
                             &TpExecutionSlotPool::releaseExecutionSlot);
 }
 
+ExecutionSlotLease TpExecutionSlotPool::TryAcquireExecutionSlot() {
+  bthread_mutex_lock(&mutex_);
+  if (available_slot_ids_.empty()) {
+    bthread_mutex_unlock(&mutex_);
+    return {};
+  }
+  const auto slot_id = available_slot_ids_.back();
+  available_slot_ids_.pop_back();
+  CHECK_LT(slot_id, slot_num_);
+  bthread_mutex_unlock(&mutex_);
+  return ExecutionSlotLease(&entries_[slot_id].slot, this, slot_id,
+                            &TpExecutionSlotPool::releaseExecutionSlot);
+}
+
 void TpExecutionSlotPool::releaseExecutionSlot(void* owner,
                                                size_t slot_id) noexcept {
   auto* pool = static_cast<TpExecutionSlotPool*>(owner);

--- a/src/transaction/operation_gate.cc
+++ b/src/transaction/operation_gate.cc
@@ -221,7 +221,11 @@ bool OperationGate::try_enter_phase(AdmissionState desired_phase) noexcept {
   if (OperationGateWord::phase(observed) != AdmissionState::kOpen) {
     return false;
   }
-  return OperationGateWord::try_change_phase(state_, observed, desired_phase);
+  // This caller reports failure instead of retrying, so a weak CAS could turn
+  // a spurious failure into a false admission rejection.
+  return state_.compare_exchange_strong(
+      observed, OperationGateWord::with_phase(observed, desired_phase),
+      std::memory_order_acq_rel, std::memory_order_relaxed);
 }
 
 void OperationGate::transition_phase(AdmissionState expected_phase,

--- a/src/transaction/operation_gate.cc
+++ b/src/transaction/operation_gate.cc
@@ -216,6 +216,14 @@ bool OperationGate::enter_phase_until(
   }
 }
 
+bool OperationGate::try_enter_phase(AdmissionState desired_phase) noexcept {
+  uint64_t observed = state_.load(std::memory_order_acquire);
+  if (OperationGateWord::phase(observed) != AdmissionState::kOpen) {
+    return false;
+  }
+  return OperationGateWord::try_change_phase(state_, observed, desired_phase);
+}
+
 void OperationGate::transition_phase(AdmissionState expected_phase,
                                      AdmissionState desired_phase) {
   uint64_t observed = state_.load(std::memory_order_relaxed);

--- a/src/transaction/snapshot_cow_write_transaction.cc
+++ b/src/transaction/snapshot_cow_write_transaction.cc
@@ -42,21 +42,30 @@ SnapshotCowWriteTransaction::SnapshotCowWriteTransaction(
       alloc_(other.alloc_),
       wal_writer_(other.wal_writer_),
       snapshot_store_(other.snapshot_store_),
-      timestamp_lease_(std::move(other.timestamp_lease_)) {}
+      timestamp_lease_(std::move(other.timestamp_lease_)),
+      prepared_snapshot_(std::move(other.prepared_snapshot_)) {}
 
 SnapshotCowWriteTransaction::~SnapshotCowWriteTransaction() noexcept {
   Abort();
 }
 
 bool SnapshotCowWriteTransaction::Commit() {
+  auto status = PrepareCommit();
+  if (!status.ok()) {
+    return false;
+  }
+  return CommitPrepared();
+}
+
+Status SnapshotCowWriteTransaction::PrepareCommit() {
   if (!active()) {
-    return true;
+    return Status::OK();
   }
 
   auto& logical_redo = workspace_.logical_redo();
   if (logical_redo.op_num() == 0 && logical_redo.content_size() == 0) {
     release(std::nullopt);
-    return true;
+    return Status::OK();
   }
 
   const bool planning_changed = workspace_.PlanningChanged();
@@ -64,7 +73,7 @@ bool SnapshotCowWriteTransaction::Commit() {
                               std::numeric_limits<uint64_t>::max()) {
     LOG(ERROR) << "Planning generation space exhausted";
     Abort();
-    return false;
+    return Status::InternalError("Planning generation space exhausted.");
   }
   const uint64_t committed_planning_generation =
       workspace_.base_planning_generation() + (planning_changed ? 1 : 0);
@@ -75,11 +84,24 @@ bool SnapshotCowWriteTransaction::Commit() {
     LOG(ERROR) << "Failed to prepare graph snapshot: "
                << prepared_result.error().ToString();
     Abort();
+    return prepared_result.error();
+  }
+  logical_redo.finalize(timestamp());
+  prepared_snapshot_.emplace(std::move(prepared_result).value());
+  return Status::OK();
+}
+
+bool SnapshotCowWriteTransaction::CommitPrepared() {
+  if (!active()) {
+    return true;
+  }
+  if (!prepared_snapshot_) {
+    LOG(ERROR) << "Snapshot write commit was not prepared";
+    Abort();
     return false;
   }
-  auto prepared = std::move(prepared_result).value();
 
-  logical_redo.finalize(timestamp());
+  auto& logical_redo = workspace_.logical_redo();
   // append() does not distinguish a pre-write failure from a partial append.
   // Until W1 framing makes recovery able to discard incomplete records, do not
   // report a normal rollback after starting the durability boundary.
@@ -97,12 +119,14 @@ bool SnapshotCowWriteTransaction::Commit() {
   }
 
   timestamp_lease_.BeginCommit();
-  const uint32_t snapshot_generation = std::move(prepared).Publish();
+  const uint32_t snapshot_generation = std::move(*prepared_snapshot_).Publish();
+  prepared_snapshot_.reset();
   release(snapshot_generation);
   return true;
 }
 
 void SnapshotCowWriteTransaction::Abort() noexcept {
+  prepared_snapshot_.reset();
   if (active()) {
     release(std::nullopt);
   }

--- a/src/transaction/timestamp_lease.cc
+++ b/src/transaction/timestamp_lease.cc
@@ -29,6 +29,15 @@ UpdateTimestampLease::UpdateTimestampLease(IVersionManager& version_manager)
   CHECK_NE(timestamp_, kInactiveTimestamp);
 }
 
+std::optional<UpdateTimestampLease> UpdateTimestampLease::TryAcquire(
+    IVersionManager& version_manager) {
+  uint32_t timestamp = kInactiveTimestamp;
+  if (!version_manager.try_acquire_update_timestamp(timestamp)) {
+    return std::nullopt;
+  }
+  return UpdateTimestampLease(version_manager, timestamp);
+}
+
 UpdateTimestampLease::UpdateTimestampLease(
     IVersionManager& version_manager,
     std::chrono::steady_clock::time_point deadline)

--- a/src/transaction/version_manager.cc
+++ b/src/transaction/version_manager.cc
@@ -263,6 +263,19 @@ uint32_t VersionManager::acquire_update_timestamp_until(
   return reserve_update_timestamp();
 }
 
+bool VersionManager::try_acquire_update_timestamp(uint32_t& timestamp) {
+  if (!gate_.try_enter_phase(AdmissionState::kInsertsBlocked)) {
+    return false;
+  }
+  const uint64_t gate = gate_.load_acquire();
+  if (OperationGateWord::inserters(gate) != 0) {
+    gate_.reopen();
+    return false;
+  }
+  timestamp = reserve_update_timestamp();
+  return true;
+}
+
 void VersionManager::begin_update_commit(uint32_t ts) {
   (void) ts;
 

--- a/tests/transaction/test_read_view_publication.cc
+++ b/tests/transaction/test_read_view_publication.cc
@@ -93,6 +93,7 @@ class ScriptedVersionManager : public IVersionManager {
       std::chrono::steady_clock::time_point) override {
     return 1;
   }
+  bool try_acquire_update_timestamp(uint32_t&) override { return false; }
   void begin_update_commit(uint32_t) override {}
   void drain_readers() override {}
   void finish_update_timestamp(uint32_t,

--- a/tests/transaction/test_transaction_release_order.cc
+++ b/tests/transaction/test_transaction_release_order.cc
@@ -67,6 +67,7 @@ class ReleaseOrderVersionManager : public IVersionManager {
       std::chrono::steady_clock::time_point) override {
     return 1;
   }
+  bool try_acquire_update_timestamp(uint32_t&) override { return false; }
   void begin_update_commit(uint32_t) override {}
   void drain_readers() override {}
   void finish_update_timestamp(uint32_t,

--- a/tests/unittest/test_db_svc.cc
+++ b/tests/unittest/test_db_svc.cc
@@ -1132,7 +1132,6 @@ TEST_F(NeugDBServiceTest, ExplicitTransactionUsesDedicatedHttpSession) {
   const auto* location = begin.http_response().GetHeader("Location");
   ASSERT_NE(location, nullptr);
   EXPECT_EQ(*location, "/transactions/" + transaction_id);
-  EXPECT_EQ(begin.http_response().GetHeader("X-Transaction-Id"), nullptr);
   const auto* cache_control = begin.http_response().GetHeader("Cache-Control");
   ASSERT_NE(cache_control, nullptr);
   EXPECT_EQ(*cache_control, "no-store");

--- a/tests/unittest/test_db_svc.cc
+++ b/tests/unittest/test_db_svc.cc
@@ -21,12 +21,14 @@
 #include <fstream>
 #include <functional>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <utility>
 #include <vector>
 
 #include <brpc/channel.h>
 #include <brpc/controller.h>
+#include <rapidjson/document.h>
 #include "bthread/bthread.h"
 #include "neug/common/types/value.h"
 #include "neug/generated/proto/response/response.pb.h"
@@ -73,26 +75,37 @@ int StartBthread(bthread_t& tid, BthreadTask& task) {
 
 void PostHttp(brpc::Channel& channel, const std::string& uri,
               const std::string& path, const std::string& body,
-              brpc::Controller& controller,
-              const std::string* transaction_id = nullptr) {
+              brpc::Controller& controller) {
   controller.http_request().uri() = (uri + path).c_str();
   controller.http_request().set_method(brpc::HTTP_METHOD_POST);
-  if (transaction_id != nullptr) {
-    controller.http_request().SetHeader("X-Transaction-Id", *transaction_id);
-  }
   controller.request_attachment().append(body);
   channel.CallMethod(nullptr, &controller, nullptr, nullptr, nullptr);
 }
 
 void GetHttp(brpc::Channel& channel, const std::string& uri,
-             const std::string& path, brpc::Controller& controller,
-             const std::string* transaction_id = nullptr) {
+             const std::string& path, brpc::Controller& controller) {
   controller.http_request().uri() = (uri + path).c_str();
   controller.http_request().set_method(brpc::HTTP_METHOD_GET);
-  if (transaction_id != nullptr) {
-    controller.http_request().SetHeader("X-Transaction-Id", *transaction_id);
-  }
   channel.CallMethod(nullptr, &controller, nullptr, nullptr, nullptr);
+}
+
+std::string TransactionPath(std::string_view transaction_id,
+                            std::string_view operation) {
+  return "/transactions/" + std::string(transaction_id) + "/" +
+         std::string(operation);
+}
+
+std::string ReadTransactionId(const brpc::Controller& controller) {
+  const auto body = controller.response_attachment().to_string();
+  rapidjson::Document document;
+  document.Parse(body.data(), body.size());
+  EXPECT_FALSE(document.HasParseError());
+  EXPECT_TRUE(document.IsObject());
+  if (!document.IsObject() || !document.HasMember("transaction_id") ||
+      !document["transaction_id"].IsString()) {
+    return {};
+  }
+  return document["transaction_id"].GetString();
 }
 
 QueryResponse ReadHttpQueryResponse(const brpc::Controller& controller) {
@@ -1100,9 +1113,26 @@ TEST_F(NeugDBServiceTest, ExplicitTransactionUsesDedicatedHttpSession) {
   brpc::Controller begin;
   PostHttp(channel, uri, "/transactions", R"({"mode":"read_write"})", begin);
   ASSERT_FALSE(begin.Failed()) << begin.ErrorText();
-  const auto* transaction_id =
-      begin.http_response().GetHeader("X-Transaction-Id");
-  ASSERT_NE(transaction_id, nullptr);
+  ASSERT_EQ(begin.http_response().status_code(), brpc::HTTP_STATUS_CREATED);
+  EXPECT_EQ(begin.http_response().content_type(), "application/json");
+  const auto begin_body = begin.response_attachment().to_string();
+  rapidjson::Document begin_document;
+  begin_document.Parse(begin_body.data(), begin_body.size());
+  ASSERT_FALSE(begin_document.HasParseError());
+  ASSERT_TRUE(begin_document.HasMember("transaction_id"));
+  ASSERT_TRUE(begin_document["transaction_id"].IsString());
+  const std::string transaction_id =
+      begin_document["transaction_id"].GetString();
+  ASSERT_FALSE(transaction_id.empty());
+  ASSERT_TRUE(begin_document.HasMember("mode"));
+  ASSERT_TRUE(begin_document["mode"].IsString());
+  EXPECT_STREQ(begin_document["mode"].GetString(), "read_write");
+  ASSERT_TRUE(begin_document.HasMember("expires_at"));
+  EXPECT_TRUE(begin_document["expires_at"].IsString());
+  const auto* location = begin.http_response().GetHeader("Location");
+  ASSERT_NE(location, nullptr);
+  EXPECT_EQ(*location, "/transactions/" + transaction_id);
+  EXPECT_EQ(begin.http_response().GetHeader("X-Transaction-Id"), nullptr);
   const auto* cache_control = begin.http_response().GetHeader("Cache-Control");
   ASSERT_NE(cache_control, nullptr);
   EXPECT_EQ(*cache_control, "no-store");
@@ -1114,25 +1144,19 @@ TEST_F(NeugDBServiceTest, ExplicitTransactionUsesDedicatedHttpSession) {
   EXPECT_EQ(competing_begin.http_response().status_code(),
             brpc::HTTP_STATUS_SERVICE_UNAVAILABLE);
 
-  brpc::Controller nested_begin;
-  PostHttp(channel, uri, "/transactions", R"({"mode":"read_write"})",
-           nested_begin, transaction_id);
-  EXPECT_TRUE(nested_begin.Failed());
-  EXPECT_EQ(nested_begin.http_response().status_code(),
-            brpc::HTTP_STATUS_CONFLICT);
-
   const auto create = RequestSerializer::SerializeRequest(
       "CREATE (:person {id: 90002, name: 'explicit-tx', age: 1});", "update",
       {});
   brpc::Controller write;
-  PostHttp(channel, uri, "/transactions/query", create, write, transaction_id);
+  PostHttp(channel, uri, TransactionPath(transaction_id, "query"), create,
+           write);
   ASSERT_FALSE(write.Failed()) << write.ErrorText();
 
   const auto read = RequestSerializer::SerializeRequest(
       "MATCH (n:person {id: 90002}) RETURN n;", "read", {});
   brpc::Controller read_your_writes;
-  PostHttp(channel, uri, "/transactions/query", read, read_your_writes,
-           transaction_id);
+  PostHttp(channel, uri, TransactionPath(transaction_id, "query"), read,
+           read_your_writes);
   ASSERT_FALSE(read_your_writes.Failed()) << read_your_writes.ErrorText();
   EXPECT_EQ(ReadHttpQueryResponse(read_your_writes).row_count(), 1);
 
@@ -1140,12 +1164,12 @@ TEST_F(NeugDBServiceTest, ExplicitTransactionUsesDedicatedHttpSession) {
       "CREATE NODE TABLE transaction_schema(id INT64, PRIMARY KEY(id));",
       "schema", {});
   brpc::Controller ddl;
-  PostHttp(channel, uri, "/transactions/query", create_table, ddl,
-           transaction_id);
+  PostHttp(channel, uri, TransactionPath(transaction_id, "query"), create_table,
+           ddl);
   ASSERT_FALSE(ddl.Failed()) << ddl.ErrorText();
 
   brpc::Controller schema;
-  GetHttp(channel, uri, "/transactions/schema", schema, transaction_id);
+  GetHttp(channel, uri, TransactionPath(transaction_id, "schema"), schema);
   ASSERT_FALSE(schema.Failed()) << schema.ErrorText();
   EXPECT_NE(schema.response_attachment().to_string().find("transaction_schema"),
             std::string::npos);
@@ -1155,15 +1179,8 @@ TEST_F(NeugDBServiceTest, ExplicitTransactionUsesDedicatedHttpSession) {
   ASSERT_FALSE(before_commit.Failed()) << before_commit.ErrorText();
   EXPECT_EQ(ReadHttpQueryResponse(before_commit).row_count(), 0);
 
-  brpc::Controller rejected_regular_query;
-  PostHttp(channel, uri, "/cypher", read, rejected_regular_query,
-           transaction_id);
-  EXPECT_TRUE(rejected_regular_query.Failed());
-  EXPECT_EQ(rejected_regular_query.http_response().status_code(),
-            brpc::HTTP_STATUS_BAD_REQUEST);
-
   brpc::Controller commit;
-  PostHttp(channel, uri, "/transactions/commit", "", commit, transaction_id);
+  PostHttp(channel, uri, TransactionPath(transaction_id, "commit"), "", commit);
   ASSERT_FALSE(commit.Failed()) << commit.ErrorText();
 
   brpc::Controller after_commit;
@@ -1175,46 +1192,51 @@ TEST_F(NeugDBServiceTest, ExplicitTransactionUsesDedicatedHttpSession) {
   PostHttp(channel, uri, "/transactions", R"({"mode":"read_only"})",
            read_only_begin);
   ASSERT_FALSE(read_only_begin.Failed()) << read_only_begin.ErrorText();
-  const auto* read_only_id =
-      read_only_begin.http_response().GetHeader("X-Transaction-Id");
-  ASSERT_NE(read_only_id, nullptr);
+  const auto read_only_id = ReadTransactionId(read_only_begin);
+  ASSERT_FALSE(read_only_id.empty());
+
+  brpc::Controller read_only_query;
+  PostHttp(channel, uri, TransactionPath(read_only_id, "query"), read,
+           read_only_query);
+  ASSERT_FALSE(read_only_query.Failed()) << read_only_query.ErrorText();
+  EXPECT_EQ(ReadHttpQueryResponse(read_only_query).row_count(), 1);
 
   brpc::Controller rejected_write;
-  PostHttp(channel, uri, "/transactions/query", create, rejected_write,
-           read_only_id);
+  PostHttp(channel, uri, TransactionPath(read_only_id, "query"), create,
+           rejected_write);
   EXPECT_TRUE(rejected_write.Failed());
   EXPECT_EQ(rejected_write.http_response().status_code(),
             brpc::HTTP_STATUS_CONFLICT);
 
   brpc::Controller rejected_commit;
-  PostHttp(channel, uri, "/transactions/commit", "", rejected_commit,
-           read_only_id);
+  PostHttp(channel, uri, TransactionPath(read_only_id, "commit"), "",
+           rejected_commit);
   EXPECT_TRUE(rejected_commit.Failed());
   EXPECT_EQ(rejected_commit.http_response().status_code(),
             brpc::HTTP_STATUS_CONFLICT);
 
   brpc::Controller rollback;
-  PostHttp(channel, uri, "/transactions/rollback", "", rollback, read_only_id);
+  PostHttp(channel, uri, TransactionPath(read_only_id, "rollback"), "",
+           rollback);
   EXPECT_FALSE(rollback.Failed()) << rollback.ErrorText();
 
   brpc::Controller rollback_begin;
   PostHttp(channel, uri, "/transactions", R"({"mode":"read_write"})",
            rollback_begin);
   ASSERT_FALSE(rollback_begin.Failed()) << rollback_begin.ErrorText();
-  const auto* rollback_id =
-      rollback_begin.http_response().GetHeader("X-Transaction-Id");
-  ASSERT_NE(rollback_id, nullptr);
+  const auto rollback_id = ReadTransactionId(rollback_begin);
+  ASSERT_FALSE(rollback_id.empty());
   const auto rollback_write = RequestSerializer::SerializeRequest(
       "CREATE (:person {id: 90003, name: 'rollback-tx', age: 1});", "update",
       {});
   brpc::Controller rollback_write_response;
-  PostHttp(channel, uri, "/transactions/query", rollback_write,
-           rollback_write_response, rollback_id);
+  PostHttp(channel, uri, TransactionPath(rollback_id, "query"), rollback_write,
+           rollback_write_response);
   ASSERT_FALSE(rollback_write_response.Failed())
       << rollback_write_response.ErrorText();
   brpc::Controller rollback_write_transaction;
-  PostHttp(channel, uri, "/transactions/rollback", "",
-           rollback_write_transaction, rollback_id);
+  PostHttp(channel, uri, TransactionPath(rollback_id, "rollback"), "",
+           rollback_write_transaction);
   ASSERT_FALSE(rollback_write_transaction.Failed())
       << rollback_write_transaction.ErrorText();
 
@@ -1224,6 +1246,55 @@ TEST_F(NeugDBServiceTest, ExplicitTransactionUsesDedicatedHttpSession) {
   PostHttp(channel, uri, "/cypher", rollback_read, after_rollback);
   ASSERT_FALSE(after_rollback.Failed()) << after_rollback.ErrorText();
   EXPECT_EQ(ReadHttpQueryResponse(after_rollback).row_count(), 0);
+  service.Stop();
+}
+
+TEST_F(NeugDBServiceTest,
+       ExplicitTransactionFailureRequiresRollbackAndInvalidatesSession) {
+  config_.query_port = 19995;
+  neug::NeugDBService service(*db_, config_);
+  const auto uri = service.Start();
+
+  brpc::ChannelOptions options;
+  options.protocol = "http";
+  options.timeout_ms = 5000;
+  options.max_retry = 0;
+  brpc::Channel channel;
+  ASSERT_EQ(channel.Init(uri.c_str(), "", &options), 0);
+
+  brpc::Controller begin;
+  PostHttp(channel, uri, "/transactions", R"({"mode":"read_write"})", begin);
+  ASSERT_FALSE(begin.Failed()) << begin.ErrorText();
+  const auto transaction_id = ReadTransactionId(begin);
+  ASSERT_FALSE(transaction_id.empty());
+
+  const auto invalid_query = RequestSerializer::SerializeRequest(
+      "MATCH (n:missing) RETURN n;", "read", {});
+  brpc::Controller failed_query;
+  PostHttp(channel, uri, TransactionPath(transaction_id, "query"),
+           invalid_query, failed_query);
+  EXPECT_TRUE(failed_query.Failed());
+
+  const auto read = RequestSerializer::SerializeRequest(
+      "MATCH (n:person) RETURN n LIMIT 1;", "read", {});
+  brpc::Controller rejected_reuse;
+  PostHttp(channel, uri, TransactionPath(transaction_id, "query"), read,
+           rejected_reuse);
+  EXPECT_TRUE(rejected_reuse.Failed());
+  EXPECT_EQ(rejected_reuse.http_response().status_code(),
+            brpc::HTTP_STATUS_CONFLICT);
+
+  brpc::Controller rollback;
+  PostHttp(channel, uri, TransactionPath(transaction_id, "rollback"), "",
+           rollback);
+  ASSERT_FALSE(rollback.Failed()) << rollback.ErrorText();
+
+  brpc::Controller invalidated_id;
+  PostHttp(channel, uri, TransactionPath(transaction_id, "query"), read,
+           invalidated_id);
+  EXPECT_TRUE(invalidated_id.Failed());
+  EXPECT_EQ(invalidated_id.http_response().status_code(),
+            brpc::HTTP_STATUS_NOT_FOUND);
   service.Stop();
 }
 
@@ -1281,8 +1352,8 @@ TEST_F(NeugDBServiceTest,
 
   const std::string unknown_transaction_id = "unknown-transaction";
   brpc::Controller unknown_schema;
-  GetHttp(channel, uri, "/transactions/schema", unknown_schema,
-          &unknown_transaction_id);
+  GetHttp(channel, uri, TransactionPath(unknown_transaction_id, "schema"),
+          unknown_schema);
   EXPECT_TRUE(unknown_schema.Failed());
   EXPECT_EQ(unknown_schema.http_response().status_code(),
             brpc::HTTP_STATUS_NOT_FOUND);
@@ -1293,13 +1364,12 @@ TEST_F(NeugDBServiceTest,
   PostHttp(channel, uri, "/transactions", R"({"mode":"read_only"})",
            second_begin);
   ASSERT_FALSE(second_begin.Failed()) << second_begin.ErrorText();
-  const auto* second_transaction_id =
-      second_begin.http_response().GetHeader("X-Transaction-Id");
-  ASSERT_NE(second_transaction_id, nullptr);
+  const auto second_transaction_id = ReadTransactionId(second_begin);
+  ASSERT_FALSE(second_transaction_id.empty());
 
   brpc::Controller rollback;
-  PostHttp(channel, uri, "/transactions/rollback", "", rollback,
-           second_transaction_id);
+  PostHttp(channel, uri, TransactionPath(second_transaction_id, "rollback"), "",
+           rollback);
   EXPECT_FALSE(rollback.Failed()) << rollback.ErrorText();
   service.Stop();
 }

--- a/tests/unittest/test_db_svc.cc
+++ b/tests/unittest/test_db_svc.cc
@@ -71,6 +71,37 @@ int StartBthread(bthread_t& tid, BthreadTask& task) {
                                   &task);
 }
 
+void PostHttp(brpc::Channel& channel, const std::string& uri,
+              const std::string& path, const std::string& body,
+              brpc::Controller& controller,
+              const std::string* transaction_id = nullptr) {
+  controller.http_request().uri() = (uri + path).c_str();
+  controller.http_request().set_method(brpc::HTTP_METHOD_POST);
+  if (transaction_id != nullptr) {
+    controller.http_request().SetHeader("X-Transaction-Id", *transaction_id);
+  }
+  controller.request_attachment().append(body);
+  channel.CallMethod(nullptr, &controller, nullptr, nullptr, nullptr);
+}
+
+void GetHttp(brpc::Channel& channel, const std::string& uri,
+             const std::string& path, brpc::Controller& controller,
+             const std::string* transaction_id = nullptr) {
+  controller.http_request().uri() = (uri + path).c_str();
+  controller.http_request().set_method(brpc::HTTP_METHOD_GET);
+  if (transaction_id != nullptr) {
+    controller.http_request().SetHeader("X-Transaction-Id", *transaction_id);
+  }
+  channel.CallMethod(nullptr, &controller, nullptr, nullptr, nullptr);
+}
+
+QueryResponse ReadHttpQueryResponse(const brpc::Controller& controller) {
+  QueryResponse response;
+  EXPECT_TRUE(
+      response.ParseFromString(controller.response_attachment().to_string()));
+  return response;
+}
+
 }  // namespace
 
 timestamp_t InsertModernPersonAndReturnTimestamp(NeugDBService& service,
@@ -1051,6 +1082,225 @@ TEST_F(NeugDBServiceTest, UnsupportedCapabilityMapsToHttp501) {
   EXPECT_TRUE(controller.Failed());
   EXPECT_EQ(controller.http_response().status_code(),
             brpc::HTTP_STATUS_NOT_IMPLEMENTED);
+  service.Stop();
+}
+
+TEST_F(NeugDBServiceTest, ExplicitTransactionUsesDedicatedHttpSession) {
+  config_.query_port = 19998;
+  neug::NeugDBService service(*db_, config_);
+  const auto uri = service.Start();
+
+  brpc::ChannelOptions options;
+  options.protocol = "http";
+  options.timeout_ms = 5000;
+  options.max_retry = 0;
+  brpc::Channel channel;
+  ASSERT_EQ(channel.Init(uri.c_str(), "", &options), 0);
+
+  brpc::Controller begin;
+  PostHttp(channel, uri, "/transactions", R"({"mode":"read_write"})", begin);
+  ASSERT_FALSE(begin.Failed()) << begin.ErrorText();
+  const auto* transaction_id =
+      begin.http_response().GetHeader("X-Transaction-Id");
+  ASSERT_NE(transaction_id, nullptr);
+  const auto* cache_control = begin.http_response().GetHeader("Cache-Control");
+  ASSERT_NE(cache_control, nullptr);
+  EXPECT_EQ(*cache_control, "no-store");
+
+  brpc::Controller competing_begin;
+  PostHttp(channel, uri, "/transactions", R"({"mode":"read_write"})",
+           competing_begin);
+  EXPECT_TRUE(competing_begin.Failed());
+  EXPECT_EQ(competing_begin.http_response().status_code(),
+            brpc::HTTP_STATUS_SERVICE_UNAVAILABLE);
+
+  brpc::Controller nested_begin;
+  PostHttp(channel, uri, "/transactions", R"({"mode":"read_write"})",
+           nested_begin, transaction_id);
+  EXPECT_TRUE(nested_begin.Failed());
+  EXPECT_EQ(nested_begin.http_response().status_code(),
+            brpc::HTTP_STATUS_CONFLICT);
+
+  const auto create = RequestSerializer::SerializeRequest(
+      "CREATE (:person {id: 90002, name: 'explicit-tx', age: 1});", "update",
+      {});
+  brpc::Controller write;
+  PostHttp(channel, uri, "/transactions/query", create, write, transaction_id);
+  ASSERT_FALSE(write.Failed()) << write.ErrorText();
+
+  const auto read = RequestSerializer::SerializeRequest(
+      "MATCH (n:person {id: 90002}) RETURN n;", "read", {});
+  brpc::Controller read_your_writes;
+  PostHttp(channel, uri, "/transactions/query", read, read_your_writes,
+           transaction_id);
+  ASSERT_FALSE(read_your_writes.Failed()) << read_your_writes.ErrorText();
+  EXPECT_EQ(ReadHttpQueryResponse(read_your_writes).row_count(), 1);
+
+  const auto create_table = RequestSerializer::SerializeRequest(
+      "CREATE NODE TABLE transaction_schema(id INT64, PRIMARY KEY(id));",
+      "schema", {});
+  brpc::Controller ddl;
+  PostHttp(channel, uri, "/transactions/query", create_table, ddl,
+           transaction_id);
+  ASSERT_FALSE(ddl.Failed()) << ddl.ErrorText();
+
+  brpc::Controller schema;
+  GetHttp(channel, uri, "/transactions/schema", schema, transaction_id);
+  ASSERT_FALSE(schema.Failed()) << schema.ErrorText();
+  EXPECT_NE(schema.response_attachment().to_string().find("transaction_schema"),
+            std::string::npos);
+
+  brpc::Controller before_commit;
+  PostHttp(channel, uri, "/cypher", read, before_commit);
+  ASSERT_FALSE(before_commit.Failed()) << before_commit.ErrorText();
+  EXPECT_EQ(ReadHttpQueryResponse(before_commit).row_count(), 0);
+
+  brpc::Controller rejected_regular_query;
+  PostHttp(channel, uri, "/cypher", read, rejected_regular_query,
+           transaction_id);
+  EXPECT_TRUE(rejected_regular_query.Failed());
+  EXPECT_EQ(rejected_regular_query.http_response().status_code(),
+            brpc::HTTP_STATUS_BAD_REQUEST);
+
+  brpc::Controller commit;
+  PostHttp(channel, uri, "/transactions/commit", "", commit, transaction_id);
+  ASSERT_FALSE(commit.Failed()) << commit.ErrorText();
+
+  brpc::Controller after_commit;
+  PostHttp(channel, uri, "/cypher", read, after_commit);
+  ASSERT_FALSE(after_commit.Failed()) << after_commit.ErrorText();
+  EXPECT_EQ(ReadHttpQueryResponse(after_commit).row_count(), 1);
+
+  brpc::Controller read_only_begin;
+  PostHttp(channel, uri, "/transactions", R"({"mode":"read_only"})",
+           read_only_begin);
+  ASSERT_FALSE(read_only_begin.Failed()) << read_only_begin.ErrorText();
+  const auto* read_only_id =
+      read_only_begin.http_response().GetHeader("X-Transaction-Id");
+  ASSERT_NE(read_only_id, nullptr);
+
+  brpc::Controller rejected_write;
+  PostHttp(channel, uri, "/transactions/query", create, rejected_write,
+           read_only_id);
+  EXPECT_TRUE(rejected_write.Failed());
+  EXPECT_EQ(rejected_write.http_response().status_code(),
+            brpc::HTTP_STATUS_CONFLICT);
+
+  brpc::Controller rejected_commit;
+  PostHttp(channel, uri, "/transactions/commit", "", rejected_commit,
+           read_only_id);
+  EXPECT_TRUE(rejected_commit.Failed());
+  EXPECT_EQ(rejected_commit.http_response().status_code(),
+            brpc::HTTP_STATUS_CONFLICT);
+
+  brpc::Controller rollback;
+  PostHttp(channel, uri, "/transactions/rollback", "", rollback, read_only_id);
+  EXPECT_FALSE(rollback.Failed()) << rollback.ErrorText();
+
+  brpc::Controller rollback_begin;
+  PostHttp(channel, uri, "/transactions", R"({"mode":"read_write"})",
+           rollback_begin);
+  ASSERT_FALSE(rollback_begin.Failed()) << rollback_begin.ErrorText();
+  const auto* rollback_id =
+      rollback_begin.http_response().GetHeader("X-Transaction-Id");
+  ASSERT_NE(rollback_id, nullptr);
+  const auto rollback_write = RequestSerializer::SerializeRequest(
+      "CREATE (:person {id: 90003, name: 'rollback-tx', age: 1});", "update",
+      {});
+  brpc::Controller rollback_write_response;
+  PostHttp(channel, uri, "/transactions/query", rollback_write,
+           rollback_write_response, rollback_id);
+  ASSERT_FALSE(rollback_write_response.Failed())
+      << rollback_write_response.ErrorText();
+  brpc::Controller rollback_write_transaction;
+  PostHttp(channel, uri, "/transactions/rollback", "",
+           rollback_write_transaction, rollback_id);
+  ASSERT_FALSE(rollback_write_transaction.Failed())
+      << rollback_write_transaction.ErrorText();
+
+  const auto rollback_read = RequestSerializer::SerializeRequest(
+      "MATCH (n:person {id: 90003}) RETURN n;", "read", {});
+  brpc::Controller after_rollback;
+  PostHttp(channel, uri, "/cypher", rollback_read, after_rollback);
+  ASSERT_FALSE(after_rollback.Failed()) << after_rollback.ErrorText();
+  EXPECT_EQ(ReadHttpQueryResponse(after_rollback).row_count(), 0);
+  service.Stop();
+}
+
+TEST_F(NeugDBServiceTest, ReadOnlyServiceRejectsReadWriteTransactionBegin) {
+  db_->Close();
+  neug::NeugDBConfig read_only_config((test_dir_ / "graph").string(), 4);
+  read_only_config.mode = DBMode::READ_ONLY;
+  db_ = std::make_unique<neug::NeugDB>();
+  db_->Open(read_only_config);
+
+  config_.query_port = 19997;
+  neug::NeugDBService service(*db_, config_);
+  const auto uri = service.Start();
+
+  brpc::ChannelOptions options;
+  options.protocol = "http";
+  options.timeout_ms = 5000;
+  options.max_retry = 0;
+  brpc::Channel channel;
+  ASSERT_EQ(channel.Init(uri.c_str(), "", &options), 0);
+
+  brpc::Controller begin;
+  PostHttp(channel, uri, "/transactions", R"({"mode":"read_write"})", begin);
+  EXPECT_TRUE(begin.Failed());
+  EXPECT_EQ(begin.http_response().status_code(), brpc::HTTP_STATUS_BAD_REQUEST);
+  service.Stop();
+}
+
+TEST_F(NeugDBServiceTest,
+       ExplicitTransactionCapacityExpiryAndUnknownIdAreHandled) {
+  config_.query_port = 19996;
+  config_.max_explicit_transactions = 1;
+  config_.explicit_transaction_timeout_ms = 20;
+  neug::NeugDBService service(*db_, config_);
+  const auto uri = service.Start();
+
+  brpc::ChannelOptions options;
+  options.protocol = "http";
+  options.timeout_ms = 5000;
+  options.max_retry = 0;
+  brpc::Channel channel;
+  ASSERT_EQ(channel.Init(uri.c_str(), "", &options), 0);
+
+  brpc::Controller first_begin;
+  PostHttp(channel, uri, "/transactions", R"({"mode":"read_only"})",
+           first_begin);
+  ASSERT_FALSE(first_begin.Failed()) << first_begin.ErrorText();
+
+  brpc::Controller capacity_rejected;
+  PostHttp(channel, uri, "/transactions", R"({"mode":"read_only"})",
+           capacity_rejected);
+  EXPECT_TRUE(capacity_rejected.Failed());
+  EXPECT_EQ(capacity_rejected.http_response().status_code(),
+            brpc::HTTP_STATUS_SERVICE_UNAVAILABLE);
+
+  const std::string unknown_transaction_id = "unknown-transaction";
+  brpc::Controller unknown_schema;
+  GetHttp(channel, uri, "/transactions/schema", unknown_schema,
+          &unknown_transaction_id);
+  EXPECT_TRUE(unknown_schema.Failed());
+  EXPECT_EQ(unknown_schema.http_response().status_code(),
+            brpc::HTTP_STATUS_NOT_FOUND);
+
+  // The reaper removes the first expired session, freeing the only slot.
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  brpc::Controller second_begin;
+  PostHttp(channel, uri, "/transactions", R"({"mode":"read_only"})",
+           second_begin);
+  ASSERT_FALSE(second_begin.Failed()) << second_begin.ErrorText();
+  const auto* second_transaction_id =
+      second_begin.http_response().GetHeader("X-Transaction-Id");
+  ASSERT_NE(second_transaction_id, nullptr);
+
+  brpc::Controller rollback;
+  PostHttp(channel, uri, "/transactions/rollback", "", rollback,
+           second_transaction_id);
+  EXPECT_FALSE(rollback.Failed()) << rollback.ErrorText();
   service.Stop();
 }
 

--- a/tests/unittest/test_db_svc.cc
+++ b/tests/unittest/test_db_svc.cc
@@ -1137,6 +1137,15 @@ TEST_F(NeugDBServiceTest, ExplicitTransactionUsesDedicatedHttpSession) {
   ASSERT_NE(cache_control, nullptr);
   EXPECT_EQ(*cache_control, "no-store");
 
+  brpc::Controller get_commit;
+  GetHttp(channel, uri, TransactionPath(transaction_id, "commit"), get_commit);
+  EXPECT_TRUE(get_commit.Failed());
+  EXPECT_EQ(get_commit.http_response().status_code(),
+            brpc::HTTP_STATUS_METHOD_NOT_ALLOWED);
+  const auto* allow = get_commit.http_response().GetHeader("Allow");
+  ASSERT_NE(allow, nullptr);
+  EXPECT_EQ(*allow, "POST");
+
   brpc::Controller competing_begin;
   PostHttp(channel, uri, "/transactions", R"({"mode":"read_write"})",
            competing_begin);
@@ -1168,11 +1177,14 @@ TEST_F(NeugDBServiceTest, ExplicitTransactionUsesDedicatedHttpSession) {
            ddl);
   ASSERT_FALSE(ddl.Failed()) << ddl.ErrorText();
 
-  brpc::Controller schema;
-  GetHttp(channel, uri, TransactionPath(transaction_id, "schema"), schema);
-  ASSERT_FALSE(schema.Failed()) << schema.ErrorText();
-  EXPECT_NE(schema.response_attachment().to_string().find("transaction_schema"),
-            std::string::npos);
+  const auto read_private_schema = RequestSerializer::SerializeRequest(
+      "MATCH (n:transaction_schema) RETURN n;", "read", {});
+  brpc::Controller private_schema_query;
+  PostHttp(channel, uri, TransactionPath(transaction_id, "query"),
+           read_private_schema, private_schema_query);
+  ASSERT_FALSE(private_schema_query.Failed())
+      << private_schema_query.ErrorText();
+  EXPECT_EQ(ReadHttpQueryResponse(private_schema_query).row_count(), 0);
 
   brpc::Controller before_commit;
   PostHttp(channel, uri, "/cypher", read, before_commit);
@@ -1323,8 +1335,7 @@ TEST_F(NeugDBServiceTest, ReadOnlyServiceRejectsReadWriteTransactionBegin) {
   service.Stop();
 }
 
-TEST_F(NeugDBServiceTest,
-       ExplicitTransactionCapacityExpiryAndUnknownIdAreHandled) {
+TEST_F(NeugDBServiceTest, ExplicitTransactionCapacityAndExpiryAreHandled) {
   config_.query_port = 19996;
   config_.max_explicit_transactions = 1;
   config_.explicit_transaction_timeout_ms = 20;
@@ -1349,14 +1360,6 @@ TEST_F(NeugDBServiceTest,
   EXPECT_TRUE(capacity_rejected.Failed());
   EXPECT_EQ(capacity_rejected.http_response().status_code(),
             brpc::HTTP_STATUS_SERVICE_UNAVAILABLE);
-
-  const std::string unknown_transaction_id = "unknown-transaction";
-  brpc::Controller unknown_schema;
-  GetHttp(channel, uri, TransactionPath(unknown_transaction_id, "schema"),
-          unknown_schema);
-  EXPECT_TRUE(unknown_schema.Failed());
-  EXPECT_EQ(unknown_schema.http_response().status_code(),
-            brpc::HTTP_STATUS_NOT_FOUND);
 
   // The reaper removes the first expired session, freeing the only slot.
   std::this_thread::sleep_for(std::chrono::milliseconds(100));


### PR DESCRIPTION
## Summary

- Add service-owned explicit transaction sessions for TP HTTP clients, using an opaque transaction ID across requests.
- Support read-only and read-write sessions, private read-your-writes, private DDL schema visibility, commit, rollback, timeout cleanup, and rollback on close.
- Borrow execution slots per request and use non-blocking TP admission so active sessions do not pin slots or block worker threads.
- Document the v0.2 service transaction API and add focused lifecycle, isolation, and admission regressions.

## Scope

- Reject transaction control in Cypher and unsupported operations within an explicit session.
- Keep WAL append failure handling and recovery framing out of scope for this PR.

## Validation

- cmake --build build --target neug test_db_svc -j4
- cmake --build build --target transaction_test -j4
- Focused service HTTP explicit-transaction tests
- Focused non-blocking update-timestamp admission test
- git diff --check

Refs #779