### PR TITLE
fix: cap HNSW ef_search parameters

### DIFF
--- a/extension/vector_search/src/hnsw_index.cc
+++ b/extension/vector_search/src/hnsw_index.cc
@@ -256,9 +256,10 @@ void HNSWIndex::Open(Checkpoint& ckp, const ModuleDescriptor& descriptor,
   options.copy_on_write = false;
   auto ret = zvec_index_->Open(zvec_runtime_path_, options);
   if (ret != 0) {
-    THROW_RUNTIME_ERROR("[zvec] Failed to open HNSW index at " +
+    THROW_RUNTIME_ERROR("ZVec internal open failed for HNSW index at " +
                         zvec_runtime_path_ +
-                        ", error code: " + std::to_string(ret));
+                        ", error code: " + std::to_string(ret) +
+                        ". See logs for details.");
   }
   LOG(INFO) << "[zvec] Opened HNSW index at " << zvec_runtime_path_;
 }
@@ -346,9 +347,10 @@ Status HNSWIndex::BulkBuild(const VertexSet& vertices) {
         zvec::core_interface::DenseVector{vec_source_->get_vector(index_id)};
     auto ret = zvec_index_->AddWithSource(vector, index_id, *vec_source_);
     if (ret != 0) {
-      return Status::RuntimeError("ZVec HNSW bulk build failed for vertex " +
-                                  std::to_string(vid) + " with error code " +
-                                  std::to_string(ret));
+      return Status::RuntimeError(
+          "ZVec internal bulk build failed for vertex " +
+          std::to_string(vid) + " with error code " + std::to_string(ret) +
+          ". See logs for details.");
     }
   }
   return Status::OK();
@@ -466,7 +468,8 @@ result<std::vector<SearchCandidate>> HNSWIndex::SearchImpl(
                                            &search_result);
   if (ret != 0) {
     RETURN_ERROR(Status::RuntimeError(
-        "ZVec HNSW search failed with error code " + std::to_string(ret)));
+        "ZVec internal search failed with error code " + std::to_string(ret) +
+        ". See logs for details."));
   }
 
   std::vector<SearchCandidate> result;
@@ -503,8 +506,9 @@ Status HNSWIndex::AppendImpl(index_id_t index_id, const IndexValues& values) {
   vector.vector = zvec::core_interface::DenseVector{dense.data()};
   auto ret = zvec_index_->AddWithSource(vector, index_id, *vec_source_);
   if (ret != 0) {
-    return Status::RuntimeError("ZVec HNSW append failed with error code " +
-                                std::to_string(ret));
+    return Status::RuntimeError("ZVec internal append failed with error code " +
+                                std::to_string(ret) +
+                                ". See logs for details.");
   }
   return Status::OK();
 }

--- a/extension/vector_search/src/hnsw_index.cc
+++ b/extension/vector_search/src/hnsw_index.cc
@@ -256,10 +256,9 @@ void HNSWIndex::Open(Checkpoint& ckp, const ModuleDescriptor& descriptor,
   options.copy_on_write = false;
   auto ret = zvec_index_->Open(zvec_runtime_path_, options);
   if (ret != 0) {
-    THROW_RUNTIME_ERROR("ZVec internal open failed for HNSW index at " +
-                        zvec_runtime_path_ +
-                        ", error code: " + std::to_string(ret) +
-                        ". See logs for details.");
+    THROW_RUNTIME_ERROR(
+        "ZVec internal open failed for HNSW index at " + zvec_runtime_path_ +
+        ", error code: " + std::to_string(ret) + ". See logs for details.");
   }
   LOG(INFO) << "[zvec] Opened HNSW index at " << zvec_runtime_path_;
 }
@@ -348,8 +347,8 @@ Status HNSWIndex::BulkBuild(const VertexSet& vertices) {
     auto ret = zvec_index_->AddWithSource(vector, index_id, *vec_source_);
     if (ret != 0) {
       return Status::RuntimeError(
-          "ZVec internal bulk build failed for vertex " +
-          std::to_string(vid) + " with error code " + std::to_string(ret) +
+          "ZVec internal bulk build failed for vertex " + std::to_string(vid) +
+          " with error code " + std::to_string(ret) +
           ". See logs for details.");
     }
   }
@@ -467,9 +466,9 @@ result<std::vector<SearchCandidate>> HNSWIndex::SearchImpl(
   auto ret = zvec_index_->SearchWithSource(query, query_param, *vec_source_,
                                            &search_result);
   if (ret != 0) {
-    RETURN_ERROR(Status::RuntimeError(
-        "ZVec internal search failed with error code " + std::to_string(ret) +
-        ". See logs for details."));
+    RETURN_ERROR(
+        Status::RuntimeError("ZVec internal search failed with error code " +
+                             std::to_string(ret) + ". See logs for details."));
   }
 
   std::vector<SearchCandidate> result;

--- a/extension/vector_search/src/hnsw_index_scan.cc
+++ b/extension/vector_search/src/hnsw_index_scan.cc
@@ -305,11 +305,13 @@ execution::Context ExecuteHNSWIndexScan(
   params.target_value = input.bound_target_value;
   params.topk = input.topk;
   constexpr uint32_t kMinEfSearch = 100;
+  constexpr uint32_t kMaxEfSearch = 2048;
   const auto doubled_topk =
       input.topk > std::numeric_limits<uint32_t>::max() / 2
           ? std::numeric_limits<uint32_t>::max()
           : input.topk * 2;
-  params.ef_search = std::max(doubled_topk, kMinEfSearch);
+  params.ef_search = std::min(
+      std::max(doubled_topk, kMinEfSearch), kMaxEfSearch);
 
   std::vector<std::shared_ptr<IVertexColumn>> filter_inputs;
   size_t scalar_filter_size = 0;

--- a/extension/vector_search/src/hnsw_index_scan.cc
+++ b/extension/vector_search/src/hnsw_index_scan.cc
@@ -310,8 +310,8 @@ execution::Context ExecuteHNSWIndexScan(
       input.topk > std::numeric_limits<uint32_t>::max() / 2
           ? std::numeric_limits<uint32_t>::max()
           : input.topk * 2;
-  params.ef_search = std::min(
-      std::max(doubled_topk, kMinEfSearch), kMaxEfSearch);
+  params.ef_search =
+      std::min(std::max(doubled_topk, kMinEfSearch), kMaxEfSearch);
 
   std::vector<std::shared_ptr<IVertexColumn>> filter_inputs;
   size_t scalar_filter_size = 0;

--- a/tools/python_bind/tests/test_hnsw_index.py
+++ b/tools/python_bind/tests/test_hnsw_index.py
@@ -263,6 +263,11 @@ def test_inner_product_index_scan(advanced_connection):
     )
 
 
+def test_hnsw_limit_above_1024(advanced_connection):
+    rows = _l2_search(advanced_connection, 500.0, 1025)
+    assert len(rows) == NUM_VECTORS
+
+
 def test_graph_filtering_during_index_scan(advanced_connection):
     rows = list(
         advanced_connection.execute(

--- a/tools/python_bind/tests/test_hnsw_index.py
+++ b/tools/python_bind/tests/test_hnsw_index.py
@@ -160,11 +160,9 @@ def test_l2_index_scan_and_index_filtering(advanced_connection):
     assert [row[0] for row in rows[:3]] == [3, 4, 2]
     assert [row[1] for row in rows[:3]] == pytest.approx([0.16, 12.96, 19.36], abs=1e-5)
     assert _l2_search(advanced_connection, 0.0)[0][0] == 0
-    assert [row[0] for row in _l2_search(advanced_connection, 500.0)[:3]] == [
-        500,
-        501,
-        499,
-    ]
+    centered = _l2_search(advanced_connection, 500.0)[:3]
+    assert centered[0][0] == 500
+    assert {row[0] for row in centered[1:]} == {499, 501}
     assert _l2_search(advanced_connection, 999.0)[0][0] == 999
     filtered = _l2_search(advanced_connection, 3.1, 2, "n.group_id = 0")
     assert [row[0] for row in filtered] == [4, 2]

--- a/tools/python_bind/tests/test_hnsw_index.py
+++ b/tools/python_bind/tests/test_hnsw_index.py
@@ -265,8 +265,14 @@ def test_inner_product_index_scan(advanced_connection):
 
 
 def test_hnsw_limit_above_1024(advanced_connection):
-    rows = _l2_search(advanced_connection, 500.0, 1025)
+    result = advanced_connection.execute(
+        "PROFILE MATCH (n:Item) RETURN n.id, "
+        f"vector_distance_l2(n.l2_vec, {_array_literal(_constant_vector(500.0))}) "
+        "AS score ORDER BY score ASC LIMIT 1025;"
+    )
+    rows = list(result)
     assert len(rows) == 1025
+    assert "IndexScanOpr" in _profile_operator_names(result)
 
 
 def test_graph_filtering_during_index_scan(advanced_connection):

--- a/tools/python_bind/tests/test_hnsw_index.py
+++ b/tools/python_bind/tests/test_hnsw_index.py
@@ -36,7 +36,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 DIMENSION = 16
-NUM_VECTORS = 1000
+NUM_VECTORS = 2000
 
 
 def _array_literal(values):
@@ -257,15 +257,16 @@ def test_inner_product_index_scan(advanced_connection):
             "AS score ORDER BY score DESC LIMIT 3;"
         )
     )
-    assert [row[0] for row in rows] == [999, 998, 997]
+    expected_ids = [NUM_VECTORS - 1, NUM_VECTORS - 2, NUM_VECTORS - 3]
+    assert [row[0] for row in rows] == expected_ids
     assert [row[1] for row in rows] == pytest.approx(
-        [999 * DIMENSION, 998 * DIMENSION, 997 * DIMENSION]
+        [index * DIMENSION for index in expected_ids]
     )
 
 
 def test_hnsw_limit_above_1024(advanced_connection):
     rows = _l2_search(advanced_connection, 500.0, 1025)
-    assert len(rows) == NUM_VECTORS
+    assert len(rows) == 1025
 
 
 def test_graph_filtering_during_index_scan(advanced_connection):


### PR DESCRIPTION
## Summary

- cap query-time HNSW ef_search at ZVec maximum 2048 while preserving the existing minimum and 2x top-k heuristic
- clarify that ZVec operation failures are internal errors and direct users to logs for details
- add a Python regression test covering LIMIT 1025

## Testing

- NEUG_RUN_EXTENSION_TESTS=1 python3 -m pytest -q tests/test_hnsw_index.py -k test_hnsw_limit_above_1024

Fixes #955