### PR TITLE
fix: make vertex deletion idempotent

### DIFF
--- a/include/neug/storages/graph/graph_interface.h
+++ b/include/neug/storages/graph/graph_interface.h
@@ -632,6 +632,9 @@ class StorageUpdateInterface : public StorageReadInterface,
 
   /**
    * @brief Delete a single vertex and its associated edges.
+   *
+   * For a valid vertex label, deleting a missing or already deleted internal
+   * ID is a successful no-op.
    */
   Status DeleteVertex(label_t label, vid_t lid) {
     return DeleteVertexImpl(label, lid);
@@ -667,7 +670,8 @@ class StorageUpdateInterface : public StorageReadInterface,
    *
    * @param v_label_id Vertex label
    * @param vids Vector of internal vertex IDs to delete
-   * @return Status indicating success or failure
+   * @return Status indicating success or failure. For a valid vertex label,
+   *         missing or already deleted IDs are successful no-ops.
    */
   Status BatchDeleteVertices(label_t v_label_id,
                              const std::vector<vid_t>& vids) {

--- a/include/neug/storages/graph/property_graph.h
+++ b/include/neug/storages/graph/property_graph.h
@@ -378,7 +378,9 @@ class NEUG_API PropertyGraph {
    * @param label Vertex label id.
    * @param oid Vertex original id.
    * @param ts Timestamp of the deletion.
-   * @return true if deletion is successful, false otherwise.
+   * @return Status indicating success or failure. For a valid vertex label,
+   *         deleting a missing or already deleted vertex is a successful
+   *         no-op.
    * @note We always delete vertex in detach mode.
    */
   Status DeleteVertex(label_t v_label, const Value& oid, timestamp_t ts);

--- a/src/execution/execute/ops/batch/batch_delete_vertex.cc
+++ b/src/execution/execute/ops/batch/batch_delete_vertex.cc
@@ -16,6 +16,7 @@
 #include "neug/execution/execute/ops/batch/batch_delete_vertex.h"
 #include "neug/common/columns/edge_columns.h"
 #include "neug/common/columns/vertex_columns.h"
+#include "neug/utils/property/types.h"
 
 #include <unordered_set>
 
@@ -45,7 +46,10 @@ neug::result<Context> BatchDeleteVertexOpr::Eval(
     IStorageInterface& graph_interface, const ParamsMap& params, Context&& ctx,
     OprTimer* timer) {
   auto& graph = dynamic_cast<StorageUpdateInterface&>(graph_interface);
-  std::unordered_map<label_t, std::unordered_set<vid_t>> deleted_vids;
+  std::unordered_set<GlobalId::gid_t> deleted_vids;
+  auto to_gid = [](label_t label, vid_t vid) {
+    return GlobalId(label, vid).global_id;
+  };
   return ctx.apply_chunks([&](ContextChunk&& chunk)
                               -> neug::result<ContextChunk> {
     size_t binding_size = vertex_bindings_.size();
@@ -59,7 +63,7 @@ neug::result<Context> BatchDeleteVertexOpr::Eval(
         const auto label = sl_vertex_column->label();
         std::vector<vid_t> vids;
         for (auto v : sl_vertex_column->vertices()) {
-          if (deleted_vids[label].insert(v).second) {
+          if (deleted_vids.insert(to_gid(label, v)).second) {
             vids.emplace_back(v);
           }
         }
@@ -78,7 +82,7 @@ neug::result<Context> BatchDeleteVertexOpr::Eval(
         size_t vertex_size = vertex_column->size();
         for (size_t j = 0; j < vertex_size; j++) {
           auto vertex = vertex_column->get_vertex(j);
-          if (deleted_vids[vertex.label_].insert(vertex.vid_).second) {
+          if (deleted_vids.insert(to_gid(vertex.label_, vertex.vid_)).second) {
             vids_map.at(vertex.label_).emplace_back(vertex.vid_);
           }
         }

--- a/src/execution/execute/ops/batch/batch_delete_vertex.cc
+++ b/src/execution/execute/ops/batch/batch_delete_vertex.cc
@@ -16,9 +16,6 @@
 #include "neug/execution/execute/ops/batch/batch_delete_vertex.h"
 #include "neug/common/columns/edge_columns.h"
 #include "neug/common/columns/vertex_columns.h"
-#include "neug/utils/property/types.h"
-
-#include <unordered_set>
 
 namespace neug {
 namespace execution {
@@ -46,63 +43,52 @@ neug::result<Context> BatchDeleteVertexOpr::Eval(
     IStorageInterface& graph_interface, const ParamsMap& params, Context&& ctx,
     OprTimer* timer) {
   auto& graph = dynamic_cast<StorageUpdateInterface&>(graph_interface);
-  std::unordered_set<GlobalId::gid_t> deleted_vids;
-  auto to_gid = [](label_t label, vid_t vid) {
-    return GlobalId(label, vid).global_id;
-  };
-  return ctx.apply_chunks([&](ContextChunk&& chunk)
-                              -> neug::result<ContextChunk> {
-    size_t binding_size = vertex_bindings_.size();
-    for (size_t i = 0; i < binding_size; i++) {
-      int32_t alias = vertex_bindings_[i];
-      auto vertex_column =
-          std::dynamic_pointer_cast<IVertexColumn>(chunk.get(alias));
-      if (vertex_column->vertex_column_type() == VertexColumnType::kSingle) {
-        auto sl_vertex_column =
-            std::dynamic_pointer_cast<SLVertexColumn>(vertex_column);
-        const auto label = sl_vertex_column->label();
-        std::vector<vid_t> vids;
-        for (auto v : sl_vertex_column->vertices()) {
-          if (deleted_vids.insert(to_gid(label, v)).second) {
-            vids.emplace_back(v);
-          }
-        }
-        if (!vids.empty()) {
-          RETURN_STATUS_ERROR_IF_NOT_OK(graph.BatchDeleteVertices(label, vids));
-        }
-      } else if (vertex_column->vertex_column_type() ==
-                     VertexColumnType::kMultiple ||
-                 vertex_column->vertex_column_type() ==
-                     VertexColumnType::kMultiSegment) {
-        std::unordered_map<label_t, std::vector<vid_t>> vids_map;
-        for (auto label : vertex_column->get_labels_set()) {
-          std::vector<vid_t> vids;
-          vids_map.insert({label, vids});
-        }
-        size_t vertex_size = vertex_column->size();
-        for (size_t j = 0; j < vertex_size; j++) {
-          auto vertex = vertex_column->get_vertex(j);
-          if (deleted_vids.insert(to_gid(vertex.label_, vertex.vid_)).second) {
-            vids_map.at(vertex.label_).emplace_back(vertex.vid_);
-          }
-        }
-        for (auto& vids_pair : vids_map) {
-          if (!vids_pair.second.empty()) {
+  return ctx.apply_chunks(
+      [&](ContextChunk&& chunk) -> neug::result<ContextChunk> {
+        size_t binding_size = vertex_bindings_.size();
+        for (size_t i = 0; i < binding_size; i++) {
+          int32_t alias = vertex_bindings_[i];
+          auto vertex_column =
+              std::dynamic_pointer_cast<IVertexColumn>(chunk.get(alias));
+          if (vertex_column->vertex_column_type() ==
+              VertexColumnType::kSingle) {
+            auto sl_vertex_column =
+                std::dynamic_pointer_cast<SLVertexColumn>(vertex_column);
+            std::vector<vid_t> vids;
+            for (auto v : sl_vertex_column->vertices()) {
+              vids.emplace_back(v);
+            }
             RETURN_STATUS_ERROR_IF_NOT_OK(
-                graph.BatchDeleteVertices(vids_pair.first, vids_pair.second));
+                graph.BatchDeleteVertices(sl_vertex_column->label(), vids));
+          } else if (vertex_column->vertex_column_type() ==
+                         VertexColumnType::kMultiple ||
+                     vertex_column->vertex_column_type() ==
+                         VertexColumnType::kMultiSegment) {
+            std::unordered_map<label_t, std::vector<vid_t>> vids_map;
+            for (auto label : vertex_column->get_labels_set()) {
+              std::vector<vid_t> vids;
+              vids_map.insert({label, vids});
+            }
+            size_t vertex_size = vertex_column->size();
+            for (size_t j = 0; j < vertex_size; j++) {
+              auto vertex = vertex_column->get_vertex(j);
+              vids_map.at(vertex.label_).emplace_back(vertex.vid_);
+            }
+            for (auto& vids_pair : vids_map) {
+              RETURN_STATUS_ERROR_IF_NOT_OK(
+                  graph.BatchDeleteVertices(vids_pair.first, vids_pair.second));
+            }
+          } else {
+            THROW_RUNTIME_ERROR(
+                "Unsupported vertex column type for batch delete vertex "
+                "operation.");
           }
+          sel_vec_t offsets;
+          chunk.reshuffle(
+              offsets);  // reshuffle with empty offsets to remove all data
         }
-      } else {
-        THROW_RUNTIME_ERROR(
-            "Unsupported vertex column type for batch delete vertex "
-            "operation.");
-      }
-      sel_vec_t offsets;
-      chunk.reshuffle(
-          offsets);  // reshuffle with empty offsets to remove all data
-    }
-    return chunk;
-  });
+        return chunk;
+      });
 }
 
 neug::result<OpBuildResultT> BatchDeleteVertexOprBuilder::Build(

--- a/src/execution/execute/ops/batch/batch_delete_vertex.cc
+++ b/src/execution/execute/ops/batch/batch_delete_vertex.cc
@@ -17,6 +17,8 @@
 #include "neug/common/columns/edge_columns.h"
 #include "neug/common/columns/vertex_columns.h"
 
+#include <unordered_set>
+
 namespace neug {
 namespace execution {
 namespace ops {
@@ -43,6 +45,7 @@ neug::result<Context> BatchDeleteVertexOpr::Eval(
     IStorageInterface& graph_interface, const ParamsMap& params, Context&& ctx,
     OprTimer* timer) {
   auto& graph = dynamic_cast<StorageUpdateInterface&>(graph_interface);
+  std::unordered_map<label_t, std::unordered_set<vid_t>> deleted_vids;
   return ctx.apply_chunks(
       [&](ContextChunk&& chunk) -> neug::result<ContextChunk> {
         size_t binding_size = vertex_bindings_.size();
@@ -54,12 +57,17 @@ neug::result<Context> BatchDeleteVertexOpr::Eval(
               VertexColumnType::kSingle) {
             auto sl_vertex_column =
                 std::dynamic_pointer_cast<SLVertexColumn>(vertex_column);
+            const auto label = sl_vertex_column->label();
             std::vector<vid_t> vids;
             for (auto v : sl_vertex_column->vertices()) {
-              vids.emplace_back(v);
+              if (deleted_vids[label].insert(v).second) {
+                vids.emplace_back(v);
+              }
             }
-            RETURN_STATUS_ERROR_IF_NOT_OK(
-                graph.BatchDeleteVertices(sl_vertex_column->label(), vids));
+            if (!vids.empty()) {
+              RETURN_STATUS_ERROR_IF_NOT_OK(
+                  graph.BatchDeleteVertices(label, vids));
+            }
           } else if (vertex_column->vertex_column_type() ==
                          VertexColumnType::kMultiple ||
                      vertex_column->vertex_column_type() ==
@@ -72,11 +80,15 @@ neug::result<Context> BatchDeleteVertexOpr::Eval(
             size_t vertex_size = vertex_column->size();
             for (size_t j = 0; j < vertex_size; j++) {
               auto vertex = vertex_column->get_vertex(j);
-              vids_map.at(vertex.label_).emplace_back(vertex.vid_);
+              if (deleted_vids[vertex.label_].insert(vertex.vid_).second) {
+                vids_map.at(vertex.label_).emplace_back(vertex.vid_);
+              }
             }
             for (auto& vids_pair : vids_map) {
-              RETURN_STATUS_ERROR_IF_NOT_OK(
-                  graph.BatchDeleteVertices(vids_pair.first, vids_pair.second));
+              if (!vids_pair.second.empty()) {
+                RETURN_STATUS_ERROR_IF_NOT_OK(graph.BatchDeleteVertices(
+                    vids_pair.first, vids_pair.second));
+              }
             }
           } else {
             THROW_RUNTIME_ERROR(

--- a/src/execution/execute/ops/batch/batch_delete_vertex.cc
+++ b/src/execution/execute/ops/batch/batch_delete_vertex.cc
@@ -46,61 +46,59 @@ neug::result<Context> BatchDeleteVertexOpr::Eval(
     OprTimer* timer) {
   auto& graph = dynamic_cast<StorageUpdateInterface&>(graph_interface);
   std::unordered_map<label_t, std::unordered_set<vid_t>> deleted_vids;
-  return ctx.apply_chunks(
-      [&](ContextChunk&& chunk) -> neug::result<ContextChunk> {
-        size_t binding_size = vertex_bindings_.size();
-        for (size_t i = 0; i < binding_size; i++) {
-          int32_t alias = vertex_bindings_[i];
-          auto vertex_column =
-              std::dynamic_pointer_cast<IVertexColumn>(chunk.get(alias));
-          if (vertex_column->vertex_column_type() ==
-              VertexColumnType::kSingle) {
-            auto sl_vertex_column =
-                std::dynamic_pointer_cast<SLVertexColumn>(vertex_column);
-            const auto label = sl_vertex_column->label();
-            std::vector<vid_t> vids;
-            for (auto v : sl_vertex_column->vertices()) {
-              if (deleted_vids[label].insert(v).second) {
-                vids.emplace_back(v);
-              }
-            }
-            if (!vids.empty()) {
-              RETURN_STATUS_ERROR_IF_NOT_OK(
-                  graph.BatchDeleteVertices(label, vids));
-            }
-          } else if (vertex_column->vertex_column_type() ==
-                         VertexColumnType::kMultiple ||
-                     vertex_column->vertex_column_type() ==
-                         VertexColumnType::kMultiSegment) {
-            std::unordered_map<label_t, std::vector<vid_t>> vids_map;
-            for (auto label : vertex_column->get_labels_set()) {
-              std::vector<vid_t> vids;
-              vids_map.insert({label, vids});
-            }
-            size_t vertex_size = vertex_column->size();
-            for (size_t j = 0; j < vertex_size; j++) {
-              auto vertex = vertex_column->get_vertex(j);
-              if (deleted_vids[vertex.label_].insert(vertex.vid_).second) {
-                vids_map.at(vertex.label_).emplace_back(vertex.vid_);
-              }
-            }
-            for (auto& vids_pair : vids_map) {
-              if (!vids_pair.second.empty()) {
-                RETURN_STATUS_ERROR_IF_NOT_OK(graph.BatchDeleteVertices(
-                    vids_pair.first, vids_pair.second));
-              }
-            }
-          } else {
-            THROW_RUNTIME_ERROR(
-                "Unsupported vertex column type for batch delete vertex "
-                "operation.");
+  return ctx.apply_chunks([&](ContextChunk&& chunk)
+                              -> neug::result<ContextChunk> {
+    size_t binding_size = vertex_bindings_.size();
+    for (size_t i = 0; i < binding_size; i++) {
+      int32_t alias = vertex_bindings_[i];
+      auto vertex_column =
+          std::dynamic_pointer_cast<IVertexColumn>(chunk.get(alias));
+      if (vertex_column->vertex_column_type() == VertexColumnType::kSingle) {
+        auto sl_vertex_column =
+            std::dynamic_pointer_cast<SLVertexColumn>(vertex_column);
+        const auto label = sl_vertex_column->label();
+        std::vector<vid_t> vids;
+        for (auto v : sl_vertex_column->vertices()) {
+          if (deleted_vids[label].insert(v).second) {
+            vids.emplace_back(v);
           }
-          sel_vec_t offsets;
-          chunk.reshuffle(
-              offsets);  // reshuffle with empty offsets to remove all data
         }
-        return chunk;
-      });
+        if (!vids.empty()) {
+          RETURN_STATUS_ERROR_IF_NOT_OK(graph.BatchDeleteVertices(label, vids));
+        }
+      } else if (vertex_column->vertex_column_type() ==
+                     VertexColumnType::kMultiple ||
+                 vertex_column->vertex_column_type() ==
+                     VertexColumnType::kMultiSegment) {
+        std::unordered_map<label_t, std::vector<vid_t>> vids_map;
+        for (auto label : vertex_column->get_labels_set()) {
+          std::vector<vid_t> vids;
+          vids_map.insert({label, vids});
+        }
+        size_t vertex_size = vertex_column->size();
+        for (size_t j = 0; j < vertex_size; j++) {
+          auto vertex = vertex_column->get_vertex(j);
+          if (deleted_vids[vertex.label_].insert(vertex.vid_).second) {
+            vids_map.at(vertex.label_).emplace_back(vertex.vid_);
+          }
+        }
+        for (auto& vids_pair : vids_map) {
+          if (!vids_pair.second.empty()) {
+            RETURN_STATUS_ERROR_IF_NOT_OK(
+                graph.BatchDeleteVertices(vids_pair.first, vids_pair.second));
+          }
+        }
+      } else {
+        THROW_RUNTIME_ERROR(
+            "Unsupported vertex column type for batch delete vertex "
+            "operation.");
+      }
+      sel_vec_t offsets;
+      chunk.reshuffle(
+          offsets);  // reshuffle with empty offsets to remove all data
+    }
+    return chunk;
+  });
 }
 
 neug::result<OpBuildResultT> BatchDeleteVertexOprBuilder::Build(

--- a/src/storages/graph/property_graph.cc
+++ b/src/storages/graph/property_graph.cc
@@ -726,14 +726,16 @@ Status PropertyGraph::DeleteVertex(label_t label, const Value& oid,
   RETURN_IF_NOT_OK(vertex_label_check(label));
   vid_t lid;
   if (!vertex_tables_.at(label).get_index(oid, lid, ts)) {
-    return Status(StatusCode::ERR_INVALID_ARGUMENT,
-                  "Vertex oid does not exist.");
+    return Status::OK();
   }
   return DeleteVertex(label, lid, ts);
 }
 
 Status PropertyGraph::DeleteVertex(label_t label, vid_t lid, timestamp_t ts) {
   RETURN_IF_NOT_OK(vertex_label_check(label));
+  if (!IsValidLid(label, lid, ts)) {
+    return Status::OK();
+  }
   for (label_t i = 0; i < vertex_label_total_count_; i++) {
     if (!schema_.is_vertex_label_valid(i)) {
       continue;

--- a/src/transaction/cow_graph_storage.cc
+++ b/src/transaction/cow_graph_storage.cc
@@ -720,8 +720,7 @@ Status CowGraphStorage::AddVertexImpl(label_t label, const Value& oid,
 
 Status CowGraphStorage::DeleteVertexImpl(label_t label, vid_t lid) {
   if (!graph_.IsValidLid(label, lid, read_ts_)) {
-    return Status(StatusCode::ERR_INVALID_ARGUMENT,
-                  "Vertex id is out of range or already deleted");
+    return Status::OK();
   }
   auto oid = graph_.GetOid(label, lid, read_ts_);
 

--- a/tests/storage/test_property_graph.cc
+++ b/tests/storage/test_property_graph.cc
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+#include <limits>
+
 #include <gtest/gtest.h>
 
 #include "neug/common/types/value.h"
@@ -155,6 +157,33 @@ TEST_F(PropertyGraphTest, TestOpenAndBulkInsert) {
                                MAX_TIMESTAMP, allocator, oe_offset, prop)
                      .ok());
   }
+}
+
+TEST_F(PropertyGraphTest, DeleteMissingVerticesIsNoOp) {
+  CreateModernGraphSchema();
+  const auto person_label = graph_->schema().get_vertex_label_id("person");
+  vid_t alice_vid;
+  ASSERT_TRUE(graph_
+                  ->AddVertex(person_label, Value::INT64(1),
+                              {Value::STRING("Alice"), Value::INT32(30),
+                               Value::DOUBLE(88.5)},
+                              alice_vid, MAX_TIMESTAMP)
+                  .ok());
+
+  const auto missing_vid = std::numeric_limits<vid_t>::max();
+  EXPECT_TRUE(
+      graph_->DeleteVertex(person_label, Value::INT64(2), MAX_TIMESTAMP).ok());
+  EXPECT_TRUE(
+      graph_->DeleteVertex(person_label, missing_vid, MAX_TIMESTAMP).ok());
+  EXPECT_TRUE(graph_
+                  ->BatchDeleteVertices(person_label,
+                                        {alice_vid, alice_vid, missing_vid})
+                  .ok());
+  EXPECT_TRUE(
+      graph_->DeleteVertex(person_label, alice_vid, MAX_TIMESTAMP).ok());
+  EXPECT_TRUE(
+      graph_->DeleteVertex(person_label, Value::INT64(1), MAX_TIMESTAMP).ok());
+  EXPECT_EQ(graph_->VertexNum(person_label), 0);
 }
 
 }  // namespace neug

--- a/tests/transaction/test_snapshot_cow_write_transaction.cc
+++ b/tests/transaction/test_snapshot_cow_write_transaction.cc
@@ -3070,7 +3070,8 @@ TEST_F(SnapshotCowWriteTransactionTest, BatchDeleteEdges) {
   db.Close();
 }
 
-TEST_F(SnapshotCowWriteTransactionTest, BatchDeleteVerticesFailure) {
+TEST_F(SnapshotCowWriteTransactionTest,
+       DeleteVerticesIgnoresMissingAndAlreadyDeletedVertices) {
   neug::NeugDB db;
   neug::NeugDBConfig config(db_dir);
   config.memory_level = neug::MemoryLevel::kInMemory;
@@ -3086,17 +3087,20 @@ TEST_F(SnapshotCowWriteTransactionTest, BatchDeleteVerticesFailure) {
     EXPECT_TRUE(
         txn.GetVertexIndex(person_label, neug::Value::INT64(1), alice_vid));
     auto invalid_vid = std::numeric_limits<neug::vid_t>::max();
-    EXPECT_FALSE(
-        interface.BatchDeleteVertices(person_label, {alice_vid, invalid_vid})
-            .ok());
-    txn.Abort();
+    EXPECT_TRUE(interface
+                    .BatchDeleteVertices(person_label,
+                                         {alice_vid, alice_vid, invalid_vid})
+                    .ok());
+    EXPECT_TRUE(interface.DeleteVertex(person_label, alice_vid).ok());
+    EXPECT_TRUE(interface.DeleteVertex(person_label, invalid_vid).ok());
+    EXPECT_TRUE(txn.Commit());
   }
   {
     auto slot = svc->AcquireExecutionSlot();
     auto txn = slot->BeginSnapshotReadTransaction();
     neug::StorageReadInterface gi(txn.view(), txn.timestamp());
     auto person_label = gi.schema().get_vertex_label_id("person");
-    EXPECT_EQ(count_vertices(gi, person_label), 2);
+    EXPECT_EQ(count_vertices(gi, person_label), 1);
   }
   svc.reset();
   db.Close();

--- a/tools/python_bind/tests/test_dml.py
+++ b/tools/python_bind/tests/test_dml.py
@@ -410,6 +410,38 @@ def test_delete_vertex_detach_edge(tmp_path):
     db.close()
 
 
+# Regression test for issue #965: an undirected edge expansion emits the same
+# target twice. DETACH DELETE must de-duplicate vertex IDs before batch delete.
+def test_detach_delete_after_undirected_match(tmp_path):
+    db_dir = tmp_path / "detach_delete_after_undirected_match"
+    db = Database(db_path=str(db_dir), mode="w")
+    conn = db.connect()
+    try:
+        conn.execute(
+            "CREATE NODE TABLE Entity (uuid STRING, group_id STRING, PRIMARY KEY(uuid));"
+        )
+        conn.execute("CREATE NODE TABLE EdgeDoc (uuid STRING, PRIMARY KEY(uuid));")
+        conn.execute(
+            "CREATE REL TABLE RELATES_TO (FROM Entity TO Entity, uuid STRING);"
+        )
+        conn.execute("CREATE (a:Entity {uuid: 'a', group_id: 'g'});")
+        conn.execute("CREATE (b:Entity {uuid: 'b', group_id: 'g'});")
+        conn.execute("CREATE (d:EdgeDoc {uuid: 'e1'});")
+        conn.execute(
+            "MATCH (a:Entity {uuid: 'a'}), (b:Entity {uuid: 'b'}) "
+            "CREATE (a)-[:RELATES_TO {uuid: 'e1'}]->(b);"
+        )
+        conn.execute(
+            "MATCH (n:Entity {group_id: 'g'})-[e:RELATES_TO]-(m:Entity), "
+            "(d:EdgeDoc {uuid: e.uuid}) DETACH DELETE d;"
+        )
+
+        assert list(conn.execute("MATCH (d:EdgeDoc) RETURN d.uuid;")) == []
+    finally:
+        conn.close()
+        db.close()
+
+
 def test_delete_vertex_detach_edge2(tmp_path):
     db_dir = str(tmp_path / "test_delete_vertex_detach_edge2")
     logger.info("Starting test_delete_vertex_detach_edge2")

--- a/tools/python_bind/tests/test_dml.py
+++ b/tools/python_bind/tests/test_dml.py
@@ -411,7 +411,7 @@ def test_delete_vertex_detach_edge(tmp_path):
 
 
 # Regression test for issue #965: an undirected edge expansion emits the same
-# target twice. DETACH DELETE must de-duplicate vertex IDs before batch delete.
+# target twice. DETACH DELETE succeeds because vertex deletion is idempotent.
 def test_detach_delete_after_undirected_match(tmp_path):
     db_dir = tmp_path / "detach_delete_after_undirected_match"
     db = Database(db_path=str(db_dir), mode="w")


### PR DESCRIPTION
## Summary

Fix #965

- Make public vertex deletion idempotent: with a valid vertex label, deleting a missing or already-deleted vertex is a successful no-op.
- Apply the same contract to CowGraphStorage and the OID, VID, and batch entry points of PropertyGraph.
- Keep BatchDeleteVertexOpr stateless; it forwards duplicate IDs to storage.
- Add storage, transactional, and Python end-to-end regressions.

## Root cause

An undirected edge expansion can emit the same target vertex more than once. Storage previously rejected the second deletion as invalid, so DETACH DELETE failed even though the requested end state had already been reached.