### PR TITLE
fix: support branch-local LIMIT in UNION ALL

### DIFF
--- a/src/compiler/gopt/g_alias_manager.cpp
+++ b/src/compiler/gopt/g_alias_manager.cpp
@@ -151,6 +151,7 @@ void GAliasManager::extractGAliasNames(
   case planner::LogicalOperatorType::FILTER:
   case planner::LogicalOperatorType::ORDER_BY:
   case planner::LogicalOperatorType::LIMIT:
+  case planner::LogicalOperatorType::MULTIPLICITY_REDUCER:
   case planner::LogicalOperatorType::SET_PROPERTY:
   case planner::LogicalOperatorType::DELETE_OP:
   case planner::LogicalOperatorType::INSERT: {
@@ -180,7 +181,6 @@ void GAliasManager::extractGAliasNames(
   case planner::LogicalOperatorType::CREATE_TABLE:
   case planner::LogicalOperatorType::INDEX_LOOK_UP:
   case planner::LogicalOperatorType::PARTITIONER:
-  case planner::LogicalOperatorType::MULTIPLICITY_REDUCER:
   case planner::LogicalOperatorType::DUMMY_SCAN:
   case planner::LogicalOperatorType::FLATTEN:
   case planner::LogicalOperatorType::ACCUMULATE:

--- a/src/compiler/gopt/g_query_converter.cpp
+++ b/src/compiler/gopt/g_query_converter.cpp
@@ -107,8 +107,11 @@ std::unique_ptr<::physical::PhysicalPlan> GQueryConvertor::convert(
     auto sink = std::make_unique<::physical::Sink>();
     auto lastOp = plan.getLastOperator();
     if (lastOp->getOperatorType() == planner::LogicalOperatorType::UNION_ALL) {
-      auto schema = lastOp->getSchema();
-      NEUG_ASSERT(schema);
+      auto* schema = lastOp->getSchema();
+      if (schema == nullptr) {
+        THROW_EXCEPTION_WITH_FILE_LINE(
+            "Cannot build UNION ALL physical plan: output schema is not set");
+      }
       for (const auto& expr : schema->getExpressionsInScope()) {
         auto tag = sink->add_tags();
         tag->mutable_tag()->set_value(
@@ -2376,9 +2379,17 @@ void GQueryConvertor::convertUnion(const planner::LogicalUnion& unionOp,
       THROW_EXCEPTION_WITH_FILE_LINE(
           "Union operator should have at least one sub query");
     }
+    ++subQueryOffset;
+  }
+  const auto subQueryCount = unionOp.getNumChildren() - subQueryOffset;
+  if (subQueryCount != 2) {
+    THROW_NOT_SUPPORTED_EXCEPTION(
+        "UNION ALL currently supports exactly two branches; got " +
+        std::to_string(subQueryCount));
+  }
+  if (unionOp.getPreQuery()) {
     auto preQuery = unionOp.getChild(0);
     convertOperator(*preQuery, plan);
-    ++subQueryOffset;
   }
   auto unionPB = std::make_unique<::physical::Union>();
   for (auto pos = subQueryOffset; pos < unionOp.getNumChildren(); ++pos) {

--- a/src/compiler/gopt/g_query_converter.cpp
+++ b/src/compiler/gopt/g_query_converter.cpp
@@ -111,9 +111,8 @@ std::unique_ptr<::physical::PhysicalPlan> GQueryConvertor::convert(
       NEUG_ASSERT(schema);
       for (const auto& expr : schema->getExpressionsInScope()) {
         auto tag = sink->add_tags();
-        auto alias = std::make_unique<::google::protobuf::Int32Value>();
-        alias->set_value(aliasManager->getAliasId(expr->getUniqueName()));
-        tag->set_allocated_tag(alias.release());
+        tag->mutable_tag()->set_value(
+            aliasManager->getAliasId(expr->getUniqueName()));
       }
     }
     auto physicalOpr = std::make_unique<::physical::PhysicalOpr>();

--- a/src/compiler/gopt/g_query_converter.cpp
+++ b/src/compiler/gopt/g_query_converter.cpp
@@ -105,6 +105,17 @@ std::unique_ptr<::physical::PhysicalPlan> GQueryConvertor::convert(
   convertOperator(*plan.getLastOperator(), planPB.get());
   if (!skipSink) {
     auto sink = std::make_unique<::physical::Sink>();
+    auto lastOp = plan.getLastOperator();
+    if (lastOp->getOperatorType() == planner::LogicalOperatorType::UNION_ALL) {
+      auto schema = lastOp->getSchema();
+      NEUG_ASSERT(schema);
+      for (const auto& expr : schema->getExpressionsInScope()) {
+        auto tag = sink->add_tags();
+        auto alias = std::make_unique<::google::protobuf::Int32Value>();
+        alias->set_value(aliasManager->getAliasId(expr->getUniqueName()));
+        tag->set_allocated_tag(alias.release());
+      }
+    }
     auto physicalOpr = std::make_unique<::physical::PhysicalOpr>();
     auto oprPB = std::make_unique<::physical::PhysicalOpr_Operator>();
     oprPB->set_allocated_sink(sink.release());

--- a/src/execution/execute/ops/retrieve/union.cc
+++ b/src/execution/execute/ops/retrieve/union.cc
@@ -85,7 +85,6 @@ neug::result<OpBuildResultT> UnionOprBuilder::Build(
     const physical::PhysicalPlan& plan, int op_idx) {
   std::vector<Pipeline> sub_plans;
   std::vector<ContextMeta> sub_metas;
-  ContextMeta ret_meta = ctx_meta;
   for (int i = 0; i < plan.plan(op_idx).opr().union_().sub_plans_size(); ++i) {
     auto& sub_plan = plan.plan(op_idx).opr().union_().sub_plans(i);
     auto pair_res = PlanParser::get().parse_execute_pipeline_with_meta(
@@ -96,6 +95,11 @@ neug::result<OpBuildResultT> UnionOprBuilder::Build(
     auto pair = std::move(pair_res.value());
     sub_plans.emplace_back(std::move(pair.first));
     sub_metas.push_back(pair.second);
+  }
+
+  ContextMeta ret_meta = ctx_meta;
+  if (!sub_metas.empty()) {
+    ret_meta = sub_metas.front();
   }
 
   return std::make_pair(std::make_unique<UnionOpr>(std::move(sub_plans)),

--- a/src/execution/execute/ops/retrieve/union.cc
+++ b/src/execution/execute/ops/retrieve/union.cc
@@ -83,14 +83,21 @@ class UnionOpr : public IOperator {
 neug::result<OpBuildResultT> UnionOprBuilder::Build(
     const neug::Schema& schema, const ContextMeta& ctx_meta,
     const physical::PhysicalPlan& plan, int op_idx) {
+  const auto& union_op = plan.plan(op_idx).opr().union_();
+  if (union_op.sub_plans_size() != 2) {
+    RETURN_UNSUPPORTED_ERROR(
+        "Union: exactly two sub-plans are supported, got " +
+        std::to_string(union_op.sub_plans_size()));
+  }
+
   std::vector<Pipeline> sub_plans;
   std::vector<ContextMeta> sub_metas;
-  for (int i = 0; i < plan.plan(op_idx).opr().union_().sub_plans_size(); ++i) {
-    auto& sub_plan = plan.plan(op_idx).opr().union_().sub_plans(i);
+  for (int i = 0; i < union_op.sub_plans_size(); ++i) {
+    const auto& sub_plan = union_op.sub_plans(i);
     auto pair_res = PlanParser::get().parse_execute_pipeline_with_meta(
         schema, ctx_meta, sub_plan);
     if (!pair_res) {
-      return std::make_pair(nullptr, ContextMeta());
+      RETURN_ERROR(pair_res.error());
     }
     auto pair = std::move(pair_res.value());
     sub_plans.emplace_back(std::move(pair.first));
@@ -100,6 +107,24 @@ neug::result<OpBuildResultT> UnionOprBuilder::Build(
   ContextMeta ret_meta = ctx_meta;
   if (!sub_metas.empty()) {
     ret_meta = sub_metas.front();
+    const auto& expected_columns = ret_meta.columns();
+    for (size_t i = 1; i < sub_metas.size(); ++i) {
+      const auto& actual_columns = sub_metas[i].columns();
+      bool aliases_match = actual_columns.size() == expected_columns.size();
+      if (aliases_match) {
+        for (const auto& column : expected_columns) {
+          if (actual_columns.find(column.first) == actual_columns.end()) {
+            aliases_match = false;
+            break;
+          }
+        }
+      }
+      if (!aliases_match) {
+        RETURN_STATUS_ERROR(neug::StatusCode::ERR_SCHEMA_MISMATCH,
+                            "Union: output aliases of branch " +
+                                std::to_string(i) + " do not match branch 0");
+      }
+    }
   }
 
   return std::make_pair(std::make_unique<UnionOpr>(std::move(sub_plans)),

--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -14,6 +14,7 @@ add_neug_test(
 	explain_test.cpp
 	project_test.cpp
 	result_test.cpp
+	union_test.cpp
 	# cyclic_test.cpp
 	lsqb_test.cpp
 	# TODO: enable the test after the match order of BI is ready

--- a/tests/compiler/union_test.cpp
+++ b/tests/compiler/union_test.cpp
@@ -1,0 +1,152 @@
+/**
+ * Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gopt_test.h"
+
+#include "neug/execution/common/context.h"
+#include "neug/execution/execute/ops/retrieve/union.h"
+#include "neug/execution/execute/plan_parser.h"
+
+namespace neug {
+namespace gopt {
+
+namespace {
+
+int findUnionOperator(const physical::PhysicalPlan& plan) {
+  for (int i = 0; i < plan.plan_size(); ++i) {
+    if (plan.plan(i).opr().has_union_()) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+physical::Project* findLastProject(physical::PhysicalPlan* plan) {
+  for (int i = plan->plan_size() - 1; i >= 0; --i) {
+    auto* opr = plan->mutable_plan(i)->mutable_opr();
+    if (opr->has_project()) {
+      return opr->mutable_project();
+    }
+  }
+  return nullptr;
+}
+
+class UnionMetaTest : public GOptTest {
+ public:
+  static void SetUpTestSuite() { execution::PlanParser::get().init(); }
+};
+
+TEST_F(UnionMetaTest, ReturnsFirstBranchOutputMeta) {
+  auto logical =
+      planLogical("RETURN 1 AS id LIMIT 1 UNION ALL RETURN 2 AS id LIMIT 1");
+  auto physical = planPhysical(*logical);
+  const int union_idx = findUnionOperator(*physical);
+  ASSERT_GE(union_idx, 0);
+
+  auto* union_op =
+      physical->mutable_plan(union_idx)->mutable_opr()->mutable_union_();
+  ASSERT_EQ(union_op->sub_plans_size(), 2);
+  auto* first_project = findLastProject(union_op->mutable_sub_plans(0));
+  ASSERT_NE(first_project, nullptr);
+  ASSERT_EQ(first_project->mappings_size(), 1);
+  ASSERT_TRUE(first_project->mappings(0).has_alias());
+  const int expected_alias = first_project->mappings(0).alias().value();
+
+  execution::ops::UnionOprBuilder builder;
+  auto result = builder.Build(currentSchema, execution::ContextMeta(),
+                              *physical, union_idx);
+
+  ASSERT_TRUE(result) << result.error().ToString();
+  ASSERT_NE(result.value().first, nullptr);
+  EXPECT_EQ(result.value().second.columns().size(), 1);
+  EXPECT_TRUE(result.value().second.exist(expected_alias));
+}
+
+TEST_F(UnionMetaTest, RejectsDifferentBranchOutputAliases) {
+  auto logical =
+      planLogical("RETURN 1 AS id LIMIT 1 UNION ALL RETURN 2 AS id LIMIT 1");
+  auto physical = planPhysical(*logical);
+  const int union_idx = findUnionOperator(*physical);
+  ASSERT_GE(union_idx, 0);
+
+  auto* union_op =
+      physical->mutable_plan(union_idx)->mutable_opr()->mutable_union_();
+  ASSERT_EQ(union_op->sub_plans_size(), 2);
+  auto* first_project = findLastProject(union_op->mutable_sub_plans(0));
+  auto* second_project = findLastProject(union_op->mutable_sub_plans(1));
+  ASSERT_NE(first_project, nullptr);
+  ASSERT_NE(second_project, nullptr);
+  ASSERT_EQ(first_project->mappings_size(), 1);
+  ASSERT_EQ(second_project->mappings_size(), 1);
+  ASSERT_TRUE(first_project->mappings(0).has_alias());
+  ASSERT_TRUE(second_project->mappings(0).has_alias());
+
+  const int first_alias = first_project->mappings(0).alias().value();
+  second_project->mutable_mappings(0)->mutable_alias()->set_value(first_alias +
+                                                                  1);
+
+  execution::ops::UnionOprBuilder builder;
+  auto result = builder.Build(currentSchema, execution::ContextMeta(),
+                              *physical, union_idx);
+
+  ASSERT_FALSE(result);
+  EXPECT_EQ(result.error().error_code(), neug::StatusCode::ERR_SCHEMA_MISMATCH);
+  EXPECT_NE(result.error().error_message().find(
+                "output aliases of branch 1 do not match branch 0"),
+            std::string::npos);
+}
+
+TEST_F(UnionMetaTest, RejectsMoreThanTwoBranchesDuringConversion) {
+  auto logical = planLogical(
+      "RETURN 1 AS id UNION ALL RETURN 2 AS id UNION ALL RETURN 3 AS id");
+
+  try {
+    auto physical = planPhysical(*logical);
+    FAIL() << "Expected conversion to reject an N-ary UNION ALL";
+  } catch (const exception::NotSupportedException& e) {
+    EXPECT_NE(std::string(e.what()).find(
+                  "UNION ALL currently supports exactly two branches; got 3"),
+              std::string::npos);
+  }
+}
+
+TEST_F(UnionMetaTest, RejectsPhysicalPlanWithMoreThanTwoSubPlans) {
+  auto logical = planLogical("RETURN 1 AS id UNION ALL RETURN 2 AS id");
+  auto physical = planPhysical(*logical);
+  const int union_idx = findUnionOperator(*physical);
+  ASSERT_GE(union_idx, 0);
+
+  auto* union_op =
+      physical->mutable_plan(union_idx)->mutable_opr()->mutable_union_();
+  ASSERT_EQ(union_op->sub_plans_size(), 2);
+  physical::PhysicalPlan third_sub_plan = union_op->sub_plans(0);
+  union_op->add_sub_plans()->CopyFrom(third_sub_plan);
+
+  execution::ops::UnionOprBuilder builder;
+  auto result = builder.Build(currentSchema, execution::ContextMeta(),
+                              *physical, union_idx);
+
+  ASSERT_FALSE(result);
+  EXPECT_EQ(result.error().error_code(), neug::StatusCode::ERR_NOT_SUPPORTED);
+  EXPECT_NE(result.error().error_message().find(
+                "exactly two sub-plans are supported, got 3"),
+            std::string::npos);
+}
+
+}  // namespace
+
+}  // namespace gopt
+}  // namespace neug

--- a/tools/python_bind/tests/test_query.py
+++ b/tools/python_bind/tests/test_query.py
@@ -423,35 +423,40 @@ def test_union_all_remains_supported(empty_db):
 
 def _create_union_all_limit_data(conn):
     conn.execute(
-        "CREATE NODE TABLE Person(id INT64, PRIMARY KEY(id));",
+        "CREATE NODE TABLE Person(id INT64, name STRING, PRIMARY KEY(id));",
         access_mode="schema",
     )
     conn.execute(
-        "CREATE NODE TABLE Animal(id INT64, PRIMARY KEY(id));",
+        "CREATE NODE TABLE Animal(id INT64, name STRING, PRIMARY KEY(id));",
         access_mode="schema",
     )
-    for person_id in (1, 2):
-        conn.execute(f"CREATE (:Person {{id: {person_id}}});", access_mode="update")
-    for animal_id in (10, 20):
-        conn.execute(f"CREATE (:Animal {{id: {animal_id}}});", access_mode="update")
+    for person_id, name in ((1, "Alice"), (2, "Bob")):
+        conn.execute(
+            f"CREATE (:Person {{id: {person_id}, name: '{name}'}});",
+            access_mode="update",
+        )
+    for animal_id, name in ((10, "Cat"), (20, "Dog")):
+        conn.execute(
+            f"CREATE (:Animal {{id: {animal_id}, name: '{name}'}});",
+            access_mode="update",
+        )
 
 
 @pytest.mark.parametrize(
-    "person_limit, animal_limit, expected_persons, expected_animals",
+    "person_suffix, animal_suffix, expected_persons, expected_animals",
     [
-        (True, True, 1, 1),
-        (True, False, 1, 2),
-        (False, True, 2, 1),
+        (" LIMIT 1", " LIMIT 1", 1, 1),
+        (" LIMIT 1", "", 1, 2),
+        ("", " LIMIT 1", 2, 1),
+        (" SKIP 1", "", 1, 2),
     ],
 )
-def test_union_all_with_branch_local_limit(
-    empty_db, person_limit, animal_limit, expected_persons, expected_animals
+def test_union_all_with_branch_local_skip_or_limit(
+    empty_db, person_suffix, animal_suffix, expected_persons, expected_animals
 ):
     _, conn = empty_db
     _create_union_all_limit_data(conn)
 
-    person_suffix = " LIMIT 1" if person_limit else ""
-    animal_suffix = " LIMIT 1" if animal_limit else ""
     result = conn.execute(
         "MATCH (p:Person) RETURN p.id AS id"
         + person_suffix
@@ -464,6 +469,26 @@ def test_union_all_with_branch_local_limit(
     values = [row[0] for row in result]
     assert sum(value < 10 for value in values) == expected_persons
     assert sum(value >= 10 for value in values) == expected_animals
+
+
+def test_union_all_with_branch_local_limit_preserves_column_order(empty_db):
+    _, conn = empty_db
+    _create_union_all_limit_data(conn)
+
+    result = conn.execute(
+        "MATCH (p:Person) RETURN p.id AS id, p.name AS name LIMIT 1 "
+        "UNION ALL "
+        "MATCH (a:Animal) RETURN a.id AS id, a.name AS name LIMIT 1",
+        access_mode="read",
+    )
+
+    assert result.column_names() == ["id", "name"]
+    rows = list(result)
+    assert len(rows) == 2
+    expected_rows = {(1, "Alice"), (2, "Bob"), (10, "Cat"), (20, "Dog")}
+    assert all(tuple(row) in expected_rows for row in rows)
+    assert sum(row[0] < 10 for row in rows) == 1
+    assert sum(row[0] >= 10 for row in rows) == 1
 
 
 def test_union_all_with_branch_local_limit_validates_logical_types(empty_db):
@@ -485,7 +510,9 @@ def test_union_all_with_branch_local_limit_validates_logical_types(empty_db):
             access_mode="read",
         )
 
-    assert str(ERR_COMPILATION) in str(excinfo.value)
+    message = str(excinfo.value)
+    assert str(ERR_COMPILATION) in message
+    assert "id has data type VARCHAR but INT64 was expected" in message
 
 
 def test_result(modern_graph):

--- a/tools/python_bind/tests/test_query.py
+++ b/tools/python_bind/tests/test_query.py
@@ -418,6 +418,74 @@ def test_union_all_remains_supported(empty_db):
 
     assert len(result) == 4
     assert len(result.column_names()) == 1
+    assert sorted(row[0] for row in result) == ["Alice", "Alice", "Bob", "Bob"]
+
+
+def _create_union_all_limit_data(conn):
+    conn.execute(
+        "CREATE NODE TABLE Person(id INT64, PRIMARY KEY(id));",
+        access_mode="schema",
+    )
+    conn.execute(
+        "CREATE NODE TABLE Animal(id INT64, PRIMARY KEY(id));",
+        access_mode="schema",
+    )
+    for person_id in (1, 2):
+        conn.execute(f"CREATE (:Person {{id: {person_id}}});", access_mode="update")
+    for animal_id in (10, 20):
+        conn.execute(f"CREATE (:Animal {{id: {animal_id}}});", access_mode="update")
+
+
+@pytest.mark.parametrize(
+    "person_limit, animal_limit, expected_persons, expected_animals",
+    [
+        (True, True, 1, 1),
+        (True, False, 1, 2),
+        (False, True, 2, 1),
+    ],
+)
+def test_union_all_with_branch_local_limit(
+    empty_db, person_limit, animal_limit, expected_persons, expected_animals
+):
+    _, conn = empty_db
+    _create_union_all_limit_data(conn)
+
+    person_suffix = " LIMIT 1" if person_limit else ""
+    animal_suffix = " LIMIT 1" if animal_limit else ""
+    result = conn.execute(
+        "MATCH (p:Person) RETURN p.id AS id"
+        + person_suffix
+        + " UNION ALL MATCH (a:Animal) RETURN a.id AS id"
+        + animal_suffix,
+        access_mode="read",
+    )
+
+    assert result.column_names() == ["id"]
+    values = [row[0] for row in result]
+    assert sum(value < 10 for value in values) == expected_persons
+    assert sum(value >= 10 for value in values) == expected_animals
+
+
+def test_union_all_with_branch_local_limit_validates_logical_types(empty_db):
+    _, conn = empty_db
+    conn.execute(
+        "CREATE NODE TABLE Person(id INT64, PRIMARY KEY(id));",
+        access_mode="schema",
+    )
+    conn.execute(
+        "CREATE NODE TABLE Animal(id STRING, PRIMARY KEY(id));",
+        access_mode="schema",
+    )
+
+    with pytest.raises(Exception) as excinfo:
+        conn.execute(
+            "MATCH (p:Person) RETURN p.id AS id LIMIT 1 "
+            "UNION ALL "
+            "MATCH (a:Animal) RETURN a.id AS id LIMIT 1",
+            access_mode="read",
+        )
+
+    assert str(ERR_COMPILATION) in str(excinfo.value)
 
 
 def test_result(modern_graph):


### PR DESCRIPTION
## Summary

Fix `UNION ALL` queries whose branches contain a local `LIMIT`.

Previously, these queries could be parsed and planned successfully but failed while building the physical union pipeline because aliases behind a `MULTIPLICITY_REDUCER` were no longer visible to the physical-plan converter.

## Root cause

`SKIP` and `LIMIT` insert a `MULTIPLICITY_REDUCER` into each affected branch. Alias extraction treated this operator as a leaf, even though it does not create or remove columns and only copies its child schema.

As a result:

- aliases produced below the reducer were not forwarded;
- union subplans could expose stale or inconsistent `ContextMeta`;
- the union sink could reference aliases that were not present in the output context;
- failures surfaced as internal pipeline errors.

## Changes

- Treat `MULTIPLICITY_REDUCER` as an alias-transparent operator by recursively extracting aliases from its child.
- Return the first union branch's output `ContextMeta` instead of the stale input `ContextMeta`.
- Validate that all union branches expose the same physical alias set before building the union operator.
- Preserve subplan parsing errors instead of replacing them with `No operator returned`.
- Populate union sink tags from the logical union output schema, preserving schema column order.
- Replace the Release-disabled schema assertion with an explicit compilation error when the union output schema is missing.
- Reject non-binary `UNION ALL` plans during physical conversion with a clear `ERR_NOT_SUPPORTED` error.

`MULTIPLICITY_REDUCER` is also inserted for projections containing random functions. The alias-transparent handling therefore applies to that planner path as well. `GEN_RANDOM_UUID` is currently declared but not implemented or registered, so an end-to-end test for that path cannot currently be added.

## Scope

This PR adds support for branch-local `LIMIT` and `SKIP` to the currently supported binary `UNION ALL` execution path.

General N-ary `UNION ALL` execution and the pre-query schema issue tracked in #988 remain outside the scope of this PR.