### PR TITLE
fix: support TP transaction lookup on older libstdc++

### DIFF
--- a/src/server/service_transaction_manager.cc
+++ b/src/server/service_transaction_manager.cc
@@ -315,7 +315,7 @@ ServiceTransactionManager::LockEntry(std::string_view transaction_id) {
 ServiceTransactionManager::EntryPtr ServiceTransactionManager::Find(
     std::string_view transaction_id) const {
   std::lock_guard lock(mutex_);
-  const auto found = entries_.find(transaction_id);
+  const auto found = entries_.find(std::string(transaction_id));
   return found == entries_.end() ? nullptr : found->second;
 }
 
@@ -323,7 +323,7 @@ void ServiceTransactionManager::Remove(std::string_view transaction_id,
                                        const EntryPtr& entry) {
   {
     std::lock_guard lock(mutex_);
-    const auto found = entries_.find(transaction_id);
+    const auto found = entries_.find(std::string(transaction_id));
     if (found != entries_.end() && found->second == entry) {
       entries_.erase(found);
     }

--- a/src/server/service_transaction_manager.h
+++ b/src/server/service_transaction_manager.h
@@ -18,7 +18,6 @@
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
-#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -84,17 +83,6 @@ class ServiceTransactionManager {
     std::unique_lock<std::mutex> lock;
   };
 
-  struct TransparentStringHash {
-    using is_transparent = void;
-
-    size_t operator()(std::string_view value) const noexcept {
-      return std::hash<std::string_view>{}(value);
-    }
-    size_t operator()(const std::string& value) const noexcept {
-      return operator()(std::string_view(value));
-    }
-  };
-
   result<LockedEntry> LockEntry(std::string_view transaction_id);
   EntryPtr Find(std::string_view transaction_id) const;
   void Remove(std::string_view transaction_id, const EntryPtr& entry);
@@ -108,9 +96,7 @@ class ServiceTransactionManager {
 
   mutable std::mutex mutex_;
   std::condition_variable changed_;
-  std::unordered_map<std::string, EntryPtr, TransparentStringHash,
-                     std::equal_to<>>
-      entries_;
+  std::unordered_map<std::string, EntryPtr> entries_;
   size_t pending_begins_{0};
   bool accepting_{true};
   bool stop_reaper_{false};


### PR DESCRIPTION
Closes #969

## Summary

- use the portable `std::string` lookup overload for TP transaction-session lookup and removal
- remove the redundant transparent hash helper

## Validation

- `cmake --build build --target test_db_svc`
- `MODERN_GRAPH_DATA_DIR="$PWD/example_dataset/modern_graph" build/tests/unittest/test_db_svc --gtest_filter=NeugDBServiceTest.ExplicitTransaction*`