### PR TITLE
test: cover fixed array direct indexing

### DIFF
--- a/tools/python_bind/tests/test_db_array.py
+++ b/tools/python_bind/tests/test_db_array.py
@@ -700,8 +700,7 @@ def test_list_and_array_index_supported(tmp_path):
     conn.execute("CREATE (s:Sensor {id: 1, readings: [10, 20, 30]});")
     rows = list(
         conn.execute(
-            "MATCH (s:Sensor) "
-            "RETURN s.readings[0], s.readings[1], s.readings[2];"
+            "MATCH (s:Sensor) " "RETURN s.readings[0], s.readings[1], s.readings[2];"
         )
     )
     assert tuple(rows[0]) == (10, 20, 30)

--- a/tools/python_bind/tests/test_db_array.py
+++ b/tools/python_bind/tests/test_db_array.py
@@ -698,8 +698,13 @@ def test_list_and_array_index_supported(tmp_path):
         "CREATE NODE TABLE Sensor(id INT64, readings INT32[3], PRIMARY KEY(id));"
     )
     conn.execute("CREATE (s:Sensor {id: 1, readings: [10, 20, 30]});")
-    res = list(conn.execute("MATCH (s:Sensor) RETURN s.readings[2];"))
-    assert res[0][0] == 30
+    rows = list(
+        conn.execute(
+            "MATCH (s:Sensor) "
+            "RETURN s.readings[0], s.readings[1], s.readings[2];"
+        )
+    )
+    assert tuple(rows[0]) == (10, 20, 30)
 
     conn.close()
     db.close()


### PR DESCRIPTION
## What do these changes do?

Extend the existing execution test for list and fixed-size ARRAY indexing to verify direct access to the first, middle, and last ARRAY elements. This specifically covers the `property[0]` behavior requested by the issue.

## Related issue number

Fixes #600

## Testing

- `python3 -m pytest -q tools/python_bind/tests/test_db_array.py::test_list_and_array_index_supported`