### PR TITLE
feat: add Node.js bindings for AP explicit transactions

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -87,7 +87,11 @@ myst_enable_extensions = [
 # Source file suffixes
 # Keep .md before .rst so duplicated docnames (e.g. index.md + index.rst)
 # resolve to Markdown, which is where the Java API landing content lives.
-source_suffix = ['.md', '.mdx', '.rst']
+source_suffix = {
+    '.md': 'myst',
+    '.mdx': 'myst',
+    '.rst': 'restructuredtext',
+}
 
 # API documentation settings
 # Templates for API documentation

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -80,7 +80,7 @@ NeuG documentation
    :maxdepth: 1
    :caption: Transaction
 
-   transaction/transaction.md
+   transaction/transaction.mdx
    transaction/checkpoint.md
 
 .. toctree::

--- a/doc/source/storage_index/index.md
+++ b/doc/source/storage_index/index.md
@@ -106,7 +106,7 @@ transaction as graph changes:
 Readers therefore cannot observe committed graph data with stale index data,
 or an index lifecycle change without its associated transaction. For the
 general ACID and isolation model, see [Transaction
-Management](../transaction/transaction.md).
+Management](../transaction/transaction.mdx).
 
 ## Persistence and Recovery
 

--- a/doc/source/transaction/checkpoint.md
+++ b/doc/source/transaction/checkpoint.md
@@ -15,7 +15,7 @@ two roles:
 | What is recovered after restart? | `CURRENT` plus WAL records after `base_ts` | The checkpoint selected by `CURRENT`; bulk rows are not repeated in WAL |
 
 For transaction boundaries and concurrency outside checkpoint operations, see
-[Transaction Management](transaction.md).
+[Transaction Management](transaction.mdx).
 
 ## Run a checkpoint
 

--- a/doc/source/transaction/transaction.md
+++ b/doc/source/transaction/transaction.md
@@ -29,10 +29,10 @@ conn.execute("CREATE (p:Person {name: 'Bob'})")    # Transaction 2
 ### Since version v0.2
 
 Since version v0.2, auto-commit remains the default in every supported
-interface. The embedded C++ `Connection` API additionally supports
+interface. The embedded C++ and Node.js `Connection` APIs additionally support
 programmatic explicit transactions for AP mode, as described below.
 
-#### Explicit Transactions in Embedded C++ AP Mode
+#### Explicit Transactions in Embedded AP Mode
 
 An explicit transaction is owned by its `Connection` and spans multiple
 `Query()` calls:
@@ -72,10 +72,11 @@ calls report a transaction-state error without changing an otherwise active
 transaction.
 
 This first API does **not** accept Cypher `BEGIN`, `COMMIT`, or `ROLLBACK`;
-use the C++ methods above. It also does not yet include TP service sessions,
-remote clients, Python or Java bindings, savepoints, transaction timeouts, or
-explicit-transaction `COPY`, batch, checkpoint, procedure calls, or temporary
-schema operations.
+use the C++ methods above or Node.js `beginTransaction()`, `commit()`, and
+`rollback()`. It also does not yet include TP service sessions, remote clients,
+Python or Java bindings, savepoints, transaction timeouts, or
+explicit-transaction `COPY`, batch, index, checkpoint, procedure calls, or
+temporary schema operations.
 
 ## Deployment Modes Overview
 

--- a/doc/source/transaction/transaction.mdx
+++ b/doc/source/transaction/transaction.mdx
@@ -2,6 +2,8 @@
 
 This document describes NeuG's transaction management system, which operates differently depending on the deployment mode. NeuG supports two primary modes: **Embedded mode** suitable for analytical processing (AP) and **Service mode** suitable for transactional processing (TP).
 
+import { Tabs } from 'nextra/components'
+
 ## Design Philosophy
 
 NeuG's transaction model reflects trade-offs based on deep understanding of graph workload characteristics:
@@ -35,7 +37,11 @@ programmatic explicit transactions for AP mode, as described below.
 #### Explicit Transactions in Embedded AP Mode
 
 An explicit transaction is owned by its `Connection` and spans multiple
-`Query()` calls:
+queries:
+
+<Tabs items={['C++', 'Node.js']}>
+
+<Tab>
 
 ```cpp
 auto status = conn->BeginTransaction(neug::TransactionMode::kReadWrite);
@@ -49,34 +55,53 @@ auto visible = conn->Query("MATCH (p:Person) RETURN p.name", "read");
 status = conn->Commit();  // Publishes all successful writes as one commit.
 ```
 
-`TransactionMode::kReadOnly` pins one read view for the entire transaction and
-rejects writes. `TransactionMode::kReadWrite` holds one private COW write view:
-its successful statements can read their own writes, but the private changes
-are not published until `Commit()` succeeds. An AP read-write transaction holds
-exclusive AP admission for its full lifetime. Any AP operation that contends
-for that admission waits until the transaction calls `Commit()`, `Rollback()`,
-or `Close()`; explicit transactions currently have no timeout. Applications
-should therefore finish them promptly. Embedded READ_WRITE mode currently
-allows only one public `Connection` at a time.
+</Tab>
 
-Any failed `Query()` call aborts the owner and leaves the connection
-rollback-only. This includes query analysis, syntax or compilation errors,
-access-mode or parameter validation errors, execution failures, read-only
-writes, and rejected bulk or maintenance operations. Because Cypher
-transaction-control statements are unsupported, issuing `COMMIT;` through
-`Query()` is also a failed statement and makes the transaction rollback-only.
-In that state, call `Rollback()` (or `Close()`) before issuing another query or
-beginning another transaction. `HasActiveTransaction()` stays true while the
-connection is rollback-only. Nested begin and invalid programmatic control
-calls report a transaction-state error without changing an otherwise active
-transaction.
+<Tab>
+
+```javascript
+conn.beginTransaction();
+
+const created = conn.execute("CREATE (:Person {name: 'Alice'})", 'insert');
+const visible = conn.execute('MATCH (p:Person) RETURN p.name', 'read');
+
+conn.commit(); // Publishes all successful writes as one commit.
+```
+
+</Tab>
+
+</Tabs>
+
+In C++, `TransactionMode::kReadOnly` pins one read view for the entire
+transaction and rejects writes; in Node.js, use
+`beginTransaction({ readOnly: true })`. C++
+`TransactionMode::kReadWrite` and the default Node.js mode hold one private COW
+write view: successful statements can read their own writes, but private
+changes are not published until `Commit()` or `commit()` succeeds. An AP
+read-write transaction holds exclusive AP admission for its full lifetime. Any
+AP operation that contends for that admission waits until the transaction is
+committed, rolled back, or its connection is closed; explicit transactions
+currently have no timeout. Applications should therefore finish them promptly.
+Embedded READ_WRITE mode currently allows only one public `Connection` at a
+time.
+
+Any failed query call aborts the owner and leaves the connection rollback-only.
+This includes query analysis, syntax or compilation errors, access-mode or
+parameter validation errors, execution failures, read-only writes, and rejected
+bulk or maintenance operations. Because Cypher transaction-control statements
+are unsupported, issuing `COMMIT;` through `Query()` or `execute()` is also a
+failed statement and makes the transaction rollback-only. In that state, call
+`Rollback()`/`rollback()` (or close the connection) before issuing another
+query or beginning another transaction. `HasActiveTransaction()` in C++ and
+`hasActiveTransaction` in Node.js stay true while the connection is
+rollback-only. Nested begin and invalid programmatic control calls report a
+transaction-state error without changing an otherwise active transaction.
 
 This first API does **not** accept Cypher `BEGIN`, `COMMIT`, or `ROLLBACK`;
-use the C++ methods above or Node.js `beginTransaction()`, `commit()`, and
-`rollback()`. It also does not yet include TP service sessions, remote clients,
-Python or Java bindings, savepoints, transaction timeouts, or
-explicit-transaction `COPY`, batch, index, checkpoint, procedure calls, or
-temporary schema operations.
+use the programmatic `Connection` methods shown above. It also does not yet
+include TP service sessions, remote clients, Python or Java bindings,
+savepoints, transaction timeouts, or explicit-transaction `COPY`, batch, index,
+checkpoint, procedure calls, or temporary schema operations.
 
 ## Deployment Modes Overview
 
@@ -326,18 +351,20 @@ session = Session("http://localhost:10000/")
 try:
     # Reads and inserts can be concurrent across sessions
     session.execute("CREATE (p:Person {name: 'Alice'})", access_mode="insert")
-    
+
     # Reads don't block inserts
     result = session.execute("MATCH (p:Person) RETURN count(p)", access_mode="read")
-    
+
     # Updates are serialized with inserts and other updates. Reads continue on
     # consistent snapshots, but keep updates short in high-concurrency scenarios.
-    session.execute("MATCH (p:Person) WHERE p.name = 'Alice' SET p.verified = true", 
-                   access_mode="update")
-    
+    session.execute(
+        "MATCH (p:Person) WHERE p.name = 'Alice' SET p.verified = true",
+        access_mode="update",
+    )
+
     # Periodic checkpoint to consolidate WAL (optional)
     session.execute("CHECKPOINT")
-    
+
 finally:
     session.close()
 ```

--- a/include/neug/transaction/README.md
+++ b/include/neug/transaction/README.md
@@ -2,7 +2,7 @@
 
 > This file documents internal implementation details. For application-facing
 > behavior, see
-> [Transaction Management](../../../doc/source/transaction/transaction.md).
+> [Transaction Management](../../../doc/source/transaction/transaction.mdx).
 
 For ordinary queries, the transactional `ExecutionSlot` strategy uses
 `SnapshotReadTransaction`, `MvccInsertTransaction`, and

--- a/tools/nodejs_bind/README.md
+++ b/tools/nodejs_bind/README.md
@@ -138,3 +138,30 @@ for (const row of result) {
 conn.close();
 db.close();
 ```
+
+## Explicit Transactions
+
+Since v0.2, the embedded Node.js `Connection` API supports explicit AP
+transactions. Auto-commit remains the default; begin a transaction only when
+multiple ordinary queries must share one private view and one final commit.
+
+```js
+const conn = db.connect();
+
+conn.beginTransaction();
+conn.execute("CREATE (p:person {id: 3, name: 'Carol'});");
+// Reads on this connection see the new vertex before publication.
+conn.execute('MATCH (p:person) RETURN p.name;');
+conn.commit();
+
+conn.beginTransaction({ readOnly: true });
+// This transaction pins one read view and rejects writes.
+conn.execute('MATCH (p:person) RETURN p.name;');
+conn.rollback();
+```
+
+`hasActiveTransaction` remains true after a failed statement because the
+connection is rollback-only. Call `rollback()` before issuing another query.
+Nested transactions, read-to-write upgrades, Cypher `BEGIN`/`COMMIT`/`ROLLBACK`,
+and explicit-transaction COPY, batch, index, checkpoint, procedure, and
+temporary-schema operations are not supported.

--- a/tools/nodejs_bind/lib/connection.js
+++ b/tools/nodejs_bind/lib/connection.js
@@ -60,6 +60,64 @@ class Connection {
   }
 
   /**
+   * Whether this connection has an unfinished explicit transaction.
+   *
+   * The property remains true while a failed transaction is rollback-only.
+   * Call {@link rollback} before issuing another query.
+   *
+   * @returns {boolean}
+   */
+  get hasActiveTransaction() {
+    return this._isOpen && this._conn.hasActiveTransaction();
+  }
+
+  /**
+   * Begin an explicit embedded AP transaction.
+   *
+   * @param {{readOnly?: boolean}} [options={}] Transaction options.
+   * @param {boolean} [options.readOnly=false] Pin one read view and reject
+   *   writes. By default, the transaction uses a private COW write view.
+   * @throws {Error} If the connection is closed or already has an active
+   *   transaction.
+   */
+  beginTransaction(options = {}) {
+    this._ensureOpen('beginning a transaction');
+    if (
+      typeof options !== 'object' ||
+      options === null ||
+      Array.isArray(options)
+    ) {
+      throw new TypeError('Transaction options must be an object.');
+    }
+    const { readOnly = false } = options;
+    if (typeof readOnly !== 'boolean') {
+      throw new TypeError('options.readOnly must be a boolean.');
+    }
+    this._checkTransactionStatus(
+      'begin transaction',
+      this._conn.beginTransaction(readOnly)
+    );
+  }
+
+  /**
+   * Commit the active explicit transaction.
+   *
+   * A rollback-only transaction must be rolled back instead.
+   */
+  commit() {
+    this._ensureOpen('committing a transaction');
+    this._checkTransactionStatus('commit transaction', this._conn.commit());
+  }
+
+  /**
+   * Roll back the active explicit transaction and return to auto-commit mode.
+   */
+  rollback() {
+    this._ensureOpen('rolling back a transaction');
+    this._checkTransactionStatus('roll back transaction', this._conn.rollback());
+  }
+
+  /**
    * Execute a cypher query on the database.
    *
    * @param {string} query - The cypher query to execute.
@@ -81,12 +139,7 @@ class Connection {
    * );
    */
   execute(query, accessMode = '', parameters = null) {
-    if (!this._isOpen) {
-      throw new Error(
-        `Connection is closed. Please open the connection before executing queries. ` +
-        `Error code: ${ERR_CONNECTION_CLOSED}`
-      );
-    }
+    this._ensureOpen('executing queries');
 
     if (accessMode !== '' && !isAccessModeValid(accessMode.toLowerCase())) {
       throw new Error(
@@ -120,7 +173,26 @@ class Connection {
    * @returns {string} The schema as a string.
    */
   getSchema() {
+    this._ensureOpen('getting the schema');
     return this._conn.getSchema();
+  }
+
+  _ensureOpen(action) {
+    if (!this._isOpen) {
+      throw new Error(
+        `Connection is closed. Please open the connection before ${action}. ` +
+        `Error code: ${ERR_CONNECTION_CLOSED}`
+      );
+    }
+  }
+
+  _checkTransactionStatus(action, status) {
+    if (status.code !== OK) {
+      throw new Error(
+        `Failed to ${action}. Error code: ${status.code}, Error Message: ` +
+        `${codeName(status.code)}: ${status.message}`
+      );
+    }
   }
 }
 

--- a/tools/nodejs_bind/src/node_connection.cc
+++ b/tools/nodejs_bind/src/node_connection.cc
@@ -152,7 +152,15 @@ Napi::Value NodeConnection::HasActiveTransaction(
 }
 
 Napi::Value NodeConnection::GetSchema(const Napi::CallbackInfo& info) {
-  return Napi::String::New(info.Env(), conn_->GetSchema());
+  Napi::Env env = info.Env();
+  try {
+    return Napi::String::New(env, conn_->GetSchema());
+  } catch (const neug::exception::Exception& e) {
+    Napi::Error::New(env, e.what()).ThrowAsJavaScriptException();
+  } catch (const std::exception& e) {
+    Napi::Error::New(env, e.what()).ThrowAsJavaScriptException();
+  }
+  return env.Null();
 }
 
 Napi::Value NodeConnection::Close(const Napi::CallbackInfo& info) {

--- a/tools/nodejs_bind/src/node_connection.cc
+++ b/tools/nodejs_bind/src/node_connection.cc
@@ -29,16 +29,36 @@
 
 namespace neug {
 
+namespace {
+
+Napi::Object StatusToJs(Napi::Env env, const Status& status) {
+  auto result = Napi::Object::New(env);
+  result.Set("code", Napi::Number::New(env, status.error_code()));
+  result.Set("message", Napi::String::New(env, status.error_message()));
+  return result;
+}
+
+Status ClosedConnectionStatus() {
+  return Status(StatusCode::ERR_CONNECTION_CLOSED, "Connection is closed.");
+}
+
+}  // namespace
+
 Napi::FunctionReference NodeConnection::constructor;
 
 Napi::Object NodeConnection::Init(Napi::Env env, Napi::Object exports) {
-  Napi::Function func =
-      DefineClass(env, "NodeConnection",
-                  {
-                      InstanceMethod("execute", &NodeConnection::Execute),
-                      InstanceMethod("getSchema", &NodeConnection::GetSchema),
-                      InstanceMethod("close", &NodeConnection::Close),
-                  });
+  Napi::Function func = DefineClass(
+      env, "NodeConnection",
+      {
+          InstanceMethod("execute", &NodeConnection::Execute),
+          InstanceMethod("beginTransaction", &NodeConnection::BeginTransaction),
+          InstanceMethod("commit", &NodeConnection::Commit),
+          InstanceMethod("rollback", &NodeConnection::Rollback),
+          InstanceMethod("hasActiveTransaction",
+                         &NodeConnection::HasActiveTransaction),
+          InstanceMethod("getSchema", &NodeConnection::GetSchema),
+          InstanceMethod("close", &NodeConnection::Close),
+      });
   constructor = Napi::Persistent(func);
   constructor.SuppressDestruct();
   exports.Set("NodeConnection", func);
@@ -97,6 +117,38 @@ Napi::Value NodeConnection::Execute(const Napi::CallbackInfo& info) {
     return NodeQueryResult::NewInstanceFromStatus(env, query_result.error());
   }
   return NodeQueryResult::NewInstance(env, std::move(query_result.value()));
+}
+
+Napi::Value NodeConnection::BeginTransaction(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() > 1 || (info.Length() == 1 && !info[0].IsBoolean())) {
+    Napi::TypeError::New(env, "readOnly must be a boolean")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  const bool read_only =
+      info.Length() == 1 && info[0].As<Napi::Boolean>().Value();
+  const auto status =
+      conn_ ? conn_->BeginTransaction(read_only ? TransactionMode::kReadOnly
+                                                : TransactionMode::kReadWrite)
+            : ClosedConnectionStatus();
+  return StatusToJs(env, status);
+}
+
+Napi::Value NodeConnection::Commit(const Napi::CallbackInfo& info) {
+  const auto status = conn_ ? conn_->Commit() : ClosedConnectionStatus();
+  return StatusToJs(info.Env(), status);
+}
+
+Napi::Value NodeConnection::Rollback(const Napi::CallbackInfo& info) {
+  const auto status = conn_ ? conn_->Rollback() : ClosedConnectionStatus();
+  return StatusToJs(info.Env(), status);
+}
+
+Napi::Value NodeConnection::HasActiveTransaction(
+    const Napi::CallbackInfo& info) {
+  return Napi::Boolean::New(info.Env(), conn_ && conn_->HasActiveTransaction());
 }
 
 Napi::Value NodeConnection::GetSchema(const Napi::CallbackInfo& info) {

--- a/tools/nodejs_bind/src/node_connection.h
+++ b/tools/nodejs_bind/src/node_connection.h
@@ -43,6 +43,10 @@ class NodeConnection : public Napi::ObjectWrap<NodeConnection> {
   static Napi::FunctionReference constructor;
 
   Napi::Value Execute(const Napi::CallbackInfo& info);
+  Napi::Value BeginTransaction(const Napi::CallbackInfo& info);
+  Napi::Value Commit(const Napi::CallbackInfo& info);
+  Napi::Value Rollback(const Napi::CallbackInfo& info);
+  Napi::Value HasActiveTransaction(const Napi::CallbackInfo& info);
   Napi::Value GetSchema(const Napi::CallbackInfo& info);
   Napi::Value Close(const Napi::CallbackInfo& info);
 

--- a/tools/nodejs_bind/tests/test_db_transaction.js
+++ b/tools/nodejs_bind/tests/test_db_transaction.js
@@ -22,11 +22,11 @@ const os = require('os');
 const path = require('path');
 const {
   Database,
+  ERR_CONNECTION_CLOSED,
   ERR_DATABASE_LOCKED,
   ERR_TX_STATE_CONFLICT,
   ERR_TYPE_CONVERSION,
   ERR_SCHEMA_MISMATCH,
-  ERR_TX_TIMEOUT,
 } = require('neug');
 
 // ---------------------------------------------------------------------------
@@ -165,39 +165,88 @@ test('test_auto_transaction_management', () => {
 // DB-004-08
 // ---------------------------------------------------------------------------
 
-test('test_manual_transaction_management', { skip: 'BEGIN TRANSACTION is not planned yet' }, () => {
-  // Not implemented
-});
+test('test_explicit_transaction_connection_api', () => {
+  const dbDir = makeTmpDir('explicit_tx_connection_api');
+  const db = new Database({ databasePath: dbDir, mode: 'w' });
+  const conn = db.connect();
+  conn.execute('CREATE NODE TABLE person(id INT64, name STRING, PRIMARY KEY(id));');
 
-// ---------------------------------------------------------------------------
-// DB-004-09
-// ---------------------------------------------------------------------------
+  assert.equal(conn.hasActiveTransaction, false);
+  conn.beginTransaction();
+  assert.equal(conn.hasActiveTransaction, true);
+  conn.execute('CREATE (p:person {id: $id, name: $name});', '', {
+    id: 1,
+    name: 'rolled back',
+  });
+  assert.deepEqual(
+    [...conn.execute('MATCH (p:person) WHERE p.id = $id RETURN p.name;', '', { id: 1 })],
+    [['rolled back']]
+  );
+  conn.rollback();
+  assert.equal(conn.hasActiveTransaction, false);
+  assert.deepEqual([...conn.execute('MATCH (p:person) RETURN p.id;')], []);
 
-test('test_readonly_transaction_write', { skip: 'BEGIN TRANSACTION is not planned yet' }, () => {
-  // Not implemented
-});
+  conn.beginTransaction();
+  conn.execute("CREATE (p:person {id: 2, name: 'committed'});");
+  conn.commit();
+  assert.deepEqual([...conn.execute('MATCH (p:person) RETURN p.id;')], [[2n]]);
+  assert.throws(
+    () => conn.commit(),
+    (err) => err.message.includes(String(ERR_TX_STATE_CONFLICT))
+  );
 
-// ---------------------------------------------------------------------------
-// DB-004-11
-// ---------------------------------------------------------------------------
+  conn.beginTransaction();
+  assert.throws(
+    () => conn.beginTransaction(),
+    (err) => err.message.includes(String(ERR_TX_STATE_CONFLICT))
+  );
+  conn.rollback();
 
-test('test_nested_transaction', { skip: 'BEGIN TRANSACTION is not planned yet' }, () => {
-  // Not implemented
+  conn.beginTransaction();
+  assert.throws(
+    () => conn.execute("CREATE (p:person {id: 'bad_type'});"),
+    (err) => err.message.includes(String(ERR_TYPE_CONVERSION))
+  );
+  assert.equal(conn.hasActiveTransaction, true);
+  assert.throws(
+    () => conn.execute('MATCH (p:person) RETURN p.id;'),
+    (err) => err.message.includes(String(ERR_TX_STATE_CONFLICT))
+  );
+  assert.throws(
+    () => conn.commit(),
+    (err) => err.message.includes(String(ERR_TX_STATE_CONFLICT))
+  );
+  conn.rollback();
+
+  conn.beginTransaction({ readOnly: true });
+  assert.throws(
+    () => conn.execute("CREATE (p:person {id: 3, name: 'read only'});"),
+    (err) => err.message.includes('Write queries are not allowed')
+  );
+  assert.equal(conn.hasActiveTransaction, true);
+  conn.rollback();
+
+  conn.close();
+  assert.equal(conn.hasActiveTransaction, false);
+  for (const operation of [
+    () => conn.beginTransaction(),
+    () => conn.commit(),
+    () => conn.rollback(),
+    () => conn.getSchema(),
+  ]) {
+    assert.throws(
+      operation,
+      (err) => err.message.includes(String(ERR_CONNECTION_CLOSED))
+    );
+  }
+  db.close();
 });
 
 // ---------------------------------------------------------------------------
 // DB-004-12
 // ---------------------------------------------------------------------------
 
-test('test_transaction_timeout', { skip: 'BEGIN TRANSACTION is not planned yet' }, () => {
-  // Not implemented
-});
-
-// ---------------------------------------------------------------------------
-// DB-004-13
-// ---------------------------------------------------------------------------
-
-test('test_commit_after_rollback', { skip: 'BEGIN TRANSACTION is not planned yet' }, () => {
+test('test_transaction_timeout', { skip: 'Embedded AP explicit transactions do not expose timeout configuration or enforce transaction lifetime.' }, () => {
   // Not implemented
 });
 
@@ -205,8 +254,35 @@ test('test_commit_after_rollback', { skip: 'BEGIN TRANSACTION is not planned yet
 // DB-004-14
 // ---------------------------------------------------------------------------
 
-test('test_crash_recovery', { skip: 'BEGIN TRANSACTION is not planned yet' }, () => {
-  // Not implemented
+test('test_explicit_transaction_crash_recovery', () => {
+  const dbDir = makeTmpDir('explicit_tx_recovery');
+  const db = new Database({
+    databasePath: dbDir,
+    mode: 'w',
+    checkpointOnClose: false,
+  });
+  const conn = db.connect();
+  conn.execute('CREATE NODE TABLE person(id INT64, PRIMARY KEY(id));');
+  conn.beginTransaction();
+  conn.execute('CREATE (p:person {id: 1});');
+  conn.commit();
+  conn.beginTransaction();
+  conn.execute('CREATE (p:person {id: 2});');
+  conn.close();
+  db.close();
+
+  const reopenedDb = new Database({
+    databasePath: dbDir,
+    mode: 'w',
+    checkpointOnClose: false,
+  });
+  const reopenedConn = reopenedDb.connect();
+  assert.deepEqual(
+    [...reopenedConn.execute('MATCH (p:person) RETURN p.id ORDER BY p.id;')],
+    [[1n]]
+  );
+  reopenedConn.close();
+  reopenedDb.close();
 });
 
 // ---------------------------------------------------------------------------

--- a/tools/nodejs_bind/tests/test_db_transaction.js
+++ b/tools/nodejs_bind/tests/test_db_transaction.js
@@ -216,6 +216,10 @@ test('test_explicit_transaction_connection_api', () => {
     () => conn.commit(),
     (err) => err.message.includes(String(ERR_TX_STATE_CONFLICT))
   );
+  assert.throws(
+    () => conn.getSchema(),
+    (err) => err.message.includes(String(ERR_TX_STATE_CONFLICT))
+  );
   conn.rollback();
 
   conn.beginTransaction({ readOnly: true });


### PR DESCRIPTION
## Summary
- expose the embedded AP Connection transaction lifecycle through beginTransaction, commit, rollback, and hasActiveTransaction
- keep transaction state and COW ownership in the existing C++ Connection, with JavaScript only validating options and mapping Status errors
- document the Node.js API and cover lifecycle, rollback-only, read-only, close, and WAL recovery behavior

## Verification
- cmake --build build --target neug_node_bind -j4
- explicit transaction Node.js smoke test: passed
- node --test tools/nodejs_bind/tests/test_db_transaction.js: 14 passed, 1 skipped; 2 unrelated fixture failures because /tmp/modern_graph is empty, with the second caused by the first retaining its read lock
- git diff --check

Refs #779