### PR TITLE
refactor: stream direct CSV COPY into storage

### DIFF
--- a/extension/parquet/include/parquet/arrow_reader.h
+++ b/extension/parquet/include/parquet/arrow_reader.h
@@ -77,6 +77,10 @@ class ArrowReader : public Reader<arrow::fs::FileSystem> {
   void read(std::shared_ptr<ReadLocalState> localState,
             execution::Context& ctx) override;
 
+  // Supplies unfiltered record batches for direct COPY fusion. Callers with a
+  // row filter must use read(), which retains the Arrow/filter fallback path.
+  std::shared_ptr<IDataChunkSupplier> getDataChunkSupplier();
+
   arrow::Result<std::shared_ptr<arrow::Schema>> inferSchema();
 
  protected:

--- a/extension/parquet/include/parquet_read_function.h
+++ b/extension/parquet/include/parquet_read_function.h
@@ -39,6 +39,7 @@ struct ParquetReadFunction {
         std::vector<::neug::DataTypeId>{::neug::DataTypeId::kVarchar};
     auto readFunction = std::make_unique<ReadFunction>(name, typeIDs);
     readFunction->execFunc = execFunc;
+    readFunction->supplierFunc = supplierFunc;
     readFunction->sniffFunc = sniffFunc;
     function_set functionSet;
     functionSet.push_back(std::move(readFunction));
@@ -68,6 +69,26 @@ struct ParquetReadFunction {
     auto localState = std::make_shared<reader::ReadLocalState>();
     reader->read(localState, ctx);
     return ctx;
+  }
+
+  static std::shared_ptr<IDataChunkSupplier> supplierFunc(
+      std::shared_ptr<reader::ReadSharedState> state) {
+    const auto& vfs = neug::main::MetadataRegistry::getVFS();
+    const auto& fs = vfs->Provide(state->schema.file);
+    auto resolvedPaths = std::vector<std::string>();
+    for (const auto& path : state->schema.file.paths) {
+      const auto& resolved = fs->glob(path);
+      resolvedPaths.insert(resolvedPaths.end(), resolved.begin(),
+                           resolved.end());
+    }
+    state->schema.file.paths = std::move(resolvedPaths);
+
+    auto optionsBuilder =
+        std::make_unique<reader::ArrowParquetOptionsBuilder>(state);
+    auto arrowFs = parquet::resolveArrowFileSystem(*fs);
+    return std::make_unique<reader::ArrowReader>(
+               state, std::move(optionsBuilder), std::move(arrowFs))
+        ->getDataChunkSupplier();
   }
 
   static std::shared_ptr<reader::EntrySchema> sniffFunc(

--- a/extension/parquet/src/arrow_reader.cc
+++ b/extension/parquet/src/arrow_reader.cc
@@ -142,6 +142,30 @@ void ArrowReader::read(std::shared_ptr<ReadLocalState> localState,
   }
 }
 
+std::shared_ptr<IDataChunkSupplier> ArrowReader::getDataChunkSupplier() {
+  if (!sharedState || !fileSystem) {
+    THROW_INVALID_ARGUMENT_EXCEPTION("ArrowReader state or filesystem is null");
+  }
+  if (sharedState->skipRows) {
+    THROW_INVALID_ARGUMENT_EXCEPTION(
+        "Filtered Parquet reads cannot be exposed as a chunk supplier");
+  }
+
+  auto scanner = createScanner(fileSystem);
+  auto row_num_result = scanner->CountRows();
+  if (!row_num_result.ok()) {
+    THROW_IO_EXCEPTION("Failed to count rows via scanner: " +
+                       row_num_result.status().message());
+  }
+  auto batch_reader_result = scanner->ToRecordBatchReader();
+  if (!batch_reader_result.ok()) {
+    THROW_IO_EXCEPTION("Failed to create RecordBatchReader from scanner: " +
+                       batch_reader_result.status().message());
+  }
+  return std::make_shared<RecordBatchChunkSupplier>(
+      batch_reader_result.ValueOrDie(), row_num_result.ValueOrDie());
+}
+
 std::shared_ptr<arrow::dataset::Scanner> ArrowReader::createScanner(
     std::shared_ptr<arrow::fs::FileSystem> fs) {
   if (!fs) {

--- a/include/neug/compiler/function/import/csv_read_function.h
+++ b/include/neug/compiler/function/import/csv_read_function.h
@@ -37,6 +37,7 @@ struct CSVReadFunction {
         std::vector<common::DataTypeId>{common::DataTypeId::kVarchar};
     auto readFunction = std::make_unique<ReadFunction>(name, typeIDs);
     readFunction->execFunc = execFunc;
+    readFunction->supplierFunc = supplierFunc;
     readFunction->sniffFunc = sniffFunc;
     function_set functionSet;
     functionSet.push_back(std::move(readFunction));
@@ -112,7 +113,7 @@ struct CSVReadFunction {
     }
   }
 
-  static execution::Context execFunc(
+  static std::unique_ptr<reader::CsvReader> createReader(
       std::shared_ptr<reader::ReadSharedState> state) {
     validateAndConvertExecOptions(state);
     const auto& vfs = neug::main::MetadataRegistry::getVFS();
@@ -126,12 +127,22 @@ struct CSVReadFunction {
     state->schema.file.paths = std::move(resolvedPaths);
     state->stream_opener = makeImportStreamOpener(*fs);
     auto optionsBuilder = std::make_unique<reader::CsvOptionsBuilder>(state);
-    auto reader =
-        std::make_unique<reader::CsvReader>(state, std::move(optionsBuilder));
+    return std::make_unique<reader::CsvReader>(state,
+                                               std::move(optionsBuilder));
+  }
+
+  static execution::Context execFunc(
+      std::shared_ptr<reader::ReadSharedState> state) {
+    auto reader = createReader(std::move(state));
     execution::Context ctx;
     auto localState = std::make_shared<reader::ReadLocalState>();
     reader->read(localState, ctx);
     return ctx;
+  }
+
+  static std::shared_ptr<IDataChunkSupplier> supplierFunc(
+      std::shared_ptr<reader::ReadSharedState> state) {
+    return createReader(std::move(state))->getDataChunkSupplier();
   }
 
   static std::shared_ptr<reader::EntrySchema> sniffFunc(

--- a/include/neug/compiler/function/import/json_read_function.h
+++ b/include/neug/compiler/function/import/json_read_function.h
@@ -39,6 +39,7 @@ struct JsonReadFunction {
         std::vector<common::DataTypeId>{common::DataTypeId::kVarchar};
     auto readFunction = std::make_unique<ReadFunction>(name, typeIDs);
     readFunction->execFunc = jsonExecFunc;
+    readFunction->supplierFunc = jsonSupplierFunc;
     readFunction->sniffFunc = jsonSniffFunc;
     function_set functionSet;
     functionSet.push_back(std::move(readFunction));
@@ -65,6 +66,25 @@ struct JsonReadFunction {
     auto localState = std::make_shared<reader::ReadLocalState>();
     reader->read(localState, ctx);
     return ctx;
+  }
+
+  static std::shared_ptr<IDataChunkSupplier> jsonSupplierFunc(
+      std::shared_ptr<reader::ReadSharedState> state) {
+    const auto& vfs = neug::main::MetadataRegistry::getVFS();
+    const auto& fs = vfs->Provide(state->schema.file);
+    auto resolvedPaths = std::vector<std::string>();
+    for (const auto& path : state->schema.file.paths) {
+      const auto& resolved = fs->glob(path);
+      resolvedPaths.insert(resolvedPaths.end(), resolved.begin(),
+                           resolved.end());
+    }
+    state->schema.file.paths = std::move(resolvedPaths);
+    state->stream_opener = makeImportStreamOpener(*fs);
+    auto optionsBuilder =
+        std::make_unique<reader::JsonOptionsBuilder>(state, true);
+    return std::make_unique<reader::JsonReader>(state,
+                                                std::move(optionsBuilder))
+        ->getDataChunkSupplier();
   }
 
   static std::shared_ptr<reader::EntrySchema> jsonSniffFunc(
@@ -107,6 +127,7 @@ struct JsonLReadFunction {
         std::vector<common::DataTypeId>{common::DataTypeId::kVarchar};
     auto readFunction = std::make_unique<ReadFunction>(name, typeIDs);
     readFunction->execFunc = jsonLExecFunc;
+    readFunction->supplierFunc = jsonLSupplierFunc;
     readFunction->sniffFunc = jsonLSniffFunc;
     function_set functionSet;
     functionSet.push_back(std::move(readFunction));
@@ -133,6 +154,25 @@ struct JsonLReadFunction {
     auto localState = std::make_shared<reader::ReadLocalState>();
     reader->read(localState, ctx);
     return ctx;
+  }
+
+  static std::shared_ptr<IDataChunkSupplier> jsonLSupplierFunc(
+      std::shared_ptr<reader::ReadSharedState> state) {
+    const auto& vfs = neug::main::MetadataRegistry::getVFS();
+    const auto& fs = vfs->Provide(state->schema.file);
+    auto resolvedPaths = std::vector<std::string>();
+    for (const auto& path : state->schema.file.paths) {
+      const auto& resolved = fs->glob(path);
+      resolvedPaths.insert(resolvedPaths.end(), resolved.begin(),
+                           resolved.end());
+    }
+    state->schema.file.paths = std::move(resolvedPaths);
+    state->stream_opener = makeImportStreamOpener(*fs);
+    auto optionsBuilder =
+        std::make_unique<reader::JsonOptionsBuilder>(state, false);
+    return std::make_unique<reader::JsonReader>(state,
+                                                std::move(optionsBuilder))
+        ->getDataChunkSupplier();
   }
 
   static std::shared_ptr<reader::EntrySchema> jsonLSniffFunc(

--- a/include/neug/compiler/function/read_function.h
+++ b/include/neug/compiler/function/read_function.h
@@ -24,16 +24,19 @@
 #include <vector>
 #include "neug/compiler/function/table/table_function.h"
 #include "neug/execution/common/context.h"
-#include "neug/execution/execute/ops/batch/batch_update_utils.h"
 #include "neug/utils/io/read/common/schema.h"
 #include "neug/utils/io/reader.h"
 
 namespace neug {
+class IDataChunkSupplier;
 namespace function {
 
 // The exec function invoked by data source operators to load data from external
 // data sources.
 using read_exec_func_t = std::function<execution::Context(
+    std::shared_ptr<reader::ReadSharedState> state)>;
+
+using read_supplier_func_t = std::function<std::shared_ptr<IDataChunkSupplier>(
     std::shared_ptr<reader::ReadSharedState> state)>;
 
 // The function used to sniff/infer file column names and their types from
@@ -43,6 +46,7 @@ using read_sniff_func_t = std::function<std::shared_ptr<reader::EntrySchema>(
 
 struct ReadFunction : public TableFunction {
   read_exec_func_t execFunc = nullptr;
+  read_supplier_func_t supplierFunc = nullptr;
   read_sniff_func_t sniffFunc = nullptr;
 
   ReadFunction(std::string name, std::vector<common::DataTypeId> inputTypes)

--- a/include/neug/execution/execute/ops/batch/batch_insert_edge.h
+++ b/include/neug/execution/execute/ops/batch/batch_insert_edge.h
@@ -40,6 +40,20 @@ class BatchInsertEdgeOprBuilder : public IOperatorBuilder {
   }
 };
 
+class FusedCSVEdgeInsertOprBuilder : public IOperatorBuilder {
+ public:
+  neug::result<OpBuildResultT> Build(const Schema& schema,
+                                     const ContextMeta& ctx_meta,
+                                     const physical::PhysicalPlan& plan,
+                                     int op_idx) override;
+
+  std::vector<physical::PhysicalOpr_Operator::OpKindCase> GetOpKinds()
+      const override {
+    return {physical::PhysicalOpr_Operator::OpKindCase::kSource,
+            physical::PhysicalOpr_Operator::OpKindCase::kLoadEdge};
+  }
+};
+
 }  // namespace ops
 }  // namespace execution
 }  // namespace neug

--- a/include/neug/execution/execute/ops/batch/batch_insert_edge.h
+++ b/include/neug/execution/execute/ops/batch/batch_insert_edge.h
@@ -40,7 +40,10 @@ class BatchInsertEdgeOprBuilder : public IOperatorBuilder {
   }
 };
 
-class FusedCSVEdgeInsertOprBuilder : public IOperatorBuilder {
+// Fuses a directly adjacent Source + LoadEdge pair when its reader exposes
+// an IDataChunkSupplier. Plans with projections, filters, or unsupported
+// readers use the regular pipeline; this path retains BatchAddEdges.
+class FusedStreamEdgeInsertOprBuilder : public IOperatorBuilder {
  public:
   neug::result<OpBuildResultT> Build(const Schema& schema,
                                      const ContextMeta& ctx_meta,

--- a/include/neug/execution/execute/ops/batch/batch_insert_vertex.h
+++ b/include/neug/execution/execute/ops/batch/batch_insert_vertex.h
@@ -39,6 +39,20 @@ class BatchInsertVertexOprBuilder : public IOperatorBuilder {
   }
 };
 
+class FusedCSVVertexInsertOprBuilder : public IOperatorBuilder {
+ public:
+  neug::result<OpBuildResultT> Build(const Schema& schema,
+                                     const ContextMeta& ctx_meta,
+                                     const physical::PhysicalPlan& plan,
+                                     int op_idx) override;
+
+  std::vector<physical::PhysicalOpr_Operator::OpKindCase> GetOpKinds()
+      const override {
+    return {physical::PhysicalOpr_Operator::OpKindCase::kSource,
+            physical::PhysicalOpr_Operator::OpKindCase::kLoadVertex};
+  }
+};
+
 }  // namespace ops
 }  // namespace execution
 }  // namespace neug

--- a/include/neug/execution/execute/ops/batch/batch_insert_vertex.h
+++ b/include/neug/execution/execute/ops/batch/batch_insert_vertex.h
@@ -39,7 +39,10 @@ class BatchInsertVertexOprBuilder : public IOperatorBuilder {
   }
 };
 
-class FusedCSVVertexInsertOprBuilder : public IOperatorBuilder {
+// Fuses a directly adjacent Source + LoadVertex pair when its reader exposes
+// an IDataChunkSupplier. Plans with projections, filters, or unsupported
+// readers use the regular pipeline; this path retains BatchAddVertices.
+class FusedStreamVertexInsertOprBuilder : public IOperatorBuilder {
  public:
   neug::result<OpBuildResultT> Build(const Schema& schema,
                                      const ContextMeta& ctx_meta,

--- a/include/neug/execution/execute/ops/batch/batch_update_utils.h
+++ b/include/neug/execution/execute/ops/batch/batch_update_utils.h
@@ -46,9 +46,18 @@ std::string edge_to_json_string(const EdgeRecord& edge,
 
 std::string path_to_json_string(Path& path, const StorageReadInterface& graph);
 
+// Preserves COPY input cardinality with a head-only, constant-space result.
+Context create_copy_result(size_t rows_read);
+
 std::shared_ptr<IDataChunkSupplier> create_data_chunk_supplier(
     const Context& ctx,
     const std::vector<std::pair<int32_t, std::string>>& prop_mappings);
+
+// Accumulates consumed input rows; rows_read must outlive the supplier.
+std::shared_ptr<IDataChunkSupplier> create_mapped_data_chunk_supplier(
+    std::shared_ptr<IDataChunkSupplier> supplier,
+    const std::vector<std::pair<int32_t, std::string>>& prop_mappings,
+    size_t& rows_read);
 
 std::vector<std::string> match_files_with_pattern(const std::string& file_path);
 

--- a/include/neug/execution/execute/ops/batch/data_source.h
+++ b/include/neug/execution/execute/ops/batch/data_source.h
@@ -15,12 +15,14 @@
 #pragma once
 
 #include "neug/execution/execute/operator.h"
-#include "neug/execution/execute/ops/batch/batch_update_utils.h"
 #include "neug/utils/io/reader.h"
 
 namespace neug {
 using namespace reader;
 class IDataChunkSupplier;
+namespace function {
+struct ReadFunction;
+}
 namespace execution {
 
 namespace ops {
@@ -34,6 +36,16 @@ class ReadStateBuilder {
       const ::physical::EntrySchema& entry_schema);
   static FileSchema buildFileSchema(const ::physical::FileSchema& file_schema);
 };
+
+struct ReadSource {
+  std::shared_ptr<ReadSharedState> state;
+  function::ReadFunction* function = nullptr;
+
+  bool supports_supplier() const;
+  std::shared_ptr<IDataChunkSupplier> create_supplier() const;
+};
+
+ReadSource build_read_source(const ::physical::DataSource& data_source);
 
 class DataSourceOprBuilder : public IOperatorBuilder {
  public:

--- a/include/neug/utils/io/read/csv/csv_reader.h
+++ b/include/neug/utils/io/read/csv/csv_reader.h
@@ -43,9 +43,13 @@ class CsvReader {
   void read(std::shared_ptr<ReadLocalState> localState,
             execution::Context& ctx);
 
+  std::shared_ptr<IDataChunkSupplier> getDataChunkSupplier();
+
   result<std::shared_ptr<EntrySchema>> inferSchema();
 
  private:
+  CsvReadConfig buildReadConfig();
+
   void full_read(
       const std::vector<std::shared_ptr<IDataChunkSupplier>>& suppliers,
       execution::Context& output, const CsvReadConfig& output_config);

--- a/include/neug/utils/io/read/json/json_reader.h
+++ b/include/neug/utils/io/read/json/json_reader.h
@@ -43,6 +43,10 @@ class JsonReader {
   void read(std::shared_ptr<ReadLocalState> localState,
             execution::Context& ctx);
 
+  // Supplies unfiltered chunks for direct COPY fusion. Callers requiring a
+  // filter must use read(), which preserves the full-read filter semantics.
+  std::shared_ptr<IDataChunkSupplier> getDataChunkSupplier();
+
   result<std::shared_ptr<EntrySchema>> inferSchema();
 
  private:

--- a/src/execution/execute/ops/batch/batch_insert_edge.cc
+++ b/src/execution/execute/ops/batch/batch_insert_edge.cc
@@ -16,6 +16,7 @@
 #include "neug/execution/execute/ops/batch/batch_insert_edge.h"
 #include "neug/execution/common/context.h"
 #include "neug/execution/execute/ops/batch/batch_update_utils.h"
+#include "neug/execution/execute/ops/batch/data_source.h"
 #include "neug/storages/graph/graph_interface.h"
 #include "neug/utils/exception/exception.h"
 #include "neug/utils/result.h"
@@ -35,14 +36,14 @@ namespace ops {
 
 namespace {
 
-bool resolve_vertex_label_id(const Schema& schema, const common::NameOrId& ni,
+bool resolve_vertex_label_id(const Schema& schema, const ::common::NameOrId& ni,
                              label_t& out) {
   switch (ni.item_case()) {
-  case common::NameOrId::kId: {
+  case ::common::NameOrId::kId: {
     out = ni.id();
     return true;
   }
-  case common::NameOrId::kName: {
+  case ::common::NameOrId::kName: {
     if (!schema.is_vertex_label_valid(ni.name())) {
       LOG(ERROR) << "Unknown vertex type: " << ni.DebugString();
       return false;
@@ -62,10 +63,10 @@ bool resolve_edge_triplet(const Schema& schema,
                           label_t& edge_label, label_t& src_type,
                           label_t& dst_type) {
   switch (edge_type.type_name().item_case()) {
-  case common::NameOrId::kId:
+  case ::common::NameOrId::kId:
     edge_label = edge_type.type_name().id();
     break;
-  case common::NameOrId::kName: {
+  case ::common::NameOrId::kName: {
     const auto& name = edge_type.type_name().name();
     if (!schema.is_edge_label_valid(name)) {
       LOG(ERROR) << "Unknown edge type: "
@@ -96,14 +97,17 @@ class BatchInsertEdgeOpr : public IOperator {
       physical::EdgeType edge_type,
       std::vector<std::pair<int32_t, std::string>> prop_mappings,
       std::vector<std::pair<int32_t, std::string>> src_vertex_bindings,
-      std::vector<std::pair<int32_t, std::string>> dst_vertex_bindings)
+      std::vector<std::pair<int32_t, std::string>> dst_vertex_bindings,
+      ReadSource source = {})
       : edge_type_(std::move(edge_type)),
         prop_mappings_(std::move(prop_mappings)),
         src_vertex_bindings_(std::move(src_vertex_bindings)),
-        dst_vertex_bindings_(std::move(dst_vertex_bindings)) {}
+        dst_vertex_bindings_(std::move(dst_vertex_bindings)),
+        source_(std::move(source)) {}
 
   std::string get_operator_name() const override {
-    return "BatchInsertEdgeOpr";
+    return source_.supports_supplier() ? "FusedCSVEdgeInsertOpr"
+                                       : "BatchInsertEdgeOpr";
   }
 
   neug::result<Context> Eval(IStorageInterface& graph, const ParamsMap& params,
@@ -113,6 +117,7 @@ class BatchInsertEdgeOpr : public IOperator {
   physical::EdgeType edge_type_;
   std::vector<std::pair<int32_t, std::string>> prop_mappings_,
       src_vertex_bindings_, dst_vertex_bindings_;
+  ReadSource source_;
 };
 
 neug::result<Context> BatchInsertEdgeOpr::Eval(
@@ -143,11 +148,57 @@ neug::result<Context> BatchInsertEdgeOpr::Eval(
   for (const auto& mapping : prop_mappings_) {
     total_mappings.emplace_back(mapping);
   }
-  auto supplier = create_data_chunk_supplier(ctx, total_mappings);
+  size_t rows_read = 0;
+  auto supplier =
+      source_.supports_supplier()
+          ? create_mapped_data_chunk_supplier(source_.create_supplier(),
+                                              total_mappings, rows_read)
+          : create_data_chunk_supplier(ctx, total_mappings);
 
   RETURN_STATUS_ERROR_IF_NOT_OK(
       graph.BatchAddEdges(src_label_id, dst_label_id, edge_label_id, supplier));
+  if (source_.supports_supplier()) {
+    return create_copy_result(rows_read);
+  }
   return neug::result<Context>(std::move(ctx));
+}
+
+neug::result<OpBuildResultT> FusedCSVEdgeInsertOprBuilder::Build(
+    const Schema& schema, const ContextMeta& ctx_meta,
+    const physical::PhysicalPlan& plan, int op_idx) {
+  (void) schema;
+  const auto& source_opr = plan.plan(op_idx).opr().source();
+  if (source_opr.file_schema().format() != "csv" ||
+      source_opr.has_skip_rows()) {
+    return std::make_pair(nullptr, ContextMeta());
+  }
+
+  auto source = build_read_source(source_opr);
+  if (!source.supports_supplier()) {
+    return std::make_pair(nullptr, ContextMeta());
+  }
+
+  const auto& insert_opr = plan.plan(op_idx + 1).opr().load_edge();
+  if (!insert_opr.has_edge_type()) {
+    THROW_INTERNAL_EXCEPTION(
+        "BatchInsertEdgeOprBuilder::Build: edge type is not set");
+  }
+
+  std::vector<std::pair<int32_t, std::string>> prop_mappings,
+      src_vertex_bindings, dst_vertex_binds;
+  parse_property_mappings(insert_opr.property_mappings(), prop_mappings);
+  parse_property_mappings(insert_opr.source_vertex_binding(),
+                          src_vertex_bindings);
+  parse_property_mappings(insert_opr.destination_vertex_binding(),
+                          dst_vertex_binds);
+
+  physical::EdgeType edge_type;
+  edge_type.CopyFrom(insert_opr.edge_type());
+  return std::make_pair(std::make_unique<BatchInsertEdgeOpr>(
+                            std::move(edge_type), std::move(prop_mappings),
+                            std::move(src_vertex_bindings),
+                            std::move(dst_vertex_binds), std::move(source)),
+                        ctx_meta);
 }
 
 neug::result<OpBuildResultT> BatchInsertEdgeOprBuilder::Build(

--- a/src/execution/execute/ops/batch/batch_insert_edge.cc
+++ b/src/execution/execute/ops/batch/batch_insert_edge.cc
@@ -106,7 +106,7 @@ class BatchInsertEdgeOpr : public IOperator {
         source_(std::move(source)) {}
 
   std::string get_operator_name() const override {
-    return source_.supports_supplier() ? "FusedCSVEdgeInsertOpr"
+    return source_.supports_supplier() ? "FusedStreamEdgeInsertOpr"
                                        : "BatchInsertEdgeOpr";
   }
 
@@ -163,13 +163,14 @@ neug::result<Context> BatchInsertEdgeOpr::Eval(
   return neug::result<Context>(std::move(ctx));
 }
 
-neug::result<OpBuildResultT> FusedCSVEdgeInsertOprBuilder::Build(
+neug::result<OpBuildResultT> FusedStreamEdgeInsertOprBuilder::Build(
     const Schema& schema, const ContextMeta& ctx_meta,
     const physical::PhysicalPlan& plan, int op_idx) {
   (void) schema;
   const auto& source_opr = plan.plan(op_idx).opr().source();
-  if (source_opr.file_schema().format() != "csv" ||
-      source_opr.has_skip_rows()) {
+  // Filtering requires the reader's full-read path. All unfiltered formats
+  // that expose a supplier can use the same stream-to-storage pipeline.
+  if (source_opr.has_skip_rows()) {
     return std::make_pair(nullptr, ContextMeta());
   }
 

--- a/src/execution/execute/ops/batch/batch_insert_vertex.cc
+++ b/src/execution/execute/ops/batch/batch_insert_vertex.cc
@@ -43,7 +43,7 @@ class BatchInsertVertexOpr : public IOperator {
         source_(std::move(source)) {}
 
   std::string get_operator_name() const override {
-    return source_.supports_supplier() ? "FusedCSVVertexInsertOpr"
+    return source_.supports_supplier() ? "FusedStreamVertexInsertOpr"
                                        : "BatchInsertVertexOpr";
   }
 
@@ -97,13 +97,14 @@ neug::result<Context> BatchInsertVertexOpr::Eval(
   return neug::result<Context>(std::move(ctx));
 }
 
-neug::result<OpBuildResultT> FusedCSVVertexInsertOprBuilder::Build(
+neug::result<OpBuildResultT> FusedStreamVertexInsertOprBuilder::Build(
     const Schema& schema, const ContextMeta& ctx_meta,
     const physical::PhysicalPlan& plan, int op_idx) {
   (void) schema;
   const auto& source_opr = plan.plan(op_idx).opr().source();
-  if (source_opr.file_schema().format() != "csv" ||
-      source_opr.has_skip_rows()) {
+  // Filtering requires the reader's full-read path. All unfiltered formats
+  // that expose a supplier can use the same stream-to-storage pipeline.
+  if (source_opr.has_skip_rows()) {
     return std::make_pair(nullptr, ContextMeta());
   }
 

--- a/src/execution/execute/ops/batch/batch_insert_vertex.cc
+++ b/src/execution/execute/ops/batch/batch_insert_vertex.cc
@@ -16,6 +16,7 @@
 #include "neug/execution/execute/ops/batch/batch_insert_vertex.h"
 #include "neug/execution/common/context.h"
 #include "neug/execution/execute/ops/batch/batch_update_utils.h"
+#include "neug/execution/execute/ops/batch/data_source.h"
 #include "neug/storages/graph/graph_interface.h"
 #include "neug/utils/exception/exception.h"
 #include "neug/utils/result.h"
@@ -34,21 +35,25 @@ namespace ops {
 class BatchInsertVertexOpr : public IOperator {
  public:
   BatchInsertVertexOpr(
-      common::NameOrId vertex_type,
-      std::vector<std::pair<int32_t, std::string>> prop_mappings)
+      ::common::NameOrId vertex_type,
+      std::vector<std::pair<int32_t, std::string>> prop_mappings,
+      ReadSource source = {})
       : vertex_type_(std::move(vertex_type)),
-        prop_mappings_(std::move(prop_mappings)) {}
+        prop_mappings_(std::move(prop_mappings)),
+        source_(std::move(source)) {}
 
   std::string get_operator_name() const override {
-    return "BatchInsertVertexOpr";
+    return source_.supports_supplier() ? "FusedCSVVertexInsertOpr"
+                                       : "BatchInsertVertexOpr";
   }
 
   neug::result<Context> Eval(IStorageInterface& graph, const ParamsMap& params,
                              Context&& ctx, OprTimer* timer) override;
 
  private:
-  common::NameOrId vertex_type_;
+  ::common::NameOrId vertex_type_;
   std::vector<std::pair<int32_t, std::string>> prop_mappings_;
+  ReadSource source_;
 };
 
 neug::result<Context> BatchInsertVertexOpr::Eval(
@@ -59,10 +64,10 @@ neug::result<Context> BatchInsertVertexOpr::Eval(
   auto& graph = dynamic_cast<StorageUpdateInterface&>(graph_interface);
   label_t vertex_label_id = 0;
   switch (vertex_type_.item_case()) {
-  case common::NameOrId::kId:
+  case ::common::NameOrId::kId:
     vertex_label_id = vertex_type_.id();
     break;
-  case common::NameOrId::kName: {
+  case ::common::NameOrId::kName: {
     const auto& name = vertex_type_.name();
     if (!graph.schema().is_vertex_label_valid(name)) {
       LOG(ERROR) << "Unknown vertex type: " << vertex_type_.DebugString();
@@ -77,11 +82,49 @@ neug::result<Context> BatchInsertVertexOpr::Eval(
         "BatchInsertVertexOpr: invalid vertex_type: " +
         vertex_type_.DebugString());
   }
-  auto supplier = create_data_chunk_supplier(ctx, prop_mappings_);
+  size_t rows_read = 0;
+  auto supplier =
+      source_.supports_supplier()
+          ? create_mapped_data_chunk_supplier(source_.create_supplier(),
+                                              prop_mappings_, rows_read)
+          : create_data_chunk_supplier(ctx, prop_mappings_);
   GS_AUTO(inserted_vids,
           graph.BatchAddVertices(vertex_label_id, std::move(supplier)));
   (void) inserted_vids;
+  if (source_.supports_supplier()) {
+    return create_copy_result(rows_read);
+  }
   return neug::result<Context>(std::move(ctx));
+}
+
+neug::result<OpBuildResultT> FusedCSVVertexInsertOprBuilder::Build(
+    const Schema& schema, const ContextMeta& ctx_meta,
+    const physical::PhysicalPlan& plan, int op_idx) {
+  (void) schema;
+  const auto& source_opr = plan.plan(op_idx).opr().source();
+  if (source_opr.file_schema().format() != "csv" ||
+      source_opr.has_skip_rows()) {
+    return std::make_pair(nullptr, ContextMeta());
+  }
+
+  auto source = build_read_source(source_opr);
+  if (!source.supports_supplier()) {
+    return std::make_pair(nullptr, ContextMeta());
+  }
+
+  const auto& insert_opr = plan.plan(op_idx + 1).opr().load_vertex();
+  if (!insert_opr.has_vertex_type()) {
+    THROW_INTERNAL_EXCEPTION("BatchInsertVertexOpr must have vertex type");
+  }
+  std::vector<std::pair<int32_t, std::string>> prop_mappings;
+  parse_property_mappings(insert_opr.property_mappings(), prop_mappings);
+
+  ::common::NameOrId vertex_type;
+  vertex_type.CopyFrom(insert_opr.vertex_type());
+  return std::make_pair(
+      std::make_unique<BatchInsertVertexOpr>(
+          std::move(vertex_type), std::move(prop_mappings), std::move(source)),
+      ctx_meta);
 }
 
 neug::result<OpBuildResultT> BatchInsertVertexOprBuilder::Build(
@@ -97,7 +140,7 @@ neug::result<OpBuildResultT> BatchInsertVertexOprBuilder::Build(
   std::vector<std::pair<int32_t, std::string>> prop_mappings;
   parse_property_mappings(opr.property_mappings(), prop_mappings);
 
-  common::NameOrId vertex_type;
+  ::common::NameOrId vertex_type;
   vertex_type.CopyFrom(opr.vertex_type());
   return std::make_pair(std::make_unique<BatchInsertVertexOpr>(
                             std::move(vertex_type), std::move(prop_mappings)),

--- a/src/execution/execute/ops/batch/batch_update_utils.cc
+++ b/src/execution/execute/ops/batch/batch_update_utils.cc
@@ -273,6 +273,68 @@ std::string path_to_json_string(Path& path, const StorageReadInterface& graph) {
   return buffer.GetString();
 }
 
+namespace {
+
+/**
+ * @brief Constant-space head column preserving the input row count of fused
+ * COPY.
+ *
+ * Fused COPY streams batches into storage without retaining their columns in
+ * Context. This column represents N NULL values using only a row count, so
+ * ContextChunk's head-only fallback preserves QueryResult length and PROFILE
+ * output rows. The count reflects consumed input rows, including dangling edges
+ * skipped by storage, rather than the number of records actually inserted.
+ *
+ * Used only as the head of a zero-column COPY result, it is not an output
+ * column. Reading an element returns NULL; shuffle and optional_shuffle use the
+ * selection size, while union adds the two row counts. These operations
+ * preserve chunk transformation semantics without materializing values.
+ */
+class CopyResultColumn final : public IContextColumn {
+ public:
+  explicit CopyResultColumn(size_t row_count) : row_count_(row_count) {}
+
+  size_t size() const override { return row_count_; }
+  std::string column_info() const override { return "CopyResultColumn"; }
+  ContextColumnType column_type() const override {
+    return ContextColumnType::kNone;
+  }
+  const DataType& elem_type() const override {
+    static const DataType type(DataType::SQLNULL);
+    return type;
+  }
+  Value get_elem(size_t) const override { return Value(DataType::SQLNULL); }
+  bool has_value(size_t) const override { return false; }
+  bool is_optional() const override { return true; }
+
+  std::shared_ptr<IContextColumn> shuffle(
+      const sel_vec_t& offsets) const override {
+    return std::make_shared<CopyResultColumn>(offsets.size());
+  }
+
+  std::shared_ptr<IContextColumn> optional_shuffle(
+      const sel_vec_t& offsets) const override {
+    return shuffle(offsets);
+  }
+
+  std::shared_ptr<IContextColumn> union_col(
+      std::shared_ptr<IContextColumn> other) const override {
+    const auto& rhs = dynamic_cast<const CopyResultColumn&>(*other);
+    return std::make_shared<CopyResultColumn>(row_count_ + rhs.size());
+  }
+
+ private:
+  size_t row_count_;
+};
+
+}  // namespace
+
+Context create_copy_result(size_t rows_read) {
+  Context ctx;
+  ctx.append_chunk(DataChunk(), std::make_shared<CopyResultColumn>(rows_read));
+  return ctx;
+}
+
 /// A supplier that yields pre-projected DataChunks one by one.
 class MultiChunkSupplier : public IDataChunkSupplier {
  public:
@@ -298,6 +360,48 @@ class MultiChunkSupplier : public IDataChunkSupplier {
   size_t index_;
 };
 
+std::shared_ptr<DataChunk> map_data_chunk(
+    const DataChunk& chunk,
+    const std::vector<std::pair<int32_t, std::string>>& prop_mappings) {
+  auto out_chunk = std::make_shared<DataChunk>();
+  for (size_t i = 0; i < prop_mappings.size(); ++i) {
+    auto tag_id = prop_mappings[i].first;
+    auto column = chunk.get(tag_id);
+    if (column == nullptr) {
+      THROW_INTERNAL_EXCEPTION("Column not found for tag id: " +
+                               std::to_string(tag_id));
+    }
+    out_chunk->set(static_cast<int>(i), column);
+  }
+  return out_chunk;
+}
+
+class MappedChunkSupplier : public IDataChunkSupplier {
+ public:
+  MappedChunkSupplier(
+      std::shared_ptr<IDataChunkSupplier> supplier,
+      std::vector<std::pair<int32_t, std::string>> prop_mappings,
+      size_t& rows_read)
+      : supplier_(std::move(supplier)),
+        prop_mappings_(std::move(prop_mappings)),
+        rows_read_(rows_read) {}
+
+  std::shared_ptr<DataChunk> GetNextChunk() override {
+    auto chunk = supplier_->GetNextChunk();
+    if (chunk) {
+      rows_read_ += chunk->row_num();
+    }
+    return chunk ? map_data_chunk(*chunk, prop_mappings_) : nullptr;
+  }
+
+  int64_t RowNum() const override { return supplier_->RowNum(); }
+
+ private:
+  std::shared_ptr<IDataChunkSupplier> supplier_;
+  std::vector<std::pair<int32_t, std::string>> prop_mappings_;
+  size_t& rows_read_;
+};
+
 std::shared_ptr<IDataChunkSupplier> create_data_chunk_supplier(
     const Context& ctx,
     const std::vector<std::pair<int32_t, std::string>>& prop_mappings) {
@@ -305,19 +409,17 @@ std::shared_ptr<IDataChunkSupplier> create_data_chunk_supplier(
   projected_chunks.reserve(ctx.chunk_num());
   for (size_t i = 0; i < ctx.chunk_num(); ++i) {
     const auto& chunk = ctx.chunk(i).chunk();
-    auto out_chunk = std::make_shared<DataChunk>();
-    for (size_t j = 0; j < prop_mappings.size(); ++j) {
-      auto tag_id = prop_mappings[j].first;
-      auto column = chunk.get(tag_id);
-      if (column == nullptr) {
-        THROW_INTERNAL_EXCEPTION("Column not found for tag id: " +
-                                 std::to_string(tag_id));
-      }
-      out_chunk->set(static_cast<int>(j), column);
-    }
-    projected_chunks.push_back(std::move(out_chunk));
+    projected_chunks.push_back(map_data_chunk(chunk, prop_mappings));
   }
   return std::make_shared<MultiChunkSupplier>(std::move(projected_chunks));
+}
+
+std::shared_ptr<IDataChunkSupplier> create_mapped_data_chunk_supplier(
+    std::shared_ptr<IDataChunkSupplier> supplier,
+    const std::vector<std::pair<int32_t, std::string>>& prop_mappings,
+    size_t& rows_read) {
+  return std::make_shared<MappedChunkSupplier>(std::move(supplier),
+                                               prop_mappings, rows_read);
 }
 
 std::vector<std::string> match_files_with_pattern(

--- a/src/execution/execute/ops/batch/data_source.cc
+++ b/src/execution/execute/ops/batch/data_source.cc
@@ -114,7 +114,11 @@ ReadSource build_read_source(const ::physical::DataSource& data_source) {
 }
 
 std::shared_ptr<IDataChunkSupplier> ReadSource::create_supplier() const {
-  return function->supplierFunc(state);
+  // Reader setup resolves globs and installs execution-specific stream state.
+  // Keep the cached plan state immutable so every execution starts from the
+  // original paths, including a retry after a read failure.
+  auto execution_state = std::make_shared<ReadSharedState>(*state);
+  return function->supplierFunc(std::move(execution_state));
 }
 
 bool ReadSource::supports_supplier() const {

--- a/src/execution/execute/ops/batch/data_source.cc
+++ b/src/execution/execute/ops/batch/data_source.cc
@@ -47,7 +47,7 @@ class DataSourceOpr : public IOperator {
       IStorageInterface& graph, const ParamsMap& params,
       neug::execution::Context&& ctx,
       neug::execution::OprTimer* timer) override {
-    NEUG_ASSERT(ƒ.function != nullptr);
+    NEUG_ASSERT(source_.function != nullptr);
     auto state = std::make_shared<reader::ReadSharedState>(*source_.state);
     state->parameters = params;
     return source_.function->execFunc(state);

--- a/src/execution/execute/ops/batch/data_source.cc
+++ b/src/execution/execute/ops/batch/data_source.cc
@@ -24,6 +24,7 @@
 #include "neug/compiler/main/metadata_registry.h"
 #include "neug/execution/common/context.h"
 #include "neug/execution/execute/ops/batch/data_source.h"
+#include "neug/utils/io/read/common/options.h"
 #include "neug/utils/io/read/common/schema.h"
 #include "neug/utils/io/reader.h"
 #include "neug/utils/result.h"
@@ -122,7 +123,11 @@ std::shared_ptr<IDataChunkSupplier> ReadSource::create_supplier() const {
 }
 
 bool ReadSource::supports_supplier() const {
-  return function != nullptr && function->supplierFunc != nullptr;
+  if (function == nullptr || function->supplierFunc == nullptr ||
+      state == nullptr) {
+    return false;
+  }
+  return ReadOptions().batch_read.get(state->schema.file.options);
 }
 
 // Build DataSourceOpr from PB, there are two key fields:

--- a/src/execution/execute/ops/batch/data_source.cc
+++ b/src/execution/execute/ops/batch/data_source.cc
@@ -36,14 +36,8 @@ class OprTimer;
 namespace ops {
 
 class DataSourceOpr : public IOperator {
- private:
-  std::shared_ptr<reader::ReadSharedState> sharedState;
-  function::ReadFunction* readFunction;
-
  public:
-  DataSourceOpr(const std::shared_ptr<reader::ReadSharedState>& sharedState,
-                function::ReadFunction* readFunction)
-      : sharedState(std::move(sharedState)), readFunction(readFunction) {}
+  explicit DataSourceOpr(ReadSource source) : source_(std::move(source)) {}
 
   ~DataSourceOpr() override = default;
 
@@ -53,12 +47,14 @@ class DataSourceOpr : public IOperator {
       IStorageInterface& graph, const ParamsMap& params,
       neug::execution::Context&& ctx,
       neug::execution::OprTimer* timer) override {
-    NEUG_ASSERT(readFunction != nullptr);
-    // Parameters belong to this evaluation, not to the cached physical plan.
-    auto state = std::make_shared<reader::ReadSharedState>(*sharedState);
+    NEUG_ASSERT(ƒ.function != nullptr);
+    auto state = std::make_shared<reader::ReadSharedState>(*source_.state);
     state->parameters = params;
-    return readFunction->execFunc(state);
+    return source_.function->execFunc(state);
   }
+
+ private:
+  ReadSource source_;
 };
 
 std::shared_ptr<ReadSharedState> ReadStateBuilder::build(
@@ -110,6 +106,21 @@ FileSchema ReadStateBuilder::buildFileSchema(
   return file_schema;
 }
 
+ReadSource build_read_source(const ::physical::DataSource& data_source) {
+  auto state = ReadStateBuilder().build(data_source);
+  auto gCatalog = neug::main::MetadataRegistry::getCatalog();
+  auto func = gCatalog->getFunctionWithSignature(data_source.extension_name());
+  return {std::move(state), func->ptrCast<function::ReadFunction>()};
+}
+
+std::shared_ptr<IDataChunkSupplier> ReadSource::create_supplier() const {
+  return function->supplierFunc(state);
+}
+
+bool ReadSource::supports_supplier() const {
+  return function != nullptr && function->supplierFunc != nullptr;
+}
+
 // Build DataSourceOpr from PB, there are two key fields:
 // 1. ReadSharedState: can be built from PB, which contains the entry and file
 // schema info.
@@ -119,16 +130,8 @@ neug::result<OpBuildResultT> DataSourceOprBuilder::Build(
     const neug::Schema& schema, const ContextMeta& ctx_meta,
     const physical::PhysicalPlan& plan, int op_idx) {
   auto sourcePB = plan.plan(op_idx).opr().source();
-  auto stateBuilder = ReadStateBuilder();
-  // build read shared state from PB
-  auto state = stateBuilder.build(sourcePB);
-
-  // look up read function from catalog
-  auto signatureName = sourcePB.extension_name();
-  auto gCatalog = neug::main::MetadataRegistry::getCatalog();
-  auto func = gCatalog->getFunctionWithSignature(signatureName);
-  auto readFunc = func->ptrCast<function::ReadFunction>();
-  return std::make_pair(std::make_unique<DataSourceOpr>(state, readFunc),
+  auto source = build_read_source(sourcePB);
+  return std::make_pair(std::make_unique<DataSourceOpr>(std::move(source)),
                         ctx_meta);
 }
 

--- a/src/execution/execute/plan_parser.cc
+++ b/src/execution/execute/plan_parser.cc
@@ -130,6 +130,10 @@ void PlanParser::init() {
 
   register_operator_builder(std::make_unique<ops::DataExportOprBuilder>());
 
+  register_operator_builder(
+      std::make_unique<ops::FusedCSVVertexInsertOprBuilder>());
+  register_operator_builder(
+      std::make_unique<ops::FusedCSVEdgeInsertOprBuilder>());
   register_operator_builder(std::make_unique<ops::DataSourceOprBuilder>());
   register_operator_builder(
       std::make_unique<ops::BatchInsertVertexOprBuilder>());

--- a/src/execution/execute/plan_parser.cc
+++ b/src/execution/execute/plan_parser.cc
@@ -131,9 +131,9 @@ void PlanParser::init() {
   register_operator_builder(std::make_unique<ops::DataExportOprBuilder>());
 
   register_operator_builder(
-      std::make_unique<ops::FusedCSVVertexInsertOprBuilder>());
+      std::make_unique<ops::FusedStreamVertexInsertOprBuilder>());
   register_operator_builder(
-      std::make_unique<ops::FusedCSVEdgeInsertOprBuilder>());
+      std::make_unique<ops::FusedStreamEdgeInsertOprBuilder>());
   register_operator_builder(std::make_unique<ops::DataSourceOprBuilder>());
   register_operator_builder(
       std::make_unique<ops::BatchInsertVertexOprBuilder>());

--- a/src/storages/loader/loader_utils.cc
+++ b/src/storages/loader/loader_utils.cc
@@ -884,7 +884,9 @@ struct CsvSupplierRuntime {
                                   config.double_quote, config.delimiter,
                                   config.use_threads, stream_factory_)
                    .count();
-    reset_reader();
+    if (row_num_ > rows_to_skip_) {
+      reset_reader();
+    }
   }
 
   std::shared_ptr<DataChunk> get_next_chunk() {

--- a/src/storages/loader/loader_utils.cc
+++ b/src/storages/loader/loader_utils.cc
@@ -39,6 +39,7 @@
 #include <thread>
 #include <type_traits>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "csv.hpp"
@@ -640,7 +641,7 @@ class CsvRowCountCounter {
         use_threads_(use_threads),
         stream_factory_(std::move(stream_factory)) {}
 
-  int64_t count() const {
+  std::pair<int64_t, bool> count() const {
     if (stream_factory_) {
       return count_stream();
     }
@@ -650,9 +651,9 @@ class CsvRowCountCounter {
     }
     auto file_size = static_cast<size_t>(st.st_size);
     if (file_size == 0)
-      return 0;
+      return {0, false};
     if (!use_threads_)
-      return count_single(file_size);
+      return {count_single(file_size), true};
 
     constexpr size_t kMinChunkSize = 4 << 20;  // 4 MB
     unsigned num_threads = std::thread::hardware_concurrency();
@@ -663,8 +664,8 @@ class CsvRowCountCounter {
           std::max(1u, static_cast<unsigned>(file_size / kMinChunkSize));
     }
     if (num_threads <= 1)
-      return count_single(file_size);
-    return count_parallel(file_size, num_threads);
+      return {count_single(file_size), true};
+    return {count_parallel(file_size, num_threads), true};
   }
 
  private:
@@ -758,10 +759,11 @@ class CsvRowCountCounter {
   /// Single-threaded scan over a stream source (remote objects). The
   /// parallel scan path relies on byte-range seeks into local files and
   /// stays local-only.
-  int64_t count_stream() const {
+  std::pair<int64_t, bool> count_stream() const {
     auto stream = stream_factory_();
     RowCounterState state;
     state.init(false, quoting_, quote_char_, double_quote_, delimiter_);
+    bool has_bytes = false;
     constexpr size_t kBufSize = 1 << 20;  // 1 MB
     std::vector<char> buffer(kBufSize);
     while (true) {
@@ -773,6 +775,7 @@ class CsvRowCountCounter {
       if (*r == 0) {
         break;
       }
+      has_bytes = true;
       for (int64_t i = 0; i < *r; ++i) {
         state.step(buffer[i]);
       }
@@ -780,7 +783,7 @@ class CsvRowCountCounter {
     int64_t total = state.count;
     if (state.has_content)
       ++total;  // last row without trailing newline
-    return total;
+    return {total, has_bytes};
   }
 
   /// Single-threaded scan.
@@ -878,13 +881,13 @@ struct CsvSupplierRuntime {
     if (selected_column_indices_.empty()) {
       THROW_SCHEMA_MISMATCH("No columns selected for CSV file: " + file_path_);
     }
-    const auto raw_row_num =
+    const auto [raw_row_num, has_bytes] =
         CsvRowCountCounter(file_path, config.quoting, config.quote_char,
                            config.double_quote, config.delimiter,
                            config.use_threads, stream_factory_)
             .count();
     row_num_ = std::max<int64_t>(0, raw_row_num - rows_to_skip_);
-    if (row_num_ > 0) {
+    if (has_bytes) {
       reset_reader();
     }
   }

--- a/src/storages/loader/loader_utils.cc
+++ b/src/storages/loader/loader_utils.cc
@@ -627,10 +627,8 @@ struct RowCounterState {
 /// parallelizes via speculative dual-state-machine scan for large files.
 class CsvRowCountCounter {
  public:
-  // rows_to_skip is intentionally NOT a parameter: the counter counts
-  // all non-empty rows.  The reader's skip_rows() handles skipping
-  // separately, and RowNum() is only a pre-allocation hint, so a slight
-  // overcount (by at most skip_rows, typically 1 for header) is safe.
+  // The counter reports all non-empty rows. CsvSupplierRuntime subtracts
+  // skipped rows before exposing the value as a pre-allocation hint.
   CsvRowCountCounter(std::string file_path, bool quoting, char quote_char,
                      bool double_quote, char delimiter, bool use_threads,
                      io::InputStreamFactory stream_factory = nullptr)
@@ -880,11 +878,13 @@ struct CsvSupplierRuntime {
     if (selected_column_indices_.empty()) {
       THROW_SCHEMA_MISMATCH("No columns selected for CSV file: " + file_path_);
     }
-    row_num_ = CsvRowCountCounter(file_path, config.quoting, config.quote_char,
-                                  config.double_quote, config.delimiter,
-                                  config.use_threads, stream_factory_)
-                   .count();
-    if (row_num_ > rows_to_skip_) {
+    const auto raw_row_num =
+        CsvRowCountCounter(file_path, config.quoting, config.quote_char,
+                           config.double_quote, config.delimiter,
+                           config.use_threads, stream_factory_)
+            .count();
+    row_num_ = std::max<int64_t>(0, raw_row_num - rows_to_skip_);
+    if (row_num_ > 0) {
       reset_reader();
     }
   }

--- a/src/utils/io/read/csv/csv_reader.cc
+++ b/src/utils/io/read/csv/csv_reader.cc
@@ -44,12 +44,6 @@ namespace neug {
 namespace reader {
 namespace {
 
-CsvReadConfig read_config_for_supplier(const CsvReadConfig& config) {
-  CsvReadConfig read_config = config;
-  read_config.include_columns = config.column_names;
-  return read_config;
-}
-
 std::vector<std::shared_ptr<IDataChunkSupplier>> create_chunk_suppliers(
     const std::shared_ptr<ReadSharedState>& state,
     const CsvReadConfig& config) {

--- a/src/utils/io/read/csv/csv_reader.cc
+++ b/src/utils/io/read/csv/csv_reader.cc
@@ -50,6 +50,52 @@ CsvReadConfig read_config_for_supplier(const CsvReadConfig& config) {
   return read_config;
 }
 
+std::vector<std::shared_ptr<IDataChunkSupplier>> create_chunk_suppliers(
+    const std::shared_ptr<ReadSharedState>& state,
+    const CsvReadConfig& config) {
+  const auto& paths = state->schema.file.paths;
+  if (paths.empty()) {
+    THROW_INVALID_ARGUMENT_EXCEPTION("No file paths provided");
+  }
+
+  std::vector<std::shared_ptr<IDataChunkSupplier>> suppliers;
+  suppliers.reserve(paths.size());
+  for (const auto& path : paths) {
+    suppliers.push_back(std::make_shared<CSVChunkSupplier>(
+        path, config, io::bindInputStream(state->stream_opener, path)));
+  }
+  return suppliers;
+}
+
+class SequentialChunkSupplier : public IDataChunkSupplier {
+ public:
+  explicit SequentialChunkSupplier(
+      std::vector<std::shared_ptr<IDataChunkSupplier>> suppliers)
+      : suppliers_(std::move(suppliers)) {
+    for (const auto& supplier : suppliers_) {
+      row_num_ += supplier->RowNum();
+    }
+  }
+
+  std::shared_ptr<DataChunk> GetNextChunk() override {
+    while (supplier_idx_ < suppliers_.size()) {
+      auto chunk = suppliers_[supplier_idx_]->GetNextChunk();
+      if (chunk) {
+        return chunk;
+      }
+      ++supplier_idx_;
+    }
+    return nullptr;
+  }
+
+  int64_t RowNum() const override { return row_num_; }
+
+ private:
+  std::vector<std::shared_ptr<IDataChunkSupplier>> suppliers_;
+  size_t supplier_idx_ = 0;
+  int64_t row_num_ = 0;
+};
+
 }  // namespace
 
 CsvReader::CsvReader(std::shared_ptr<ReadSharedState> sharedState,
@@ -59,8 +105,7 @@ CsvReader::CsvReader(std::shared_ptr<ReadSharedState> sharedState,
 
 CsvReader::~CsvReader() = default;
 
-void CsvReader::read(std::shared_ptr<ReadLocalState> /*localState*/,
-                     execution::Context& ctx) {
+CsvReadConfig CsvReader::buildReadConfig() {
   if (!sharedState_) {
     THROW_INVALID_ARGUMENT_EXCEPTION("SharedState is null");
   }
@@ -69,48 +114,43 @@ void CsvReader::read(std::shared_ptr<ReadLocalState> /*localState*/,
   }
 
   auto config = optionsBuilder_->build();
-  if (!optionsBuilder_->projectColumns(config)) {
-    LOG(WARNING) << "Failed to set column projection, using all columns";
-  }
+  optionsBuilder_->projectColumns(config);
+  return config;
+}
+
+void CsvReader::read(std::shared_ptr<ReadLocalState> /*localState*/,
+                     execution::Context& ctx) {
+  auto config = buildReadConfig();
 
   const auto& fileSchema = sharedState_->schema.file;
   ReadOptions readOpts;
   const bool use_batch_read = readOpts.batch_read.get(fileSchema.options);
 
-  auto read_config = read_config_for_supplier(config);
-  if (sharedState_->skipRows) {
-    // Need all columns to evaluate row-filter expression;
-    // full_read will project afterwards.
+  auto read_config = config;
+  if (sharedState_->skipRows ||
+      (!use_batch_read && !sharedState_->projectColumns.empty())) {
+    // Filters need all columns; full_read applies projection after merging.
     read_config.include_columns = config.column_names;
-  } else if (!sharedState_->projectColumns.empty()) {
-    if (use_batch_read) {
-      // batch_read streams chunks directly to the consumer without
-      // post-projection, so push column projection down to the supplier.
-      read_config.include_columns = config.include_columns;
-    } else {
-      // full_read handles projection via project_chunk().
-      read_config.include_columns = config.column_names;
-    }
   }
 
-  const auto& paths = fileSchema.paths;
-  if (paths.empty()) {
-    THROW_INVALID_ARGUMENT_EXCEPTION("No file paths provided");
-  }
-
-  std::vector<std::shared_ptr<IDataChunkSupplier>> suppliers;
-  suppliers.reserve(paths.size());
-  for (const auto& path : paths) {
-    suppliers.push_back(std::make_shared<CSVChunkSupplier>(
-        path, read_config,
-        io::bindInputStream(sharedState_->stream_opener, path)));
-  }
+  auto suppliers = create_chunk_suppliers(sharedState_, read_config);
 
   if (use_batch_read && !sharedState_->skipRows) {
     batch_read(suppliers, ctx);
   } else {
     full_read(suppliers, ctx, config);
   }
+}
+
+std::shared_ptr<IDataChunkSupplier> CsvReader::getDataChunkSupplier() {
+  auto config = buildReadConfig();
+  if (sharedState_->skipRows) {
+    THROW_INVALID_ARGUMENT_EXCEPTION(
+        "Filtered CSV reads cannot be exposed as a chunk supplier");
+  }
+
+  return std::make_shared<SequentialChunkSupplier>(
+      create_chunk_suppliers(sharedState_, config));
 }
 
 void CsvReader::full_read(

--- a/src/utils/io/read/json/json_reader.cc
+++ b/src/utils/io/read/json/json_reader.cc
@@ -527,11 +527,9 @@ std::shared_ptr<IDataChunkSupplier> JsonReader::getDataChunkSupplier() {
 
   std::vector<std::shared_ptr<IDataChunkSupplier>> suppliers;
   suppliers.reserve(paths.size());
-  auto read_config = read_config_for_supplier(config);
   for (const auto& path : paths) {
     suppliers.push_back(std::make_shared<JsonChunkSupplier>(
-        path, read_config,
-        io::bindInputStream(sharedState_->stream_opener, path)));
+        path, config, io::bindInputStream(sharedState_->stream_opener, path)));
   }
   return std::make_shared<SequentialJsonChunkSupplier>(std::move(suppliers));
 }

--- a/src/utils/io/read/json/json_reader.cc
+++ b/src/utils/io/read/json/json_reader.cc
@@ -418,6 +418,35 @@ JsonReadConfig read_config_for_supplier(const JsonReadConfig& config) {
   return read_config;
 }
 
+class SequentialJsonChunkSupplier : public IDataChunkSupplier {
+ public:
+  explicit SequentialJsonChunkSupplier(
+      std::vector<std::shared_ptr<IDataChunkSupplier>> suppliers)
+      : suppliers_(std::move(suppliers)) {
+    for (const auto& supplier : suppliers_) {
+      row_num_ += supplier->RowNum();
+    }
+  }
+
+  std::shared_ptr<DataChunk> GetNextChunk() override {
+    while (supplier_idx_ < suppliers_.size()) {
+      auto chunk = suppliers_[supplier_idx_]->GetNextChunk();
+      if (chunk) {
+        return chunk;
+      }
+      ++supplier_idx_;
+    }
+    return nullptr;
+  }
+
+  int64_t RowNum() const override { return row_num_; }
+
+ private:
+  std::vector<std::shared_ptr<IDataChunkSupplier>> suppliers_;
+  size_t supplier_idx_ = 0;
+  int64_t row_num_ = 0;
+};
+
 }  // namespace
 
 JsonReader::JsonReader(std::shared_ptr<ReadSharedState> sharedState,
@@ -476,6 +505,35 @@ void JsonReader::read(std::shared_ptr<ReadLocalState> /*localState*/,
   } else {
     full_read(suppliers, ctx, config);
   }
+}
+
+std::shared_ptr<IDataChunkSupplier> JsonReader::getDataChunkSupplier() {
+  if (!sharedState_ || !optionsBuilder_) {
+    THROW_INVALID_ARGUMENT_EXCEPTION("JsonReader state or builder is null");
+  }
+  if (sharedState_->skipRows) {
+    THROW_INVALID_ARGUMENT_EXCEPTION(
+        "Filtered JSON reads cannot be exposed as a chunk supplier");
+  }
+
+  auto config = optionsBuilder_->build();
+  if (!optionsBuilder_->projectColumns(config)) {
+    THROW_INVALID_ARGUMENT_EXCEPTION("Failed to set JSON column projection");
+  }
+  const auto& paths = sharedState_->schema.file.paths;
+  if (paths.empty()) {
+    THROW_INVALID_ARGUMENT_EXCEPTION("No file paths provided");
+  }
+
+  std::vector<std::shared_ptr<IDataChunkSupplier>> suppliers;
+  suppliers.reserve(paths.size());
+  auto read_config = read_config_for_supplier(config);
+  for (const auto& path : paths) {
+    suppliers.push_back(std::make_shared<JsonChunkSupplier>(
+        path, read_config,
+        io::bindInputStream(sharedState_->stream_opener, path)));
+  }
+  return std::make_shared<SequentialJsonChunkSupplier>(std::move(suppliers));
 }
 
 void JsonReader::full_read(

--- a/src/utils/io/read/json/json_reader.cc
+++ b/src/utils/io/read/json/json_reader.cc
@@ -412,12 +412,6 @@ class JsonChunkSupplier : public IDataChunkSupplier {
   std::unique_ptr<StreamLineReader> line_reader_;  // remote JSONL mode
 };
 
-JsonReadConfig read_config_for_supplier(const JsonReadConfig& config) {
-  JsonReadConfig read_config = config;
-  read_config.include_columns = config.column_names;
-  return read_config;
-}
-
 class SequentialJsonChunkSupplier : public IDataChunkSupplier {
  public:
   explicit SequentialJsonChunkSupplier(
@@ -471,20 +465,11 @@ void JsonReader::read(std::shared_ptr<ReadLocalState> /*localState*/,
   ReadOptions readOpts;
   const bool use_batch_read = readOpts.batch_read.get(fileSchema.options);
 
-  auto read_config = read_config_for_supplier(config);
-  if (sharedState_->skipRows) {
-    // Need all columns to evaluate row-filter expression;
-    // full_read will project afterwards.
+  auto read_config = config;
+  if (sharedState_->skipRows ||
+      (!use_batch_read && !sharedState_->projectColumns.empty())) {
+    // Filters need all columns; full_read applies projection after merging.
     read_config.include_columns = config.column_names;
-  } else if (!sharedState_->projectColumns.empty()) {
-    if (use_batch_read) {
-      // batch_read streams chunks directly to the consumer without
-      // post-projection, so push column projection down to the supplier.
-      read_config.include_columns = config.include_columns;
-    } else {
-      // full_read handles projection via project_chunk().
-      read_config.include_columns = config.column_names;
-    }
   }
 
   const auto& paths = fileSchema.paths;

--- a/tests/execution/test_runtime_column.cc
+++ b/tests/execution/test_runtime_column.cc
@@ -1430,12 +1430,98 @@ TEST_F(PathColumnTest, OptionalPathColumnForeach) {
   EXPECT_EQ(collected[0].second, p1);
 }
 
-class ArrowColumnTest : public ::testing::Test {
- protected:
-  void SetUp() override {}
-};
+TEST(DataChunkSupplierTest, MappedSupplierReordersColumnsAndCountsRows) {
+  Context input;
+  for (int batch = 0; batch < 2; ++batch) {
+    DataChunk chunk;
+    for (int column = 0; column < 3; ++column) {
+      ValueColumnBuilder<int32_t> builder;
+      for (int row = 0; row < batch + 1; ++row) {
+        builder.push_back_opt(batch * 100 + column * 10 + row);
+      }
+      chunk.set(column, builder.finish());
+    }
+    input.append_chunk(std::move(chunk));
+  }
+  size_t rows_read = 0;
+  auto supplier = ops::create_mapped_data_chunk_supplier(
+      ops::create_data_chunk_supplier(input, {{0, "a"}, {1, "b"}, {2, "c"}}),
+      {{2, "c"}, {0, "a"}, {2, "duplicate"}}, rows_read);
+  EXPECT_EQ(rows_read, 0);
+  for (size_t batch = 0; batch < input.chunk_num(); ++batch) {
+    auto chunk = supplier->GetNextChunk();
+    ASSERT_NE(chunk, nullptr);
+    EXPECT_EQ(chunk->col_num(), 3);
+    EXPECT_EQ(chunk->row_num(), batch + 1);
+    // Mapping is shallow, including repeated selections, and drops column b.
+    EXPECT_EQ(chunk->get(0), input.chunk(batch).get(2));
+    EXPECT_EQ(chunk->get(1), input.chunk(batch).get(0));
+    EXPECT_EQ(chunk->get(2), chunk->get(0));
+  }
+  EXPECT_EQ(rows_read, 3);
+  EXPECT_EQ(supplier->GetNextChunk(), nullptr);
+  EXPECT_EQ(supplier->GetNextChunk(), nullptr);
+  EXPECT_EQ(rows_read, 3);
 
-TEST_F(ArrowColumnTest, DataChunkSupplierBasic) {
+  auto result = ops::create_copy_result(rows_read);
+  EXPECT_EQ(result.row_num(), 3);
+  EXPECT_EQ(result.chunk_num(), 1);
+  EXPECT_EQ(result.col_num(), 0);
+  Context moved(std::move(result));
+  EXPECT_EQ(moved.row_num(), 3);
+  moved.clear();
+  EXPECT_EQ(moved.row_num(), 0);
+}
+
+TEST(CopyResultTest, UsesOnlyHeadForCardinality) {
+  for (size_t rows : {size_t{0}, size_t{3}, size_t{1'000'000'000}}) {
+    auto result = ops::create_copy_result(rows);
+    ASSERT_EQ(result.chunk_num(), 1);
+    EXPECT_EQ(result.row_num(), rows);
+    EXPECT_EQ(result.col_num(), 0);
+    EXPECT_TRUE(result.tag_ids.empty());
+    auto head = result.chunk(0).head();
+    ASSERT_NE(head, nullptr);
+    EXPECT_EQ(head->size(), rows);
+    EXPECT_EQ(head->elem_type().id(), DataType::SQLNULL);
+    EXPECT_TRUE(head->is_optional());
+    if (rows != 0) {
+      EXPECT_TRUE(head->get_elem(rows - 1).IsNull());
+      EXPECT_FALSE(head->has_value(rows - 1));
+    }
+  }
+}
+
+TEST(CopyResultTest, PreservesChunkTransformSemantics) {
+  auto result = ops::create_copy_result(3);
+  auto transformed = result.apply_chunks(
+      [](ContextChunk&& chunk) -> neug::result<ContextChunk> {
+        return std::move(chunk);
+      });
+  ASSERT_TRUE(transformed.has_value());
+  auto& ctx = transformed.value();
+  EXPECT_EQ(ctx.row_num(), 3);
+  ctx.chunk(0).reshuffle({2, 0});
+  EXPECT_EQ(ctx.row_num(), 2);
+  ctx.chunk(0).optional_reshuffle({std::numeric_limits<sel_t>::max(), 0, 1});
+  EXPECT_EQ(ctx.row_num(), 3);
+  EXPECT_FALSE(ctx.chunk(0).head()->has_value(0));
+
+  auto more = ops::create_copy_result(2);
+  ctx.append_chunk(std::move(more.chunk(0)));
+  auto empty = ops::create_copy_result(0);
+  ctx.append_chunk(std::move(empty.chunk(0)));
+  EXPECT_EQ(ctx.row_num(), 5);
+  ctx.flatten();
+  EXPECT_EQ(ctx.chunk_num(), 1);
+  EXPECT_EQ(ctx.row_num(), 5);
+  EXPECT_EQ(ctx.col_num(), 0);
+  EXPECT_TRUE(ctx.chunk(0).head()->get_elem(4).IsNull());
+  ctx.chunk(0).reshuffle({});
+  EXPECT_EQ(ctx.row_num(), 0);
+}
+
+TEST(DataChunkSupplierTest, CsvBasic) {
   const char* var = std::getenv("TEST_PATH");
   std::string test_path = var ? var : "/workspaces/neug/tests";
   std::string resource_path = test_path + "/execution/resources";
@@ -1464,7 +1550,7 @@ TEST_F(ArrowColumnTest, DataChunkSupplierBasic) {
   EXPECT_GT(total_rows, 0);
 }
 
-TEST_F(ArrowColumnTest, CsvCollectionNullElements) {
+TEST(DataChunkSupplierTest, CsvCollectionNullElements) {
   const char* var = std::getenv("TEST_PATH");
   std::string test_path = var ? var : "/workspaces/neug/tests";
   std::string file_path =

--- a/tests/utils/test_reader.cc
+++ b/tests/utils/test_reader.cc
@@ -1068,6 +1068,59 @@ TEST_F(ReaderTest, TestJsonStreamingRead) {
   EXPECT_EQ(ctx.row_num(), 3);
 }
 
+TEST_F(ReaderTest, TestCsvChunkSupplierStreamsFilesInOrder) {
+  createCsvFile("supplier_1.csv",
+                "id|name|score\n1|Alice|91.5\n2|Bob|82.0\n3|Carol|73.5\n");
+  createCsvFile("supplier_2.csv", "id|name|score\n4|Dave|64.0\n5|Eve|55.5\n");
+
+  std::vector<std::string> columnNames = {"id", "name", "score"};
+  std::vector<std::shared_ptr<::common::DataType>> columnTypes = {
+      createInt32Type(), createStringType(), createDoubleType()};
+  auto sharedState = createSharedState(
+      "supplier_1.csv", columnNames, columnTypes,
+      {{"skip_rows", "1"}, {"batch_size", "2"}, {"batch_read", "false"}},
+      {"score", "id"});
+  sharedState->schema.file.paths.push_back(std::string(ARROW_READER_TEST_DIR) +
+                                           "/supplier_2.csv");
+
+  auto supplier = createCsvReader(sharedState)->getDataChunkSupplier();
+  // RowNum is a pre-allocation hint and includes each skipped header row.
+  EXPECT_EQ(supplier->RowNum(), 7);
+
+  std::vector<double> scores;
+  std::vector<int32_t> ids;
+  size_t chunkCount = 0;
+  while (auto chunk = supplier->GetNextChunk()) {
+    ++chunkCount;
+    ASSERT_EQ(chunk->col_num(), 2);
+    auto scoreColumn =
+        std::dynamic_pointer_cast<ValueColumn<double>>(chunk->get(0));
+    auto idColumn =
+        std::dynamic_pointer_cast<ValueColumn<int32_t>>(chunk->get(1));
+    ASSERT_NE(scoreColumn, nullptr);
+    ASSERT_NE(idColumn, nullptr);
+    for (size_t row = 0; row < chunk->row_num(); ++row) {
+      scores.push_back(scoreColumn->get_value(row));
+      ids.push_back(idColumn->get_value(row));
+    }
+  }
+
+  EXPECT_EQ(chunkCount, 3);
+  EXPECT_EQ(ids, (std::vector<int32_t>{1, 2, 3, 4, 5}));
+  EXPECT_EQ(scores, (std::vector<double>{91.5, 82.0, 73.5, 64.0, 55.5}));
+}
+
+TEST_F(ReaderTest, TestCsvChunkSupplierHandlesEmptyFile) {
+  createCsvFile("supplier_empty.csv", "");
+  auto sharedState =
+      createSharedState("supplier_empty.csv", {"id"}, {createInt64Type()},
+                        {{"batch_size", "2"}, {"batch_read", "false"}});
+
+  auto supplier = createCsvReader(sharedState)->getDataChunkSupplier();
+  EXPECT_EQ(supplier->RowNum(), 0);
+  EXPECT_EQ(supplier->GetNextChunk(), nullptr);
+}
+
 // A header-only CSV has no data rows: full_read must return an empty
 // result instead of failing the column-count validation ("Column number
 // mismatch between schema and CSV data").

--- a/tests/utils/test_reader.cc
+++ b/tests/utils/test_reader.cc
@@ -1068,6 +1068,35 @@ TEST_F(ReaderTest, TestJsonStreamingRead) {
   EXPECT_EQ(ctx.row_num(), 3);
 }
 
+TEST_F(ReaderTest, TestJsonChunkSupplierPreservesProjection) {
+  createJsonFile("supplier_projection.json",
+                 "[{\"id\":1,\"name\":\"Alice\",\"score\":95.5}]");
+  createJsonFile("supplier_projection.jsonl",
+                 "{\"id\":1,\"name\":\"Alice\",\"score\":95.5}\n");
+
+  std::vector<std::string> column_names = {"id", "name", "score"};
+  std::vector<std::shared_ptr<::common::DataType>> column_types = {
+      createInt64Type(), createStringType(), createDoubleType()};
+
+  for (const auto& [file_name, json_array_input] :
+       std::vector<std::pair<std::string, bool>>{
+           {"supplier_projection.json", true},
+           {"supplier_projection.jsonl", false}}) {
+    auto shared_state =
+        createJsonSharedState(file_name, column_names, column_types);
+    shared_state->projectColumns = {"score", "id"};
+
+    auto supplier = createJsonReader(shared_state, json_array_input)
+                        ->getDataChunkSupplier();
+    auto chunk = supplier->GetNextChunk();
+    ASSERT_NE(chunk, nullptr);
+    ASSERT_EQ(chunk->col_num(), 2);
+    EXPECT_DOUBLE_EQ(chunk->get(0)->get_elem(0).GetValue<double>(), 95.5);
+    EXPECT_EQ(chunk->get(1)->get_elem(0).GetValue<int64_t>(), 1);
+    EXPECT_EQ(supplier->GetNextChunk(), nullptr);
+  }
+}
+
 TEST_F(ReaderTest, TestCsvChunkSupplierStreamsFilesInOrder) {
   createCsvFile("supplier_1.csv",
                 "id|name|score\n1|Alice|91.5\n2|Bob|82.0\n3|Carol|73.5\n");

--- a/tests/utils/test_reader.cc
+++ b/tests/utils/test_reader.cc
@@ -1160,6 +1160,20 @@ TEST_F(ReaderTest, TestCsvChunkSupplierHandlesFullySkippedFile) {
   EXPECT_EQ(supplier->GetNextChunk(), nullptr);
 }
 
+TEST_F(ReaderTest, TestCsvChunkSupplierReadsAfterSkippedEmptyRow) {
+  createCsvFile("supplier_leading_empty.csv", "\n42\n");
+  auto sharedState = createSharedState(
+      "supplier_leading_empty.csv", {"id"}, {createInt64Type()},
+      {{"skip_rows", "1"}, {"batch_read", "true"}});
+
+  auto supplier = createCsvReader(sharedState)->getDataChunkSupplier();
+  auto chunk = supplier->GetNextChunk();
+  ASSERT_NE(chunk, nullptr);
+  ASSERT_EQ(chunk->row_num(), 1);
+  EXPECT_EQ(chunk->get(0)->get_elem(0).GetValue<int64_t>(), 42);
+  EXPECT_EQ(supplier->GetNextChunk(), nullptr);
+}
+
 // A header-only CSV has no data rows: full_read must return an empty
 // result instead of failing the column-count validation ("Column number
 // mismatch between schema and CSV data").

--- a/tests/utils/test_reader.cc
+++ b/tests/utils/test_reader.cc
@@ -1113,8 +1113,7 @@ TEST_F(ReaderTest, TestCsvChunkSupplierStreamsFilesInOrder) {
                                            "/supplier_2.csv");
 
   auto supplier = createCsvReader(sharedState)->getDataChunkSupplier();
-  // RowNum is a pre-allocation hint and includes each skipped header row.
-  EXPECT_EQ(supplier->RowNum(), 7);
+  EXPECT_EQ(supplier->RowNum(), 5);
 
   std::vector<double> scores;
   std::vector<int32_t> ids;
@@ -1144,6 +1143,17 @@ TEST_F(ReaderTest, TestCsvChunkSupplierHandlesEmptyFile) {
   auto sharedState =
       createSharedState("supplier_empty.csv", {"id"}, {createInt64Type()},
                         {{"batch_size", "2"}, {"batch_read", "false"}});
+
+  auto supplier = createCsvReader(sharedState)->getDataChunkSupplier();
+  EXPECT_EQ(supplier->RowNum(), 0);
+  EXPECT_EQ(supplier->GetNextChunk(), nullptr);
+}
+
+TEST_F(ReaderTest, TestCsvChunkSupplierHandlesFullySkippedFile) {
+  createCsvFile("supplier_skipped.csv", "1\n2\n");
+  auto sharedState =
+      createSharedState("supplier_skipped.csv", {"id"}, {createInt64Type()},
+                        {{"skip_rows", "2"}, {"batch_read", "true"}});
 
   auto supplier = createCsvReader(sharedState)->getDataChunkSupplier();
   EXPECT_EQ(supplier->RowNum(), 0);

--- a/tools/python_bind/tests/test_db_import_export.py
+++ b/tools/python_bind/tests/test_db_import_export.py
@@ -530,6 +530,104 @@ def test_copy_from_no_schema_node_subquery(tmp_path):
     db.close()
 
 
+def test_copy_from_projection_fallback_matches_load_from(tmp_path):
+    """RETURN keeps Project between Source and Load, so COPY uses fallback."""
+    db_dir = tmp_path / "fallback_projection_ab"
+    db_dir.mkdir()
+    db = Database(db_path=str(db_dir), mode="w")
+    conn = db.connect()
+    try:
+        csv_path = tmp_path / "proj.csv"
+        with open(csv_path, "w") as f:
+            f.write("a|b|c|d\n")
+            for i in range(1, 51):
+                f.write(f"{i}|name{i}|{i * 10}|tag{i % 5}\n")
+
+        load_from = f'LOAD FROM "{Path(csv_path).as_posix()}" (header=true, delim="|")'
+        projection = "RETURN a, d, b"  # reordered + subset (drops column c)
+
+        # Reference: standalone LOAD FROM runs the non-fused full_read path.
+        ref = sorted(tuple(row) for row in conn.execute(f"{load_from} {projection}"))
+
+        result = conn.execute(
+            f"PROFILE COPY proj_node FROM ({load_from} {projection});"
+        )
+        operators = [
+            op["operator_name"] for op in result.get_profile_metrics()["operators"]
+        ]
+        assert "FusedCSVVertexInsertOpr" not in operators
+        assert "DataSourceOpr" in operators
+        assert "BatchInsertVertexOpr" in operators
+        assert len(result) == 50
+        loaded = sorted(
+            tuple(row)
+            for row in conn.execute("MATCH (n:proj_node) RETURN n.a, n.d, n.b")
+        )
+
+        assert len(loaded) == 50
+        assert loaded == ref
+    finally:
+        # Always release the DB so pytest can remove the tmp_path data, even if
+        # an assertion above fails.
+        conn.close()
+        db.close()
+
+
+def test_copy_from_edge_projection_fallback_matches_load_from(tmp_path):
+    """Edge COPY with a RETURN projection also retains the fallback path."""
+    db_dir = tmp_path / "fallback_edge_projection_ab"
+    db_dir.mkdir()
+    db = Database(db_path=str(db_dir), mode="w")
+    conn = db.connect()
+    try:
+        person_csv = tmp_path / "person.csv"
+        with open(person_csv, "w") as f:
+            f.write("id\n")
+            for i in range(1, 11):
+                f.write(f"{i}\n")
+        conn.execute("CREATE NODE TABLE person(id INT64, PRIMARY KEY(id));")
+        conn.execute(f'COPY person FROM "{Path(person_csv).as_posix()}" (header=true);')
+
+        edge_csv = tmp_path / "edges.csv"
+        with open(edge_csv, "w") as f:
+            f.write("src|dst|weight|note\n")
+            for i in range(1, 10):
+                f.write(f"{i}|{i + 1}|{i * 100}|n{i}\n")
+
+        load_from = f'LOAD FROM "{Path(edge_csv).as_posix()}" (header=true, delim="|")'
+        projection = "RETURN src, dst, note, weight"  # properties reordered
+
+        # Reference: standalone LOAD FROM runs the non-fused full_read path.
+        ref = sorted(tuple(row) for row in conn.execute(f"{load_from} {projection}"))
+
+        result = conn.execute(
+            f"PROFILE COPY follows FROM ({load_from} {projection}) "
+            '(from="person", to="person");'
+        )
+        operators = [
+            op["operator_name"] for op in result.get_profile_metrics()["operators"]
+        ]
+        assert "FusedCSVEdgeInsertOpr" not in operators
+        assert "DataSourceOpr" in operators
+        assert "BatchInsertEdgeOpr" in operators
+        assert len(result) == 9
+        loaded = sorted(
+            tuple(row)
+            for row in conn.execute(
+                "MATCH (a:person)-[f:follows]->(b:person) "
+                "RETURN a.id, b.id, f.note, f.weight"
+            )
+        )
+
+        assert len(loaded) == 9
+        assert loaded == ref
+    finally:
+        # Always release the DB so pytest can remove the tmp_path data, even if
+        # an assertion above fails.
+        conn.close()
+        db.close()
+
+
 def test_copy_from_no_schema_edge_from_file(tmp_path):
     """COPY <new_edge> FROM 'file.csv' (from='src_label', to='dst_label')
     Vertex tables must already exist; edge table is auto-created.

--- a/tools/python_bind/tests/test_db_import_export.py
+++ b/tools/python_bind/tests/test_db_import_export.py
@@ -555,7 +555,7 @@ def test_copy_from_projection_fallback_matches_load_from(tmp_path):
         operators = [
             op["operator_name"] for op in result.get_profile_metrics()["operators"]
         ]
-        assert "FusedCSVVertexInsertOpr" not in operators
+        assert "FusedStreamVertexInsertOpr" not in operators
         assert "DataSourceOpr" in operators
         assert "BatchInsertVertexOpr" in operators
         assert len(result) == 50
@@ -607,7 +607,7 @@ def test_copy_from_edge_projection_fallback_matches_load_from(tmp_path):
         operators = [
             op["operator_name"] for op in result.get_profile_metrics()["operators"]
         ]
-        assert "FusedCSVEdgeInsertOpr" not in operators
+        assert "FusedStreamEdgeInsertOpr" not in operators
         assert "DataSourceOpr" in operators
         assert "BatchInsertEdgeOpr" in operators
         assert len(result) == 9

--- a/tools/python_bind/tests/test_load.py
+++ b/tools/python_bind/tests/test_load.py
@@ -1825,6 +1825,41 @@ class TestCopyFrom:
             )
         ) == [[4, 5, 1.5]]
 
+    def test_batch_read_false_disables_fused_stream_operators(self):
+        nodes_path = self.tmp_path / "fallback_nodes.csv"
+        nodes_path.write_text("id,name\n1,Alice\n2,Bob\n", encoding="utf-8")
+        edges_path = self.tmp_path / "fallback_edges.csv"
+        edges_path.write_text("from,to,weight\n1,2,1.5\n", encoding="utf-8")
+
+        self.conn.execute(
+            "CREATE NODE TABLE fallback_node ("
+            "id INT64, name STRING, PRIMARY KEY (id))"
+        )
+        node_result = self.conn.execute(
+            f'PROFILE COPY fallback_node FROM "{nodes_path.as_posix()}" '
+            '(header=true, delimiter=",", batch_read=false)'
+        )
+        node_operators = _operator_names(node_result)
+        assert "FusedStreamVertexInsertOpr" not in node_operators
+        assert "DataSourceOpr" in node_operators
+        assert "BatchInsertVertexOpr" in node_operators
+        assert len(node_result) == 2
+
+        self.conn.execute(
+            "CREATE REL TABLE fallback_edge ("
+            "FROM fallback_node TO fallback_node, weight DOUBLE)"
+        )
+        edge_result = self.conn.execute(
+            f'PROFILE COPY fallback_edge FROM "{edges_path.as_posix()}" '
+            '(from="fallback_node", to="fallback_node", header=true, '
+            'delimiter=",", batch_read=false)'
+        )
+        edge_operators = _operator_names(edge_result)
+        assert "FusedStreamEdgeInsertOpr" not in edge_operators
+        assert "DataSourceOpr" in edge_operators
+        assert "BatchInsertEdgeOpr" in edge_operators
+        assert len(edge_result) == 1
+
     def test_fused_copy_retry_reexpands_file_pattern(self):
         first_path = self.tmp_path / "retry_1.csv"
         first_path.write_text("id,value\n1,10\n2,bad\n", encoding="utf-8")

--- a/tools/python_bind/tests/test_load.py
+++ b/tools/python_bind/tests/test_load.py
@@ -50,6 +50,13 @@ def _nested_list(value):
         return value
 
 
+def _operator_names(result):
+    return [
+        operator["operator_name"]
+        for operator in result.get_profile_metrics()["operators"]
+    ]
+
+
 def get_tinysnb_dataset_path():
     """Get the path to tinysnb dataset CSV files."""
     # Try to get from environment variable first
@@ -1659,6 +1666,117 @@ class TestCopyFrom:
         assert records[0][3] == "Bob", "Target person name should be Bob"
         assert records[0][4] == 5, "Times should be 5"
         assert records[0][5] is not None, "Location should not be None"
+
+    @pytest.mark.parametrize("profile", [False, True])
+    def test_direct_csv_copy_uses_fused_operators(self, profile):
+        """Direct CSV COPY streams into storage while subqueries retain the old path."""
+        (self.tmp_path / "nodes_1.csv").write_text(
+            "id,name\n1,Alice\n2,Bob\n", encoding="utf-8"
+        )
+        (self.tmp_path / "nodes_2.csv").write_text(
+            "id,name\n3,Carol\n", encoding="utf-8"
+        )
+        edges_path = self.tmp_path / "edges.csv"
+        edges_path.write_text(
+            "from,to,weight\n1,2,1.5\n2,3,2.5\n3,99,3.5\n", encoding="utf-8"
+        )
+
+        self.conn.execute(
+            "CREATE NODE TABLE person (id INT64, name STRING, PRIMARY KEY (id))"
+        )
+        node_pattern = (self.tmp_path / "nodes_*.csv").as_posix()
+        prefix = "PROFILE " if profile else ""
+        node_result = self.conn.execute(
+            f'{prefix}COPY person FROM "{node_pattern}" '
+            '(header=true, delimiter=",", batch_size=1)'
+        )
+        assert len(node_result) == 3
+        if profile:
+            assert _operator_names(node_result) == [
+                "FusedCSVVertexInsertOpr",
+                "SinkOpr",
+            ]
+            assert node_result.get_profile_metrics()["total_output_rows"] == 3
+            assert [
+                op["output_rows"]
+                for op in node_result.get_profile_metrics()["operators"]
+            ] == [3, 3]
+        assert list(
+            self.conn.execute("MATCH (p:person) RETURN p.id, p.name ORDER BY p.id")
+        ) == [[1, "Alice"], [2, "Bob"], [3, "Carol"]]
+
+        self.conn.execute(
+            "CREATE REL TABLE knows (FROM person TO person, weight DOUBLE)"
+        )
+        edge_result = self.conn.execute(
+            f'{prefix}COPY knows FROM "{edges_path.as_posix()}" '
+            '(from="person", to="person", header=true, delimiter=",", '
+            "batch_size=1)"
+        )
+        # Preserve input cardinality even when storage skips a dangling edge.
+        assert len(edge_result) == 3
+        if profile:
+            assert _operator_names(edge_result) == ["FusedCSVEdgeInsertOpr", "SinkOpr"]
+            assert edge_result.get_profile_metrics()["total_output_rows"] == 3
+            assert [
+                op["output_rows"]
+                for op in edge_result.get_profile_metrics()["operators"]
+            ] == [3, 3]
+        assert list(
+            self.conn.execute(
+                "MATCH (a:person)-[r:knows]->(b:person) "
+                "RETURN a.id, b.id, r.weight ORDER BY a.id"
+            )
+        ) == [[1, 2, 1.5], [2, 3, 2.5]]
+
+        for table, header, options, operator in [
+            ("person", "id,name\n", "", "FusedCSVVertexInsertOpr"),
+            (
+                "knows",
+                "from,to,weight\n",
+                'from="person", to="person", ',
+                "FusedCSVEdgeInsertOpr",
+            ),
+        ]:
+            empty_path = self.tmp_path / f"{table}_empty.csv"
+            empty_path.write_text(header, encoding="utf-8")
+            result = self.conn.execute(
+                f'{prefix}COPY {table} FROM "{empty_path.as_posix()}" '
+                f'({options}header=true, delimiter=",")'
+            )
+            assert len(result) == 0
+            if profile:
+                assert _operator_names(result) == [operator, "SinkOpr"]
+                assert [
+                    op["output_rows"]
+                    for op in result.get_profile_metrics()["operators"]
+                ] == [0, 0]
+
+        self.conn.execute(
+            "CREATE NODE TABLE fallback_person ("
+            "id INT64, name STRING, PRIMARY KEY (id))"
+        )
+        fallback_result = self.conn.execute(
+            f'PROFILE COPY fallback_person FROM (LOAD FROM "{node_pattern}" '
+            '(header=true, delimiter=",") RETURN id, name)'
+        )
+        fallback_operators = _operator_names(fallback_result)
+        assert "FusedCSVVertexInsertOpr" not in fallback_operators
+        assert "DataSourceOpr" in fallback_operators
+        assert "BatchInsertVertexOpr" in fallback_operators
+
+        json_path = self.tmp_path / "nodes.jsonl"
+        json_path.write_text('{"id": 4, "name": "Dora"}\n', encoding="utf-8")
+        self.conn.execute(
+            "CREATE NODE TABLE json_person (" "id INT64, name STRING, PRIMARY KEY (id))"
+        )
+        json_result = self.conn.execute(
+            f'PROFILE COPY json_person FROM "{json_path.as_posix()}"'
+        )
+        json_operators = _operator_names(json_result)
+        assert "FusedCSVVertexInsertOpr" not in json_operators
+        assert "DataSourceOpr" in json_operators
+        assert "BatchInsertVertexOpr" in json_operators
 
     def test_create_edge_after_copy_from_edges(self):
         """Vertices created after edge COPY retain usable CSR slots."""

--- a/tools/python_bind/tests/test_load.py
+++ b/tools/python_bind/tests/test_load.py
@@ -1825,6 +1825,30 @@ class TestCopyFrom:
             )
         ) == [[4, 5, 1.5]]
 
+    def test_fused_copy_retry_reexpands_file_pattern(self):
+        first_path = self.tmp_path / "retry_1.csv"
+        first_path.write_text("id,value\n1,10\n2,bad\n", encoding="utf-8")
+        file_pattern = (self.tmp_path / "retry_*.csv").as_posix()
+
+        self.conn.execute(
+            "CREATE NODE TABLE retry_node (" "id INT64, value INT64, PRIMARY KEY (id))"
+        )
+        copy_query = (
+            f'COPY retry_node FROM "{file_pattern}" '
+            '(header=true, delimiter=",", batch_size=1)'
+        )
+        with pytest.raises(Exception):
+            self.conn.execute(copy_query)
+
+        first_path.write_text("id,value\n1,10\n2,20\n", encoding="utf-8")
+        (self.tmp_path / "retry_2.csv").write_text("id,value\n3,30\n", encoding="utf-8")
+
+        result = self.conn.execute(copy_query)
+        assert len(result) == 3
+        assert list(
+            self.conn.execute("MATCH (n:retry_node) RETURN n.id, n.value ORDER BY n.id")
+        ) == [[1, 10], [2, 20], [3, 30]]
+
     def test_create_edge_after_copy_from_edges(self):
         """Vertices created after edge COPY retain usable CSR slots."""
         nodes_csv = self.tmp_path / "files.csv"

--- a/tools/python_bind/tests/test_load.py
+++ b/tools/python_bind/tests/test_load.py
@@ -1668,8 +1668,8 @@ class TestCopyFrom:
         assert records[0][5] is not None, "Location should not be None"
 
     @pytest.mark.parametrize("profile", [False, True])
-    def test_direct_csv_copy_uses_fused_operators(self, profile):
-        """Direct CSV COPY streams into storage while subqueries retain the old path."""
+    def test_direct_copy_uses_fused_stream_operators(self, profile):
+        """Direct COPY streams supported formats while transformed inputs fall back."""
         (self.tmp_path / "nodes_1.csv").write_text(
             "id,name\n1,Alice\n2,Bob\n", encoding="utf-8"
         )
@@ -1693,7 +1693,7 @@ class TestCopyFrom:
         assert len(node_result) == 3
         if profile:
             assert _operator_names(node_result) == [
-                "FusedCSVVertexInsertOpr",
+                "FusedStreamVertexInsertOpr",
                 "SinkOpr",
             ]
             assert node_result.get_profile_metrics()["total_output_rows"] == 3
@@ -1716,7 +1716,10 @@ class TestCopyFrom:
         # Preserve input cardinality even when storage skips a dangling edge.
         assert len(edge_result) == 3
         if profile:
-            assert _operator_names(edge_result) == ["FusedCSVEdgeInsertOpr", "SinkOpr"]
+            assert _operator_names(edge_result) == [
+                "FusedStreamEdgeInsertOpr",
+                "SinkOpr",
+            ]
             assert edge_result.get_profile_metrics()["total_output_rows"] == 3
             assert [
                 op["output_rows"]
@@ -1730,12 +1733,12 @@ class TestCopyFrom:
         ) == [[1, 2, 1.5], [2, 3, 2.5]]
 
         for table, header, options, operator in [
-            ("person", "id,name\n", "", "FusedCSVVertexInsertOpr"),
+            ("person", "id,name\n", "", "FusedStreamVertexInsertOpr"),
             (
                 "knows",
                 "from,to,weight\n",
                 'from="person", to="person", ',
-                "FusedCSVEdgeInsertOpr",
+                "FusedStreamEdgeInsertOpr",
             ),
         ]:
             empty_path = self.tmp_path / f"{table}_empty.csv"
@@ -1761,22 +1764,66 @@ class TestCopyFrom:
             '(header=true, delimiter=",") RETURN id, name)'
         )
         fallback_operators = _operator_names(fallback_result)
-        assert "FusedCSVVertexInsertOpr" not in fallback_operators
+        assert "FusedStreamVertexInsertOpr" not in fallback_operators
         assert "DataSourceOpr" in fallback_operators
         assert "BatchInsertVertexOpr" in fallback_operators
 
-        json_path = self.tmp_path / "nodes.jsonl"
-        json_path.write_text('{"id": 4, "name": "Dora"}\n', encoding="utf-8")
+        json_path = self.tmp_path / "nodes.json"
+        json_path.write_text(
+            json.dumps([{"id": 4, "name": "Dora"}, {"id": 5, "name": "Eve"}]),
+            encoding="utf-8",
+        )
         self.conn.execute(
             "CREATE NODE TABLE json_person (" "id INT64, name STRING, PRIMARY KEY (id))"
         )
         json_result = self.conn.execute(
-            f'PROFILE COPY json_person FROM "{json_path.as_posix()}"'
+            f'{prefix}COPY json_person FROM "{json_path.as_posix()}"'
         )
-        json_operators = _operator_names(json_result)
-        assert "FusedCSVVertexInsertOpr" not in json_operators
-        assert "DataSourceOpr" in json_operators
-        assert "BatchInsertVertexOpr" in json_operators
+        assert len(json_result) == 2
+        if profile:
+            assert _operator_names(json_result) == [
+                "FusedStreamVertexInsertOpr",
+                "SinkOpr",
+            ]
+        assert list(
+            self.conn.execute("MATCH (p:json_person) RETURN p.id, p.name ORDER BY p.id")
+        ) == [[4, "Dora"], [5, "Eve"]]
+
+        self.conn.execute(
+            "CREATE NODE TABLE json_fallback ("
+            "id INT64, name STRING, PRIMARY KEY (id))"
+        )
+        json_fallback_result = self.conn.execute(
+            f'PROFILE COPY json_fallback FROM (LOAD FROM "{json_path.as_posix()}" '
+            "RETURN id, name)"
+        )
+        json_fallback_operators = _operator_names(json_fallback_result)
+        assert "FusedStreamVertexInsertOpr" not in json_fallback_operators
+        assert "DataSourceOpr" in json_fallback_operators
+        assert "BatchInsertVertexOpr" in json_fallback_operators
+
+        jsonl_path = self.tmp_path / "json_edges.jsonl"
+        jsonl_path.write_text('{"from": 4, "to": 5, "weight": 1.5}\n', encoding="utf-8")
+        self.conn.execute(
+            "CREATE REL TABLE json_knows (FROM json_person TO json_person, "
+            "weight DOUBLE)"
+        )
+        jsonl_result = self.conn.execute(
+            f'{prefix}COPY json_knows FROM "{jsonl_path.as_posix()}" '
+            '(from="json_person", to="json_person")'
+        )
+        assert len(jsonl_result) == 1
+        if profile:
+            assert _operator_names(jsonl_result) == [
+                "FusedStreamEdgeInsertOpr",
+                "SinkOpr",
+            ]
+        assert list(
+            self.conn.execute(
+                "MATCH (a:json_person)-[r:json_knows]->(b:json_person) "
+                "RETURN a.id, b.id, r.weight"
+            )
+        ) == [[4, 5, 1.5]]
 
     def test_create_edge_after_copy_from_edges(self):
         """Vertices created after edge COPY retain usable CSR slots."""
@@ -2044,7 +2091,11 @@ class TestCopyFrom:
             RETURN ID, age, fName, gender, eyeSight, isStudent
         )
         """
-        self.conn.execute(copy_query)
+        copy_result = self.conn.execute(f"PROFILE {copy_query}")
+        copy_operators = _operator_names(copy_result)
+        assert "FusedStreamVertexInsertOpr" not in copy_operators
+        assert "DataSourceOpr" in copy_operators
+        assert "BatchInsertVertexOpr" in copy_operators
 
         query = "MATCH (p:person_parquet_remap) RETURN p.ID, p.age, p.fName, p.gender, p.eyeSight ORDER BY p.ID LIMIT 3"
         result = self.conn.execute(query)
@@ -2395,10 +2446,21 @@ class TestCopyFrom:
         self.conn.execute(
             "CREATE REL TABLE Knows(FROM Person TO Person, weight DOUBLE);"
         )
-        self.conn.execute(f'COPY Person FROM "{Path(node_pq).as_posix()}";')
-        self.conn.execute(
-            f'COPY Knows FROM "{Path(edge_pq).as_posix()}" (from="Person", to="Person");'
+        node_result = self.conn.execute(
+            f'PROFILE COPY Person FROM "{Path(node_pq).as_posix()}";'
         )
+        assert _operator_names(node_result) == [
+            "FusedStreamVertexInsertOpr",
+            "SinkOpr",
+        ]
+        edge_result = self.conn.execute(
+            f'PROFILE COPY Knows FROM "{Path(edge_pq).as_posix()}" '
+            '(from="Person", to="Person");'
+        )
+        assert _operator_names(edge_result) == [
+            "FusedStreamEdgeInsertOpr",
+            "SinkOpr",
+        ]
 
         res = self.conn.execute("MATCH ()-[r:Knows]->() RETURN count(r);")
         count = next(res)[0]


### PR DESCRIPTION
## What do these changes do?

- Fuse an adjacent direct `DataSource + BatchInsertVertex/BatchInsertEdge` pair while parsing the execution pipeline; logical and physical plans remain unchanged.
- Support CSV, JSON, JSONL, and Parquet readers that expose `IDataChunkSupplier`.
- Stream source `DataChunk` batches to the existing `BatchAddVertices` and `BatchAddEdges` storage APIs instead of materializing the complete source in `Context` before insertion.
- Reuse existing format validation, VFS/glob and remote-stream initialization, column mapping, transaction, checkpoint, and error-handling paths.
- Report `FusedStreamVertexInsertOpr` and `FusedStreamEdgeInsertOpr` in PROFILE output.

## Scope and limitations

- Fusion applies only when the physical plan contains a directly adjacent `Source + LoadVertex` or `Source + LoadEdge` pair and its reader provides `IDataChunkSupplier`.
- COPY statements with an intervening operator, including `LOAD FROM ... RETURN ...` projections or other transformations, retain the original `DataSourceOpr + BatchInsert*Opr` path.
- Reads with `skip_rows` filtering, non-streaming readers, or future formats without `supplierFunc` also retain the original path.
- JSONL and Parquet supply batches incrementally. JSON array input still parses its complete JSON document before yielding batches, so fusion removes `Context` materialization but does not eliminate that parser-side buffering.
- This change streams and remaps `DataChunk` batches, but it does not make a parser write final `TypedColumn` storage columns directly; insertion continues through `BatchAddVertices` and `BatchAddEdges`.
- This change does not introduce new parallel-loading behavior, repeatable chunk sources, or storage interfaces.

This is a deliberately narrow replacement for the streaming portion of #734.

## Validation

- Core build: `neug_execution` and `neug_py_bind`
- Parquet-enabled build: `neug_parquet_extension` and `neug_py_bind`
- Direct CSV, JSON, and JSONL fused COPY test: 2 passed
- Projection fallback tests: 2 passed
- Manual Parquet smoke tests verified direct node and edge COPY PROFILE output includes `FusedStreamVertexInsertOpr` and `FusedStreamEdgeInsertOpr`.
- `black --check` and `git diff --check`

## Related issue number

Fixes #1001

Related to #735
