### PR TITLE
feat: use primary key index for IN predicates

### DIFF
--- a/include/neug/compiler/gopt/g_expr_converter.h
+++ b/include/neug/compiler/gopt/g_expr_converter.h
@@ -55,7 +55,8 @@ class GExprConverter {
   std::unique_ptr<::common::Expression> convert(
       const binder::Expression& expr, const planner::LogicalOperator& child);
   std::unique_ptr<::algebra::IndexPredicate> convertPrimaryKey(
-      const std::string& key, const binder::Expression& expr);
+      const std::string& key, const binder::Expression& expr,
+      ::common::Logical compare);
   std::unique_ptr<::common::Expression> convertVar(common::alias_id_t columnId);
   std::unique_ptr<::common::NameOrId> convertAlias(common::alias_id_t aliasId);
   std::unique_ptr<::physical::GroupBy_AggFunc> convertAggFunc(

--- a/include/neug/compiler/planner/operator/scan/logical_scan_node_table.h
+++ b/include/neug/compiler/planner/operator/scan/logical_scan_node_table.h
@@ -7,6 +7,7 @@
 #include "neug/compiler/gopt/g_graph_type.h"
 #include "neug/compiler/planner/operator/logical_operator.h"
 #include "neug/compiler/storage/predicate/column_predicate.h"
+#include "neug/generated/proto/plan/expr.pb.h"
 
 namespace neug {
 namespace planner {
@@ -33,16 +34,18 @@ struct ExtraScanNodeTableInfo {
 
 struct PrimaryKeyScanInfo final : ExtraScanNodeTableInfo {
   std::shared_ptr<binder::Expression> key;
+  ::common::Logical compare;
 
-  explicit PrimaryKeyScanInfo(std::shared_ptr<binder::Expression> key)
-      : key{std::move(key)} {}
+  PrimaryKeyScanInfo(std::shared_ptr<binder::Expression> key,
+                     ::common::Logical compare)
+      : key{std::move(key)}, compare{compare} {}
 
   ExtraScanNodeTableInfoType getType() const override {
     return ExtraScanNodeTableInfoType::PRIMARY_KEY_SCAN;
   }
 
   std::unique_ptr<ExtraScanNodeTableInfo> copy() const override {
-    return std::make_unique<PrimaryKeyScanInfo>(key);
+    return std::make_unique<PrimaryKeyScanInfo>(key, compare);
   }
 };
 

--- a/include/neug/execution/execute/ops/retrieve/scan_utils.h
+++ b/include/neug/execution/execute/ops/retrieve/scan_utils.h
@@ -36,9 +36,8 @@ namespace ops {
 
 class ScanUtils {
  public:
-  static std::vector<Value> parse_ids_with_type(
-      DataTypeId type, const algebra::IndexPredicate_Triplet& triplet,
-      const ParamsMap& params);
+  static std::vector<Value> parse_ids(
+      const algebra::IndexPredicate_Triplet& triplet, const ParamsMap& params);
 
   static bool check_idx_predicate(const physical::Scan& scan_opr);
 };

--- a/proto/algebra.proto
+++ b/proto/algebra.proto
@@ -196,11 +196,14 @@ message IndexPredicate {
   message Triplet {
     common.Property key = 1;
     oneof value {
+         // Deprecated: use expression instead.
          common.Value const = 2;
+         // Deprecated: use expression instead.
          common.DynamicParam param = 3;
+         common.Expression expression = 4;
     }
     // TODO(longbin) More comparators (gt, ge, lt, le, ne) other than equivalence (eq or within) may be required
-    common.Logical cmp = 4;
+    common.Logical cmp = 5;
   }
   // A collection of `Triplet` that forms a logical **AND** of all `Predicate`s.
   message AndPredicate {

--- a/proto/algebra.proto
+++ b/proto/algebra.proto
@@ -191,19 +191,12 @@ message Limit {
 // where the values referred by k1, k2, ... are indexed and hence the
 // predicate can be efficiently verified by leveraging the index.
 message IndexPredicate {
-  // A triplet defines that a key must be **equal** to a given value.
-  // The value can be a constant value, or a dynamic parameter.
+  // A triplet compares an indexed key with an expression.
   message Triplet {
     common.Property key = 1;
-    oneof value {
-         // Deprecated: use expression instead.
-         common.Value const = 2;
-         // Deprecated: use expression instead.
-         common.DynamicParam param = 3;
-         common.Expression expression = 4;
-    }
+    common.Expression expression = 2;
     // TODO(longbin) More comparators (gt, ge, lt, le, ne) other than equivalence (eq or within) may be required
-    common.Logical cmp = 5;
+    common.Logical cmp = 3;
   }
   // A collection of `Triplet` that forms a logical **AND** of all `Predicate`s.
   message AndPredicate {

--- a/src/compiler/gopt/g_expr_converter.cpp
+++ b/src/compiler/gopt/g_expr_converter.cpp
@@ -242,12 +242,13 @@ static std::unique_ptr<::common::Value> convertCollectionLiteral(
 }
 
 std::unique_ptr<::algebra::IndexPredicate> GExprConverter::convertPrimaryKey(
-    const std::string& key, const binder::Expression& expr) {
+    const std::string& key, const binder::Expression& expr,
+    ::common::Logical compare) {
   auto keyPB = convertPropertyExpr(key);
   auto tripletPB = std::make_unique<::algebra::IndexPredicate_Triplet>();
   tripletPB->set_allocated_key(keyPB.release());
 
-  if (function::ListFunctionUtils::isListLike(expr.getDataType())) {
+  if (compare == ::common::Logical::WITHIN) {
     if (expr.expressionType == common::ExpressionType::LITERAL) {
       tripletPB->set_allocated_const_(
           convertCollectionLiteral(expr.constCast<binder::LiteralExpression>())
@@ -260,8 +261,7 @@ std::unique_ptr<::algebra::IndexPredicate> GExprConverter::convertPrimaryKey(
           "Unsupported collection expression in primary key: " +
           expr.toString());
     }
-    tripletPB->set_cmp(::common::Logical::WITHIN);
-  } else {
+  } else if (compare == ::common::Logical::EQ) {
     auto valuePB = convert(expr, {})->operators(0);
     if (valuePB.has_const_()) {
       tripletPB->set_allocated_const_(valuePB.release_const_());
@@ -271,8 +271,12 @@ std::unique_ptr<::algebra::IndexPredicate> GExprConverter::convertPrimaryKey(
       THROW_EXCEPTION_WITH_FILE_LINE("Unsupported value type in primary key: " +
                                      expr.getDataType().ToString());
     }
-    tripletPB->set_cmp(::common::Logical::EQ);
+  } else {
+    THROW_EXCEPTION_WITH_FILE_LINE(
+        "Unsupported comparison operator in primary key: " +
+        ::common::Logical_Name(compare));
   }
+  tripletPB->set_cmp(compare);
   auto andPB = std::make_unique<::algebra::IndexPredicate_AndPredicate>();
   andPB->mutable_predicates()->AddAllocated(tripletPB.release());
   auto indexPB = std::make_unique<::algebra::IndexPredicate>();

--- a/src/compiler/gopt/g_expr_converter.cpp
+++ b/src/compiler/gopt/g_expr_converter.cpp
@@ -221,6 +221,10 @@ static std::unique_ptr<::common::Value> convertCollectionLiteral(
     const binder::LiteralExpression& literal) {
   auto result = std::make_unique<::common::Value>();
   const auto& value = literal.value;
+  if (value.isNull()) {
+    result->set_allocated_none(new ::common::None());
+    return result;
+  }
   auto elementType =
       function::ListFunctionUtils::getElementType(literal.getDataType()).id();
   switch (elementType) {

--- a/src/compiler/gopt/g_expr_converter.cpp
+++ b/src/compiler/gopt/g_expr_converter.cpp
@@ -39,6 +39,7 @@
 #include "neug/compiler/common/value_converter.h"
 #include "neug/compiler/function/arithmetic/vector_arithmetic_functions.h"
 #include "neug/compiler/function/cast/vector_cast_functions.h"
+#include "neug/compiler/function/list/functions/list_function_utils.h"
 #include "neug/compiler/function/neug_scalar_function.h"
 #include "neug/compiler/function/struct/vector_struct_functions.h"
 #include "neug/compiler/gopt/g_alias_manager.h"
@@ -205,21 +206,77 @@ std::unique_ptr<::common::Expression> GExprConverter::convertVar(
   return result;
 }
 
+template <typename T, typename ArrayPB>
+static void appendPKCollectionValues(const compiler_impl::Value& value,
+                                     ArrayPB* array) {
+  for (auto i = 0u; i < value.childrenSize; ++i) {
+    const auto& child = *value.children[i];
+    if (!child.isNull()) {
+      array->add_item(child.getValue<T>());
+    }
+  }
+}
+
+static std::unique_ptr<::common::Value> convertCollectionLiteral(
+    const binder::LiteralExpression& literal) {
+  auto result = std::make_unique<::common::Value>();
+  const auto& value = literal.value;
+  auto elementType = function::ListFunctionUtils::getElementType(
+                         literal.getDataType())
+                         .id();
+  switch (elementType) {
+  case common::DataTypeId::kInt32:
+    appendPKCollectionValues<int32_t>(value, result->mutable_i32_array());
+    break;
+  case common::DataTypeId::kInt64:
+    appendPKCollectionValues<int64_t>(value, result->mutable_i64_array());
+    break;
+  case common::DataTypeId::kVarchar:
+    appendPKCollectionValues<std::string>(value,
+                                          result->mutable_str_array());
+    break;
+  default:
+    THROW_EXCEPTION_WITH_FILE_LINE(
+        "Unsupported collection element type in primary key: " +
+        literal.getDataType().ToString());
+  }
+  return result;
+}
+
 std::unique_ptr<::algebra::IndexPredicate> GExprConverter::convertPrimaryKey(
     const std::string& key, const binder::Expression& expr) {
   auto keyPB = convertPropertyExpr(key);
-  auto valuePB = convert(expr, {})->operators(0);
   auto tripletPB = std::make_unique<::algebra::IndexPredicate_Triplet>();
   tripletPB->set_allocated_key(keyPB.release());
-  if (valuePB.has_const_()) {
-    tripletPB->set_allocated_const_(valuePB.release_const_());
-  } else if (valuePB.has_param()) {
-    tripletPB->set_allocated_param(valuePB.release_param());
+
+  if (function::ListFunctionUtils::isListLike(expr.getDataType())) {
+    if (expr.expressionType == common::ExpressionType::LITERAL) {
+      tripletPB->set_allocated_const_(
+          convertCollectionLiteral(
+              expr.constCast<binder::LiteralExpression>())
+              .release());
+    } else if (expr.expressionType == common::ExpressionType::PARAMETER) {
+      auto valuePB = convert(expr, {})->operators(0);
+      tripletPB->set_allocated_param(valuePB.release_param());
+    } else {
+      THROW_EXCEPTION_WITH_FILE_LINE(
+          "Unsupported collection expression in primary key: " +
+          expr.toString());
+    }
+    tripletPB->set_cmp(::common::Logical::WITHIN);
   } else {
-    THROW_EXCEPTION_WITH_FILE_LINE("Unsupported value type in primary key: " +
-                                   expr.getDataType().ToString());
+    auto valuePB = convert(expr, {})->operators(0);
+    if (valuePB.has_const_()) {
+      tripletPB->set_allocated_const_(valuePB.release_const_());
+    } else if (valuePB.has_param()) {
+      tripletPB->set_allocated_param(valuePB.release_param());
+    } else {
+      THROW_EXCEPTION_WITH_FILE_LINE(
+          "Unsupported value type in primary key: " +
+          expr.getDataType().ToString());
+    }
+    tripletPB->set_cmp(::common::Logical::EQ);
   }
-  tripletPB->set_cmp(::common::Logical::EQ);
   auto andPB = std::make_unique<::algebra::IndexPredicate_AndPredicate>();
   andPB->mutable_predicates()->AddAllocated(tripletPB.release());
   auto indexPB = std::make_unique<::algebra::IndexPredicate>();

--- a/src/compiler/gopt/g_expr_converter.cpp
+++ b/src/compiler/gopt/g_expr_converter.cpp
@@ -212,32 +212,13 @@ std::unique_ptr<::algebra::IndexPredicate> GExprConverter::convertPrimaryKey(
   auto tripletPB = std::make_unique<::algebra::IndexPredicate_Triplet>();
   tripletPB->set_allocated_key(keyPB.release());
 
-  if (compare == ::common::Logical::WITHIN) {
-    if (expr.expressionType == common::ExpressionType::LITERAL) {
-      tripletPB->set_allocated_expression(convert(expr, {}).release());
-    } else if (expr.expressionType == common::ExpressionType::PARAMETER) {
-      auto valuePB = convert(expr, {})->operators(0);
-      tripletPB->set_allocated_param(valuePB.release_param());
-    } else {
-      THROW_EXCEPTION_WITH_FILE_LINE(
-          "Unsupported collection expression in primary key: " +
-          expr.toString());
-    }
-  } else if (compare == ::common::Logical::EQ) {
-    auto valuePB = convert(expr, {})->operators(0);
-    if (valuePB.has_const_()) {
-      tripletPB->set_allocated_const_(valuePB.release_const_());
-    } else if (valuePB.has_param()) {
-      tripletPB->set_allocated_param(valuePB.release_param());
-    } else {
-      THROW_EXCEPTION_WITH_FILE_LINE("Unsupported value type in primary key: " +
-                                     expr.getDataType().ToString());
-    }
-  } else {
+  if (compare != ::common::Logical::WITHIN &&
+      compare != ::common::Logical::EQ) {
     THROW_EXCEPTION_WITH_FILE_LINE(
         "Unsupported comparison operator in primary key: " +
         ::common::Logical_Name(compare));
   }
+  tripletPB->set_allocated_expression(convert(expr, {}).release());
   tripletPB->set_cmp(compare);
   auto andPB = std::make_unique<::algebra::IndexPredicate_AndPredicate>();
   andPB->mutable_predicates()->AddAllocated(tripletPB.release());

--- a/src/compiler/gopt/g_expr_converter.cpp
+++ b/src/compiler/gopt/g_expr_converter.cpp
@@ -221,9 +221,8 @@ static std::unique_ptr<::common::Value> convertCollectionLiteral(
     const binder::LiteralExpression& literal) {
   auto result = std::make_unique<::common::Value>();
   const auto& value = literal.value;
-  auto elementType = function::ListFunctionUtils::getElementType(
-                         literal.getDataType())
-                         .id();
+  auto elementType =
+      function::ListFunctionUtils::getElementType(literal.getDataType()).id();
   switch (elementType) {
   case common::DataTypeId::kInt32:
     appendPKCollectionValues<int32_t>(value, result->mutable_i32_array());
@@ -232,8 +231,7 @@ static std::unique_ptr<::common::Value> convertCollectionLiteral(
     appendPKCollectionValues<int64_t>(value, result->mutable_i64_array());
     break;
   case common::DataTypeId::kVarchar:
-    appendPKCollectionValues<std::string>(value,
-                                          result->mutable_str_array());
+    appendPKCollectionValues<std::string>(value, result->mutable_str_array());
     break;
   default:
     THROW_EXCEPTION_WITH_FILE_LINE(
@@ -252,8 +250,7 @@ std::unique_ptr<::algebra::IndexPredicate> GExprConverter::convertPrimaryKey(
   if (function::ListFunctionUtils::isListLike(expr.getDataType())) {
     if (expr.expressionType == common::ExpressionType::LITERAL) {
       tripletPB->set_allocated_const_(
-          convertCollectionLiteral(
-              expr.constCast<binder::LiteralExpression>())
+          convertCollectionLiteral(expr.constCast<binder::LiteralExpression>())
               .release());
     } else if (expr.expressionType == common::ExpressionType::PARAMETER) {
       auto valuePB = convert(expr, {})->operators(0);
@@ -271,9 +268,8 @@ std::unique_ptr<::algebra::IndexPredicate> GExprConverter::convertPrimaryKey(
     } else if (valuePB.has_param()) {
       tripletPB->set_allocated_param(valuePB.release_param());
     } else {
-      THROW_EXCEPTION_WITH_FILE_LINE(
-          "Unsupported value type in primary key: " +
-          expr.getDataType().ToString());
+      THROW_EXCEPTION_WITH_FILE_LINE("Unsupported value type in primary key: " +
+                                     expr.getDataType().ToString());
     }
     tripletPB->set_cmp(::common::Logical::EQ);
   }

--- a/src/compiler/gopt/g_expr_converter.cpp
+++ b/src/compiler/gopt/g_expr_converter.cpp
@@ -39,7 +39,6 @@
 #include "neug/compiler/common/value_converter.h"
 #include "neug/compiler/function/arithmetic/vector_arithmetic_functions.h"
 #include "neug/compiler/function/cast/vector_cast_functions.h"
-#include "neug/compiler/function/list/functions/list_function_utils.h"
 #include "neug/compiler/function/neug_scalar_function.h"
 #include "neug/compiler/function/struct/vector_struct_functions.h"
 #include "neug/compiler/gopt/g_alias_manager.h"
@@ -206,45 +205,6 @@ std::unique_ptr<::common::Expression> GExprConverter::convertVar(
   return result;
 }
 
-template <typename T, typename ArrayPB>
-static void appendPKCollectionValues(const compiler_impl::Value& value,
-                                     ArrayPB* array) {
-  for (auto i = 0u; i < value.childrenSize; ++i) {
-    const auto& child = *value.children[i];
-    if (!child.isNull()) {
-      array->add_item(child.getValue<T>());
-    }
-  }
-}
-
-static std::unique_ptr<::common::Value> convertCollectionLiteral(
-    const binder::LiteralExpression& literal) {
-  auto result = std::make_unique<::common::Value>();
-  const auto& value = literal.value;
-  if (value.isNull()) {
-    result->set_allocated_none(new ::common::None());
-    return result;
-  }
-  auto elementType =
-      function::ListFunctionUtils::getElementType(literal.getDataType()).id();
-  switch (elementType) {
-  case common::DataTypeId::kInt32:
-    appendPKCollectionValues<int32_t>(value, result->mutable_i32_array());
-    break;
-  case common::DataTypeId::kInt64:
-    appendPKCollectionValues<int64_t>(value, result->mutable_i64_array());
-    break;
-  case common::DataTypeId::kVarchar:
-    appendPKCollectionValues<std::string>(value, result->mutable_str_array());
-    break;
-  default:
-    THROW_EXCEPTION_WITH_FILE_LINE(
-        "Unsupported collection element type in primary key: " +
-        literal.getDataType().ToString());
-  }
-  return result;
-}
-
 std::unique_ptr<::algebra::IndexPredicate> GExprConverter::convertPrimaryKey(
     const std::string& key, const binder::Expression& expr,
     ::common::Logical compare) {
@@ -254,9 +214,7 @@ std::unique_ptr<::algebra::IndexPredicate> GExprConverter::convertPrimaryKey(
 
   if (compare == ::common::Logical::WITHIN) {
     if (expr.expressionType == common::ExpressionType::LITERAL) {
-      tripletPB->set_allocated_const_(
-          convertCollectionLiteral(expr.constCast<binder::LiteralExpression>())
-              .release());
+      tripletPB->set_allocated_expression(convert(expr, {}).release());
     } else if (expr.expressionType == common::ExpressionType::PARAMETER) {
       auto valuePB = convert(expr, {})->operators(0);
       tripletPB->set_allocated_param(valuePB.release_param());

--- a/src/compiler/gopt/g_query_converter.cpp
+++ b/src/compiler/gopt/g_query_converter.cpp
@@ -400,7 +400,9 @@ void GQueryConvertor::convertScan(const planner::LogicalScanNodeTable& scan,
   auto pkOpt = scan.getPrimaryKey(catalog);
   if (pkOpt.has_value()) {
     scanPB->set_allocated_idx_predicate(
-        exprConvertor->convertPrimaryKey(pkOpt->key, *pkOpt->value->key)
+        exprConvertor
+            ->convertPrimaryKey(pkOpt->key, *pkOpt->value->key,
+                                pkOpt->value->compare)
             .release());
   }
 

--- a/src/compiler/optimizer/filter_push_down_optimizer.cpp
+++ b/src/compiler/optimizer/filter_push_down_optimizer.cpp
@@ -232,7 +232,8 @@ static bool tryRewriteNodePKIn(PredicateSet& predicates,
     }
 
     scan.setScanType(LogicalScanNodeTableType::PRIMARY_KEY_SCAN);
-    scan.setExtraInfo(std::make_unique<PrimaryKeyScanInfo>(collection));
+    scan.setExtraInfo(std::make_unique<PrimaryKeyScanInfo>(
+        collection, ::common::Logical::WITHIN));
     scan.computeFlatSchema();
     predicates.nonEqualityPredicates.erase(
         predicates.nonEqualityPredicates.begin() + i);
@@ -253,7 +254,8 @@ FilterPushDownOptimizer::visitScanNodeTableReplace(
   if (primaryKeyEqualityComparison != nullptr) {
     auto rhs = primaryKeyEqualityComparison->getChild(1);
     if (isConstantExpression(rhs)) {
-      auto extraInfo = std::make_unique<PrimaryKeyScanInfo>(rhs);
+      auto extraInfo =
+          std::make_unique<PrimaryKeyScanInfo>(rhs, ::common::Logical::EQ);
       scan.setScanType(LogicalScanNodeTableType::PRIMARY_KEY_SCAN);
       scan.setExtraInfo(std::move(extraInfo));
       scan.computeFlatSchema();

--- a/src/compiler/optimizer/filter_push_down_optimizer.cpp
+++ b/src/compiler/optimizer/filter_push_down_optimizer.cpp
@@ -214,18 +214,11 @@ static bool tryRewriteNodePKIn(PredicateSet& predicates,
     auto elementType =
         function::ListFunctionUtils::getElementType(collection->getDataType())
             .id();
-    // Condition 4: Literal collections support INT32, INT64, and STRING;
-    // parameter collections additionally support UINT32 and UINT64.
-    const auto supportsLiteral = elementType == DataTypeId::kInt32 ||
-                                 elementType == DataTypeId::kInt64 ||
-                                 elementType == DataTypeId::kVarchar;
-    const auto supportsParameter = supportsLiteral ||
-                                   elementType == DataTypeId::kUInt32 ||
-                                   elementType == DataTypeId::kUInt64;
-    if ((collection->expressionType == ExpressionType::LITERAL &&
-         !supportsLiteral) ||
-        (collection->expressionType == ExpressionType::PARAMETER &&
-         !supportsParameter)) {
+    if (elementType != DataTypeId::kInt32 &&
+        elementType != DataTypeId::kInt64 &&
+        elementType != DataTypeId::kUInt32 &&
+        elementType != DataTypeId::kUInt64 &&
+        elementType != DataTypeId::kVarchar) {
       continue;
     }
 

--- a/src/compiler/optimizer/filter_push_down_optimizer.cpp
+++ b/src/compiler/optimizer/filter_push_down_optimizer.cpp
@@ -27,6 +27,8 @@
 #include "neug/compiler/binder/expression/property_expression.h"
 #include "neug/compiler/binder/expression/scalar_function_expression.h"
 #include "neug/compiler/common/types/types.h"
+#include "neug/compiler/function/list/functions/list_function_utils.h"
+#include "neug/compiler/function/list/vector_list_functions.h"
 #include "neug/compiler/main/client_context.h"
 #include "neug/compiler/planner/operator/extend/logical_extend.h"
 #include "neug/compiler/planner/operator/logical_filter.h"
@@ -176,6 +178,59 @@ static bool isConstantExpression(const std::shared_ptr<Expression> expression) {
   }
 }
 
+static bool isNodePrimaryKey(
+    const Expression& expression, const Expression& nodeID,
+    const std::vector<common::table_id_t>& tableIDs);
+
+static bool tryRewriteNodePKIn(PredicateSet& predicates,
+                               LogicalScanNodeTable& scan) {
+  for (auto i = 0u; i < predicates.nonEqualityPredicates.size(); ++i) {
+    auto candidate = predicates.nonEqualityPredicates[i];
+    // Condition 1: The predicate must be a binary scalar function.
+    if (candidate->expressionType != ExpressionType::FUNCTION ||
+        candidate->getNumChildren() != 2) {
+      continue;
+    }
+
+    // Condition 2: The function must be LIST_CONTAINS and its second argument
+    // must be the primary key of the current node scan.
+    auto& scalarFunction = candidate->constCast<ScalarFunctionExpression>();
+    if (scalarFunction.getFunction().name !=
+            function::ListContainsFunction::name ||
+        !isNodePrimaryKey(*candidate->getChild(1), *scan.getNodeID(),
+                          scan.getTableIDs())) {
+      continue;
+    }
+
+    // Condition 3: The collection must be a direct List/Array literal or
+    // dynamic parameter. Computed and upstream expressions fall back.
+    auto collection = candidate->getChild(0);
+    if (!function::ListFunctionUtils::isListLike(collection->getDataType()) ||
+        (collection->expressionType != ExpressionType::LITERAL &&
+         collection->expressionType != ExpressionType::PARAMETER)) {
+      continue;
+    }
+
+    auto elementType = function::ListFunctionUtils::getElementType(
+                           collection->getDataType())
+                           .id();
+    // Condition 4: IndexPredicate constants support these element types.
+    if (elementType != DataTypeId::kInt32 &&
+        elementType != DataTypeId::kInt64 &&
+        elementType != DataTypeId::kVarchar) {
+      continue;
+    }
+
+    scan.setScanType(LogicalScanNodeTableType::PRIMARY_KEY_SCAN);
+    scan.setExtraInfo(std::make_unique<PrimaryKeyScanInfo>(collection));
+    scan.computeFlatSchema();
+    predicates.nonEqualityPredicates.erase(
+        predicates.nonEqualityPredicates.begin() + i);
+    return true;
+  }
+  return false;
+}
+
 std::shared_ptr<LogicalOperator>
 FilterPushDownOptimizer::visitScanNodeTableReplace(
     const std::shared_ptr<LogicalOperator>& op) {
@@ -195,6 +250,8 @@ FilterPushDownOptimizer::visitScanNodeTableReplace(
     } else {
       predicateSet.addPredicate(primaryKeyEqualityComparison);
     }
+  } else {
+    tryRewriteNodePKIn(predicateSet, scan);
   }
   return finishPushDown(op);
 }

--- a/src/compiler/optimizer/filter_push_down_optimizer.cpp
+++ b/src/compiler/optimizer/filter_push_down_optimizer.cpp
@@ -178,9 +178,9 @@ static bool isConstantExpression(const std::shared_ptr<Expression> expression) {
   }
 }
 
-static bool isNodePrimaryKey(
-    const Expression& expression, const Expression& nodeID,
-    const std::vector<common::table_id_t>& tableIDs);
+static bool isNodePrimaryKey(const Expression& expression,
+                             const Expression& nodeID,
+                             const std::vector<common::table_id_t>& tableIDs);
 
 static bool tryRewriteNodePKIn(PredicateSet& predicates,
                                LogicalScanNodeTable& scan) {
@@ -211,9 +211,9 @@ static bool tryRewriteNodePKIn(PredicateSet& predicates,
       continue;
     }
 
-    auto elementType = function::ListFunctionUtils::getElementType(
-                           collection->getDataType())
-                           .id();
+    auto elementType =
+        function::ListFunctionUtils::getElementType(collection->getDataType())
+            .id();
     // Condition 4: IndexPredicate constants support these element types.
     if (elementType != DataTypeId::kInt32 &&
         elementType != DataTypeId::kInt64 &&

--- a/src/compiler/optimizer/filter_push_down_optimizer.cpp
+++ b/src/compiler/optimizer/filter_push_down_optimizer.cpp
@@ -216,14 +216,12 @@ static bool tryRewriteNodePKIn(PredicateSet& predicates,
             .id();
     // Condition 4: Literal collections support INT32, INT64, and STRING;
     // parameter collections additionally support UINT32 and UINT64.
-    const auto supportsLiteral =
-        elementType == DataTypeId::kInt32 ||
-        elementType == DataTypeId::kInt64 ||
-        elementType == DataTypeId::kVarchar;
-    const auto supportsParameter =
-        supportsLiteral ||
-        elementType == DataTypeId::kUInt32 ||
-        elementType == DataTypeId::kUInt64;
+    const auto supportsLiteral = elementType == DataTypeId::kInt32 ||
+                                 elementType == DataTypeId::kInt64 ||
+                                 elementType == DataTypeId::kVarchar;
+    const auto supportsParameter = supportsLiteral ||
+                                   elementType == DataTypeId::kUInt32 ||
+                                   elementType == DataTypeId::kUInt64;
     if ((collection->expressionType == ExpressionType::LITERAL &&
          !supportsLiteral) ||
         (collection->expressionType == ExpressionType::PARAMETER &&

--- a/src/compiler/optimizer/filter_push_down_optimizer.cpp
+++ b/src/compiler/optimizer/filter_push_down_optimizer.cpp
@@ -214,10 +214,20 @@ static bool tryRewriteNodePKIn(PredicateSet& predicates,
     auto elementType =
         function::ListFunctionUtils::getElementType(collection->getDataType())
             .id();
-    // Condition 4: IndexPredicate constants support these element types.
-    if (elementType != DataTypeId::kInt32 &&
-        elementType != DataTypeId::kInt64 &&
-        elementType != DataTypeId::kVarchar) {
+    // Condition 4: Literal collections support INT32, INT64, and STRING;
+    // parameter collections additionally support UINT32 and UINT64.
+    const auto supportsLiteral =
+        elementType == DataTypeId::kInt32 ||
+        elementType == DataTypeId::kInt64 ||
+        elementType == DataTypeId::kVarchar;
+    const auto supportsParameter =
+        supportsLiteral ||
+        elementType == DataTypeId::kUInt32 ||
+        elementType == DataTypeId::kUInt64;
+    if ((collection->expressionType == ExpressionType::LITERAL &&
+         !supportsLiteral) ||
+        (collection->expressionType == ExpressionType::PARAMETER &&
+         !supportsParameter)) {
       continue;
     }
 

--- a/src/execution/execute/ops/retrieve/scan.cc
+++ b/src/execution/execute/ops/retrieve/scan.cc
@@ -73,6 +73,17 @@ class FilterOidsGPredOpr : public IOperator {
       neug::execution::OprTimer* timer) override {
     ctx = Context();
     ctx.append_chunk(DataChunk());
+    if ((oids_.has_const_() && oids_.const_().has_none()) ||
+        (oids_.has_param() && params.at(oids_.param().name()).IsNull())) {
+      static const std::vector<Value> no_oids;
+      auto empty_chunk = Scan::filter_oids(std::move(ctx.chunk(0)), graph,
+                                           params_, DummyPred(), no_oids);
+      if (!empty_chunk) {
+        return tl::make_unexpected(empty_chunk.error());
+      }
+      ctx.chunk(0) = std::move(*empty_chunk);
+      return ctx;
+    }
     DataTypeId type =
         std::get<0>(graph.schema().get_vertex_primary_key(params_.tables[0])[0])
             .id();

--- a/src/execution/execute/ops/retrieve/scan.cc
+++ b/src/execution/execute/ops/retrieve/scan.cc
@@ -85,12 +85,7 @@ class FilterOidsGPredOpr : public IOperator {
       ctx.chunk(0) = std::move(*empty_chunk);
       return ctx;
     }
-    DataTypeId type =
-        std::get<0>(graph.schema().get_vertex_primary_key(params_.tables[0])[0])
-            .id();
-
-    std::vector<Value> oid_values =
-        ScanUtils::parse_ids_with_type(type, oids_, params);
+    std::vector<Value> oid_values = ScanUtils::parse_ids(oids_, params);
     if (oids_.cmp() == common::Logical::WITHIN) {
       oid_values = deduplicate_ids(std::move(oid_values));
     }

--- a/src/execution/execute/ops/retrieve/scan.cc
+++ b/src/execution/execute/ops/retrieve/scan.cc
@@ -73,8 +73,9 @@ class FilterOidsGPredOpr : public IOperator {
       neug::execution::OprTimer* timer) override {
     ctx = Context();
     ctx.append_chunk(DataChunk());
-    if ((oids_.has_const_() && oids_.const_().has_none()) ||
-        (oids_.has_param() && params.at(oids_.param().name()).IsNull())) {
+    const auto& rhs_op = oids_.expression().operators(0);
+    if ((rhs_op.has_const_() && rhs_op.const_().has_none()) ||
+        (rhs_op.has_param() && params.at(rhs_op.param().name()).IsNull())) {
       static const std::vector<Value> no_oids;
       auto empty_chunk = Scan::filter_oids(std::move(ctx.chunk(0)), graph,
                                            params_, DummyPred(), no_oids);

--- a/src/execution/execute/ops/retrieve/scan.cc
+++ b/src/execution/execute/ops/retrieve/scan.cc
@@ -15,7 +15,7 @@
 
 #include "neug/execution/execute/ops/retrieve/scan.h"
 
-#include <set>
+#include <unordered_set>
 
 #include "neug/common/columns/value_columns.h"
 #include "neug/common/columns/vertex_columns.h"
@@ -32,7 +32,24 @@ class OprTimer;
 namespace ops {
 
 static std::vector<Value> deduplicate_ids(std::vector<Value> values) {
-  std::set<Value> seen;
+  auto hash = [](const Value& value) {
+    switch (value.type().id()) {
+    case DataTypeId::kInt32:
+      return std::hash<int32_t>{}(value.GetValue<int32_t>());
+    case DataTypeId::kInt64:
+      return std::hash<int64_t>{}(value.GetValue<int64_t>());
+    case DataTypeId::kUInt32:
+      return std::hash<uint32_t>{}(value.GetValue<uint32_t>());
+    case DataTypeId::kUInt64:
+      return std::hash<uint64_t>{}(value.GetValue<uint64_t>());
+    case DataTypeId::kVarchar:
+      return std::hash<std::string>{}(StringValue::Get(value));
+    default:
+      return size_t{0};
+    }
+  };
+  std::unordered_set<Value, decltype(hash)> seen(0, hash);
+  seen.reserve(values.size());
   std::vector<Value> result;
   result.reserve(values.size());
   for (auto& value : values) {

--- a/src/execution/execute/ops/retrieve/scan.cc
+++ b/src/execution/execute/ops/retrieve/scan.cc
@@ -15,6 +15,8 @@
 
 #include "neug/execution/execute/ops/retrieve/scan.h"
 
+#include <set>
+
 #include "neug/common/columns/value_columns.h"
 #include "neug/common/columns/vertex_columns.h"
 #include "neug/execution/common/operators/retrieve/scan.h"
@@ -28,6 +30,18 @@ namespace execution {
 class OprTimer;
 
 namespace ops {
+
+static std::vector<Value> deduplicate_ids(std::vector<Value> values) {
+  std::set<Value> seen;
+  std::vector<Value> result;
+  result.reserve(values.size());
+  for (auto& value : values) {
+    if (!value.IsNull() && seen.insert(value).second) {
+      result.emplace_back(std::move(value));
+    }
+  }
+  return result;
+}
 
 class FilterOidsGPredOpr : public IOperator {
  public:
@@ -48,6 +62,9 @@ class FilterOidsGPredOpr : public IOperator {
 
     std::vector<Value> oid_values =
         ScanUtils::parse_ids_with_type(type, oids_, params);
+    if (oids_.cmp() == common::Logical::WITHIN) {
+      oid_values = deduplicate_ids(std::move(oid_values));
+    }
 
     if (pred_ == nullptr) {
       if (params_.tables.size() == 1 && oid_values.size() == 1) {

--- a/src/execution/execute/ops/retrieve/scan_utils.cc
+++ b/src/execution/execute/ops/retrieve/scan_utils.cc
@@ -55,20 +55,24 @@ std::vector<Value> parse_ids_from_idx_predicate(
     return {};
   }
   const auto& opr = expression.operators(0);
-  if (opr.has_const_()) {
+  if (triplet.expression().operators(0).has_const_()) {
     std::vector<Value> ret;
-    if (opr.const_().item_case() == common::Value::kI32) {
-      ret.emplace_back(
-          Value::CreateValue<T>(static_cast<T>(opr.const_().i32())));
-    } else if (opr.const_().item_case() == common::Value::kI64) {
-      ret.emplace_back(
-          Value::CreateValue<T>(static_cast<T>(opr.const_().i64())));
-    } else if (opr.const_().item_case() == common::Value::kU32) {
-      ret.emplace_back(
-          Value::CreateValue<T>(static_cast<T>(opr.const_().u32())));
-    } else if (opr.const_().item_case() == common::Value::kU64) {
-      ret.emplace_back(
-          Value::CreateValue<T>(static_cast<T>(opr.const_().u64())));
+    if (triplet.expression().operators(0).const_().item_case() ==
+        common::Value::kI32) {
+      ret.emplace_back(Value::CreateValue<T>(
+          static_cast<T>(triplet.expression().operators(0).const_().i32())));
+    } else if (triplet.expression().operators(0).const_().item_case() ==
+               common::Value::kI64) {
+      ret.emplace_back(Value::CreateValue<T>(
+          static_cast<T>(triplet.expression().operators(0).const_().i64())));
+    } else if (triplet.expression().operators(0).const_().item_case() ==
+               common::Value::kU32) {
+      ret.emplace_back(Value::CreateValue<T>(
+          static_cast<T>(triplet.expression().operators(0).const_().u32())));
+    } else if (triplet.expression().operators(0).const_().item_case() ==
+               common::Value::kU64) {
+      ret.emplace_back(Value::CreateValue<T>(
+          static_cast<T>(triplet.expression().operators(0).const_().u64())));
     }
     return ret;
   }
@@ -136,8 +140,7 @@ std::vector<Value> parse_ids_from_idx_predicate(
 
 static const std::vector<Value>* get_pk_collection_param(
     const algebra::IndexPredicate_Triplet& triplet, const ParamsMap& params) {
-  if (!triplet.has_expression() ||
-      triplet.expression().operators_size() != 1 ||
+  if (!triplet.has_expression() || triplet.expression().operators_size() != 1 ||
       !triplet.expression().operators(0).has_param()) {
     return nullptr;
   }
@@ -212,8 +215,7 @@ bool ScanUtils::check_idx_predicate(const physical::Scan& scan_opr) {
     return false;
   }
 
-  if (!triplet.has_expression() ||
-      triplet.expression().operators_size() == 0) {
+  if (!triplet.has_expression() || triplet.expression().operators_size() == 0) {
     return false;
   }
 

--- a/src/execution/execute/ops/retrieve/scan_utils.cc
+++ b/src/execution/execute/ops/retrieve/scan_utils.cc
@@ -17,173 +17,54 @@
 
 #include "neug/execution/execute/ops/retrieve/scan_utils.h"
 #include "neug/common/types/value.h"
-#include "neug/execution/utils/pb_parse_utils.h"
+#include "neug/execution/expression/expr.h"
 #include "neug/utils/exception/exception.h"
 
 namespace neug {
 namespace execution {
 namespace ops {
 
-static std::vector<const common::Value*> parse_collection_expression(
-    const common::Expression& expression) {
-  std::vector<const common::Value*> values;
-  if (expression.operators_size() != 1) {
-    return values;
+static Value evaluate_index_expression(
+    const algebra::IndexPredicate_Triplet& triplet, const ParamsMap& params) {
+  auto expr =
+      parse_expression(triplet.expression(), ContextMeta{}, VarType::kRecord);
+  if (!expr) {
+    THROW_INVALID_ARGUMENT_EXCEPTION(
+        "failed to parse primary key index predicate expression");
   }
-  const auto& opr = expression.operators(0);
-  if (!opr.has_to_list() && !opr.has_to_array()) {
-    THROW_NOT_SUPPORTED_EXCEPTION(
-        "unsupported expression in primary key index predicate");
+  auto bound_expr = expr->bind(nullptr, params);
+  if (!bound_expr) {
+    THROW_INVALID_ARGUMENT_EXCEPTION(
+        "failed to bind primary key index predicate expression");
   }
-  const auto& fields =
-      opr.has_to_list() ? opr.to_list().fields() : opr.to_array().fields();
-  for (const auto& field : fields) {
-    if (field.operators_size() != 1 || !field.operators(0).has_const_()) {
-      THROW_NOT_SUPPORTED_EXCEPTION(
-          "primary key collection elements must be constants");
-    }
-    values.emplace_back(&field.operators(0).const_());
-  }
-  return values;
+
+  DataChunk empty_chunk;
+  return bound_expr->Cast<RecordExprBase>().eval_record(empty_chunk, 0);
 }
 
-template <typename T>
-std::vector<Value> parse_ids_from_idx_predicate(
+std::vector<Value> ScanUtils::parse_ids(
     const algebra::IndexPredicate_Triplet& triplet, const ParamsMap& params) {
-  const auto& expression = triplet.expression();
-  if (expression.operators_size() == 0) {
+  auto value = evaluate_index_expression(triplet, params);
+  if (value.IsNull()) {
     return {};
   }
-  const auto& opr = expression.operators(0);
-  if (triplet.expression().operators(0).has_const_()) {
-    std::vector<Value> ret;
-    if (triplet.expression().operators(0).const_().item_case() ==
-        common::Value::kI32) {
-      ret.emplace_back(Value::CreateValue<T>(
-          static_cast<T>(triplet.expression().operators(0).const_().i32())));
-    } else if (triplet.expression().operators(0).const_().item_case() ==
-               common::Value::kI64) {
-      ret.emplace_back(Value::CreateValue<T>(
-          static_cast<T>(triplet.expression().operators(0).const_().i64())));
-    } else if (triplet.expression().operators(0).const_().item_case() ==
-               common::Value::kU32) {
-      ret.emplace_back(Value::CreateValue<T>(
-          static_cast<T>(triplet.expression().operators(0).const_().u32())));
-    } else if (triplet.expression().operators(0).const_().item_case() ==
-               common::Value::kU64) {
-      ret.emplace_back(Value::CreateValue<T>(
-          static_cast<T>(triplet.expression().operators(0).const_().u64())));
-    }
-    return ret;
+  std::vector<Value> values;
+  if (value.type().id() == DataTypeId::kList) {
+    values = ListValue::GetChildren(value);
+  } else if (value.type().id() == DataTypeId::kArray) {
+    values = ArrayValue::GetChildren(value);
+  } else {
+    values.emplace_back(std::move(value));
   }
-  if (opr.has_param()) {
-    auto param_type = parse_from_ir_data_type(opr.param().data_type());
 
-    if (param_type.id() == DataTypeId::kInt32) {
-      return std::vector<Value>{Value::CreateValue<T>(
-          params.at(opr.param().name()).template GetValue<T>())};
-    } else if (param_type.id() == DataTypeId::kInt64) {
-      return std::vector<Value>{Value::CreateValue<T>(
-          params.at(opr.param().name()).template GetValue<T>())};
-    }
-  }
-  if (opr.has_to_list() || opr.has_to_array()) {
-    std::vector<Value> ret;
-    for (const auto* value : parse_collection_expression(expression)) {
-      if (value->item_case() == common::Value::kI32) {
-        ret.emplace_back(Value::CreateValue<T>(static_cast<T>(value->i32())));
-      } else if (value->item_case() == common::Value::kI64) {
-        ret.emplace_back(Value::CreateValue<T>(static_cast<T>(value->i64())));
-      } else if (value->item_case() == common::Value::kU32) {
-        ret.emplace_back(Value::CreateValue<T>(static_cast<T>(value->u32())));
-      } else if (value->item_case() == common::Value::kU64) {
-        ret.emplace_back(Value::CreateValue<T>(static_cast<T>(value->u64())));
-      }
-    }
-    return ret;
-  }
-  return {};
-}
-
-std::vector<Value> parse_ids_from_idx_predicate(
-    const algebra::IndexPredicate_Triplet& triplet, const ParamsMap& params) {
   std::vector<Value> ret;
-  const auto& expression = triplet.expression();
-  if (expression.operators_size() == 0) {
-    return ret;
-  }
-  const auto& opr = expression.operators(0);
-  if (opr.has_const_()) {
-    if (opr.const_().item_case() == common::Value::kStr) {
-      ret.emplace_back(Value::STRING(opr.const_().str()));
+  ret.reserve(values.size());
+  for (auto& item : values) {
+    if (!item.IsNull()) {
+      ret.emplace_back(std::move(item));
     }
-    return ret;
-  }
-  if (opr.has_param()) {
-    auto param_type = parse_from_ir_data_type(opr.param().data_type());
-
-    if (param_type.id() == DataTypeId::kVarchar) {
-      ret.emplace_back(params.at(opr.param().name()));
-      return ret;
-    }
-  }
-  if (opr.has_to_list() || opr.has_to_array()) {
-    for (const auto* value : parse_collection_expression(expression)) {
-      if (value->item_case() == common::Value::kStr) {
-        ret.emplace_back(Value::STRING(value->str()));
-      }
-    }
-    return ret;
   }
   return ret;
-}
-
-static const std::vector<Value>* get_pk_collection_param(
-    const algebra::IndexPredicate_Triplet& triplet, const ParamsMap& params) {
-  if (!triplet.has_expression() || triplet.expression().operators_size() != 1 ||
-      !triplet.expression().operators(0).has_param()) {
-    return nullptr;
-  }
-  const auto& param = triplet.expression().operators(0).param();
-  const auto& value = params.at(param.name());
-  const auto type = value.type().id();
-  if (type == DataTypeId::kList) {
-    return &ListValue::GetChildren(value);
-  }
-  if (type == DataTypeId::kArray) {
-    return &ArrayValue::GetChildren(value);
-  }
-  return nullptr;
-}
-
-std::vector<Value> ScanUtils::parse_ids_with_type(
-    DataTypeId type, const algebra::IndexPredicate_Triplet& triplet,
-    const ParamsMap& params) {
-  if (auto collectionValues = get_pk_collection_param(triplet, params)) {
-    return *collectionValues;
-  }
-  switch (type) {
-  case DataTypeId::kInt64: {
-    return parse_ids_from_idx_predicate<int64_t>(triplet, params);
-  }
-  case DataTypeId::kInt32: {
-    return parse_ids_from_idx_predicate<int32_t>(triplet, params);
-  }
-  case DataTypeId::kUInt64: {
-    return parse_ids_from_idx_predicate<uint64_t>(triplet, params);
-  }
-  case DataTypeId::kUInt32: {
-    return parse_ids_from_idx_predicate<uint32_t>(triplet, params);
-  }
-  case DataTypeId::kVarchar: {
-    return parse_ids_from_idx_predicate(triplet, params);
-  }
-  default:
-    THROW_NOT_SUPPORTED_EXCEPTION("unsupported type" +
-                                  std::to_string(static_cast<int>(type)));
-    break;
-  }
-  return {};
 }
 bool ScanUtils::check_idx_predicate(const physical::Scan& scan_opr) {
   if (scan_opr.scan_opt() != physical::Scan::VERTEX) {

--- a/src/execution/execute/ops/retrieve/scan_utils.cc
+++ b/src/execution/execute/ops/retrieve/scan_utils.cc
@@ -110,10 +110,16 @@ static const std::vector<Value>* getPKCollectionParam(
     return nullptr;
   }
   const auto& value = params.at(triplet.param().name());
-  if (value.type().id() == DataTypeId::kList) {
+  const auto type = value.type().id();
+  if (value.IsNull() &&
+      (type == DataTypeId::kList || type == DataTypeId::kArray)) {
+    static const std::vector<Value> empty_collection;
+    return &empty_collection;
+  }
+  if (type == DataTypeId::kList) {
     return &ListValue::GetChildren(value);
   }
-  if (value.type().id() == DataTypeId::kArray) {
+  if (type == DataTypeId::kArray) {
     return &ArrayValue::GetChildren(value);
   }
   return nullptr;

--- a/src/execution/execute/ops/retrieve/scan_utils.cc
+++ b/src/execution/execute/ops/retrieve/scan_utils.cc
@@ -156,7 +156,7 @@ std::vector<Value> parse_ids_from_idx_predicate(
   return ret;
 }
 
-static const std::vector<Value>* getPKCollectionParam(
+static const std::vector<Value>* get_pk_collection_param(
     const algebra::IndexPredicate_Triplet& triplet, const ParamsMap& params) {
   if (!triplet.has_param()) {
     return nullptr;
@@ -175,7 +175,7 @@ static const std::vector<Value>* getPKCollectionParam(
 std::vector<Value> ScanUtils::parse_ids_with_type(
     DataTypeId type, const algebra::IndexPredicate_Triplet& triplet,
     const ParamsMap& params) {
-  if (auto collectionValues = getPKCollectionParam(triplet, params)) {
+  if (auto collectionValues = get_pk_collection_param(triplet, params)) {
     return *collectionValues;
   }
   switch (type) {

--- a/src/execution/execute/ops/retrieve/scan_utils.cc
+++ b/src/execution/execute/ops/retrieve/scan_utils.cc
@@ -31,9 +31,6 @@ static std::vector<const common::Value*> parse_collection_expression(
     return values;
   }
   const auto& opr = expression.operators(0);
-  if (opr.has_const_()) {
-    return values;
-  }
   if (!opr.has_to_list() && !opr.has_to_array()) {
     THROW_NOT_SUPPORTED_EXCEPTION(
         "unsupported expression in primary key index predicate");
@@ -53,51 +50,42 @@ static std::vector<const common::Value*> parse_collection_expression(
 template <typename T>
 std::vector<Value> parse_ids_from_idx_predicate(
     const algebra::IndexPredicate_Triplet& triplet, const ParamsMap& params) {
-  switch (triplet.value_case()) {
-  case algebra::IndexPredicate_Triplet::ValueCase::kConst: {
+  const auto& expression = triplet.expression();
+  if (expression.operators_size() == 0) {
+    return {};
+  }
+  const auto& opr = expression.operators(0);
+  if (opr.has_const_()) {
     std::vector<Value> ret;
-    if (triplet.const_().item_case() == common::Value::kI32) {
+    if (opr.const_().item_case() == common::Value::kI32) {
       ret.emplace_back(
-          Value::CreateValue<T>(static_cast<T>(triplet.const_().i32())));
-    } else if (triplet.const_().item_case() == common::Value::kI64) {
+          Value::CreateValue<T>(static_cast<T>(opr.const_().i32())));
+    } else if (opr.const_().item_case() == common::Value::kI64) {
       ret.emplace_back(
-          Value::CreateValue<T>(static_cast<T>(triplet.const_().i64())));
-    } else if (triplet.const_().item_case() == common::Value::kU32) {
+          Value::CreateValue<T>(static_cast<T>(opr.const_().i64())));
+    } else if (opr.const_().item_case() == common::Value::kU32) {
       ret.emplace_back(
-          Value::CreateValue<T>(static_cast<T>(triplet.const_().u32())));
-    } else if (triplet.const_().item_case() == common::Value::kU64) {
+          Value::CreateValue<T>(static_cast<T>(opr.const_().u32())));
+    } else if (opr.const_().item_case() == common::Value::kU64) {
       ret.emplace_back(
-          Value::CreateValue<T>(static_cast<T>(triplet.const_().u64())));
-    } else if (triplet.const_().item_case() == common::Value::kI64Array) {
-      const auto& arr = triplet.const_().i64_array();
-      for (int i = 0; i < arr.item_size(); ++i) {
-        ret.emplace_back(Value::CreateValue<T>(static_cast<T>(arr.item(i))));
-      }
-    } else if (triplet.const_().item_case() == common::Value::kI32Array) {
-      const auto& arr = triplet.const_().i32_array();
-      for (int i = 0; i < arr.item_size(); ++i) {
-        ret.emplace_back(Value::CreateValue<T>(static_cast<T>(arr.item(i))));
-      }
+          Value::CreateValue<T>(static_cast<T>(opr.const_().u64())));
     }
     return ret;
   }
-
-  case algebra::IndexPredicate_Triplet::ValueCase::kParam: {
-    auto param_type = parse_from_ir_data_type(triplet.param().data_type());
+  if (opr.has_param()) {
+    auto param_type = parse_from_ir_data_type(opr.param().data_type());
 
     if (param_type.id() == DataTypeId::kInt32) {
       return std::vector<Value>{Value::CreateValue<T>(
-          params.at(triplet.param().name()).template GetValue<T>())};
+          params.at(opr.param().name()).template GetValue<T>())};
     } else if (param_type.id() == DataTypeId::kInt64) {
       return std::vector<Value>{Value::CreateValue<T>(
-          params.at(triplet.param().name()).template GetValue<T>())};
+          params.at(opr.param().name()).template GetValue<T>())};
     }
   }
-
-  case algebra::IndexPredicate_Triplet::ValueCase::kExpression: {
+  if (opr.has_to_list() || opr.has_to_array()) {
     std::vector<Value> ret;
-    for (const auto* value :
-         parse_collection_expression(triplet.expression())) {
+    for (const auto* value : parse_collection_expression(expression)) {
       if (value->item_case() == common::Value::kI32) {
         ret.emplace_back(Value::CreateValue<T>(static_cast<T>(value->i32())));
       } else if (value->item_case() == common::Value::kI64) {
@@ -110,58 +98,51 @@ std::vector<Value> parse_ids_from_idx_predicate(
     }
     return ret;
   }
-  default:
-    break;
-  }
   return {};
 }
 
 std::vector<Value> parse_ids_from_idx_predicate(
     const algebra::IndexPredicate_Triplet& triplet, const ParamsMap& params) {
   std::vector<Value> ret;
-  switch (triplet.value_case()) {
-  case algebra::IndexPredicate_Triplet::ValueCase::kConst: {
-    if (triplet.const_().item_case() == common::Value::kStr) {
-      ret.emplace_back(Value::STRING(triplet.const_().str()));
-
-    } else if (triplet.const_().item_case() == common::Value::kStrArray) {
-      const auto& arr = triplet.const_().str_array();
-      for (int i = 0; i < arr.item_size(); ++i) {
-        ret.emplace_back(Value::STRING(arr.item(i)));
-      }
+  const auto& expression = triplet.expression();
+  if (expression.operators_size() == 0) {
+    return ret;
+  }
+  const auto& opr = expression.operators(0);
+  if (opr.has_const_()) {
+    if (opr.const_().item_case() == common::Value::kStr) {
+      ret.emplace_back(Value::STRING(opr.const_().str()));
     }
     return ret;
   }
-
-  case algebra::IndexPredicate_Triplet::ValueCase::kParam: {
-    auto param_type = parse_from_ir_data_type(triplet.param().data_type());
+  if (opr.has_param()) {
+    auto param_type = parse_from_ir_data_type(opr.param().data_type());
 
     if (param_type.id() == DataTypeId::kVarchar) {
-      ret.emplace_back(params.at(triplet.param().name()));
+      ret.emplace_back(params.at(opr.param().name()));
       return ret;
     }
   }
-  case algebra::IndexPredicate_Triplet::ValueCase::kExpression: {
-    for (const auto* value :
-         parse_collection_expression(triplet.expression())) {
+  if (opr.has_to_list() || opr.has_to_array()) {
+    for (const auto* value : parse_collection_expression(expression)) {
       if (value->item_case() == common::Value::kStr) {
         ret.emplace_back(Value::STRING(value->str()));
       }
     }
     return ret;
   }
-  default:
-    break;
-  }
   return ret;
 }
 
 static const std::vector<Value>* get_pk_collection_param(
     const algebra::IndexPredicate_Triplet& triplet, const ParamsMap& params) {
-  if (!triplet.has_param()) {
+  if (!triplet.has_expression() ||
+      triplet.expression().operators_size() != 1 ||
+      !triplet.expression().operators(0).has_param()) {
     return nullptr;
   }
-  const auto& value = params.at(triplet.param().name());
+  const auto& param = triplet.expression().operators(0).param();
+  const auto& value = params.at(param.name());
   const auto type = value.type().id();
   if (type == DataTypeId::kList) {
     return &ListValue::GetChildren(value);
@@ -231,16 +212,9 @@ bool ScanUtils::check_idx_predicate(const physical::Scan& scan_opr) {
     return false;
   }
 
-  switch (triplet.value_case()) {
-  case algebra::IndexPredicate_Triplet::ValueCase::kConst: {
-  } break;
-  case algebra::IndexPredicate_Triplet::ValueCase::kParam: {
-  } break;
-  case algebra::IndexPredicate_Triplet::ValueCase::kExpression: {
-  } break;
-  default: {
+  if (!triplet.has_expression() ||
+      triplet.expression().operators_size() == 0) {
     return false;
-  } break;
   }
 
   return true;

--- a/src/execution/execute/ops/retrieve/scan_utils.cc
+++ b/src/execution/execute/ops/retrieve/scan_utils.cc
@@ -103,9 +103,28 @@ std::vector<Value> parse_ids_from_idx_predicate(
   }
   return ret;
 }
+
+static const std::vector<Value>* getPKCollectionParam(
+    const algebra::IndexPredicate_Triplet& triplet, const ParamsMap& params) {
+  if (!triplet.has_param()) {
+    return nullptr;
+  }
+  const auto& value = params.at(triplet.param().name());
+  if (value.type().id() == DataTypeId::kList) {
+    return &ListValue::GetChildren(value);
+  }
+  if (value.type().id() == DataTypeId::kArray) {
+    return &ArrayValue::GetChildren(value);
+  }
+  return nullptr;
+}
+
 std::vector<Value> ScanUtils::parse_ids_with_type(
     DataTypeId type, const algebra::IndexPredicate_Triplet& triplet,
     const ParamsMap& params) {
+  if (auto collectionValues = getPKCollectionParam(triplet, params)) {
+    return *collectionValues;
+  }
   switch (type) {
   case DataTypeId::kInt64: {
     return parse_ids_from_idx_predicate<int64_t>(triplet, params);

--- a/src/execution/execute/ops/retrieve/scan_utils.cc
+++ b/src/execution/execute/ops/retrieve/scan_utils.cc
@@ -111,11 +111,6 @@ static const std::vector<Value>* getPKCollectionParam(
   }
   const auto& value = params.at(triplet.param().name());
   const auto type = value.type().id();
-  if (value.IsNull() &&
-      (type == DataTypeId::kList || type == DataTypeId::kArray)) {
-    static const std::vector<Value> empty_collection;
-    return &empty_collection;
-  }
   if (type == DataTypeId::kList) {
     return &ListValue::GetChildren(value);
   }

--- a/src/execution/execute/ops/retrieve/scan_utils.cc
+++ b/src/execution/execute/ops/retrieve/scan_utils.cc
@@ -24,6 +24,32 @@ namespace neug {
 namespace execution {
 namespace ops {
 
+static std::vector<const common::Value*> parse_collection_expression(
+    const common::Expression& expression) {
+  std::vector<const common::Value*> values;
+  if (expression.operators_size() != 1) {
+    return values;
+  }
+  const auto& opr = expression.operators(0);
+  if (opr.has_const_()) {
+    return values;
+  }
+  if (!opr.has_to_list() && !opr.has_to_array()) {
+    THROW_NOT_SUPPORTED_EXCEPTION(
+        "unsupported expression in primary key index predicate");
+  }
+  const auto& fields =
+      opr.has_to_list() ? opr.to_list().fields() : opr.to_array().fields();
+  for (const auto& field : fields) {
+    if (field.operators_size() != 1 || !field.operators(0).has_const_()) {
+      THROW_NOT_SUPPORTED_EXCEPTION(
+          "primary key collection elements must be constants");
+    }
+    values.emplace_back(&field.operators(0).const_());
+  }
+  return values;
+}
+
 template <typename T>
 std::vector<Value> parse_ids_from_idx_predicate(
     const algebra::IndexPredicate_Triplet& triplet, const ParamsMap& params) {
@@ -67,6 +93,23 @@ std::vector<Value> parse_ids_from_idx_predicate(
           params.at(triplet.param().name()).template GetValue<T>())};
     }
   }
+
+  case algebra::IndexPredicate_Triplet::ValueCase::kExpression: {
+    std::vector<Value> ret;
+    for (const auto* value :
+         parse_collection_expression(triplet.expression())) {
+      if (value->item_case() == common::Value::kI32) {
+        ret.emplace_back(Value::CreateValue<T>(static_cast<T>(value->i32())));
+      } else if (value->item_case() == common::Value::kI64) {
+        ret.emplace_back(Value::CreateValue<T>(static_cast<T>(value->i64())));
+      } else if (value->item_case() == common::Value::kU32) {
+        ret.emplace_back(Value::CreateValue<T>(static_cast<T>(value->u32())));
+      } else if (value->item_case() == common::Value::kU64) {
+        ret.emplace_back(Value::CreateValue<T>(static_cast<T>(value->u64())));
+      }
+    }
+    return ret;
+  }
   default:
     break;
   }
@@ -97,6 +140,15 @@ std::vector<Value> parse_ids_from_idx_predicate(
       ret.emplace_back(params.at(triplet.param().name()));
       return ret;
     }
+  }
+  case algebra::IndexPredicate_Triplet::ValueCase::kExpression: {
+    for (const auto* value :
+         parse_collection_expression(triplet.expression())) {
+      if (value->item_case() == common::Value::kStr) {
+        ret.emplace_back(Value::STRING(value->str()));
+      }
+    }
+    return ret;
   }
   default:
     break;
@@ -183,6 +235,8 @@ bool ScanUtils::check_idx_predicate(const physical::Scan& scan_opr) {
   case algebra::IndexPredicate_Triplet::ValueCase::kConst: {
   } break;
   case algebra::IndexPredicate_Triplet::ValueCase::kParam: {
+  } break;
+  case algebra::IndexPredicate_Triplet::ValueCase::kExpression: {
   } break;
   default: {
     return false;

--- a/src/execution/execute/plan_parser.cc
+++ b/src/execution/execute/plan_parser.cc
@@ -425,14 +425,7 @@ static void parse_params_type_impl(const physical::PhysicalPlan& plan,
       if (scan_opr.has_idx_predicate()) {
         const auto& predicate = scan_opr.idx_predicate();
         const auto& triplet = predicate.or_predicates(0).predicates(0);
-        if (triplet.value_case() ==
-            algebra::IndexPredicate_Triplet::ValueCase::kParam) {
-          const auto& param = triplet.param();
-          if (params_type.find(param.name()) == params_type.end()) {
-            params_type[param.name()] =
-                parse_from_ir_data_type(param.data_type());
-          }
-        }
+        expression_parse(triplet.expression(), params_type);
       }
       break;
     }

--- a/tests/compiler/resources/dml_test/CREATE_EDGE_physical
+++ b/tests/compiler/resources/dml_test/CREATE_EDGE_physical
@@ -39,8 +39,14 @@
                    "name": "id"
                   }
                  },
-                 "const": {
-                  "i64": "1"
+                 "expression": {
+                   "operators": [
+                     {
+                       "const": {
+                        "i64": "1"
+                       }
+                     }
+                   ]
                  },
                  "cmp": "EQ"
                 }
@@ -104,8 +110,14 @@
                    "name": "id"
                   }
                  },
-                 "const": {
-                  "i64": "2"
+                 "expression": {
+                   "operators": [
+                     {
+                       "const": {
+                        "i64": "2"
+                       }
+                     }
+                   ]
                  },
                  "cmp": "EQ"
                 }

--- a/tests/compiler/resources/join_test/AB_CD_9_physical
+++ b/tests/compiler/resources/join_test/AB_CD_9_physical
@@ -75,8 +75,14 @@
                    "name": "ID"
                   }
                  },
-                 "const": {
-                  "i64": "0"
+                 "expression": {
+                   "operators": [
+                     {
+                       "const": {
+                        "i64": "0"
+                       }
+                     }
+                   ]
                  },
                  "cmp": "EQ"
                 }
@@ -219,8 +225,14 @@
                    "name": "ID"
                   }
                  },
-                 "const": {
-                  "i64": "2"
+                 "expression": {
+                   "operators": [
+                     {
+                       "const": {
+                        "i64": "2"
+                       }
+                     }
+                   ]
                  },
                  "cmp": "EQ"
                 }

--- a/tests/compiler/resources/join_test/AB_OPTIONAL_ABC_21_physical
+++ b/tests/compiler/resources/join_test/AB_OPTIONAL_ABC_21_physical
@@ -28,8 +28,14 @@
              "name": "ID"
             }
            },
-           "const": {
-            "i64": "0"
+           "expression": {
+             "operators": [
+               {
+                 "const": {
+                  "i64": "0"
+                 }
+               }
+             ]
            },
            "cmp": "EQ"
           }

--- a/tests/compiler/resources/join_test/A_MATCH_B_1_physical
+++ b/tests/compiler/resources/join_test/A_MATCH_B_1_physical
@@ -71,8 +71,14 @@
                    "name": "ID"
                   }
                  },
-                 "const": {
-                  "i64": "7"
+                 "expression": {
+                   "operators": [
+                     {
+                       "const": {
+                        "i64": "7"
+                       }
+                     }
+                   ]
                  },
                  "cmp": "EQ"
                 }

--- a/tests/compiler/resources/ldbc_test/IC_10_physical
+++ b/tests/compiler/resources/ldbc_test/IC_10_physical
@@ -110,14 +110,20 @@
                  "name": "id"
                 }
                },
-               "param": {
-                "name": "personId",
-                "index": 0,
-                "data_type": {
-                 "data_type": {
-                  "primitive_type": "DT_SIGNED_INT64"
-                 }
-                }
+               "expression": {
+                 "operators": [
+                   {
+                     "param": {
+                      "name": "personId",
+                      "index": 0,
+                      "data_type": {
+                       "data_type": {
+                        "primitive_type": "DT_SIGNED_INT64"
+                       }
+                      }
+                     }
+                   }
+                 ]
                },
                "cmp": "EQ"
               }
@@ -277,14 +283,20 @@
                  "name": "id"
                 }
                },
-               "param": {
-                "name": "personId",
-                "index": 0,
-                "data_type": {
-                 "data_type": {
-                  "primitive_type": "DT_SIGNED_INT64"
-                 }
-                }
+               "expression": {
+                 "operators": [
+                   {
+                     "param": {
+                      "name": "personId",
+                      "index": 0,
+                      "data_type": {
+                       "data_type": {
+                        "primitive_type": "DT_SIGNED_INT64"
+                       }
+                      }
+                     }
+                   }
+                 ]
                },
                "cmp": "EQ"
               }
@@ -1843,14 +1855,20 @@
                        "name": "id"
                       }
                      },
-                     "param": {
-                      "name": "personId",
-                      "index": 0,
-                      "data_type": {
-                       "data_type": {
-                        "primitive_type": "DT_SIGNED_INT64"
-                       }
-                      }
+                     "expression": {
+                       "operators": [
+                         {
+                           "param": {
+                            "name": "personId",
+                            "index": 0,
+                            "data_type": {
+                             "data_type": {
+                              "primitive_type": "DT_SIGNED_INT64"
+                             }
+                            }
+                           }
+                         }
+                       ]
                      },
                      "cmp": "EQ"
                     }

--- a/tests/compiler/resources/ldbc_test/IC_14_physical
+++ b/tests/compiler/resources/ldbc_test/IC_14_physical
@@ -27,14 +27,20 @@
                                                 "name": "id"
                                             }
                                         },
-                                        "param": {
-                                            "name": "person1Id",
-                                            "index": 0,
-                                            "data_type": {
-                                                "data_type": {
-                                                    "primitive_type": "DT_SIGNED_INT64"
-                                                }
+                                        "expression": {
+                                          "operators": [
+                                            {
+                                              "param": {
+                                                  "name": "person1Id",
+                                                  "index": 0,
+                                                  "data_type": {
+                                                      "data_type": {
+                                                          "primitive_type": "DT_SIGNED_INT64"
+                                                      }
+                                                  }
+                                              }
                                             }
+                                          ]
                                         },
                                         "cmp": "EQ"
                                     }

--- a/tests/compiler/resources/ldbc_test/IC_5_physical
+++ b/tests/compiler/resources/ldbc_test/IC_5_physical
@@ -27,14 +27,20 @@
                                                 "name": "id"
                                             }
                                         },
-                                        "param": {
-                                            "name": "personId",
-                                            "index": 0,
-                                            "data_type": {
-                                                "data_type": {
-                                                    "primitive_type": "DT_SIGNED_INT64"
-                                                }
+                                        "expression": {
+                                          "operators": [
+                                            {
+                                              "param": {
+                                                  "name": "personId",
+                                                  "index": 0,
+                                                  "data_type": {
+                                                      "data_type": {
+                                                          "primitive_type": "DT_SIGNED_INT64"
+                                                      }
+                                                  }
+                                              }
                                             }
+                                          ]
                                         },
                                         "cmp": "EQ"
                                     }

--- a/tests/compiler/resources/path_test/ANY_SHORTEST_Path_physical
+++ b/tests/compiler/resources/path_test/ANY_SHORTEST_Path_physical
@@ -27,8 +27,14 @@
             "name": "id"
            }
           },
-          "const": {
-           "i64": "1"
+          "expression": {
+            "operators": [
+              {
+                "const": {
+                 "i64": "1"
+                }
+              }
+            ]
           },
           "cmp": "EQ"
          }

--- a/tests/compiler/resources/path_test/KNOWS_1_2_physical
+++ b/tests/compiler/resources/path_test/KNOWS_1_2_physical
@@ -27,8 +27,14 @@
             "name": "id"
            }
           },
-          "const": {
-           "i64": "7"
+          "expression": {
+            "operators": [
+              {
+                "const": {
+                 "i64": "7"
+                }
+              }
+            ]
           },
           "cmp": "EQ"
          }

--- a/tests/compiler/resources/path_test/KNOWS_V2_1_2_physical
+++ b/tests/compiler/resources/path_test/KNOWS_V2_1_2_physical
@@ -27,8 +27,14 @@
             "name": "id"
            }
           },
-          "const": {
-           "i64": "7"
+          "expression": {
+            "operators": [
+              {
+                "const": {
+                 "i64": "7"
+                }
+              }
+            ]
           },
           "cmp": "EQ"
          }

--- a/tests/compiler/resources/path_test/WSHORTEST_COST_physical
+++ b/tests/compiler/resources/path_test/WSHORTEST_COST_physical
@@ -27,8 +27,14 @@
             "name": "id"
            }
           },
-          "const": {
-           "i64": "123"
+          "expression": {
+            "operators": [
+              {
+                "const": {
+                 "i64": "123"
+                }
+              }
+            ]
           },
           "cmp": "EQ"
          }

--- a/tests/compiler/resources/path_test/WSHORTEST_PATH_physical
+++ b/tests/compiler/resources/path_test/WSHORTEST_PATH_physical
@@ -27,8 +27,14 @@
             "name": "id"
            }
           },
-          "const": {
-           "i64": "123"
+          "expression": {
+            "operators": [
+              {
+                "const": {
+                 "i64": "123"
+                }
+              }
+            ]
           },
           "cmp": "EQ"
          }

--- a/tests/compiler/resources/pattern_test/CALL_UNION_physical
+++ b/tests/compiler/resources/pattern_test/CALL_UNION_physical
@@ -28,8 +28,14 @@
              "name": "id"
             }
            },
-           "const": {
-            "i64": "123"
+           "expression": {
+             "operators": [
+               {
+                 "const": {
+                  "i64": "123"
+                 }
+               }
+             ]
            },
            "cmp": "EQ"
           }

--- a/tests/compiler/resources/pattern_test/EXPAND_FILTER_physical
+++ b/tests/compiler/resources/pattern_test/EXPAND_FILTER_physical
@@ -27,8 +27,14 @@
                                                 "name": "id"
                                             }
                                         },
-                                        "const": {
-                                            "i64": "1"
+                                        "expression": {
+                                          "operators": [
+                                            {
+                                              "const": {
+                                                  "i64": "1"
+                                              }
+                                            }
+                                          ]
                                         },
                                         "cmp": "EQ"
                                     }

--- a/tests/compiler/resources/pattern_test/GETV_FILTER_physical
+++ b/tests/compiler/resources/pattern_test/GETV_FILTER_physical
@@ -27,8 +27,14 @@
                                                 "name": "id"
                                             }
                                         },
-                                        "const": {
-                                            "i64": "1"
+                                        "expression": {
+                                          "operators": [
+                                            {
+                                              "const": {
+                                                  "i64": "1"
+                                              }
+                                            }
+                                          ]
                                         },
                                         "cmp": "EQ"
                                     }

--- a/tests/compiler/resources/pattern_test/SCAN_FILTER_physical
+++ b/tests/compiler/resources/pattern_test/SCAN_FILTER_physical
@@ -27,8 +27,14 @@
             "name": "id"
            }
           },
-          "const": {
-           "i64": "1"
+          "expression": {
+            "operators": [
+              {
+                "const": {
+                 "i64": "1"
+                }
+              }
+            ]
           },
           "cmp": "EQ"
          }

--- a/tests/compiler/resources/project_test/EDGE_STAR_physical
+++ b/tests/compiler/resources/project_test/EDGE_STAR_physical
@@ -27,8 +27,14 @@
             "name": "ID"
            }
           },
-          "const": {
-           "i64": "7"
+          "expression": {
+            "operators": [
+              {
+                "const": {
+                 "i64": "7"
+                }
+              }
+            ]
           },
           "cmp": "EQ"
          }

--- a/tests/compiler/resources/rbo_test/EV_FUSION_ALIAS_physical
+++ b/tests/compiler/resources/rbo_test/EV_FUSION_ALIAS_physical
@@ -27,8 +27,14 @@
                                                 "name": "id"
                                             }
                                         },
-                                        "const": {
-                                            "i64": "1"
+                                        "expression": {
+                                          "operators": [
+                                            {
+                                              "const": {
+                                                  "i64": "1"
+                                              }
+                                            }
+                                          ]
                                         },
                                         "cmp": "EQ"
                                     }

--- a/tests/compiler/resources/rbo_test/EV_FUSION_LABEL_2_physical
+++ b/tests/compiler/resources/rbo_test/EV_FUSION_LABEL_2_physical
@@ -27,8 +27,14 @@
                                                 "name": "id"
                                             }
                                         },
-                                        "const": {
-                                            "i64": "1"
+                                        "expression": {
+                                          "operators": [
+                                            {
+                                              "const": {
+                                                  "i64": "1"
+                                              }
+                                            }
+                                          ]
                                         },
                                         "cmp": "EQ"
                                     }

--- a/tests/compiler/resources/rbo_test/EV_FUSION_LABEL_physical
+++ b/tests/compiler/resources/rbo_test/EV_FUSION_LABEL_physical
@@ -27,8 +27,14 @@
             "name": "id"
            }
           },
-          "const": {
-           "i64": "1"
+          "expression": {
+            "operators": [
+              {
+                "const": {
+                 "i64": "1"
+                }
+              }
+            ]
           },
           "cmp": "EQ"
          }

--- a/tests/compiler/resources/rbo_test/EV_FUSION_PREDICATE_physical
+++ b/tests/compiler/resources/rbo_test/EV_FUSION_PREDICATE_physical
@@ -27,8 +27,14 @@
                                                 "name": "id"
                                             }
                                         },
-                                        "const": {
-                                            "i64": "1"
+                                        "expression": {
+                                          "operators": [
+                                            {
+                                              "const": {
+                                                  "i64": "1"
+                                              }
+                                            }
+                                          ]
                                         },
                                         "cmp": "EQ"
                                     }

--- a/tests/compiler/resources/rbo_test/EV_FUSION_physical
+++ b/tests/compiler/resources/rbo_test/EV_FUSION_physical
@@ -27,8 +27,14 @@
                                                 "name": "id"
                                             }
                                         },
-                                        "const": {
-                                            "i64": "1"
+                                        "expression": {
+                                          "operators": [
+                                            {
+                                              "const": {
+                                                  "i64": "1"
+                                              }
+                                            }
+                                          ]
                                         },
                                         "cmp": "EQ"
                                     }

--- a/tests/compiler/resources/rbo_test/FILTER_PUSH_DOWN_physical
+++ b/tests/compiler/resources/rbo_test/FILTER_PUSH_DOWN_physical
@@ -27,8 +27,14 @@
                                                 "name": "id"
                                             }
                                         },
-                                        "const": {
-                                            "i64": "1"
+                                        "expression": {
+                                          "operators": [
+                                            {
+                                              "const": {
+                                                  "i64": "1"
+                                              }
+                                            }
+                                          ]
                                         },
                                         "cmp": "EQ"
                                     }

--- a/tools/python_bind/tests/test_db_list.py
+++ b/tools/python_bind/tests/test_db_list.py
@@ -432,5 +432,12 @@ def test_primary_key_in_list_uses_index(tmp_path):
         list(result)
         assert "FilterOidsGPredOpr" in result.get_profile_text()
 
+    query = (
+        "MATCH (item:Item) WHERE item.id IN $ids "
+        "RETURN item.id ORDER BY item.id;"
+    )
+    assert list(conn.execute("RETURN 1 IN NULL;")) == [[None]]
+    assert list(conn.execute(query, parameters={"ids": None})) == []
+
     conn.close()
     db.close()

--- a/tools/python_bind/tests/test_db_list.py
+++ b/tools/python_bind/tests/test_db_list.py
@@ -471,3 +471,39 @@ def test_primary_key_in_null_collection_uses_index(tmp_path):
 
     conn.close()
     db.close()
+
+
+def test_primary_key_in_unsigned_parameter_uses_index(tmp_path):
+    db = Database(db_path=str(tmp_path), mode="w", checkpoint_on_close=False)
+    conn = db.connect()
+
+    for table, data_type in [("U32Item", "UINT32"), ("U64Item", "UINT64")]:
+        conn.execute(
+            f"CREATE NODE TABLE {table}(id {data_type}, PRIMARY KEY(id));"
+        )
+        conn.execute(
+            f"CREATE (:{table} {{id: 1}}), "
+            f"(:{table} {{id: 2}}), "
+            f"(:{table} {{id: 3}});"
+        )
+        literal_query = (
+            f"MATCH (item:{table}) WHERE item.id IN [3, 1, 3, 999] "
+            "RETURN item.id ORDER BY item.id;"
+        )
+        assert list(conn.execute(literal_query)) == [[1], [3]]
+        result = conn.execute("EXPLAIN " + literal_query)
+        list(result)
+        assert "ScanWithGPredOpr" in result.get_profile_text()
+
+        query = (
+            f"MATCH (item:{table}) WHERE item.id IN $ids "
+            "RETURN item.id ORDER BY item.id;"
+        )
+        parameters = {"ids": [3, 1, 3, 999]}
+        assert list(conn.execute(query, parameters=parameters)) == [[1], [3]]
+        result = conn.execute("EXPLAIN " + query, parameters=parameters)
+        list(result)
+        assert "FilterOidsGPredOpr" in result.get_profile_text()
+
+    conn.close()
+    db.close()

--- a/tools/python_bind/tests/test_db_list.py
+++ b/tools/python_bind/tests/test_db_list.py
@@ -507,3 +507,37 @@ def test_primary_key_in_unsigned_parameter_uses_index(tmp_path):
 
     conn.close()
     db.close()
+
+
+def test_primary_key_in_string_collection_uses_index(tmp_path):
+    db = Database(db_path=str(tmp_path), mode="w", checkpoint_on_close=False)
+    conn = db.connect()
+    conn.execute("CREATE NODE TABLE Item(id STRING, PRIMARY KEY(id));")
+    conn.execute(
+        "CREATE (:Item {id: 'a'}), (:Item {id: 'b'}), (:Item {id: 'c'});"
+    )
+
+    literal_query = (
+        "MATCH (item:Item) WHERE item.id IN ['c', 'a', 'c', 'missing'] "
+        "RETURN item.id ORDER BY item.id;"
+    )
+    assert list(conn.execute(literal_query)) == [["a"], ["c"]]
+    result = conn.execute("EXPLAIN " + literal_query)
+    list(result)
+    assert "FilterOidsGPredOpr" in result.get_profile_text()
+
+    parameter_query = (
+        "MATCH (item:Item) WHERE item.id IN $ids "
+        "RETURN item.id ORDER BY item.id;"
+    )
+    parameters = {"ids": ["c", "a", "c", "missing"]}
+    assert list(conn.execute(parameter_query, parameters=parameters)) == [
+        ["a"],
+        ["c"],
+    ]
+    result = conn.execute("EXPLAIN " + parameter_query, parameters=parameters)
+    list(result)
+    assert "FilterOidsGPredOpr" in result.get_profile_text()
+
+    conn.close()
+    db.close()

--- a/tools/python_bind/tests/test_db_list.py
+++ b/tools/python_bind/tests/test_db_list.py
@@ -459,8 +459,7 @@ def test_primary_key_in_null_collection_uses_index(tmp_path):
     conn.execute("CREATE (:Item {id: 1}), (:Item {id: 2}), (:Item {id: 3});")
 
     literal_query = (
-        "MATCH (item:Item) WHERE item.id IN NULL "
-        "RETURN item.id ORDER BY item.id;"
+        "MATCH (item:Item) WHERE item.id IN NULL " "RETURN item.id ORDER BY item.id;"
     )
     assert list(conn.execute(literal_query)) == []
     result = conn.execute("EXPLAIN " + literal_query)
@@ -468,8 +467,7 @@ def test_primary_key_in_null_collection_uses_index(tmp_path):
     assert "FilterOidsGPredOpr" in result.get_profile_text()
 
     parameter_query = (
-        "MATCH (item:Item) WHERE item.id IN $ids "
-        "RETURN item.id ORDER BY item.id;"
+        "MATCH (item:Item) WHERE item.id IN $ids " "RETURN item.id ORDER BY item.id;"
     )
     assert list(conn.execute("RETURN 1 IN NULL;")) == [[None]]
     parameters = {"ids": None}
@@ -487,9 +485,7 @@ def test_primary_key_in_unsigned_parameter_uses_index(tmp_path):
     conn = db.connect()
 
     for table, data_type in [("U32Item", "UINT32"), ("U64Item", "UINT64")]:
-        conn.execute(
-            f"CREATE NODE TABLE {table}(id {data_type}, PRIMARY KEY(id));"
-        )
+        conn.execute(f"CREATE NODE TABLE {table}(id {data_type}, PRIMARY KEY(id));")
         conn.execute(
             f"CREATE (:{table} {{id: 1}}), "
             f"(:{table} {{id: 2}}), "
@@ -522,9 +518,7 @@ def test_primary_key_in_string_collection_uses_index(tmp_path):
     db = Database(db_path=str(tmp_path), mode="w", checkpoint_on_close=False)
     conn = db.connect()
     conn.execute("CREATE NODE TABLE Item(id STRING, PRIMARY KEY(id));")
-    conn.execute(
-        "CREATE (:Item {id: 'a'}), (:Item {id: 'b'}), (:Item {id: 'c'});"
-    )
+    conn.execute("CREATE (:Item {id: 'a'}), (:Item {id: 'b'}), (:Item {id: 'c'});")
 
     literal_query = (
         "MATCH (item:Item) WHERE item.id IN ['c', 'a', 'c', 'missing'] "
@@ -536,8 +530,7 @@ def test_primary_key_in_string_collection_uses_index(tmp_path):
     assert "FilterOidsGPredOpr" in result.get_profile_text()
 
     parameter_query = (
-        "MATCH (item:Item) WHERE item.id IN $ids "
-        "RETURN item.id ORDER BY item.id;"
+        "MATCH (item:Item) WHERE item.id IN $ids " "RETURN item.id ORDER BY item.id;"
     )
     parameters = {"ids": ["c", "a", "c", "missing"]}
     assert list(conn.execute(parameter_query, parameters=parameters)) == [

--- a/tools/python_bind/tests/test_db_list.py
+++ b/tools/python_bind/tests/test_db_list.py
@@ -458,14 +458,23 @@ def test_primary_key_in_null_collection_uses_index(tmp_path):
     conn.execute("CREATE NODE TABLE Item(id INT64, PRIMARY KEY(id));")
     conn.execute("CREATE (:Item {id: 1}), (:Item {id: 2}), (:Item {id: 3});")
 
-    query = (
+    literal_query = (
+        "MATCH (item:Item) WHERE item.id IN NULL "
+        "RETURN item.id ORDER BY item.id;"
+    )
+    assert list(conn.execute(literal_query)) == []
+    result = conn.execute("EXPLAIN " + literal_query)
+    list(result)
+    assert "FilterOidsGPredOpr" in result.get_profile_text()
+
+    parameter_query = (
         "MATCH (item:Item) WHERE item.id IN $ids "
         "RETURN item.id ORDER BY item.id;"
     )
     assert list(conn.execute("RETURN 1 IN NULL;")) == [[None]]
     parameters = {"ids": None}
-    assert list(conn.execute(query, parameters=parameters)) == []
-    result = conn.execute("EXPLAIN " + query, parameters=parameters)
+    assert list(conn.execute(parameter_query, parameters=parameters)) == []
+    result = conn.execute("EXPLAIN " + parameter_query, parameters=parameters)
     list(result)
     assert "FilterOidsGPredOpr" in result.get_profile_text()
 

--- a/tools/python_bind/tests/test_db_list.py
+++ b/tools/python_bind/tests/test_db_list.py
@@ -408,3 +408,29 @@ def test_return_multiple_lists(tmp_path):
 
     conn.close()
     db.close()
+
+
+def test_primary_key_in_list_uses_index(tmp_path):
+    db = Database(db_path=str(tmp_path), mode="w", checkpoint_on_close=False)
+    conn = db.connect()
+
+    conn.execute("CREATE NODE TABLE Item(id INT64, PRIMARY KEY(id));")
+    conn.execute("CREATE (:Item {id: 1}), (:Item {id: 2}), (:Item {id: 3});")
+
+    cases = [
+        ("[3, 1, 3, 999]", None),
+        ("$ids", {"ids": [3, 1, 3, 999]}),
+    ]
+    for collection, parameters in cases:
+        query = (
+            f"MATCH (item:Item) WHERE item.id IN {collection} "
+            "RETURN item.id ORDER BY item.id;"
+        )
+        assert list(conn.execute(query, parameters=parameters)) == [[1], [3]]
+
+        result = conn.execute("EXPLAIN " + query, parameters=parameters)
+        list(result)
+        assert "FilterOidsGPredOpr" in result.get_profile_text()
+
+    conn.close()
+    db.close()

--- a/tools/python_bind/tests/test_db_list.py
+++ b/tools/python_bind/tests/test_db_list.py
@@ -413,31 +413,61 @@ def test_return_multiple_lists(tmp_path):
 def test_primary_key_in_list_uses_index(tmp_path):
     db = Database(db_path=str(tmp_path), mode="w", checkpoint_on_close=False)
     conn = db.connect()
-
     conn.execute("CREATE NODE TABLE Item(id INT64, PRIMARY KEY(id));")
     conn.execute("CREATE (:Item {id: 1}), (:Item {id: 2}), (:Item {id: 3});")
 
-    cases = [
-        ("[3, 1, 3, 999]", None),
-        ("$ids", {"ids": [3, 1, 3, 999]}),
+    literal_collections = [
+        ("[3, 1, 3, 999]", [[1], [3]]),
+        ("[1, CAST(NULL, 'INT64'), 3]", [[1], [3]]),
+        ("[CAST(NULL, 'INT64')]", []),
     ]
-    for collection, parameters in cases:
+    for collection, expected in literal_collections:
         query = (
             f"MATCH (item:Item) WHERE item.id IN {collection} "
             "RETURN item.id ORDER BY item.id;"
         )
-        assert list(conn.execute(query, parameters=parameters)) == [[1], [3]]
+        assert list(conn.execute(query)) == expected
+        result = conn.execute("EXPLAIN " + query)
+        list(result)
+        assert "FilterOidsGPredOpr" in result.get_profile_text()
 
+    parameter_collections = [
+        ([3, 1, 3, 999], [[1], [3]]),
+        ([], []),
+        ([1, None, 3], [[1], [3]]),
+        ([None], []),
+    ]
+    for collection, expected in parameter_collections:
+        query = (
+            "MATCH (item:Item) WHERE item.id IN $ids "
+            "RETURN item.id ORDER BY item.id;"
+        )
+        parameters = {"ids": collection}
+        assert list(conn.execute(query, parameters=parameters)) == expected
         result = conn.execute("EXPLAIN " + query, parameters=parameters)
         list(result)
         assert "FilterOidsGPredOpr" in result.get_profile_text()
+
+    conn.close()
+    db.close()
+
+
+def test_primary_key_in_null_collection_uses_index(tmp_path):
+    db = Database(db_path=str(tmp_path), mode="w", checkpoint_on_close=False)
+    conn = db.connect()
+    conn.execute("CREATE NODE TABLE Item(id INT64, PRIMARY KEY(id));")
+    conn.execute("CREATE (:Item {id: 1}), (:Item {id: 2}), (:Item {id: 3});")
 
     query = (
         "MATCH (item:Item) WHERE item.id IN $ids "
         "RETURN item.id ORDER BY item.id;"
     )
     assert list(conn.execute("RETURN 1 IN NULL;")) == [[None]]
-    assert list(conn.execute(query, parameters={"ids": None})) == []
+    parameters = {"ids": None}
+    assert list(conn.execute(query, parameters=parameters)) == []
+    result = conn.execute("EXPLAIN " + query, parameters=parameters)
+    list(result)
+    assert "FilterOidsGPredOpr" in result.get_profile_text()
 
     conn.close()
     db.close()


### PR DESCRIPTION
## What do these changes do?

This PR optimizes primary-key `IN` predicates by rewriting eligible `LIST_CONTAINS(collection, primary_key)` filters into primary-key index scans. The optimized predicate is encoded as an `IndexPredicate` with the `WITHIN` comparator, and duplicate IDs are removed immediately before executing the `WITHIN` lookups.

### Supported syntax

The first version intentionally supports only collections that are available directly at scan planning time:

```cypher
// Direct List/Array literal
MATCH (n:Item)
WHERE n.id IN [1, 2, 3]
RETURN n;

// User-supplied dynamic parameter
MATCH (n:Item)
WHERE n.id IN $ids
RETURN n;
```

The input collection may contain duplicate primary keys:

```cypher
MATCH (n:Item)
WHERE n.id IN [1, 2, 2, 3, 3]
RETURN n;
```

Before executing the `WITHIN` index lookups, the implementation deduplicates this collection to `[1, 2, 3]`. This only avoids redundant primary-key probes: `IN` tests collection membership, so duplicate values do not change which nodes match, and the optimized query preserves the original result semantics.

Both direct literals and dynamic parameters are covered by pytest plan assertions that verify the query uses `FilterOidsGPredOpr`.

### Current limitations

The following collection expressions intentionally fall back to the existing scan/filter path:

- Intermediate collections passed through `WITH`, for example `WITH [1, 2, 3] AS ids ... WHERE n.id IN ids`.
- Collections produced by function expressions, even when all inputs are constant, for example `WHERE n.id IN list_concat([1, 2], [3])`.
- Other computed or upstream collection expressions.

Dynamic collection parameters with `UINT32` or `UINT64` elements are not supported because the current protobuf `common.Value` representation does not provide the required unsigned-array encoding. The currently supported collection element types are `INT32`, `INT64`, and `STRING`.

## Testing

- `cmake --build build -j4`
- `/opt/homebrew/opt/python@3.14/bin/python3.14 -m pytest tools/python_bind/tests/test_db_list.py -q`
  - 10 passed

## Related issue number

#958