### PR TITLE
feat(nodejs): support Windows package builds

### DIFF
--- a/.github/workflows/npm-build-test.yml
+++ b/.github/workflows/npm-build-test.yml
@@ -223,6 +223,127 @@ jobs:
           path: ./tools/nodejs_bind/graphscope-neug-linux-arm64-*.tgz
           if-no-files-found: error
 
+  build_npm_windows_x86_64:
+    needs: format_check
+    runs-on: windows-2022
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup MSVC Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          # Keep the Windows build ABI baseline aligned with Linux package builds.
+          node-version: '20.0.0'
+          cache: 'npm'
+          cache-dependency-path: tools/nodejs_bind/package-lock.json
+
+      - name: Install OpenSSL via vcpkg
+        shell: pwsh
+        run: |
+          $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT
+          & "$vcpkgRoot\vcpkg.exe" install openssl:x64-windows-static-md
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Install Node.js build dependencies
+        shell: pwsh
+        run: |
+          npm ci --prefix tools/nodejs_bind
+
+          $nodeVersion = node -p "process.versions.node"
+          $nodeDevDir = Join-Path $env:RUNNER_TEMP "node-v$nodeVersion-dev"
+          $headersArchive = Join-Path $env:RUNNER_TEMP "node-headers.tar.gz"
+          $headersUrl = "https://nodejs.org/dist/v$nodeVersion/node-v$nodeVersion-headers.tar.gz"
+          $nodeLibUrl = "https://nodejs.org/dist/v$nodeVersion/win-x64/node.lib"
+
+          Invoke-WebRequest $headersUrl -OutFile $headersArchive
+          New-Item -ItemType Directory -Force $nodeDevDir | Out-Null
+          tar -xzf $headersArchive -C $nodeDevDir --strip-components=1
+          Invoke-WebRequest $nodeLibUrl -OutFile (Join-Path $nodeDevDir "node.lib")
+
+          "NODE_INCLUDE_DIR=$nodeDevDir\include\node" >> $env:GITHUB_ENV
+          "NODE_IMPORT_LIB=$nodeDevDir\node.lib" >> $env:GITHUB_ENV
+
+      - name: Configure CMake
+        shell: pwsh
+        run: |
+          $vcpkgToolchain = Join-Path $env:VCPKG_INSTALLATION_ROOT "scripts\buildsystems\vcpkg.cmake"
+          cmake -B build -G Ninja `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_TOOLCHAIN_FILE="$vcpkgToolchain" `
+            -DVCPKG_TARGET_TRIPLET=x64-windows-static-md `
+            -DBUILD_NODEJS=ON `
+            -DBUILD_PYTHON=OFF `
+            -DWITH_MIMALLOC=OFF `
+            -DNEUG_NATIVE_ARCH=OFF `
+            -DNODE_INCLUDE_DIR="$env:NODE_INCLUDE_DIR" `
+            -DNODE_IMPORT_LIB="$env:NODE_IMPORT_LIB" `
+            .
+
+      - name: Build
+        shell: pwsh
+        run: |
+          $jobs = [Math]::Min([Environment]::ProcessorCount, 8)
+          cmake --build build --target neug_node_bind -j $jobs
+
+      - name: Stage native artifacts
+        shell: pwsh
+        run: |
+          $stageDir = "tools/nodejs_bind/build/Release/windows_x86_64"
+          New-Item -ItemType Directory -Force $stageDir | Out-Null
+          Copy-Item "build/tools/nodejs_bind/neug_node_bind.node" $stageDir
+          Copy-Item "build/tools/nodejs_bind/neug.dll" $stageDir
+
+      - name: Prepare test data
+        shell: pwsh
+        env:
+          FLEX_DATA_DIR: ${{ github.workspace }}\example_dataset\modern_graph
+        run: |
+          $tmpRoot = Join-Path ([IO.Path]::GetPathRoot($env:RUNNER_TEMP)) "tmp"
+          New-Item -ItemType Directory -Force $tmpRoot | Out-Null
+          Remove-Item -Recurse -Force (Join-Path $tmpRoot "modern_graph") -ErrorAction SilentlyContinue
+          Set-Location tools/nodejs_bind
+          node -e "const { prepareModernGraphDataset } = require('./tests/test-shim'); const { Database } = require('./lib'); prepareModernGraphDataset(Database);"
+
+      - name: Test
+        shell: pwsh
+        env:
+          FLEX_DATA_DIR: ${{ github.workspace }}\example_dataset\modern_graph
+        run: |
+          Set-Location tools/nodejs_bind
+          node tests/test-shim.js
+
+      - name: Pack
+        shell: pwsh
+        run: |
+          Set-Location tools/nodejs_bind
+          Copy-Item package.json package.json.ci
+          try {
+            $package = Get-Content package.json -Raw | ConvertFrom-Json
+            $package.name = "@graphscope-neug/windows-x86_64"
+            $package | Add-Member -NotePropertyName os -NotePropertyValue @("win32") -Force
+            $package | Add-Member -NotePropertyName cpu -NotePropertyValue @("x64") -Force
+            $package | ConvertTo-Json -Depth 100 | Set-Content package.json
+            npm pack
+            if ($LASTEXITCODE -ne 0) { throw "npm pack failed with exit code $LASTEXITCODE" }
+          } finally {
+            Move-Item -Force package.json.ci package.json
+          }
+
+      - name: Upload npm tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: nodejs-windows-x86_64-${{ github.run_id }}
+          path: ./tools/nodejs_bind/graphscope-neug-windows-x86_64-*.tgz
+          if-no-files-found: error
+
   build_npm_macos_aarch64:
     needs: format_check
     if: github.event_name == 'workflow_call' || github.event_name == 'release' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -300,4 +421,5 @@ jobs:
       - build_npm_linux_x86_64
       - build_npm_linux_arm64
       - build_npm_macos_aarch64
+      - build_npm_windows_x86_64
     uses: ./.github/workflows/npm-package-test.yml

--- a/.github/workflows/npm-package-test.yml
+++ b/.github/workflows/npm-package-test.yml
@@ -20,13 +20,11 @@ jobs:
   package-test:
     runs-on: ${{ matrix.os }}
     env:
-      ARTIFACT_PLATFORM: ${{ matrix.os == 'ubuntu-latest' && 'linux-x86_64' || 'osx-arm64' }}
+      ARTIFACT_PLATFORM: ${{ matrix.os == 'ubuntu-latest' && 'linux-x86_64' || matrix.os == 'windows-2022' && 'windows-x86_64' || 'osx-arm64' }}
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-15
+        os: ${{ fromJSON(inputs.package_source == 'artifact' && '["ubuntu-latest", "macos-15", "windows-2022"]' || '["ubuntu-latest", "macos-15"]') }}
         node-version: ["20", "22", "24"]
 
     steps:
@@ -45,6 +43,7 @@ jobs:
           cache-dependency-path: tools/nodejs_bind/package-lock.json
 
       - name: Prepare test workspace
+        if: runner.os != 'Windows'
         run: |
           set -euo pipefail
 
@@ -52,6 +51,15 @@ jobs:
           rm -rf "${TEST_WORKSPACE}" && mkdir -p "${TEST_WORKSPACE}"
 
           cp -R "${GITHUB_WORKSPACE}/tools/nodejs_bind/tests" "${TEST_WORKSPACE}/tests"
+
+      - name: Prepare test workspace on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $testWorkspace = Join-Path $env:RUNNER_TEMP "neug-npm-package-test"
+          Remove-Item -Recurse -Force $testWorkspace -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Force $testWorkspace | Out-Null
+          Copy-Item -Recurse "$env:GITHUB_WORKSPACE\tools\nodejs_bind\tests" "$testWorkspace\tests"
 
       - name: Install NeuG package from npm
         if: inputs.package_source != 'artifact'
@@ -67,7 +75,7 @@ jobs:
           path: ${{ runner.temp }}/neug-npm-package-test
 
       - name: Install NeuG package from artifact
-        if: inputs.package_source == 'artifact'
+        if: inputs.package_source == 'artifact' && runner.os != 'Windows'
         run: |
           set -euo pipefail
 
@@ -79,7 +87,23 @@ jobs:
           # "neug" alias locally after installing the scoped artifact.
           ln -s "@graphscope-neug/${ARTIFACT_PLATFORM}" node_modules/neug
 
+      - name: Install NeuG package from artifact on Windows
+        if: inputs.package_source == 'artifact' && runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $testWorkspace = Join-Path $env:RUNNER_TEMP "neug-npm-package-test"
+          Set-Location $testWorkspace
+          $tarball = (Get-ChildItem "graphscope-neug-$env:ARTIFACT_PLATFORM-*.tgz").FullName
+          npm install $tarball
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          $aliasDir = Join-Path $testWorkspace "node_modules\neug"
+          New-Item -ItemType Directory -Force $aliasDir | Out-Null
+          '{"name":"neug","main":"index.js"}' | Set-Content (Join-Path $aliasDir "package.json")
+          "module.exports = require('@graphscope-neug/windows-x86_64');" | Set-Content (Join-Path $aliasDir "index.js")
+
       - name: Prepare modern graph dataset
+        if: runner.os != 'Windows'
         env:
           FLEX_DATA_DIR: ${{ github.workspace }}/example_dataset/modern_graph
         run: |
@@ -95,7 +119,27 @@ jobs:
           prepareModernGraphDataset(Database);
           JS
 
+      - name: Prepare modern graph dataset on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          FLEX_DATA_DIR: ${{ github.workspace }}\example_dataset\modern_graph
+        run: |
+          $tmpRoot = Join-Path ([IO.Path]::GetPathRoot($env:RUNNER_TEMP)) "tmp"
+          New-Item -ItemType Directory -Force $tmpRoot | Out-Null
+          Remove-Item -Recurse -Force (Join-Path $tmpRoot "modern_graph") -ErrorAction SilentlyContinue
+          Set-Location (Join-Path $env:RUNNER_TEMP "neug-npm-package-test")
+          node -e "const { prepareModernGraphDataset } = require('./tests/test-shim'); const { Database } = require('neug'); prepareModernGraphDataset(Database);"
+
       - name: Run Node.js tests
+        if: runner.os != 'Windows'
         run: |
           cd "${RUNNER_TEMP}/neug-npm-package-test"
+          node tests/test-shim.js
+
+      - name: Run Node.js tests on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Set-Location (Join-Path $env:RUNNER_TEMP "neug-npm-package-test")
           node tests/test-shim.js

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,6 @@ add_definitions(-DNEUG_CMAKE_VERSION="${CMAKE_PROJECT_VERSION}")
 if(WIN32)
     message(STATUS "Windows detected: disabling non-core features for core library build")
     # BUILD_PYTHON is no longer forced off; pass -DBUILD_PYTHON=ON to enable.
-    set(BUILD_NODEJS OFF CACHE BOOL "Node.js binding is not supported on Windows yet" FORCE)
     set(BUILD_HTTP_SERVER OFF CACHE BOOL "HTTP server (brpc) is not supported on Windows yet" FORCE)
     set(BUILD_EXTENSIONS "" CACHE STRING "Extensions are not supported on Windows yet" FORCE)
     set(BUILD_EXECUTABLES OFF CACHE BOOL "Executables are disabled on Windows core build" FORCE)

--- a/tools/nodejs_bind/CMakeLists.txt
+++ b/tools/nodejs_bind/CMakeLists.txt
@@ -62,13 +62,34 @@ add_dependencies(neug_node_bind neug_proto)
 set(NEUG_LIBRARIES neug)
 
 find_package(OpenSSL REQUIRED)
-target_link_libraries(neug_node_bind PRIVATE
-  ${NEUG_LIBRARIES}
-  ${GLOG_LIBRARIES}
-  ${Protobuf_LIBRARIES}
-  OpenSSL::SSL
-  OpenSSL::Crypto
-)
+if (WIN32)
+  set(NODE_IMPORT_LIB "" CACHE FILEPATH
+    "Path to the Node.js import library (node.lib)")
+  if (NOT NODE_IMPORT_LIB OR NOT EXISTS "${NODE_IMPORT_LIB}")
+    message(FATAL_ERROR
+      "Cannot find the Node.js import library. Set NODE_IMPORT_LIB to node.lib.")
+  endif()
+
+  # Protobuf namespace-scope default instances are not exported from neug.dll.
+  # Link the generated objects into the addon, matching the Windows Python binding.
+  target_link_libraries(neug_node_bind PRIVATE
+    ${NEUG_LIBRARIES}
+    ${GLOG_LIBRARIES}
+    ${Protobuf_LIBRARIES}
+    $<TARGET_OBJECTS:neug_proto>
+    OpenSSL::SSL
+    OpenSSL::Crypto
+    "${NODE_IMPORT_LIB}"
+  )
+else()
+  target_link_libraries(neug_node_bind PRIVATE
+    ${NEUG_LIBRARIES}
+    ${GLOG_LIBRARIES}
+    ${Protobuf_LIBRARIES}
+    OpenSSL::SSL
+    OpenSSL::Crypto
+  )
+endif()
 
 target_compile_definitions(neug_node_bind PRIVATE
   NAPI_VERSION=8
@@ -99,13 +120,20 @@ endif()
 # into the package and replaces non-portable RPATHs before npm pack runs.
 if(APPLE)
   set(_neug_node_rpath "@loader_path")
-else()
+elseif(NOT WIN32)
   set(_neug_node_rpath "$ORIGIN")
 endif()
 
-set_target_properties(neug_node_bind PROPERTIES
-  BUILD_RPATH "${_neug_node_rpath}"
-  INSTALL_RPATH "${_neug_node_rpath}"
-  BUILD_WITH_INSTALL_RPATH FALSE
-)
-set_property(TARGET neug APPEND PROPERTY BUILD_RPATH "${_neug_node_rpath}")
+if(NOT WIN32)
+  set_target_properties(neug_node_bind PROPERTIES
+    BUILD_RPATH "${_neug_node_rpath}"
+    INSTALL_RPATH "${_neug_node_rpath}"
+    BUILD_WITH_INSTALL_RPATH FALSE
+  )
+  set_property(TARGET neug APPEND PROPERTY BUILD_RPATH "${_neug_node_rpath}")
+else()
+  # Windows has no RPATH. Keep neug.dll beside the addon so the loader can find it.
+  add_custom_command(TARGET neug_node_bind POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            $<TARGET_FILE:neug> $<TARGET_FILE_DIR:neug_node_bind>)
+endif()

--- a/tools/nodejs_bind/lib/binding.js
+++ b/tools/nodejs_bind/lib/binding.js
@@ -16,14 +16,15 @@
 'use strict';
 
 // Native artifacts live in build/<Release|Debug>/<platform>/.
-// Platform tags: linux_x86_64, linux_arm64, osx_x86_64, osx_arm64
+// Platform tags: linux_x86_64, linux_arm64, osx_x86_64, osx_arm64,
+// windows_x86_64
 // Prefer Debug if present (dev intent); otherwise Release (the only
 // flavor shipped in npm tarballs).
 
 const path = require('path');
 const fs = require('fs');
 
-const OS_MAP = { linux: 'linux', darwin: 'osx' };
+const OS_MAP = { linux: 'linux', darwin: 'osx', win32: 'windows' };
 const ARCH_MAP = { x64: 'x86_64', arm64: 'arm64' };
 
 const os = OS_MAP[process.platform];

--- a/tools/nodejs_bind/tests/test-shim.js
+++ b/tools/nodejs_bind/tests/test-shim.js
@@ -86,13 +86,14 @@ function prepareModernGraphDataset(Database, dbDir = '/tmp/modern_graph') {
     'CREATE REL TABLE created(FROM person TO software, weight DOUBLE, since INT64);'
   );
 
-  conn.execute(`COPY person from "${path.join(dataDir, 'person.csv')}"`);
-  conn.execute(`COPY software from "${path.join(dataDir, 'software.csv')}"`);
+  const dataPath = (file) => path.join(dataDir, file).replaceAll('\\', '/');
+  conn.execute(`COPY person from "${dataPath('person.csv')}"`);
+  conn.execute(`COPY software from "${dataPath('software.csv')}"`);
   conn.execute(
-    `COPY knows from "${path.join(dataDir, 'person_knows_person.csv')}" (from="person", to="person")`
+    `COPY knows from "${dataPath('person_knows_person.csv')}" (from="person", to="person")`
   );
   conn.execute(
-    `COPY created from "${path.join(dataDir, 'person_created_software.csv')}" (from="person", to="software")`
+    `COPY created from "${dataPath('person_created_software.csv')}" (from="person", to="software")`
   );
 
   conn.close();


### PR DESCRIPTION
Closes #952

## Summary
- enable the Node.js binding on Windows and link the Node import library
- package the Windows x64 native addon with `neug.dll`
- build with Windows Server 2022 and Node.js 20.0.0
- add Windows artifacts to the Node.js 20/22/24 package test matrix

## Testing
- verified CMake configuration with `BUILD_NODEJS=ON`
- validated workflow YAML and JavaScript syntax
- Windows compilation and package tests run in CI