### PR TITLE
fix: reject null property updates

### DIFF
--- a/doc/source/extensions/fts_search.md
+++ b/doc/source/extensions/fts_search.md
@@ -448,9 +448,8 @@ WHERE article.id = 1
 DELETE article;
 ```
 
-When `SET` assigns `NULL` to an indexed property, the `NULL` value is not
-inserted into the FTS index. If the property previously contained indexed
-text, its existing index entry is removed.
+Persistent properties do not currently support `NULL`. Assigning `NULL` to an
+indexed property fails without changing the property or its index entry.
 
 For checkpoint and reopen behavior, including loading `fts` to activate a
 restored index, see [Persistence and Recovery](../storage_index/index.md#persistence-and-recovery).

--- a/extension/fts/tests/fts_extension_test.cc
+++ b/extension/fts/tests/fts_extension_test.cc
@@ -796,20 +796,6 @@ TEST(FTSIndexTest, RejectsInvalidMetadataAndParams) {
   auto result = valid_index->Search(params);
   ASSERT_TRUE(result.has_value()) << result.error().ToString();
   EXPECT_TRUE(result->empty());
-  auto null_value = valid_index->Upsert(1, MakeTextIndexValue(Value()));
-  EXPECT_TRUE(null_value.ok()) << null_value.error_message();
-  ASSERT_TRUE(
-      valid_index->Upsert(1, MakeTextIndexValue(Value::STRING("defined token")))
-          .ok());
-  auto defined = valid_index->Search(MakeQuery("defined"));
-  ASSERT_TRUE(defined.has_value()) << defined.error().ToString();
-  ASSERT_EQ(defined->size(), 1u);
-  ASSERT_TRUE(valid_index->Upsert(1, MakeTextIndexValue(Value())).ok());
-  ASSERT_TRUE(valid_index->Upsert(1, MakeTextIndexValue(Value())).ok());
-  auto deleted_by_null = valid_index->Search(MakeQuery("defined"));
-  ASSERT_TRUE(deleted_by_null.has_value())
-      << deleted_by_null.error().ToString();
-  EXPECT_TRUE(deleted_by_null->empty());
   auto wrong_type =
       valid_index->Upsert(2, MakeTextIndexValue(Value::INT64(42)));
   EXPECT_EQ(wrong_type.error_code(), StatusCode::ERR_INVALID_ARGUMENT);

--- a/src/execution/execute/ops/batch/batch_update_edge.cc
+++ b/src/execution/execute/ops/batch/batch_update_edge.cc
@@ -123,6 +123,10 @@ neug::result<Context> UpdateEdgeOpr::Eval(IStorageInterface& graph_interface,
         }
 
         auto value = record_expression.eval_record(chunk.chunk(), row);
+        if (value.IsNull()) {
+          THROW_NOT_SUPPORTED_EXCEPTION("Setting NULL for property " +
+                                        property_name);
+        }
         if (edge_schema->properties[property_id] != value.type()) {
           THROW_RUNTIME_ERROR("Property type mismatch for property " +
                               property_name);

--- a/src/execution/execute/ops/batch/batch_update_edge.cc
+++ b/src/execution/execute/ops/batch/batch_update_edge.cc
@@ -123,9 +123,7 @@ neug::result<Context> UpdateEdgeOpr::Eval(IStorageInterface& graph_interface,
         }
 
         auto value = record_expression.eval_record(chunk.chunk(), row);
-        // SET may assign NULL without carrying the property's concrete type.
-        if (!value.IsNull() &&
-            edge_schema->properties[property_id] != value.type()) {
+        if (edge_schema->properties[property_id] != value.type()) {
           THROW_RUNTIME_ERROR("Property type mismatch for property " +
                               property_name);
         }

--- a/src/execution/execute/ops/batch/batch_update_vertex.cc
+++ b/src/execution/execute/ops/batch/batch_update_vertex.cc
@@ -101,6 +101,10 @@ neug::result<ContextChunk> UpdateVertexOpr::eval_impl(
       int32_t col_id = std::distance(property_names.begin(), pos);
       assert(col_id >= 0 &&
              col_id < static_cast<int32_t>(property_names.size()));
+      if (value.IsNull()) {
+        THROW_NOT_SUPPORTED_EXCEPTION("Setting NULL for property " +
+                                      prop_name);
+      }
       if (property_types[col_id] != value.type()) {
         THROW_RUNTIME_ERROR("Property type mismatch for property " + prop_name);
       }

--- a/src/execution/execute/ops/batch/batch_update_vertex.cc
+++ b/src/execution/execute/ops/batch/batch_update_vertex.cc
@@ -101,9 +101,7 @@ neug::result<ContextChunk> UpdateVertexOpr::eval_impl(
       int32_t col_id = std::distance(property_names.begin(), pos);
       assert(col_id >= 0 &&
              col_id < static_cast<int32_t>(property_names.size()));
-      // SET may assign NULL without carrying the property's concrete type, so
-      // skip the type comparison for NULL values.
-      if (!value.IsNull() && property_types[col_id] != value.type()) {
+      if (property_types[col_id] != value.type()) {
         THROW_RUNTIME_ERROR("Property type mismatch for property " + prop_name);
       }
       RETURN_STATUS_ERROR_IF_NOT_OK(

--- a/src/execution/execute/ops/batch/batch_update_vertex.cc
+++ b/src/execution/execute/ops/batch/batch_update_vertex.cc
@@ -102,8 +102,7 @@ neug::result<ContextChunk> UpdateVertexOpr::eval_impl(
       assert(col_id >= 0 &&
              col_id < static_cast<int32_t>(property_names.size()));
       if (value.IsNull()) {
-        THROW_NOT_SUPPORTED_EXCEPTION("Setting NULL for property " +
-                                      prop_name);
+        THROW_NOT_SUPPORTED_EXCEPTION("Setting NULL for property " + prop_name);
       }
       if (property_types[col_id] != value.type()) {
         THROW_RUNTIME_ERROR("Property type mismatch for property " + prop_name);

--- a/src/storages/index/storage_index.cc
+++ b/src/storages/index/storage_index.cc
@@ -20,6 +20,7 @@
 #include <rapidjson/writer.h>
 #include <yaml-cpp/yaml.h>
 #include <algorithm>
+#include <cassert>
 
 #include "neug/storages/checkpoint.h"
 #include "neug/storages/checkpoint_manifest.h"
@@ -71,10 +72,8 @@ Status StorageIndex::Upsert(vid_t vid, const IndexValues& new_values) {
     return Status(StatusCode::ERR_INVALID_ARGUMENT,
                   "Index value count does not match metadata");
   }
-  if (std::all_of(new_values.begin(), new_values.end(),
-                  [](const Value& value) { return value.IsNull(); })) {
-    return Delete(vid);
-  }
+  assert(std::none_of(new_values.begin(), new_values.end(),
+                      [](const Value& value) { return value.IsNull(); }));
   auto index_id = index_id_accessor_->UpsertVID(vid);
   return AppendImpl(index_id, new_values);
 }

--- a/tools/python_bind/tests/test_fts_index.py
+++ b/tools/python_bind/tests/test_fts_index.py
@@ -213,9 +213,12 @@ def test_fts_multi_column_index_supports_partial_null_values(
     )
     assert {row[0] for row in title_rows} == {1, 5}
 
-    fts_multi_column_database.execute(
-        "MATCH (a:Article) WHERE a.id = 4 SET a.description = NULL;"
-    )
+    with pytest.raises(
+        RuntimeError, match="Setting NULL for property description"
+    ):
+        fts_multi_column_database.execute(
+            "MATCH (a:Article) WHERE a.id = 4 SET a.description = NULL;"
+        )
     description_rows = list(
         fts_multi_column_database.execute(
             "MATCH (a:Article) "
@@ -223,7 +226,7 @@ def test_fts_multi_column_index_supports_partial_null_values(
             "ORDER BY score ASC;"
         )
     )
-    assert [row[0] for row in description_rows] == [2]
+    assert {row[0] for row in description_rows} == {2, 4}
 
 
 def test_fts_bm25_rejects_duplicate_properties(fts_multi_column_database):
@@ -675,7 +678,7 @@ def test_fts_rejects_null_property_updates(tmp_path):
     connection.execute("CREATE INDEX item_text_fts ON Item USING FTS (text);")
     assert [row[0] for row in search(connection, "visible")] == [1]
 
-    with pytest.raises(RuntimeError, match="Property type mismatch"):
+    with pytest.raises(RuntimeError, match="Setting NULL for property text"):
         connection.execute("MATCH (n:Item) WHERE n.id = 1 SET n.text = NULL;")
     assert [row[0] for row in search(connection, "visible")] == [1]
     connection.execute("CHECKPOINT;")

--- a/tools/python_bind/tests/test_fts_index.py
+++ b/tools/python_bind/tests/test_fts_index.py
@@ -213,9 +213,7 @@ def test_fts_multi_column_index_supports_partial_null_values(
     )
     assert {row[0] for row in title_rows} == {1, 5}
 
-    with pytest.raises(
-        RuntimeError, match="Setting NULL for property description"
-    ):
+    with pytest.raises(RuntimeError, match="Setting NULL for property description"):
         fts_multi_column_database.execute(
             "MATCH (a:Article) WHERE a.id = 4 SET a.description = NULL;"
         )

--- a/tools/python_bind/tests/test_fts_index.py
+++ b/tools/python_bind/tests/test_fts_index.py
@@ -665,25 +665,19 @@ def test_fts_dynamic_query_parameter_rejects_invalid_values(fts_database):
         list(fts_database.execute(statement, parameters={"query": None}))
 
 
-def test_fts_null_values_are_not_indexed_and_transitions_are_maintained(tmp_path):
-    database_path = str(tmp_path / "fts_null_db")
+def test_fts_rejects_null_property_updates(tmp_path):
+    database_path = str(tmp_path / "fts_reject_null_db")
     db = Database(db_path=database_path, mode="w")
     connection = db.connect()
     load_fts(connection, skip_if_unavailable=True)
     create_item_table(connection)
-    connection.execute(
-        "CREATE (:Item {id: 1, text: NULL}), (:Item {id: 2}), "
-        "(:Item {id: 3, text: 'visible token'});"
-    )
+    connection.execute("CREATE (:Item {id: 1, text: 'visible token'});")
     connection.execute("CREATE INDEX item_text_fts ON Item USING FTS (text);")
-    assert [row[0] for row in search(connection, "visible")] == [3]
+    assert [row[0] for row in search(connection, "visible")] == [1]
 
-    connection.execute("CREATE (:Item {id: 4, text: NULL}), (:Item {id: 5});")
-    connection.execute("MATCH (n:Item) WHERE n.id = 3 SET n.text = NULL;")
-    assert search(connection, "visible") == []
-    connection.execute("MATCH (n:Item) WHERE n.id = 1 SET n.text = 'added token';")
-    assert [row[0] for row in search(connection, "added")] == [1]
-    connection.execute("MATCH (n:Item) WHERE n.id = 2 SET n.text = NULL;")
+    with pytest.raises(RuntimeError, match="Property type mismatch"):
+        connection.execute("MATCH (n:Item) WHERE n.id = 1 SET n.text = NULL;")
+    assert [row[0] for row in search(connection, "visible")] == [1]
     connection.execute("CHECKPOINT;")
     connection.close()
     db.close()
@@ -692,8 +686,7 @@ def test_fts_null_values_are_not_indexed_and_transitions_are_maintained(tmp_path
     reopened_connection = reopened.connect()
     try:
         load_fts(reopened_connection)
-        assert [row[0] for row in search(reopened_connection, "added")] == [1]
-        assert search(reopened_connection, "visible") == []
+        assert [row[0] for row in search(reopened_connection, "visible")] == [1]
     finally:
         reopened_connection.close()
         reopened.close()

--- a/tools/python_bind/tests/test_hnsw_index.py
+++ b/tools/python_bind/tests/test_hnsw_index.py
@@ -412,7 +412,7 @@ def test_documented_schema_index_and_query_examples(tmp_path):
         conn.execute(
             "MATCH (n:vector_node) WHERE n.id = 1 " "SET n.vec = [0.2, 0.2, 0.1, 0.1];"
         )
-        with pytest.raises(RuntimeError, match="Property type mismatch"):
+        with pytest.raises(RuntimeError, match="Setting NULL for property vec"):
             conn.execute("MATCH (n:vector_node {id: 1}) SET n.vec = NULL;")
         after_failed_null = list(
             conn.execute(

--- a/tools/python_bind/tests/test_hnsw_index.py
+++ b/tools/python_bind/tests/test_hnsw_index.py
@@ -412,15 +412,16 @@ def test_documented_schema_index_and_query_examples(tmp_path):
         conn.execute(
             "MATCH (n:vector_node) WHERE n.id = 1 " "SET n.vec = [0.2, 0.2, 0.1, 0.1];"
         )
-        conn.execute("MATCH (n:vector_node {id: 1}) SET n.vec = NULL;")
-        after_null = list(
+        with pytest.raises(RuntimeError, match="Property type mismatch"):
+            conn.execute("MATCH (n:vector_node {id: 1}) SET n.vec = NULL;")
+        after_failed_null = list(
             conn.execute(
                 "MATCH (n:vector_node) RETURN n.id, "
                 "vector_distance_l2(n.vec, [0.2, 0.2, 0.1, 0.1]) AS score "
-                "ORDER BY score ASC LIMIT 5;"
+                "ORDER BY score ASC LIMIT 2;"
             )
         )
-        assert 1 not in [row[0] for row in after_null]
+        assert {row[0] for row in after_failed_null} == {1, 3}
         conn.execute("MATCH (n:vector_node) WHERE n.id = 2 DELETE n;")
         conn.execute("DROP INDEX vec_hnsw_index IF EXISTS;")
         conn.execute("DROP TABLE vector_node;")


### PR DESCRIPTION
## Summary
- restore strict type checks for property updates
- assert storage index upserts receive non-NULL values
- update index tests and documentation

This issue was introduced in https://github.com/alibaba/neug/pull/870/commits/11cac9ce9227d2d861d064812009a38344f96281 and we should rollback it.

Closes #945