### PR TITLE
fix: resize incident CSR after bulk vertex copy

### DIFF
--- a/include/neug/storages/graph/property_graph.h
+++ b/include/neug/storages/graph/property_graph.h
@@ -356,6 +356,7 @@ class NEUG_API PropertyGraph {
                               const DeleteEdgePropertiesParam& config);
 
   Status EnsureCapacity(label_t v_label, size_t capacity);
+  Status SyncIncidentEdgeCapacity(label_t v_label);
 
   Status EnsureCapacity(label_t src_label, label_t dst_label,
                         label_t edge_label, size_t capacity);

--- a/include/neug/transaction/cow_graph_storage.h
+++ b/include/neug/transaction/cow_graph_storage.h
@@ -134,6 +134,7 @@ class CowGraphStorage : public StorageUpdateInterface,
   Status detachEdgeColumn(uint32_t edge_triplet_id, int32_t col_id);
   Status detachAdjlists(uint32_t edge_triplet_id, vid_t src_lid, vid_t dst_lid,
                         Allocator& alloc);
+  Status detachIncidentEdgeTablesForResize(label_t label);
   Status detachForResize(label_t label, size_t capacity);
   Status detachForResize(label_t src_label, label_t dst_label,
                          label_t edge_label, size_t capacity);

--- a/src/storages/graph/property_graph.cc
+++ b/src/storages/graph/property_graph.cc
@@ -134,7 +134,17 @@ Status PropertyGraph::EnsureCapacity(label_t v_label, size_t capacity) {
     if (capacity <= old_cap) {
       return neug::Status::OK();
     }
-    auto v_new_cap = vertex_tables_[v_label].EnsureCapacity(capacity);
+    vertex_tables_[v_label].EnsureCapacity(capacity);
+    return SyncIncidentEdgeCapacity(v_label);
+  } else {
+    return Status(StatusCode::ERR_INVALID_ARGUMENT,
+                  "Vertex label does not exist.");
+  }
+}
+
+Status PropertyGraph::SyncIncidentEdgeCapacity(label_t v_label) {
+  if (schema_.is_vertex_label_valid(v_label)) {
+    const auto v_capacity = vertex_tables_[v_label].Capacity();
     for (label_t dst_label = 0; dst_label < vertex_label_total_count_;
          ++dst_label) {
       if (!schema_.is_vertex_label_valid(dst_label)) {
@@ -142,15 +152,18 @@ Status PropertyGraph::EnsureCapacity(label_t v_label, size_t capacity) {
       }
       for (label_t e_label = 0; e_label < edge_label_total_count_; ++e_label) {
         size_t index = schema_.generate_edge_label(v_label, dst_label, e_label);
+        // Resizing an edge CSR directory must be checkpoint-visible.
         if (edge_tables_.count(index) > 0) {
           edge_tables_.at(index).EnsureCapacity(
-              v_new_cap, vertex_tables_[dst_label].Capacity());
+              v_capacity, vertex_tables_[dst_label].Capacity());
+          MarkEdgeTableDirty(v_label, dst_label, e_label);
         }
         if (v_label != dst_label) {
           index = schema_.generate_edge_label(dst_label, v_label, e_label);
           if (edge_tables_.count(index) > 0) {
             edge_tables_.at(index).EnsureCapacity(
-                vertex_tables_[dst_label].Capacity(), v_new_cap);
+                vertex_tables_[dst_label].Capacity(), v_capacity);
+            MarkEdgeTableDirty(dst_label, v_label, e_label);
           }
         }
       }

--- a/src/transaction/cow_graph_storage.cc
+++ b/src/transaction/cow_graph_storage.cc
@@ -1126,12 +1126,7 @@ Status CowGraphStorage::detachAdjlists(uint32_t edge_triplet_id, vid_t src_lid,
   return Status::OK();
 }
 
-Status CowGraphStorage::detachForResize(label_t label, size_t capacity) {
-  const auto& vertex_table = graph_.get_vertex_table(label);
-  if (capacity <= vertex_table.Capacity()) {
-    return Status::OK();
-  }
-  RETURN_IF_NOT_OK(detachVertexTableForInsert(label));
+Status CowGraphStorage::detachIncidentEdgeTablesForResize(label_t label) {
   const auto& schema = graph_.schema();
   auto vertex_label_count = schema.vertex_label_frontier();
   auto edge_label_count = schema.edge_label_frontier();
@@ -1151,6 +1146,15 @@ Status CowGraphStorage::detachForResize(label_t label, size_t capacity) {
     }
   }
   return Status::OK();
+}
+
+Status CowGraphStorage::detachForResize(label_t label, size_t capacity) {
+  const auto& vertex_table = graph_.get_vertex_table(label);
+  if (capacity <= vertex_table.Capacity()) {
+    return Status::OK();
+  }
+  RETURN_IF_NOT_OK(detachVertexTableForInsert(label));
+  return detachIncidentEdgeTablesForResize(label);
 }
 
 Status CowGraphStorage::detachForResize(label_t src_label, label_t dst_label,
@@ -1212,6 +1216,7 @@ Status BulkCowGraphStorage::CreateEdgeTypeImpl(
 result<std::vector<vid_t>> BulkCowGraphStorage::BatchAddVerticesImpl(
     label_t v_label_id, std::shared_ptr<IDataChunkSupplier> supplier) {
   RETURN_STATUS_ERROR_IF_NOT_OK(detachVertexTableForInsert(v_label_id));
+  const auto old_capacity = graph_.get_vertex_table(v_label_id).Capacity();
   GS_AUTO(indexes, graph_.mutable_index_manager().GetAllIndexes());
   for (auto* index : indexes) {
     if (index->GetMeta().schema.label_id == v_label_id) {
@@ -1219,6 +1224,11 @@ result<std::vector<vid_t>> BulkCowGraphStorage::BatchAddVerticesImpl(
     }
   }
   auto new_vids = graph_.BatchAddVertices(v_label_id, std::move(supplier));
+  if (graph_.get_vertex_table(v_label_id).Capacity() > old_capacity) {
+    RETURN_STATUS_ERROR_IF_NOT_OK(
+        detachIncidentEdgeTablesForResize(v_label_id));
+    RETURN_STATUS_ERROR_IF_NOT_OK(graph_.SyncIncidentEdgeCapacity(v_label_id));
+  }
   if (!new_vids || new_vids->empty()) {
     return new_vids;
   }

--- a/tools/python_bind/tests/test_load.py
+++ b/tools/python_bind/tests/test_load.py
@@ -1696,6 +1696,51 @@ class TestCopyFrom:
         )
         assert records == [["a.py", 1]]
 
+    def test_copy_vertices_after_edge_copy_persists_incident_csr_growth(self):
+        """A later vertex COPY must persist CSR growth before edge CREATE."""
+        initial_nodes_csv = self.tmp_path / "initial_nodes.csv"
+        edges_csv = self.tmp_path / "edges.csv"
+        appended_nodes_csv = self.tmp_path / "appended_nodes.csv"
+        initial_nodes_csv.write_text("id\n1\n", encoding="utf-8")
+        edges_csv.write_text("src,dst\n1,1\n", encoding="utf-8")
+        appended_nodes_csv.write_text(
+            "id\n" + "\n".join(str(node_id) for node_id in range(2, 4098)) + "\n",
+            encoding="utf-8",
+        )
+
+        self.conn.execute("CREATE NODE TABLE node(id INT64, PRIMARY KEY(id))")
+        self.conn.execute("CREATE REL TABLE rel(FROM node TO node)")
+        self.conn.execute(
+            f'COPY node FROM "{initial_nodes_csv}" (header=true, delimiter=",")'
+        )
+        self.conn.execute(f'COPY rel FROM "{edges_csv}" (header=true, delimiter=",")')
+        self.conn.execute(
+            f'COPY node FROM "{appended_nodes_csv}" (header=true, delimiter=",")'
+        )
+        self.conn.execute("CHECKPOINT")
+        self.conn.close()
+        self.db.close()
+
+        db = Database(db_path=self.db_dir, mode="w")
+        conn = db.connect()
+        conn.execute(
+            "MATCH (a:node {id: 4097}), (b:node {id: 1}) " "CREATE (a)-[:rel]->(b)"
+        )
+        conn.execute("CHECKPOINT")
+        conn.close()
+        db.close()
+
+        db = Database(db_path=self.db_dir, mode="r")
+        conn = db.connect()
+        records = list(
+            conn.execute(
+                "MATCH (a:node {id: 4097})-[r:rel]->(b:node {id: 1}) " "RETURN count(r)"
+            )
+        )
+        assert records == [[1]]
+        conn.close()
+        db.close()
+
     def test_copy_from_edge_dangling_warns(self):
         """COPY edges referencing missing vertices must log a warning (#166)."""
         nodes_csv = self.tmp_path / "persons.csv"


### PR DESCRIPTION
## Summary

- Preserve the existing `BatchAddVertices` interface and reconcile incident CSR capacity after persistent COPY actually grows a vertex table.
- Detach, resize, and mark incident EdgeTables dirty only on an actual capacity change, using the vertex table post-COPY capacity rather than `RowNum()` preflight.
- Add a regression that checkpoints and reopens immediately after node growth, before creating an edge from the newly added vertex.

Fixes #936.