### PR TITLE
fix: support bound list parameters in IN predicates

### DIFF
--- a/src/compiler/function/list/list_contains_function.cpp
+++ b/src/compiler/function/list/list_contains_function.cpp
@@ -53,7 +53,8 @@ static std::unique_ptr<FunctionBindData> bindFunc(
   // list child type because casting list is more expensive.
   std::vector<DataType> paramTypes;
   DataType listType, childType;
-  if (ExpressionUtil::isEmptyList(*input.arguments[0])) {
+  if (ExpressionUtil::isEmptyList(*input.arguments[0]) ||
+      input.arguments[0]->getDataType().containsAny()) {
     childType = input.arguments[1]->getDataType().copy();
     listType = DataType::List(childType.copy());
   } else {

--- a/tools/python_bind/tests/test_query.py
+++ b/tools/python_bind/tests/test_query.py
@@ -564,6 +564,19 @@ def test_parameterized_query(modern_graph):
     ], f"Expected value [['vadas'], ['josh']], got {records}"
 
 
+def test_parameterized_list_membership(empty_db):
+    _, conn = empty_db
+    conn.execute("CREATE NODE TABLE T(id STRING, PRIMARY KEY(id));")
+    conn.execute("CREATE (:T {id: 'n0'}), (:T {id: 'n1'}), (:T {id: 'n2'});")
+
+    result = conn.execute(
+        "MATCH (n:T) WHERE n.id IN $ids RETURN n.id;",
+        parameters={"ids": ["n0", "n1"]},
+    )
+
+    assert sorted(row[0] for row in result) == ["n0", "n1"]
+
+
 def test_parameterized_where_on_edge_string_property():
     """Test that parameterized WHERE on edge STRING property works (not just literals)."""
     db = Database(db_path=":memory", mode="w")


### PR DESCRIPTION
## Summary
- Infer an unknown list parameter type from the `IN` predicate element type.
- Add an embedded Python regression for `n.id IN $ids`.

## Validation
- `git diff --check`
- `clang-format --dry-run --Werror src/compiler/function/list/list_contains_function.cpp`
- `python3.13 -m black --check tools/python_bind/tests/test_query.py`
- Build and runtime regression were not run at the requester's direction.

Fixes #942