### PR TITLE
feat: add Python bindings for AP explicit transactions

### DIFF
--- a/doc/source/reference/python_api/connection.md
+++ b/doc/source/reference/python_api/connection.md
@@ -131,8 +131,10 @@ such as `__iter__` and `__next__`.
 
 If the query is a DDL or DML query, the result will be an empty `QueryResult` object.
 
-Inside an explicit transaction, a failed query leaves the transaction
-rollback-only. Call `rollback()` before executing another query.
+Inside an explicit transaction, a query that reaches the database engine and
+fails leaves the transaction rollback-only. Call `rollback()` before executing
+another query. Client-side validation errors that occur before execution, such
+as an invalid `access_mode`, do not change the transaction state.
 
 Some of the cypher queries could change the state of the database, such as `CREATE NODE TABLE`, `INSERT`,
 `UPDATE`, `DELETE`, etc. Other queries, such as `MATCH(n) RETURN n.id`, will not change the state of

--- a/doc/source/reference/python_api/connection.md
+++ b/doc/source/reference/python_api/connection.md
@@ -52,7 +52,60 @@ Check if the connection is open.
 def close()
 ```
 
-Close the connection.
+Close the connection. An active explicit transaction is rolled back.
+
+<a id="neug.connection.Connection.has_active_transaction"></a>
+
+### has\_active\_transaction
+
+```python
+@property
+def has_active_transaction() -> bool
+```
+
+Whether this connection has an active explicit transaction.
+
+The property remains true while a failed transaction is rollback-only. Call
+`rollback()` to return the connection to auto-commit mode.
+
+<a id="neug.connection.Connection.begin_transaction"></a>
+
+### begin\_transaction
+
+```python
+def begin_transaction(read_only: bool = False)
+```
+
+Begin an explicit embedded AP transaction.
+
+- **Parameters:**
+  - `read_only` (bool): Pin one read view and reject writes when true. The
+    default starts a read-write transaction with a private COW view.
+
+- **Raises:**
+  - **RuntimeError:** If the connection is closed or already has an active
+    transaction.
+
+<a id="neug.connection.Connection.commit"></a>
+
+### commit
+
+```python
+def commit()
+```
+
+Commit the active explicit transaction. A rollback-only transaction must be
+rolled back instead.
+
+<a id="neug.connection.Connection.rollback"></a>
+
+### rollback
+
+```python
+def rollback()
+```
+
+Roll back the active explicit transaction and return to auto-commit.
 
 <a id="neug.connection.Connection.execute"></a>
 
@@ -77,6 +130,9 @@ The QueryResult object is like an iterator, providing methods to iterate over th
 such as `__iter__` and `__next__`.
 
 If the query is a DDL or DML query, the result will be an empty `QueryResult` object.
+
+Inside an explicit transaction, a failed query leaves the transaction
+rollback-only. Call `rollback()` before executing another query.
 
 Some of the cypher queries could change the state of the database, such as `CREATE NODE TABLE`, `INSERT`,
 `UPDATE`, `DELETE`, etc. Other queries, such as `MATCH(n) RETURN n.id`, will not change the state of
@@ -138,4 +194,3 @@ Get the schema of the NeuG database.
 **Returns**:
 
 The schema of the NeuG database.
-

--- a/doc/source/transaction/transaction.mdx
+++ b/doc/source/transaction/transaction.mdx
@@ -96,12 +96,15 @@ rolled back, or its connection is closed; explicit transactions currently have
 no timeout. Applications should therefore finish them promptly. Embedded
 READ_WRITE mode currently allows only one public `Connection` at a time.
 
-Any failed query call aborts the owner and leaves the connection rollback-only.
-This includes query analysis, syntax or compilation errors, access-mode or
-parameter validation errors, execution failures, read-only writes, and rejected
-bulk or maintenance operations. Because Cypher transaction-control statements
-are unsupported, issuing `COMMIT;` through `Query()` or `execute()` is also a
-failed statement and makes the transaction rollback-only. In that state, call
+Any query that reaches the database engine and fails aborts the owner and
+leaves the connection rollback-only. This includes query analysis, syntax or
+compilation errors, execution failures, read-only writes, and rejected bulk or
+maintenance operations. Errors rejected by a client binding before the query
+reaches the engine do not change the active transaction; for example, Python
+rejects an invalid `access_mode` with `ValueError`. Because Cypher
+transaction-control statements are unsupported, issuing `COMMIT;` through
+`Query()` or `execute()` is also a failed statement and makes the transaction
+rollback-only. In that state, call
 `Rollback()`/`rollback()` (or close the connection) before issuing another
 query or beginning another transaction. `HasActiveTransaction()` in C++,
 `hasActiveTransaction` in Node.js, and `has_active_transaction` in Python stay

--- a/doc/source/transaction/transaction.mdx
+++ b/doc/source/transaction/transaction.mdx
@@ -31,7 +31,7 @@ conn.execute("CREATE (p:Person {name: 'Bob'})")    # Transaction 2
 ### Since version v0.2
 
 Since version v0.2, auto-commit remains the default in every supported
-interface. The embedded C++ and Node.js `Connection` APIs additionally support
+interface. The embedded C++, Node.js, and Python `Connection` APIs support
 programmatic explicit transactions for AP mode, as described below.
 
 #### Explicit Transactions in Embedded AP Mode
@@ -39,7 +39,7 @@ programmatic explicit transactions for AP mode, as described below.
 An explicit transaction is owned by its `Connection` and spans multiple
 queries:
 
-<Tabs items={['C++', 'Node.js']}>
+<Tabs items={['C++', 'Node.js', 'Python']}>
 
 <Tab>
 
@@ -70,20 +70,31 @@ conn.commit(); // Publishes all successful writes as one commit.
 
 </Tab>
 
+<Tab>
+
+```python
+conn.begin_transaction()
+created = conn.execute("CREATE (:Person {name: 'Alice'})", "insert")
+visible = conn.execute("MATCH (p:Person) RETURN p.name")
+conn.commit()
+```
+
+</Tab>
+
 </Tabs>
 
 In C++, `TransactionMode::kReadOnly` pins one read view for the entire
 transaction and rejects writes; in Node.js, use
-`beginTransaction({ readOnly: true })`. C++
-`TransactionMode::kReadWrite` and the default Node.js mode hold one private COW
-write view: successful statements can read their own writes, but private
-changes are not published until `Commit()` or `commit()` succeeds. An AP
-read-write transaction holds exclusive AP admission for its full lifetime. Any
-AP operation that contends for that admission waits until the transaction is
-committed, rolled back, or its connection is closed; explicit transactions
-currently have no timeout. Applications should therefore finish them promptly.
-Embedded READ_WRITE mode currently allows only one public `Connection` at a
-time.
+`beginTransaction({ readOnly: true })`; in Python, use
+`begin_transaction(read_only=True)`. C++ `TransactionMode::kReadWrite`, the
+default Node.js mode, and the default Python mode hold one private COW write
+view: successful statements can read their own writes, but private changes are
+not published until `Commit()` or `commit()` succeeds. An AP read-write
+transaction holds exclusive AP admission for its full lifetime. Any AP operation
+that contends for that admission waits until the transaction is committed,
+rolled back, or its connection is closed; explicit transactions currently have
+no timeout. Applications should therefore finish them promptly. Embedded
+READ_WRITE mode currently allows only one public `Connection` at a time.
 
 Any failed query call aborts the owner and leaves the connection rollback-only.
 This includes query analysis, syntax or compilation errors, access-mode or
@@ -92,16 +103,17 @@ bulk or maintenance operations. Because Cypher transaction-control statements
 are unsupported, issuing `COMMIT;` through `Query()` or `execute()` is also a
 failed statement and makes the transaction rollback-only. In that state, call
 `Rollback()`/`rollback()` (or close the connection) before issuing another
-query or beginning another transaction. `HasActiveTransaction()` in C++ and
-`hasActiveTransaction` in Node.js stay true while the connection is
-rollback-only. Nested begin and invalid programmatic control calls report a
-transaction-state error without changing an otherwise active transaction.
+query or beginning another transaction. `HasActiveTransaction()` in C++,
+`hasActiveTransaction` in Node.js, and `has_active_transaction` in Python stay
+true while the connection is rollback-only. Nested begin and invalid
+programmatic control calls report a transaction-state error without changing an
+otherwise active transaction.
 
-This first API does **not** accept Cypher `BEGIN`, `COMMIT`, or `ROLLBACK`;
-use the programmatic `Connection` methods shown above. It also does not yet
-include TP service sessions, remote clients, Python or Java bindings,
-savepoints, transaction timeouts, or explicit-transaction `COPY`, batch, index,
-checkpoint, procedure calls, or temporary schema operations.
+This API does **not** accept Cypher `BEGIN`, `COMMIT`, or `ROLLBACK`; use the
+programmatic `Connection` methods shown above. It does not yet include TP
+service sessions, remote clients, Java bindings, savepoints, transaction
+timeouts, or explicit-transaction `COPY`, batch, index, checkpoint, procedure
+calls, or temporary schema operations.
 
 ## Deployment Modes Overview
 

--- a/tools/python_bind/neug/connection.py
+++ b/tools/python_bind/neug/connection.py
@@ -97,11 +97,62 @@ class Connection(object):
 
     def close(self):
         """
-        Close the connection.
+        Close the connection. An active explicit transaction is rolled back.
         """
         if self._is_open:
             self._py_connection.close()
             self._is_open = False
+
+    @property
+    def has_active_transaction(self) -> bool:
+        """Whether this connection has an active explicit transaction.
+
+        The property remains true while a failed transaction is rollback-only.
+        Call :meth:`rollback` to return the connection to auto-commit mode.
+        """
+        return self._is_open and self._py_connection.has_active_transaction
+
+    def begin_transaction(self, read_only: bool = False):
+        """Begin an explicit embedded AP transaction.
+
+        Parameters
+        ----------
+        read_only : bool
+            Pin one read view and reject writes when true. The default starts a
+            read-write transaction with a private COW view.
+
+        Raises
+        ------
+        RuntimeError
+            If the connection is closed or already has an active transaction.
+        """
+        if not self._is_open:
+            raise RuntimeError(
+                f"Connection is closed. Please open the connection before beginning a transaction. "
+                f"Error code: {ERR_CONNECTION_CLOSED}"
+            )
+        self._py_connection.begin_transaction(read_only)
+
+    def commit(self):
+        """Commit the active explicit transaction.
+
+        A rollback-only transaction must be rolled back instead.
+        """
+        if not self._is_open:
+            raise RuntimeError(
+                f"Connection is closed. Please open the connection before committing a transaction. "
+                f"Error code: {ERR_CONNECTION_CLOSED}"
+            )
+        self._py_connection.commit()
+
+    def rollback(self):
+        """Roll back the active explicit transaction and return to auto-commit."""
+        if not self._is_open:
+            raise RuntimeError(
+                f"Connection is closed. Please open the connection before rolling back a transaction. "
+                f"Error code: {ERR_CONNECTION_CLOSED}"
+            )
+        self._py_connection.rollback()
 
     def execute(
         self, query: str, access_mode="", parameters: Optional[Dict[str, Any]] = None
@@ -120,6 +171,9 @@ class Connection(object):
         such as `__iter__` and `__next__`.
 
         If the query is a DDL or DML query, the result will be an empty `QueryResult` object.
+
+        Inside an explicit transaction, a failed query leaves the transaction
+        rollback-only. Call :meth:`rollback` before executing another query.
 
         Some of the cypher queries could change the state of the database, such as `CREATE TABLE`, `INSERT`,
         `UPDATE`, `DELETE`, etc. Other queries, such as `MATCH(n) RETURN n.id`, will not change the state of
@@ -212,4 +266,9 @@ class Connection(object):
 
         :return: The schema of the NeuG database.
         """
+        if not self._is_open:
+            raise RuntimeError(
+                f"Connection is closed. Please open the connection before getting the schema. "
+                f"Error code: {ERR_CONNECTION_CLOSED}"
+            )
         return self._py_connection.get_schema()

--- a/tools/python_bind/src/py_connection.cc
+++ b/tools/python_bind/src/py_connection.cc
@@ -35,6 +35,16 @@ void PyConnection::initialize(pybind11::handle& m) {
            "Connection object.\n")
       .def("close", &PyConnection::close,
            "Close the connection to the database.\n")
+      .def("begin_transaction", &PyConnection::begin_transaction,
+           pybind11::arg("read_only") = false,
+           "Begin an explicit embedded transaction.\n")
+      .def("commit", &PyConnection::commit,
+           "Commit the active explicit transaction.\n")
+      .def("rollback", &PyConnection::rollback,
+           "Roll back the active explicit transaction.\n")
+      .def_property_readonly("has_active_transaction",
+                             &PyConnection::has_active_transaction,
+                             "Whether an explicit transaction is active.\n")
       .def("execute", &PyConnection::execute, pybind11::arg("query_string"),
            pybind11::arg("access_mode") = "",
            pybind11::arg("parameters") = pybind11::dict(),
@@ -75,6 +85,32 @@ void PyConnection::close() {
     conn_->Close();
     conn_.reset();
   }
+}
+
+void PyConnection::begin_transaction(bool read_only) {
+  const auto status = conn_->BeginTransaction(
+      read_only ? TransactionMode::kReadOnly : TransactionMode::kReadWrite);
+  if (!status.ok()) {
+    THROW_RUNTIME_ERROR(status.ToString());
+  }
+}
+
+void PyConnection::commit() {
+  const auto status = conn_->Commit();
+  if (!status.ok()) {
+    THROW_RUNTIME_ERROR(status.ToString());
+  }
+}
+
+void PyConnection::rollback() {
+  const auto status = conn_->Rollback();
+  if (!status.ok()) {
+    THROW_RUNTIME_ERROR(status.ToString());
+  }
+}
+
+bool PyConnection::has_active_transaction() const {
+  return conn_->HasActiveTransaction();
 }
 
 std::unique_ptr<PyQueryResult> PyConnection::execute(

--- a/tools/python_bind/src/py_connection.h
+++ b/tools/python_bind/src/py_connection.h
@@ -36,6 +36,11 @@ class PyConnection : public std::enable_shared_from_this<PyConnection> {
 
   void close();
 
+  void begin_transaction(bool read_only = false);
+  void commit();
+  void rollback();
+  bool has_active_transaction() const;
+
   PyConnection(const PyConnection& other)
       : db_(other.db_), conn_(other.conn_) {}
 

--- a/tools/python_bind/tests/test_db_transaction.py
+++ b/tools/python_bind/tests/test_db_transaction.py
@@ -25,13 +25,41 @@ import pytest
 
 from neug.database import Database
 from neug.proto.error_pb2 import ERR_COMPILATION
+from neug.proto.error_pb2 import ERR_CONNECTION_CLOSED
 from neug.proto.error_pb2 import ERR_DATABASE_LOCKED
 from neug.proto.error_pb2 import ERR_INVALID_ARGUMENT
 from neug.proto.error_pb2 import ERR_QUERY_SYNTAX
 from neug.proto.error_pb2 import ERR_SCHEMA_MISMATCH
 from neug.proto.error_pb2 import ERR_TX_STATE_CONFLICT
-from neug.proto.error_pb2 import ERR_TX_TIMEOUT
 from neug.proto.error_pb2 import ERR_TYPE_CONVERSION
+
+
+class ConnectionApiTransactionControl:
+    """Explicit transaction control through the embedded Connection API."""
+
+    def __init__(self, conn):
+        self._conn = conn
+
+    def begin(self, read_only=False):
+        self._conn.begin_transaction(read_only=read_only)
+
+    def commit(self):
+        self._conn.commit()
+
+    def rollback(self):
+        self._conn.rollback()
+
+
+@pytest.fixture(
+    params=[pytest.param(ConnectionApiTransactionControl, id="connection-api")]
+)
+def transaction_control(request):
+    """Create the currently supported explicit-transaction control surface.
+
+    Add a Cypher control implementation here only after query-level BEGIN,
+    COMMIT, and ROLLBACK are supported.
+    """
+    return request.param
 
 
 # DB-004-01
@@ -199,156 +227,159 @@ def test_auto_transaction_management(tmp_path):
 
 
 # DB-004-08
-@pytest.mark.skip(reason="BEGIN TRANSACTION is not planned yet")
-def test_manual_transaction_management(tmp_path):
+def test_embedded_explicit_transaction_lifecycle(tmp_path, transaction_control):
     db_dir = tmp_path / "manual_tx_mgmt"
-    db_dir.mkdir()
     db = Database(db_path=str(db_dir), mode="w")
     conn = db.connect()
-    # BEGIN/COMMIT
-    conn.execute("BEGIN TRANSACTION;")
+    tx = transaction_control(conn)
+
     conn.execute("CREATE NODE TABLE T(id INT32, PRIMARY KEY(id));")
+    tx.begin()
+    assert conn.has_active_transaction
     conn.execute("CREATE (n:T {id: 1});")
-    conn.execute("COMMIT;")
-    r = conn.execute("MATCH (n:T) RETURN n;")
-    assert len(r) == 1
+    assert len(conn.execute("MATCH (n:T) RETURN n;")) == 1
+    tx.commit()
+    assert not conn.has_active_transaction
+    assert len(conn.execute("MATCH (n:T) RETURN n;")) == 1
 
-    # BEGIN/ROLLBACK: DML
-    conn.execute("BEGIN TRANSACTION;")
+    tx.begin()
     conn.execute("CREATE (n:T {id: 2});")
-    conn.execute("ROLLBACK;")
-    r2 = conn.execute("MATCH (n:T) RETURN n;")
-    assert len(r2) == 1
+    tx.rollback()
+    assert not conn.has_active_transaction
+    assert len(conn.execute("MATCH (n:T) RETURN n;")) == 1
 
-    # BEGIN/ROLLBACK: CREATE TABLE
-    conn.execute("BEGIN TRANSACTION;")
-    with pytest.raises(Exception) as excinfo:
-        conn.execute("CREATE NODE TABLE T(id INT32, PRIMARY KEY(id));")  # 已存在
-    assert str(ERR_SCHEMA_MISMATCH) in str(excinfo.value)
-    conn.execute("ROLLBACK;")
-    r3 = conn.execute("MATCH (n:T) RETURN n;")
-    assert len(r3) == 1
+    tx.begin()
+    conn.execute("CREATE (n:T {id: 3});")
+    conn.close()
 
-    # BEGIN/ROLLBACK: ALTER TABLE
-    conn.execute("BEGIN TRANSACTION;")
-    with pytest.raises(Exception) as excinfo:
-        conn.execute("ALTER TABLE T DROP COLUMN not_exist;")
-    assert str(ERR_SCHEMA_MISMATCH) in str(excinfo.value)
-    conn.execute("ROLLBACK;")
-    r4 = conn.execute("MATCH (n:T) RETURN n;")
-    assert len(r4) == 1
-
-    # BEGIN/ROLLBACK: DROP TABLE
-    conn.execute("BEGIN TRANSACTION;")
-    with pytest.raises(Exception) as excinfo:
-        conn.execute("DROP TABLE not_exist;")
-    assert str(ERR_SCHEMA_MISMATCH) in str(excinfo.value)
-    conn.execute("ROLLBACK;")
-    r5 = conn.execute("MATCH (n:T) RETURN n;")
-    assert len(r5) == 1
-
-    # BEGIN/ROLLBACK: SET properties
-    conn.execute("BEGIN TRANSACTION;")
-    with pytest.raises(Exception) as excinfo:
-        conn.execute("MATCH (n:T) WHERE n.id = 1 SET n.not_exist = 1;")
-    assert str(ERR_SCHEMA_MISMATCH) in str(excinfo.value)
-    conn.execute("ROLLBACK;")
-    r6 = conn.execute("MATCH (n:T) RETURN n;")
-    assert len(r6) == 1
-
+    conn = db.connect()
+    assert len(conn.execute("MATCH (n:T) RETURN n;")) == 1
     conn.close()
     db.close()
 
 
-# DB-004-09
-@pytest.mark.skip(reason="BEGIN TRANSACTION is not planned yet")
-def test_readonly_transaction_write(tmp_path):
-    db_dir = tmp_path / "readonly_tx_write"
-    db_dir.mkdir()
+def test_embedded_explicit_transaction_state_and_schema(tmp_path, transaction_control):
+    db_dir = tmp_path / "manual_tx_state"
     db = Database(db_path=str(db_dir), mode="w")
     conn = db.connect()
-    conn.execute("BEGIN TRANSACTION READ ONLY;")
-    with pytest.raises(Exception) as excinfo:
-        conn.execute("CREATE NODE TABLE T(id INT32, PRIMARY KEY(id));")
+    tx = transaction_control(conn)
+
+    conn.execute("CREATE NODE TABLE T(id INT32, PRIMARY KEY(id));")
+    tx.begin()
+    conn.execute("CREATE NODE TABLE PrivateT(id INT32, PRIMARY KEY(id));")
+    assert "PrivateT" in conn.get_schema()
+    tx.rollback()
+    assert "PrivateT" not in conn.get_schema()
+
+    tx.begin(read_only=True)
+    with pytest.raises(RuntimeError) as excinfo:
+        conn.execute("CREATE (n:T {id: 1});")
     assert str(ERR_TX_STATE_CONFLICT) in str(excinfo.value)
-    conn.execute("ROLLBACK;")
+    assert conn.has_active_transaction
+    with pytest.raises(RuntimeError) as excinfo:
+        tx.commit()
+    assert str(ERR_TX_STATE_CONFLICT) in str(excinfo.value)
+    tx.rollback()
+
+    tx.begin()
+    with pytest.raises(RuntimeError) as excinfo:
+        tx.begin()
+    assert str(ERR_TX_STATE_CONFLICT) in str(excinfo.value)
+    tx.rollback()
+
+    tx.begin()
+    with pytest.raises(RuntimeError):
+        conn.execute("CREATE NODE TABLE T(id INT32, PRIMARY KEY(id));")
+    assert conn.has_active_transaction
+    with pytest.raises(RuntimeError) as excinfo:
+        tx.commit()
+    assert str(ERR_TX_STATE_CONFLICT) in str(excinfo.value)
+    tx.rollback()
+
+    with pytest.raises(RuntimeError) as excinfo:
+        tx.commit()
+    assert str(ERR_TX_STATE_CONFLICT) in str(excinfo.value)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        tx.rollback()
+    assert str(ERR_TX_STATE_CONFLICT) in str(excinfo.value)
+
     conn.close()
     db.close()
 
 
-# DB-004-11
-@pytest.mark.skip(reason="BEGIN TRANSACTION is not planned yet")
-def test_nested_transaction(tmp_path):
-    db_dir = tmp_path / "nested_tx"
-    db_dir.mkdir()
+def test_embedded_explicit_transaction_preserves_python_api_contracts(
+    tmp_path, transaction_control
+):
+    db_dir = tmp_path / "python_tx_api_contracts"
     db = Database(db_path=str(db_dir), mode="w")
     conn = db.connect()
-    conn.execute("BEGIN TRANSACTION;")
-    with pytest.raises(Exception):
-        conn.execute("BEGIN TRANSACTION;")
-    conn.execute("ROLLBACK;")
+    tx = transaction_control(conn)
+
+    conn.execute("CREATE NODE TABLE T(id INT32, name STRING, PRIMARY KEY(id));")
+    tx.begin()
+    conn.execute("CREATE (n:T {id: 1, name: 'parameterized'});")
+    result = conn.execute(
+        "MATCH (n:T) WHERE n.id = $id RETURN n.name;", parameters={"id": 1}
+    )
+    tx.commit()
+    assert list(result) == [["parameterized"]]
+
+    tx.begin()
+    with pytest.raises(ValueError, match="Invalid access_mode"):
+        conn.execute("MATCH (n:T) RETURN n;", access_mode="invalid")
+    assert conn.has_active_transaction
+    assert len(conn.execute("MATCH (n:T) RETURN n;")) == 1
+    tx.rollback()
+
     conn.close()
+    assert not conn.has_active_transaction
+    for operation in (
+        conn.begin_transaction,
+        conn.commit,
+        conn.rollback,
+        conn.get_schema,
+    ):
+        with pytest.raises(RuntimeError) as excinfo:
+            operation()
+        assert str(ERR_CONNECTION_CLOSED) in str(excinfo.value)
     db.close()
 
 
 # DB-004-12
-@pytest.mark.skip(reason="BEGIN TRANSACTION is not planned yet")
-def test_transaction_timeout(tmp_path):
-    db_dir = tmp_path / "tx_timeout"
-    db_dir.mkdir()
-    db = Database(db_path=str(db_dir), mode="w")
-    conn = db.connect()
-    conn.execute("BEGIN TRANSACTION;")
-    conn.execute("CREATE NODE TABLE T(id INT32, PRIMARY KEY(id));")
-    # sleep to trigger timeout, assuming timeout is set to 5 seconds
-    time.sleep(5)
-    with pytest.raises(Exception) as excinfo:
-        conn.execute("COMMIT;")
-    assert str(ERR_TX_TIMEOUT) in str(excinfo.value)
-    conn.close()
-    db.close()
-
-
-# DB-004-13
-@pytest.mark.skip(reason="BEGIN TRANSACTION is not planned yet")
-def test_commit_after_rollback(tmp_path):
-    db_dir = tmp_path / "commit_after_rollback"
-    db_dir.mkdir()
-    db = Database(db_path=str(db_dir), mode="w")
-    conn = db.connect()
-    conn.execute("BEGIN TRANSACTION;")
-    conn.execute("ROLLBACK;")
-    with pytest.raises(Exception):
-        conn.execute("COMMIT;")
-    conn.close()
-    db.close()
+@pytest.mark.skip(
+    reason=(
+        "Embedded AP explicit transactions do not yet expose timeout "
+        "configuration or enforce transaction lifetime."
+    )
+)
+def test_embedded_explicit_transaction_timeout():
+    """Explicit transaction timeout is outside the current API scope."""
 
 
 # DB-004-14
-@pytest.mark.skip(reason="BEGIN TRANSACTION is not planned yet")
-def test_crash_recovery(tmp_path):
-    db_dir = tmp_path / "crash_recovery"
-    db_dir.mkdir()
-    db = Database(db_path=str(db_dir), mode="w")
+def test_embedded_explicit_transaction_crash_recovery(tmp_path, transaction_control):
+    db_dir = tmp_path / "tx_crash_recovery"
+    db = Database(db_path=str(db_dir), mode="w", checkpoint_on_close=False)
     conn = db.connect()
-    conn.execute("BEGIN TRANSACTION;")
+    tx = transaction_control(conn)
+
     conn.execute("CREATE NODE TABLE T(id INT32, PRIMARY KEY(id));")
+    tx.begin()
     conn.execute("CREATE (n:T {id: 1});")
-    conn.execute("COMMIT;")
-    conn.execute("BEGIN TRANSACTION;")
+    tx.commit()
+
+    tx.begin()
     conn.execute("CREATE (n:T {id: 2});")
     conn.close()
     db.close()
-    db2 = Database(db_path=str(db_dir), mode="w")
-    conn2 = db2.connect()
-    # committed transaction should be visible
-    r = conn2.execute("MATCH (n:T) WHERE n.id = 1 RETURN n;")
-    assert len(r) == 1
-    # uncommitted transaction should not be visible
-    r2 = conn2.execute("MATCH (n:T) WHERE n.id = 2 RETURN n;")
-    assert len(r2) == 0
-    conn2.close()
-    db2.close()
+
+    db = Database(db_path=str(db_dir), mode="w", checkpoint_on_close=False)
+    conn = db.connect()
+    assert len(conn.execute("MATCH (n:T) WHERE n.id = 1 RETURN n;")) == 1
+    assert len(conn.execute("MATCH (n:T) WHERE n.id = 2 RETURN n;")) == 0
+    conn.close()
+    db.close()
 
 
 # DB-004-15


### PR DESCRIPTION
## Summary
- expose the embedded AP Connection transaction lifecycle through begin_transaction, commit, rollback, and has_active_transaction
- preserve the Python API error contract, including closed connections and rollback-only state
- document the Python API and cover lifecycle, read-only, schema, recovery, and state transitions

## Verification
- cmake --build build --target neug_py_bind -j4
- black --check tools/python_bind/neug/connection.py tools/python_bind/tests/test_db_transaction.py
- pytest tools/python_bind/tests/test_db_transaction.py -k embedded_explicit_transaction (4 passed, 1 skipped)
- git diff --check

Refs #779