### PR TITLE
fix: report actionable Python Session timeout errors

### DIFF
--- a/tools/python_bind/neug/session.py
+++ b/tools/python_bind/neug/session.py
@@ -33,6 +33,7 @@ except ImportError as e:
         raise e
 
 from neug.proto.error_pb2 import ERR_NETWORK
+from neug.proto.error_pb2 import ERR_QUERY_TIMEOUT
 from neug.proto.error_pb2 import ERR_SESSION_CLOSED
 from neug.query_result import QueryResult
 from neug.utils import is_access_mode_valid
@@ -183,6 +184,17 @@ class Session:
             response = self._http_session.post(
                 self._query_endpoint, data=payload, timeout=self.timeout
             )
+        except requests.exceptions.Timeout as e:
+            error_message = (
+                f"Query timed out after {self.timeout:g} seconds "
+                f"(session timeout: {self._timeout}) while requesting "
+                f"{self._query_endpoint}. Consider increasing the Session "
+                "timeout or optimizing the query. "
+                'For example: Session(endpoint, timeout="30s"). '
+                f"Error code: {ERR_QUERY_TIMEOUT}"
+            )
+            logger.error(f"Failed to execute query: {query}. {error_message}")
+            raise TimeoutError(error_message) from e
         except requests.exceptions.RequestException as e:
             logger.error(f"Failed to execute query: {query}. Error: {e}")
             raise ConnectionError(
@@ -238,10 +250,10 @@ class Session:
         Get the timeout duration for the session, in seconds.
         """
         if isinstance(self._timeout, str):
-            if self._timeout.endswith("s"):
-                return int(self._timeout[:-1])
-            elif self._timeout.endswith("ms"):
+            if self._timeout.endswith("ms"):
                 return int(self._timeout[:-2]) / 1000
+            elif self._timeout.endswith("s"):
+                return int(self._timeout[:-1])
             else:
                 raise ValueError("Timeout must be a string ending with 's' or 'ms'.")
         elif isinstance(self._timeout, int):

--- a/tools/python_bind/neug/session.py
+++ b/tools/python_bind/neug/session.py
@@ -186,7 +186,7 @@ class Session:
             )
         except requests.exceptions.Timeout as e:
             error_message = (
-                f"Query timed out after {self.timeout:g} seconds "
+                f"Query timed out after {self.timeout} seconds "
                 f"(session timeout: {self._timeout}) while requesting "
                 f"{self._query_endpoint}. Consider increasing the Session "
                 "timeout or optimizing the query. "

--- a/tools/python_bind/tests/test_session_timeout.py
+++ b/tools/python_bind/tests/test_session_timeout.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import pytest
+import requests
+
+import neug.session as session_module
+from neug.proto.error_pb2 import ERR_QUERY_TIMEOUT
+from neug.session import Session
+
+
+class _SuccessfulResponse:
+    status_code = 200
+    text = ""
+    _content = b""
+
+
+def _session_that_times_out(monkeypatch, timeout):
+    monkeypatch.setattr(
+        requests.Session, "get", lambda self, url, timeout: _SuccessfulResponse()
+    )
+
+    def raise_timeout(self, url, data, timeout):
+        raise requests.exceptions.ReadTimeout("legacy requests timeout detail")
+
+    monkeypatch.setattr(requests.Session, "post", raise_timeout)
+    monkeypatch.setattr(
+        session_module.PyQueryRequest,
+        "serialize_request",
+        lambda query, access_mode: b"request",
+    )
+    return Session("http://localhost:10000", timeout=timeout)
+
+
+@pytest.mark.parametrize(
+    ("configured_timeout", "seconds"), [("2s", "2"), ("250ms", "0.25")]
+)
+def test_execute_timeout_has_actionable_error(monkeypatch, configured_timeout, seconds):
+    session = _session_that_times_out(monkeypatch, configured_timeout)
+
+    with pytest.raises(TimeoutError) as excinfo:
+        session.execute("MATCH (n) RETURN n")
+
+    message = str(excinfo.value)
+    assert f"timed out after {seconds} seconds" in message
+    assert f"session timeout: {configured_timeout}" in message
+    assert "increasing the Session timeout" in message
+    assert "optimizing the query" in message
+    assert 'Session(endpoint, timeout="30s")' in message
+    assert f"Error code: {ERR_QUERY_TIMEOUT}" in message
+    assert "Error code: 2001" not in message


### PR DESCRIPTION
## Summary

- distinguish HTTP query timeouts from generic network failures in the Python `Session` API
- raise `TimeoutError` with `ERR_QUERY_TIMEOUT` (3003), the configured timeout, endpoint, and actionable guidance
- fix parsing of millisecond timeout values such as `250ms`
- add deterministic regression coverage for second and millisecond timeout configurations

## Before

```text
Could not execute query: MATCH (n) RETURN n, Error code: 2001
```

## After

```text
Query timed out after 2 seconds (session timeout: 2s) while requesting http://localhost:10000/cypher. Consider increasing the Session timeout or optimizing the query. For example: Session(endpoint, timeout="30s"). Error code: 3003
```

## Testing

```text
python3.9 -m pytest -q tests/test_session_timeout.py
2 passed
```

Closes #971