### PR TITLE
feat: support named path aliases

### DIFF
--- a/doc/source/cypher_manual/query_clauses/match_clause.md
+++ b/doc/source/cypher_manual/query_clauses/match_clause.md
@@ -267,6 +267,88 @@ MATCH (p:Person {name: 'marko'})-[k:KNOWS* SHORTEST 1..2]->(f:Person {name: 'jos
 RETURN k;
 ```
 
+### Named Path
+
+A path can be bound to a variable with `p =` and returned or passed to a path function. NeuG currently supports named paths that contain exactly one relationship segment. The segment can be either a single edge or a repeated path, and the relationship may also have its own variable.
+
+```cypher
+MATCH p = (a:Person {name: 'marko'})-[:KNOWS]->(b:Person {name: 'vadas'})
+RETURN p AS path;
+```
+
+output:
+```
++------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| path                                                                                                                                                                                                 |
++======================================================================================================================================================================================================+
+| {nodes: {_ID: 0, _LABEL: person, id: 1, name: marko, age: 29}, {_ID: 1, _LABEL: person, id: 2, name: vadas, age: 27}, rels: {_ID: 1, _LABEL: knows, _SRC_ID: 0, _DST_ID: 1, weight: 0.5}, length: 1} |
++------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+```
+
+```cypher
+MATCH p = (a:Person {name: 'marko'})-[r:KNOWS*1..3]->(b:Person {name: 'josh'})
+RETURN LENGTH(p) AS path_length, LENGTH(r) AS relationship_path_length;
+```
+
+output:
+```
++-------------+----------------------------+
+| path_length | relationship_path_length   |
++=============+============================+
+| 1           | 1                          |
++-------------+----------------------------+
+```
+
+A named path containing multiple relationship segments is not currently supported. For example, the following query is unsupported:
+
+```cypher
+MATCH p = (a:Person)-[:KNOWS]->(b:Person)-[:KNOWS]->(c:Person)
+RETURN p;
+```
+
+error:
+```
+Not supported: Named paths currently support exactly one relationship segment: p
+```
+
+Named paths can be used with path functions such as `LENGTH`, `NODES`, `RELS`, `PROPERTIES`, and `COST`:
+
+```cypher
+MATCH p = (a:Person {name: 'marko'})-[:KNOWS*1..3]->(b:Person {name: 'josh'})
+RETURN LENGTH(p) AS path_length,
+       NODES(p) AS path_nodes,
+       RELS(p) AS path_rels,
+       PROPERTIES(NODES(p), 'name') AS node_names,
+       PROPERTIES(RELS(p), 'weight') AS rel_weights;
+```
+
+output:
+```
++-------------+-------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------+-------------+-------------+
+| path_length | path_nodes                                                                                                  | path_rels                                                    | node_names  | rel_weights |
++=============+=============================================================================================================+==============================================================+=============+=============+
+| 1           | {_ID: 0, _LABEL: person, id: 1, name: marko, age: 29}, {_ID: 2, _LABEL: person, id: 4, name: josh, age: 32} | {_ID: 2, _LABEL: knows, _SRC_ID: 0, _DST_ID: 2, weight: 1.0} | marko, josh | 1.0         |
++-------------+-------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------+-------------+-------------+
+```
+
+```cypher
+MATCH p = (a:Person {name: 'marko'})
+          -[:KNOWS* WSHORTEST(weight) 1..3]->
+          (b:Person {name: 'josh'})
+RETURN p AS path, COST(p) AS path_cost;
+```
+
+output:
+```
++-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+
+| path                                                                                                                                                                                                | path_cost |
++=====================================================================================================================================================================================================+===========+
+| {nodes: {_ID: 0, _LABEL: person, id: 1, name: marko, age: 29}, {_ID: 2, _LABEL: person, id: 4, name: josh, age: 32}, rels: {_ID: 2, _LABEL: knows, _SRC_ID: 0, _DST_ID: 2, weight: 1.0}, length: 1} | 1.0       |
++-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+
+```
+
+For the available path functions and their usage, see [Repeated Path Function](../expression/graph_func.md#repeated-path-function).
+
 ## Match Patterns
 
 The `MATCH` clause supports complex pattern matching that combines nodes, edges, and conditions in various ways to express sophisticated graph queries.

--- a/doc/source/cypher_manual/query_clauses/match_clause.md
+++ b/doc/source/cypher_manual/query_clauses/match_clause.md
@@ -269,7 +269,7 @@ RETURN k;
 
 ### Named Path
 
-A path can be bound to a variable with `p =` and returned or passed to a path function. NeuG currently supports named paths that contain exactly one relationship segment. The segment can be either a single edge or a repeated path, and the relationship may also have its own variable.
+A path can be bound to a variable with `p =` and returned or passed to a path function. A named path can contain one or more relationship segments. Each segment can be either a single edge or a repeated path, and the relationship may also have its own variable.
 
 ```cypher
 MATCH p = (a:Person {name: 'marko'})-[:KNOWS]->(b:Person {name: 'vadas'})
@@ -299,16 +299,42 @@ output:
 +-------------+----------------------------+
 ```
 
-A named path containing multiple relationship segments is not currently supported. For example, the following query is unsupported:
+Multiple single-edge segments are concatenated into one path:
 
 ```cypher
-MATCH p = (a:Person)-[:KNOWS]->(b:Person)-[:KNOWS]->(c:Person)
-RETURN p;
+MATCH p = (a:Person {name: 'marko'})-[]->
+          (b:Person {name: 'josh'})-[]->
+          (c:Software {name: 'lop'})
+RETURN LENGTH(p) AS path_length,
+       PROPERTIES(NODES(p), 'name') AS node_names,
+       PROPERTIES(RELS(p), 'weight') AS rel_weights;
 ```
 
-error:
+output:
 ```
-Not supported: Named paths currently support exactly one relationship segment: p
++-------------+-------------------+-------------+
+| path_length | node_names        | rel_weights |
++=============+===================+=============+
+| 2           | marko, josh, lop  | 1.0, 0.4    |
++-------------+-------------------+-------------+
+```
+
+Repeated and single-edge segments can also be combined:
+
+```cypher
+MATCH p = (a:Person {name: 'marko'})-[r:KNOWS*1..2]-
+          (b:Person {name: 'josh'})-[:CREATED]->
+          (c:Software {name: 'ripple'})
+RETURN LENGTH(p) AS path_length, LENGTH(r) AS repeated_segment_length;
+```
+
+output:
+```
++-------------+-------------------------+
+| path_length | repeated_segment_length |
++=============+=========================+
+| 2           | 1                       |
++-------------+-------------------------+
 ```
 
 Named paths can be used with path functions such as `LENGTH`, `NODES`, `RELS`, `PROPERTIES`, and `COST`:
@@ -330,6 +356,8 @@ output:
 | 1           | {_ID: 0, _LABEL: person, id: 1, name: marko, age: 29}, {_ID: 2, _LABEL: person, id: 4, name: josh, age: 32} | {_ID: 2, _LABEL: knows, _SRC_ID: 0, _DST_ID: 2, weight: 1.0} | marko, josh | 1.0         |
 +-------------+-------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------+-------------+-------------+
 ```
+
+`COST` remains restricted to a named path containing exactly one weighted repeated segment; it is not supported for a concatenated path.
 
 ```cypher
 MATCH p = (a:Person {name: 'marko'})

--- a/doc/source/cypher_manual/query_clauses/match_clause.md
+++ b/doc/source/cypher_manual/query_clauses/match_clause.md
@@ -267,43 +267,81 @@ MATCH (p:Person {name: 'marko'})-[k:KNOWS* SHORTEST 1..2]->(f:Person {name: 'jos
 RETURN k;
 ```
 
-### Named Path
+## Match Named Path
 
-A path can be bound to a variable with `p =` and returned or passed to a path function. A named path can contain one or more relationship segments. Each segment can be either a single edge or a repeated path, and the relationship may also have its own variable.
+A path pattern can be bound to a variable with `p =`. The named path must be one connected, linear path, but it may contain a single-edge expand, a repeated expand, or multiple consecutive expands.
+
+The following example binds a single-edge expand:
 
 ```cypher
 MATCH p = (a:Person {name: 'marko'})-[:KNOWS]->(b:Person {name: 'vadas'})
-RETURN p AS path;
+RETURN p;
 ```
 
 output:
 ```
 +------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| path                                                                                                                                                                                                 |
+| p                                                                                                                                                                                                    |
 +======================================================================================================================================================================================================+
 | {nodes: {_ID: 0, _LABEL: person, id: 1, name: marko, age: 29}, {_ID: 1, _LABEL: person, id: 2, name: vadas, age: 27}, rels: {_ID: 1, _LABEL: knows, _SRC_ID: 0, _DST_ID: 1, weight: 0.5}, length: 1} |
 +------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 ```
 
+A repeated expand can also be bound as a named path:
+
 ```cypher
-MATCH p = (a:Person {name: 'marko'})-[r:KNOWS*1..3]->(b:Person {name: 'josh'})
-RETURN LENGTH(p) AS path_length, LENGTH(r) AS relationship_path_length;
+MATCH p = (a:Person {name: 'marko'})-[:KNOWS*1..3]->(b:Person {name: 'josh'})
+RETURN p;
 ```
 
 output:
 ```
-+-------------+----------------------------+
-| path_length | relationship_path_length   |
-+=============+============================+
-| 1           | 1                          |
-+-------------+----------------------------+
++-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| p                                                                                                                                                                                                   |
++=====================================================================================================================================================================================================+
+| {nodes: {_ID: 0, _LABEL: person, id: 1, name: marko, age: 29}, {_ID: 2, _LABEL: person, id: 4, name: josh, age: 32}, rels: {_ID: 2, _LABEL: knows, _SRC_ID: 0, _DST_ID: 2, weight: 1.0}, length: 1} |
++-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 ```
 
-Multiple single-edge segments are concatenated into one path:
+Multiple consecutive single-edge and repeated expands can be combined into one named path:
 
 ```cypher
-MATCH p = (a:Person {name: 'marko'})-[]->
-          (b:Person {name: 'josh'})-[]->
+MATCH p = (a:Person {name: 'marko'})-[:KNOWS*1..2]->
+          (b:Person {name: 'josh'})-[:CREATED]->
+          (c:Software {name: 'ripple'})
+RETURN p;
+```
+
+output:
+```
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| p                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
++========================================================================================================================================================================================================================================================================================================================================================================================================================================================================================+
+| {nodes: {_ID: 0, _LABEL: person, id: 1, name: marko, age: 29}, {_ID: 2, _LABEL: person, id: 4, name: josh, age: 32}, {_ID: 72057594037927937, _LABEL: software, id: 5, name: ripple, lang: java}, rels: {_ID: 2, _LABEL: knows, _SRC_ID: 0, _DST_ID: 2, weight: 1.0}, {_ID: 1103808692225, _LABEL: created, _SRC_ID: 2, _DST_ID: 72057594037927937, weight: 1.0, since: 2021}, length: 2} |
++----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+```
+
+A named path cannot represent an arbitrary graph pattern composed of multiple path patterns, such as branches or comma-separated paths. In the following query, `p` names only the first path; it does not include the second path:
+
+```cypher
+MATCH p = (a)-[:KNOWS]->(b),
+          (a)-[:CREATED]->(c)
+RETURN p;
+```
+
+Bind each path separately when more than one path pattern is needed:
+
+```cypher
+MATCH p1 = (a)-[:KNOWS]->(b),
+      p2 = (a)-[:CREATED]->(c)
+RETURN p1, p2;
+```
+
+Named paths can be passed to path functions. For example, `LENGTH` and `PROPERTIES` work with paths composed of multiple expands:
+
+```cypher
+MATCH p = (a:Person {name: 'marko'})-[:KNOWS]->
+          (b:Person {name: 'josh'})-[:CREATED]->
           (c:Software {name: 'lop'})
 RETURN LENGTH(p) AS path_length,
        PROPERTIES(NODES(p), 'name') AS node_names,
@@ -312,70 +350,50 @@ RETURN LENGTH(p) AS path_length,
 
 output:
 ```
-+-------------+-------------------+-------------+
-| path_length | node_names        | rel_weights |
-+=============+===================+=============+
-| 2           | marko, josh, lop  | 1.0, 0.4    |
-+-------------+-------------------+-------------+
++-------------+------------------+-------------+
+| path_length | node_names       | rel_weights |
++=============+==================+=============+
+| 2           | marko, josh, lop | 1.0, 0.4    |
++-------------+------------------+-------------+
 ```
 
-Repeated and single-edge segments can also be combined:
+`COST` can only be applied to a path containing exactly one repeated expand that uses weighted shortest-path semantics. It is not supported for a regular repeated path, a single-edge path, or a path composed of multiple expands.
 
 ```cypher
-MATCH p = (a:Person {name: 'marko'})-[r:KNOWS*1..2]-
-          (b:Person {name: 'josh'})-[:CREATED]->
-          (c:Software {name: 'ripple'})
-RETURN LENGTH(p) AS path_length, LENGTH(r) AS repeated_segment_length;
-```
-
-output:
-```
-+-------------+-------------------------+
-| path_length | repeated_segment_length |
-+=============+=========================+
-| 2           | 1                       |
-+-------------+-------------------------+
-```
-
-Named paths can be used with path functions such as `LENGTH`, `NODES`, `RELS`, `PROPERTIES`, and `COST`:
-
-```cypher
-MATCH p = (a:Person {name: 'marko'})-[:KNOWS*1..3]->(b:Person {name: 'josh'})
-RETURN LENGTH(p) AS path_length,
-       NODES(p) AS path_nodes,
-       RELS(p) AS path_rels,
-       PROPERTIES(NODES(p), 'name') AS node_names,
-       PROPERTIES(RELS(p), 'weight') AS rel_weights;
-```
-
-output:
-```
-+-------------+-------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------+-------------+-------------+
-| path_length | path_nodes                                                                                                  | path_rels                                                    | node_names  | rel_weights |
-+=============+=============================================================================================================+==============================================================+=============+=============+
-| 1           | {_ID: 0, _LABEL: person, id: 1, name: marko, age: 29}, {_ID: 2, _LABEL: person, id: 4, name: josh, age: 32} | {_ID: 2, _LABEL: knows, _SRC_ID: 0, _DST_ID: 2, weight: 1.0} | marko, josh | 1.0         |
-+-------------+-------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------+-------------+-------------+
-```
-
-`COST` remains restricted to a named path containing exactly one weighted repeated segment; it is not supported for a concatenated path.
-
-```cypher
-MATCH p = (a:Person {name: 'marko'})
-          -[:KNOWS* WSHORTEST(weight) 1..3]->
-          (b:Person {name: 'josh'})
-RETURN p AS path, COST(p) AS path_cost;
+MATCH p = (a:person {name: 'marko'})
+          -[:knows* WSHORTEST(weight)]->
+          (b:person {name: 'josh'})
+RETURN p, COST(p) AS path_cost;
 ```
 
 output:
 ```
 +-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+
-| path                                                                                                                                                                                                | path_cost |
+| p                                                                                                                                                                                                   | path_cost |
 +=====================================================================================================================================================================================================+===========+
 | {nodes: {_ID: 0, _LABEL: person, id: 1, name: marko, age: 29}, {_ID: 2, _LABEL: person, id: 4, name: josh, age: 32}, rels: {_ID: 2, _LABEL: knows, _SRC_ID: 0, _DST_ID: 2, weight: 1.0}, length: 1} | 1.0       |
 +-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+
 ```
 
-For the available path functions and their usage, see [Repeated Path Function](../expression/graph_func.md#repeated-path-function).
+Path semantic functions can check whether a materialized path repeats relationships or nodes:
+
+```cypher
+MATCH p = (a:Person {name: 'marko'})-[:KNOWS]->
+          (b:Person {name: 'josh'})-[:CREATED]->
+          (c:Software {name: 'lop'})<-[:CREATED]-(a)
+RETURN IS_TRAIL(p) AS is_trail, IS_ACYCLIC(p) AS is_acyclic;
+```
+
+output:
+```
++----------+------------+
+| is_trail | is_acyclic |
++==========+============+
+| true     | false      |
++----------+------------+
+```
+
+For the complete list of path functions and their usage, see [Repeated Path Function](../expression/graph_func.md#repeated-path-function).
 
 ## Match Patterns
 

--- a/include/neug/compiler/binder/expression/rel_expression.h
+++ b/include/neug/compiler/binder/expression/rel_expression.h
@@ -82,6 +82,11 @@ class RelExpression final : public NodeOrRelExpression {
     return dataType.id() == common::DataTypeId::kPath;
   }
 
+  void requirePathMaterialization() { requiresPathMaterialization = true; }
+  bool isPathMaterializationRequired() const {
+    return requiresPathMaterialization;
+  }
+
   bool isBoundByMultiLabeledNode() const {
     return srcNode->isMultiLabeled() || dstNode->isMultiLabeled();
   }
@@ -151,6 +156,9 @@ class RelExpression final : public NodeOrRelExpression {
   common::QueryRelType relType;
   // Null if relationship type is non-recursive.
   std::unique_ptr<RecursiveInfo> recursiveInfo;
+  // A named path may reference an anonymous relationship. In that case the
+  // relationship still has to produce a physical value for the path.
+  bool requiresPathMaterialization = false;
 };
 
 }  // namespace binder

--- a/include/neug/compiler/gopt/g_expr_converter.h
+++ b/include/neug/compiler/gopt/g_expr_converter.h
@@ -24,6 +24,7 @@
 #include "neug/compiler/binder/expression/literal_expression.h"
 #include "neug/compiler/binder/expression/node_rel_expression.h"
 #include "neug/compiler/binder/expression/parameter_expression.h"
+#include "neug/compiler/binder/expression/path_expression.h"
 #include "neug/compiler/binder/expression/property_expression.h"
 #include "neug/compiler/binder/expression/scalar_function_expression.h"
 #include "neug/compiler/binder/expression/variable_expression.h"
@@ -138,6 +139,9 @@ class GExprConverter {
   ::common::Logical convertCompare(common::ExpressionType type);
   std::unique_ptr<::common::Expression> convertPattern(
       const binder::NodeOrRelExpression& expr);
+  std::unique_ptr<::common::Expression> convertPath(
+      const binder::PathExpression& expr,
+      const std::vector<std::string>& schemaAlias);
   std::unique_ptr<::common::Expression> convertScalarFunc(
       const binder::Expression& expr,
       const std::vector<std::string>& schemaAlias);

--- a/include/neug/compiler/planner/operator/extend/logical_recursive_extend.h
+++ b/include/neug/compiler/planner/operator/extend/logical_recursive_extend.h
@@ -108,7 +108,7 @@ class LogicalRecursiveExtend final : public LogicalOperator {
   ResultOpt getResultOpt() const {
     if (relExpr) {
       std::string relVarName = relExpr->getVariableName();
-      if (relVarName.empty()) {
+      if (relVarName.empty() && !relExpr->isPathMaterializationRequired()) {
         return ResultOpt::END_V;  // optimize the ResultOpt to 'END_V' if no
                                   // query given alias
       }

--- a/include/neug/execution/expression/exprs/path_expr.h
+++ b/include/neug/execution/expression/exprs/path_expr.h
@@ -78,6 +78,25 @@ class SingleRelationshipPathExpr : public ExprBase {
   DataType type_;
 };
 
+class PathConcatExpr : public ExprBase {
+ public:
+  PathConcatExpr(std::unique_ptr<ExprBase>&& left_expr,
+                 std::unique_ptr<ExprBase>&& right_expr)
+      : left_expr_(std::move(left_expr)),
+        right_expr_(std::move(right_expr)),
+        type_(DataType::PATH) {}
+
+  const DataType& type() const override { return type_; }
+
+  std::unique_ptr<BindedExprBase> bind(const IStorageInterface* storage,
+                                       const ParamsMap& params) const override;
+
+ private:
+  std::unique_ptr<ExprBase> left_expr_;
+  std::unique_ptr<ExprBase> right_expr_;
+  DataType type_;
+};
+
 class PathPropsExpr : public ExprBase {
  public:
   PathPropsExpr(std::unique_ptr<ExprBase>&& path_expr, const std::string& prop,

--- a/include/neug/execution/expression/exprs/path_expr.h
+++ b/include/neug/execution/expression/exprs/path_expr.h
@@ -56,26 +56,46 @@ class PathRelationsExpr : public ExprBase {
   std::unique_ptr<ExprBase> path_expr_;
 };
 
+class SingleRelationshipPathExpr : public ExprBase {
+ public:
+  SingleRelationshipPathExpr(std::unique_ptr<ExprBase>&& start_expr,
+                             std::unique_ptr<ExprBase>&& rel_expr,
+                             std::unique_ptr<ExprBase>&& end_expr)
+      : start_expr_(std::move(start_expr)),
+        rel_expr_(std::move(rel_expr)),
+        end_expr_(std::move(end_expr)),
+        type_(DataType::PATH) {}
+
+  const DataType& type() const override { return type_; }
+
+  std::unique_ptr<BindedExprBase> bind(const IStorageInterface* storage,
+                                       const ParamsMap& params) const override;
+
+ private:
+  std::unique_ptr<ExprBase> start_expr_;
+  std::unique_ptr<ExprBase> rel_expr_;
+  std::unique_ptr<ExprBase> end_expr_;
+  DataType type_;
+};
+
 class PathPropsExpr : public ExprBase {
  public:
-  PathPropsExpr(int tag, const std::string& prop, const DataType& type,
-                bool extract_vertex_prop)
-      : tag_(tag),
-        prop_(prop),
-        elem_type_(type),
+  PathPropsExpr(std::unique_ptr<ExprBase>&& path_expr, const std::string& prop,
+                const DataType& type, bool extract_vertex_prop)
+      : prop_(prop),
         type_(DataType::List(type)),
-        extract_vertex_prop_(extract_vertex_prop) {}
+        extract_vertex_prop_(extract_vertex_prop),
+        path_expr_(std::move(path_expr)) {}
   ~PathPropsExpr() override = default;
   const DataType& type() const override { return type_; }
   std::unique_ptr<BindedExprBase> bind(const IStorageInterface* storage,
                                        const ParamsMap& params) const override;
 
  private:
-  int tag_;
   std::string prop_;
-  DataType elem_type_;
   DataType type_;
   bool extract_vertex_prop_;
+  std::unique_ptr<ExprBase> path_expr_;
 };
 
 class StartEndNodeExpr : public ExprBase {

--- a/include/neug/execution/expression/exprs/path_expr.h
+++ b/include/neug/execution/expression/exprs/path_expr.h
@@ -80,11 +80,8 @@ class SingleRelationshipPathExpr : public ExprBase {
 
 class PathConcatExpr : public ExprBase {
  public:
-  PathConcatExpr(std::unique_ptr<ExprBase>&& left_expr,
-                 std::unique_ptr<ExprBase>&& right_expr)
-      : left_expr_(std::move(left_expr)),
-        right_expr_(std::move(right_expr)),
-        type_(DataType::PATH) {}
+  explicit PathConcatExpr(std::vector<std::unique_ptr<ExprBase>> path_exprs)
+      : path_exprs_(std::move(path_exprs)), type_(DataType::PATH) {}
 
   const DataType& type() const override { return type_; }
 
@@ -92,8 +89,7 @@ class PathConcatExpr : public ExprBase {
                                        const ParamsMap& params) const override;
 
  private:
-  std::unique_ptr<ExprBase> left_expr_;
-  std::unique_ptr<ExprBase> right_expr_;
+  std::vector<std::unique_ptr<ExprBase>> path_exprs_;
   DataType type_;
 };
 

--- a/src/compiler/binder/bind_expression/bind_function_expression.cpp
+++ b/src/compiler/binder/bind_expression/bind_function_expression.cpp
@@ -22,6 +22,8 @@
 
 #include "neug/compiler/binder/binder.h"
 #include "neug/compiler/binder/expression/aggregate_function_expression.h"
+#include "neug/compiler/binder/expression/expression_util.h"
+#include "neug/compiler/binder/expression/path_expression.h"
 #include "neug/compiler/binder/expression/scalar_function_expression.h"
 #include "neug/compiler/binder/expression_binder.h"
 #include "neug/compiler/binder/expression_visitor.h"
@@ -31,6 +33,7 @@
 #include "neug/compiler/common/enums/expression_type.h"
 #include "neug/compiler/function/built_in_function_utils.h"
 #include "neug/compiler/function/cast/vector_cast_functions.h"
+#include "neug/compiler/function/path/vector_path_functions.h"
 #include "neug/compiler/function/rewrite_function.h"
 #include "neug/compiler/function/scalar_macro_function.h"
 #include "neug/compiler/main/client_context.h"
@@ -79,6 +82,19 @@ std::shared_ptr<Expression> ExpressionBinder::bindScalarFunctionExpression(
       expr->setAlias(parsedExpression.getChild(i)->getAlias());
     }
     children.push_back(expr);
+  }
+  if ((functionName == NodesFunction::name ||
+       functionName == RelsFunction::name ||
+       functionName == RelationshipsFunction::name) &&
+      children.size() == 1 &&
+      children[0]->expressionType == ExpressionType::PATH) {
+    const auto& pathChildren = children[0]->getChildren();
+    if (pathChildren.size() == 3 &&
+        ExpressionUtil::isRecursiveRelPattern(*pathChildren[1])) {
+      // A single recursive relationship already produces exactly the same
+      // PathValue as its enclosing named path.
+      children[0] = pathChildren[1];
+    }
   }
   return bindScalarFunctionExpression(
       children, functionName,

--- a/src/compiler/function/path/semantic_function.cpp
+++ b/src/compiler/function/path/semantic_function.cpp
@@ -21,8 +21,12 @@
  */
 
 #include "neug/compiler/common/vector/value_vector.h"
+#include "neug/compiler/function/neug_scalar_function.h"
 #include "neug/compiler/function/path/vector_path_functions.h"
-#include "neug/compiler/function/scalar_function.h"
+
+#include <set>
+
+#include "neug/common/types/value.h"
 
 using namespace neug::binder;
 using namespace neug::common;
@@ -36,11 +40,51 @@ static std::unique_ptr<FunctionBindData> bindFunc(
                                              DataType(DataTypeId::kBoolean));
 }
 
+static const neug::Path& getPath(const std::vector<neug::Value>& args,
+                                 const char* functionName) {
+  if (args.size() != 1) {
+    THROW_RUNTIME_ERROR(std::string(functionName) +
+                        " expects exactly one argument");
+  }
+  if (args[0].type().id() != neug::DataTypeId::kPath) {
+    THROW_RUNTIME_ERROR(std::string(functionName) + " expects a PATH argument");
+  }
+  return neug::PathValue::Get(args[0]);
+}
+
+static neug::Value isTrail(const std::vector<neug::Value>& args) {
+  if (args.size() == 1 && args[0].IsNull()) {
+    return neug::Value(neug::DataType::BOOLEAN);
+  }
+  const auto& path = getPath(args, IsTrailFunction::name);
+  std::set<neug::EdgeRecord> relationships;
+  for (const auto& relationship : path.relationships()) {
+    if (!relationships.emplace(relationship).second) {
+      return neug::Value::BOOLEAN(false);
+    }
+  }
+  return neug::Value::BOOLEAN(true);
+}
+
+static neug::Value isACyclic(const std::vector<neug::Value>& args) {
+  if (args.size() == 1 && args[0].IsNull()) {
+    return neug::Value(neug::DataType::BOOLEAN);
+  }
+  const auto& path = getPath(args, IsACyclicFunction::name);
+  std::set<neug::VertexRecord> vertices;
+  for (const auto& vertex : path.nodes()) {
+    if (!vertices.emplace(vertex).second) {
+      return neug::Value::BOOLEAN(false);
+    }
+  }
+  return neug::Value::BOOLEAN(true);
+}
+
 function_set IsTrailFunction::getFunctionSet() {
   function_set functionSet;
-  auto function = std::make_unique<ScalarFunction>(
+  auto function = std::make_unique<NeugScalarFunction>(
       name, std::vector<DataTypeId>{DataTypeId::kPath}, DataTypeId::kBoolean,
-      nullptr, nullptr);
+      isTrail);
   function->bindFunc = bindFunc;
   functionSet.push_back(std::move(function));
   return functionSet;
@@ -48,9 +92,9 @@ function_set IsTrailFunction::getFunctionSet() {
 
 function_set IsACyclicFunction::getFunctionSet() {
   function_set functionSet;
-  auto function = std::make_unique<ScalarFunction>(
+  auto function = std::make_unique<NeugScalarFunction>(
       name, std::vector<DataTypeId>{DataTypeId::kPath}, DataTypeId::kBoolean,
-      nullptr, nullptr);
+      isACyclic);
   function->bindFunc = bindFunc;
   functionSet.push_back(std::move(function));
   return functionSet;

--- a/src/compiler/function/pattern/cost_function.cpp
+++ b/src/compiler/function/pattern/cost_function.cpp
@@ -20,6 +20,8 @@
  * Zhou Xiaoli in 2025 to support Neug-specific features.
  */
 
+#include "neug/compiler/binder/expression/expression_util.h"
+#include "neug/compiler/binder/expression/path_expression.h"
 #include "neug/compiler/binder/expression/rel_expression.h"
 #include "neug/compiler/function/rewrite_function.h"
 #include "neug/compiler/function/schema/vector_node_rel_functions.h"
@@ -36,7 +38,24 @@ static std::shared_ptr<Expression> rewriteFunc(
   NEUG_ASSERT(input.arguments.size() == 1);
   auto param = input.arguments[0].get();
   NEUG_ASSERT(param->getDataType().id() == DataTypeId::kPath);
-  auto recursiveInfo = param->ptrCast<RelExpression>()->getRecursiveInfo();
+  const RelExpression* rel = nullptr;
+  if (param->expressionType == ExpressionType::PATTERN) {
+    rel = param->constPtrCast<RelExpression>();
+  } else if (param->expressionType == ExpressionType::PATH) {
+    const auto& children = param->getChildren();
+    if (children.size() != 3 ||
+        !ExpressionUtil::isRecursiveRelPattern(*children[1])) {
+      THROW_BINDER_EXCEPTION(stringFormat(
+          "Cost function is only defined for a path containing exactly one "
+          "weighted recursive relationship: {}",
+          param->toString()));
+    }
+    rel = children[1]->constPtrCast<RelExpression>();
+  } else {
+    THROW_BINDER_EXCEPTION(
+        stringFormat("Cost function is not defined for {}", param->toString()));
+  }
+  auto recursiveInfo = rel->getRecursiveInfo();
   if (recursiveInfo->bindData->weightOutputExpr == nullptr) {
     THROW_BINDER_EXCEPTION(
         stringFormat("Cost function is not defined for {}", param->toString()));

--- a/src/compiler/gopt/g_alias_manager.cpp
+++ b/src/compiler/gopt/g_alias_manager.cpp
@@ -278,9 +278,24 @@ void GAliasManager::visitOperator(const planner::LogicalOperator& op,
       }
       auto uniqueName = name.uniqueName;
       auto queryName = name.queryName;
+      bool pathMaterializationRequired = false;
+      if (op.getOperatorType() == planner::LogicalOperatorType::EXTEND) {
+        pathMaterializationRequired = op.constCast<planner::LogicalExtend>()
+                                          .getRel()
+                                          ->isPathMaterializationRequired();
+      } else if (op.getOperatorType() ==
+                 planner::LogicalOperatorType::RECURSIVE_EXTEND) {
+        pathMaterializationRequired =
+            op.constCast<planner::LogicalRecursiveExtend>()
+                .getRel()
+                ->isPathMaterializationRequired();
+      }
       // if the unique name is not used by any later operators and the query
-      // given name is not set, we set it as the default alias id
-      if (!vTags.contains(uniqueName) && !queryName.has_value()) {
+      // given name is not set, we set it as the default alias id. A named path
+      // can still consume an anonymous relationship, so such a relationship
+      // needs its own implicit physical alias.
+      if (!vTags.contains(uniqueName) && !queryName.has_value() &&
+          !pathMaterializationRequired) {
         uniqueNameToId[uniqueName] = DEFAULT_ALIAS_ID;
         break;
       }

--- a/src/compiler/gopt/g_expr_converter.cpp
+++ b/src/compiler/gopt/g_expr_converter.cpp
@@ -22,7 +22,9 @@
 #include <string>
 #include <vector>
 #include "neug/compiler/binder/expression/expression.h"
+#include "neug/compiler/binder/expression/expression_util.h"
 #include "neug/compiler/binder/expression/literal_expression.h"
+#include "neug/compiler/binder/expression/path_expression.h"
 #include "neug/compiler/binder/expression/property_expression.h"
 #include "neug/compiler/binder/expression/rel_expression.h"
 #include "neug/compiler/binder/expression/scalar_function_expression.h"
@@ -106,6 +108,9 @@ std::unique_ptr<::common::Expression> GExprConverter::convert(
   case common::ExpressionType::PATTERN: {
     return convertPattern(expr.constCast<binder::NodeOrRelExpression>());
   }
+  case common::ExpressionType::PATH: {
+    return convertPath(expr.constCast<binder::PathExpression>(), schemaAlias);
+  }
   case common::ExpressionType::IS_NOT_NULL: {
     return convertIsNotNull(expr);  // convert to IS NOT NULL
   }
@@ -124,6 +129,35 @@ std::unique_ptr<::common::Expression> GExprConverter::convert(
     THROW_EXCEPTION_WITH_FILE_LINE("Unsupported expression type: " +
                                    expr.toString());
   }
+}
+
+std::unique_ptr<::common::Expression> GExprConverter::convertPath(
+    const binder::PathExpression& expr,
+    const std::vector<std::string>& schemaAlias) {
+  const auto& children = expr.getChildren();
+  if (children.size() != 3 ||
+      (!binder::ExpressionUtil::isRelPattern(*children[1]) &&
+       !binder::ExpressionUtil::isRecursiveRelPattern(*children[1]))) {
+    THROW_NOT_SUPPORTED_EXCEPTION(
+        "Named paths currently support exactly one relationship segment: " +
+        expr.toString());
+  }
+  if (binder::ExpressionUtil::isRecursiveRelPattern(*children[1])) {
+    return convert(*children[1], schemaAlias);
+  }
+
+  auto udfFuncPB = std::make_unique<::common::UserDefinedFunction>();
+  udfFuncPB->set_name("gs.function.singleRelationshipPath");
+  for (const auto& child : children) {
+    auto paramExpr = convert(*child, schemaAlias);
+    udfFuncPB->mutable_parameters()->AddAllocated(paramExpr.release());
+  }
+  auto exprPB = std::make_unique<::common::Expression>();
+  auto oprPB = exprPB->add_operators();
+  oprPB->set_allocated_udf_func(udfFuncPB.release());
+  oprPB->set_allocated_node_type(
+      typeConverter.convertLogicalType(expr.getDataType()).release());
+  return exprPB;
 }
 
 ::physical::GroupBy_AggFunc::Aggregate convertAggregate(
@@ -420,7 +454,6 @@ std::unique_ptr<::common::Expression> GExprConverter::convertListContainsFunc(
     THROW_EXCEPTION_WITH_FILE_LINE(
         "List Contains function should be a function expression");
   }
-  auto& scalarExpr = expr.constCast<binder::ScalarFunctionExpression>();
   if (expr.getChildren().size() < 2) {
     THROW_EXCEPTION_WITH_FILE_LINE(
         "List Contains function should have at least two children");
@@ -518,19 +551,10 @@ std::unique_ptr<::common::Expression> GExprConverter::convertPropertiesFunc(
     THROW_EXCEPTION_WITH_FILE_LINE(
         "Properties function should be a function expression");
   }
-  auto& scalarExpr = expr.constCast<binder::ScalarFunctionExpression>();
   if (expr.getChildren().size() < 2) {
     THROW_EXCEPTION_WITH_FILE_LINE(
         "Properties function should have at least two children");
   }
-  auto pathFuncPB = std::make_unique<::common::PathFunction>();
-  // convert property key
-  auto literalExpr =
-      expr.getChild(1)->constPtrCast<binder::LiteralExpression>();
-  auto key = literalExpr->getValue().getValue<std::string>();
-  pathFuncPB->set_allocated_property(convertPropertyExpr(key).release());
-
-  // convert path tag
   auto nodeOrRelExpr = expr.getChild(0);
   if (nodeOrRelExpr->getChildren().empty()) {
     THROW_EXCEPTION_WITH_FILE_LINE(
@@ -539,33 +563,36 @@ std::unique_ptr<::common::Expression> GExprConverter::convertPropertiesFunc(
         expr.getChild(0)->toString());
   }
   auto pathExpr = nodeOrRelExpr->getChild(0);
-  auto pathAlias = aliasManager->getAliasId(pathExpr->getUniqueName());
-  if (pathAlias != DEFAULT_ALIAS_ID) {
-    pathFuncPB->set_allocated_tag(convertAlias(pathAlias).release());
-  }
-
-  // convert function opt: vertex or edge
   const auto& listType = expr.getChild(0)->getDataType();
   const auto& childType = common::ListType::GetChildType(listType);
-  // project properties for each node in path expand
+  bool extractVertexProp;
   if (childType.id() == common::DataTypeId::kVertex) {
-    pathFuncPB->set_opt(
-        ::common::PathFunction::FuncOpt::PathFunction_FuncOpt_VERTEX);
+    extractVertexProp = true;
   } else if (childType.id() == common::DataTypeId::kEdge) {
-    pathFuncPB->set_opt(
-        ::common::PathFunction::FuncOpt::PathFunction_FuncOpt_EDGE);
+    extractVertexProp = false;
   } else {
     THROW_EXCEPTION_WITH_FILE_LINE(
         "The first child of Properties function should be a list of nodes or "
         "rels, but is " +
         expr.getChild(0)->toString());
   }
-  auto oprPB = std::make_unique<::common::ExprOpr>();
-  oprPB->set_allocated_path_func(pathFuncPB.release());
+
+  // Both materialized path aliases and computed paths are child expressions.
+  // The selector is explicit because the property result type alone cannot
+  // distinguish properties(nodes(path)) from properties(rels(path)).
+  auto udfFuncPB = std::make_unique<::common::UserDefinedFunction>();
+  udfFuncPB->set_name("gs.function.pathProperties");
+  udfFuncPB->mutable_parameters()->AddAllocated(
+      convert(*pathExpr, schemaAlias).release());
+  udfFuncPB->mutable_parameters()->AddAllocated(
+      convert(*expr.getChild(1), schemaAlias).release());
+  udfFuncPB->mutable_parameters()->AddAllocated(
+      convertValue(compiler_impl::Value(extractVertexProp)).release());
+  auto exprPB = std::make_unique<::common::Expression>();
+  auto oprPB = exprPB->add_operators();
+  oprPB->set_allocated_udf_func(udfFuncPB.release());
   oprPB->set_allocated_node_type(
       typeConverter.convertLogicalType(expr.getDataType()).release());
-  auto exprPB = std::make_unique<::common::Expression>();
-  *exprPB->add_operators() = std::move(*oprPB);
   return exprPB;
 }
 

--- a/src/compiler/gopt/g_expr_converter.cpp
+++ b/src/compiler/gopt/g_expr_converter.cpp
@@ -135,29 +135,49 @@ std::unique_ptr<::common::Expression> GExprConverter::convertPath(
     const binder::PathExpression& expr,
     const std::vector<std::string>& schemaAlias) {
   const auto& children = expr.getChildren();
-  if (children.size() != 3 ||
-      (!binder::ExpressionUtil::isRelPattern(*children[1]) &&
-       !binder::ExpressionUtil::isRecursiveRelPattern(*children[1]))) {
-    THROW_NOT_SUPPORTED_EXCEPTION(
-        "Named paths currently support exactly one relationship segment: " +
-        expr.toString());
-  }
-  if (binder::ExpressionUtil::isRecursiveRelPattern(*children[1])) {
-    return convert(*children[1], schemaAlias);
+  if (children.size() < 3 || children.size() % 2 == 0) {
+    THROW_NOT_SUPPORTED_EXCEPTION("Invalid named path expression: " +
+                                  expr.toString());
   }
 
-  auto udfFuncPB = std::make_unique<::common::UserDefinedFunction>();
-  udfFuncPB->set_name("gs.function.singleRelationshipPath");
-  for (const auto& child : children) {
-    auto paramExpr = convert(*child, schemaAlias);
-    udfFuncPB->mutable_parameters()->AddAllocated(paramExpr.release());
+  std::unique_ptr<::common::Expression> result;
+  for (size_t i = 1; i < children.size(); i += 2) {
+    const auto& rel = children[i];
+    std::unique_ptr<::common::Expression> segment;
+    if (binder::ExpressionUtil::isRecursiveRelPattern(*rel)) {
+      segment = convert(*rel, schemaAlias);
+    } else if (binder::ExpressionUtil::isRelPattern(*rel)) {
+      auto segmentFunc = std::make_unique<::common::UserDefinedFunction>();
+      segmentFunc->set_name("gs.function.singleRelationshipPath");
+      for (size_t childIdx = i - 1; childIdx <= i + 1; ++childIdx) {
+        auto paramExpr = convert(*children[childIdx], schemaAlias);
+        segmentFunc->mutable_parameters()->AddAllocated(paramExpr.release());
+      }
+      segment = std::make_unique<::common::Expression>();
+      auto segmentOpr = segment->add_operators();
+      segmentOpr->set_allocated_udf_func(segmentFunc.release());
+      segmentOpr->set_allocated_node_type(
+          typeConverter.convertLogicalType(expr.getDataType()).release());
+    } else {
+      THROW_NOT_SUPPORTED_EXCEPTION("Invalid relationship segment in path: " +
+                                    expr.toString());
+    }
+
+    if (result == nullptr) {
+      result = std::move(segment);
+      continue;
+    }
+    auto concatFunc = std::make_unique<::common::UserDefinedFunction>();
+    concatFunc->set_name("gs.function.pathConcat");
+    concatFunc->mutable_parameters()->AddAllocated(result.release());
+    concatFunc->mutable_parameters()->AddAllocated(segment.release());
+    result = std::make_unique<::common::Expression>();
+    auto concatOpr = result->add_operators();
+    concatOpr->set_allocated_udf_func(concatFunc.release());
+    concatOpr->set_allocated_node_type(
+        typeConverter.convertLogicalType(expr.getDataType()).release());
   }
-  auto exprPB = std::make_unique<::common::Expression>();
-  auto oprPB = exprPB->add_operators();
-  oprPB->set_allocated_udf_func(udfFuncPB.release());
-  oprPB->set_allocated_node_type(
-      typeConverter.convertLogicalType(expr.getDataType()).release());
-  return exprPB;
+  return result;
 }
 
 ::physical::GroupBy_AggFunc::Aggregate convertAggregate(

--- a/src/compiler/gopt/g_expr_converter.cpp
+++ b/src/compiler/gopt/g_expr_converter.cpp
@@ -140,7 +140,8 @@ std::unique_ptr<::common::Expression> GExprConverter::convertPath(
                                   expr.toString());
   }
 
-  std::unique_ptr<::common::Expression> result;
+  std::vector<std::unique_ptr<::common::Expression>> segments;
+  segments.reserve(children.size() / 2);
   for (size_t i = 1; i < children.size(); i += 2) {
     const auto& rel = children[i];
     std::unique_ptr<::common::Expression> segment;
@@ -163,20 +164,22 @@ std::unique_ptr<::common::Expression> GExprConverter::convertPath(
                                     expr.toString());
     }
 
-    if (result == nullptr) {
-      result = std::move(segment);
-      continue;
-    }
-    auto concatFunc = std::make_unique<::common::UserDefinedFunction>();
-    concatFunc->set_name("gs.function.pathConcat");
-    concatFunc->mutable_parameters()->AddAllocated(result.release());
-    concatFunc->mutable_parameters()->AddAllocated(segment.release());
-    result = std::make_unique<::common::Expression>();
-    auto concatOpr = result->add_operators();
-    concatOpr->set_allocated_udf_func(concatFunc.release());
-    concatOpr->set_allocated_node_type(
-        typeConverter.convertLogicalType(expr.getDataType()).release());
+    segments.emplace_back(std::move(segment));
   }
+  if (segments.size() == 1) {
+    return std::move(segments.front());
+  }
+
+  auto concatFunc = std::make_unique<::common::UserDefinedFunction>();
+  concatFunc->set_name("gs.function.pathConcat");
+  for (auto& segment : segments) {
+    concatFunc->mutable_parameters()->AddAllocated(segment.release());
+  }
+  auto result = std::make_unique<::common::Expression>();
+  auto concatOpr = result->add_operators();
+  concatOpr->set_allocated_udf_func(concatFunc.release());
+  concatOpr->set_allocated_node_type(
+      typeConverter.convertLogicalType(expr.getDataType()).release());
   return result;
 }
 

--- a/src/compiler/optimizer/expand_getv_fusion.cpp
+++ b/src/compiler/optimizer/expand_getv_fusion.cpp
@@ -90,6 +90,11 @@ FusionType ExpandGetVFusion::analyze(
     std::shared_ptr<planner::LogicalOperator> expand) {
   auto getVOp = getV->constPtrCast<planner::LogicalGetV>();
   auto expandOp = expand->constPtrCast<planner::LogicalExtend>();
+  // A named single-segment path is constructed from the relationship value.
+  // Keep the edge-producing expand even when that relationship is anonymous.
+  if (expandOp->getRel()->isPathMaterializationRequired()) {
+    return FusionType::EXPANDE_GETV;
+  }
   auto alias = expandOp->getGAliasName();
   // expand has a query given alias, cannot be fused;
   if (alias.queryName.has_value()) {

--- a/src/compiler/optimizer/projection_push_down_optimizer.cpp
+++ b/src/compiler/optimizer/projection_push_down_optimizer.cpp
@@ -388,6 +388,13 @@ void ProjectionPushDownOptimizer::collectExpressionsInUse(
   }
   case ExpressionType::PATTERN: {
     nodeOrRelInUse.insert(expression);
+    // Anonymous relationships referenced through a named path still need a
+    // real physical alias. Record that requirement only when the path (or a
+    // rewritten path function) is actually consumed, preserving endpoint-only
+    // expansion for unused path aliases.
+    if (auto rel = std::dynamic_pointer_cast<RelExpression>(expression)) {
+      rel->requirePathMaterialization();
+    }
     for (auto& child :
          ExpressionChildrenCollector::collectChildren(*expression)) {
       collectExpressionsInUse(child);

--- a/src/execution/expression/expr.cc
+++ b/src/execution/expression/expr.cc
@@ -21,6 +21,7 @@
 #include "neug/compiler/main/metadata_registry.h"
 #include "neug/compiler/transaction/transaction.h"
 #include "neug/execution/expression/accessors/const_accessor.h"
+#include "neug/execution/expression/accessors/record_accessor.h"
 #include "neug/execution/expression/exprs/arith_expr.h"
 #include "neug/execution/expression/exprs/case_when.h"
 #include "neug/execution/expression/exprs/extract_expr.h"
@@ -234,6 +235,33 @@ static std::unique_ptr<ExprBase> build_expr(
         return std::make_unique<PathRelationsExpr>(std::move(expr));
       } else if (name == "gs.function.nodes") {
         return std::make_unique<PathNodesExpr>(std::move(expr));
+      } else if (name == "gs.function.singleRelationshipPath") {
+        if (op.parameters_size() != 3) {
+          THROW_INVALID_ARGUMENT_EXCEPTION(
+              "singleRelationshipPath expects three parameters");
+        }
+        auto rel_expr = parse_expression(op.parameters(1), ctx_meta, var_type);
+        auto end_expr = parse_expression(op.parameters(2), ctx_meta, var_type);
+        return std::make_unique<SingleRelationshipPathExpr>(
+            std::move(expr), std::move(rel_expr), std::move(end_expr));
+      } else if (name == "gs.function.pathProperties") {
+        if (op.parameters_size() != 3 ||
+            op.parameters(1).operators_size() != 1 ||
+            !op.parameters(1).operators(0).has_const_() ||
+            !op.parameters(1).operators(0).const_().has_str() ||
+            op.parameters(2).operators_size() != 1 ||
+            !op.parameters(2).operators(0).has_const_() ||
+            !op.parameters(2).operators(0).const_().has_boolean()) {
+          THROW_INVALID_ARGUMENT_EXCEPTION(
+              "pathProperties expects a path expression, a literal property "
+              "name, and a literal vertex/edge selector");
+        }
+        const auto& prop = op.parameters(1).operators(0).const_().str();
+        auto extract_vertex_prop =
+            op.parameters(2).operators(0).const_().boolean();
+        auto type = parse_path_property_element_type(opr.node_type());
+        return std::make_unique<PathPropsExpr>(std::move(expr), prop, type,
+                                               extract_vertex_prop);
       } else if (name == "gs.function.startNode") {
         return std::make_unique<StartEndNodeExpr>(std::move(expr), true);
       } else if (name == "gs.function.endNode") {
@@ -245,14 +273,21 @@ static std::unique_ptr<ExprBase> build_expr(
     case ::common::ExprOpr::kPathFunc: {
       auto opt = opr.path_func().opt();
       const auto& name = opr.path_func().property().key().name();
-      int tag = opr.path_func().has_tag() ? opr.path_func().tag().id() : -1;
+      if (!opr.path_func().has_tag()) {
+        THROW_INVALID_ARGUMENT_EXCEPTION(
+            "legacy path function requires a materialized path tag");
+      }
+      int tag = opr.path_func().tag().id();
       auto type = parse_path_property_element_type(opr.node_type());
+      auto path_expr = std::make_unique<RecordAccessor>(tag, DataType::PATH);
 
       if (opt == ::common::PathFunction_FuncOpt::PathFunction_FuncOpt_VERTEX) {
-        return std::make_unique<PathPropsExpr>(tag, name, type, true);
+        return std::make_unique<PathPropsExpr>(std::move(path_expr), name, type,
+                                               true);
       } else if (opt ==
                  ::common::PathFunction_FuncOpt::PathFunction_FuncOpt_EDGE) {
-        return std::make_unique<PathPropsExpr>(tag, name, type, false);
+        return std::make_unique<PathPropsExpr>(std::move(path_expr), name, type,
+                                               false);
       } else {
         THROW_NOT_SUPPORTED_EXCEPTION("unsupport path function opt" +
                                       opr.DebugString());

--- a/src/execution/expression/expr.cc
+++ b/src/execution/expression/expr.cc
@@ -244,6 +244,15 @@ static std::unique_ptr<ExprBase> build_expr(
         auto end_expr = parse_expression(op.parameters(2), ctx_meta, var_type);
         return std::make_unique<SingleRelationshipPathExpr>(
             std::move(expr), std::move(rel_expr), std::move(end_expr));
+      } else if (name == "gs.function.pathConcat") {
+        if (op.parameters_size() != 2) {
+          THROW_INVALID_ARGUMENT_EXCEPTION(
+              "pathConcat expects two path parameters");
+        }
+        auto right_expr =
+            parse_expression(op.parameters(1), ctx_meta, var_type);
+        return std::make_unique<PathConcatExpr>(std::move(expr),
+                                                std::move(right_expr));
       } else if (name == "gs.function.pathProperties") {
         if (op.parameters_size() != 3 ||
             op.parameters(1).operators_size() != 1 ||

--- a/src/execution/expression/expr.cc
+++ b/src/execution/expression/expr.cc
@@ -245,14 +245,18 @@ static std::unique_ptr<ExprBase> build_expr(
         return std::make_unique<SingleRelationshipPathExpr>(
             std::move(expr), std::move(rel_expr), std::move(end_expr));
       } else if (name == "gs.function.pathConcat") {
-        if (op.parameters_size() != 2) {
+        if (op.parameters_size() < 2) {
           THROW_INVALID_ARGUMENT_EXCEPTION(
-              "pathConcat expects two path parameters");
+              "pathConcat expects at least two path parameters");
         }
-        auto right_expr =
-            parse_expression(op.parameters(1), ctx_meta, var_type);
-        return std::make_unique<PathConcatExpr>(std::move(expr),
-                                                std::move(right_expr));
+        std::vector<std::unique_ptr<ExprBase>> path_exprs;
+        path_exprs.reserve(op.parameters_size());
+        path_exprs.emplace_back(std::move(expr));
+        for (int i = 1; i < op.parameters_size(); ++i) {
+          path_exprs.emplace_back(
+              parse_expression(op.parameters(i), ctx_meta, var_type));
+        }
+        return std::make_unique<PathConcatExpr>(std::move(path_exprs));
       } else if (name == "gs.function.pathProperties") {
         if (op.parameters_size() != 3 ||
             op.parameters(1).operators_size() != 1 ||

--- a/src/execution/expression/exprs/path_expr.cc
+++ b/src/execution/expression/exprs/path_expr.cc
@@ -80,34 +80,79 @@ std::unique_ptr<BindedExprBase> PathRelationsExpr::bind(
       path_expr_->bind(storage, params));
 }
 
-class BindedPathVerticesPropsExpr : public RecordExprBase {
+class BindedSingleRelationshipPathExpr : public RecordExprBase {
  public:
-  BindedPathVerticesPropsExpr(const StorageReadInterface& graph, int tag,
-                              const std::string& prop, const DataType& type)
-      : graph_(graph),
-        tag_(tag),
-        prop_(prop),
-        elem_type_(ListType::GetChildType(type)) {
-    type_ = type;
-  }
+  BindedSingleRelationshipPathExpr(std::unique_ptr<BindedExprBase>&& start_expr,
+                                   std::unique_ptr<BindedExprBase>&& rel_expr,
+                                   std::unique_ptr<BindedExprBase>&& end_expr)
+      : start_expr_(std::move(start_expr)),
+        rel_expr_(std::move(rel_expr)),
+        end_expr_(std::move(end_expr)),
+        type_(DataType::PATH) {}
+
   const DataType& type() const override { return type_; }
 
   Value eval_record(const DataChunk& chunk, size_t idx) const override {
-    Value path_val = chunk.get(tag_)->get_elem(idx);
-    const Path& path = PathValue::Get(path_val);
-    const auto& vertices = path.nodes();
+    auto start_val =
+        start_expr_->Cast<RecordExprBase>().eval_record(chunk, idx);
+    auto rel_val = rel_expr_->Cast<RecordExprBase>().eval_record(chunk, idx);
+    auto end_val = end_expr_->Cast<RecordExprBase>().eval_record(chunk, idx);
+    if (start_val.IsNull() || rel_val.IsNull() || end_val.IsNull()) {
+      return Value(type_);
+    }
+    const auto& start = start_val.GetValue<vertex_t>();
+    const auto& rel = rel_val.GetValue<edge_t>();
+    const auto& end = end_val.GetValue<vertex_t>();
+    std::vector<std::tuple<label_t, Direction, const void*>> edge_data{
+        {rel.label.edge_label, rel.dir, rel.prop}};
+    std::vector<VertexRecord> vertices{start, end};
+    return Value::PATH(Path(edge_data, vertices));
+  }
+
+ private:
+  std::unique_ptr<BindedExprBase> start_expr_;
+  std::unique_ptr<BindedExprBase> rel_expr_;
+  std::unique_ptr<BindedExprBase> end_expr_;
+  DataType type_;
+};
+
+std::unique_ptr<BindedExprBase> SingleRelationshipPathExpr::bind(
+    const IStorageInterface* storage, const ParamsMap& params) const {
+  return std::make_unique<BindedSingleRelationshipPathExpr>(
+      start_expr_->bind(storage, params), rel_expr_->bind(storage, params),
+      end_expr_->bind(storage, params));
+}
+
+class BindedPathVerticesPropsExpr : public RecordExprBase {
+ public:
+  BindedPathVerticesPropsExpr(const StorageReadInterface& graph,
+                              std::unique_ptr<BindedExprBase>&& path_expr,
+                              const std::string& prop, const DataType& type)
+      : graph_(graph),
+        path_expr_(std::move(path_expr)),
+        prop_(prop),
+        elem_type_(ListType::GetChildType(type)),
+        type_(type) {}
+
+  const DataType& type() const override { return type_; }
+
+  Value eval_record(const DataChunk& chunk, size_t idx) const override {
+    auto path_val = path_expr_->Cast<RecordExprBase>().eval_record(chunk, idx);
+    if (path_val.IsNull()) {
+      return Value(type_);
+    }
+    const auto& vertices = PathValue::Get(path_val).nodes();
     std::vector<Value> prop_values;
     for (const auto& vertex : vertices) {
       const auto& prop_names = graph_.schema().get_vertex_property_names(
           static_cast<label_t>(vertex.label()));
       auto it = std::find(prop_names.begin(), prop_names.end(), prop_);
       if (it == prop_names.end()) {
-        prop_values.push_back(Value(elem_type_));  // null value
+        prop_values.push_back(Value(elem_type_));
       } else {
-        int prop_id = std::distance(prop_names.begin(), it);
-        Value prop =
-            graph_.GetVertexProperty(vertex.label(), vertex.vid(), prop_id);
-        prop_values.emplace_back(std::move(prop));
+        auto prop_id = static_cast<int>(std::distance(prop_names.begin(), it));
+        prop_values.emplace_back(
+            graph_.GetVertexProperty(vertex.label(), vertex.vid(), prop_id));
       }
     }
     return Value::LIST(elem_type_, std::move(prop_values));
@@ -115,41 +160,43 @@ class BindedPathVerticesPropsExpr : public RecordExprBase {
 
  private:
   const StorageReadInterface& graph_;
-  int tag_;
+  std::unique_ptr<BindedExprBase> path_expr_;
   std::string prop_;
-  DataType type_;
   DataType elem_type_;
+  DataType type_;
 };
 
 class BindedPathEdgesPropsExpr : public RecordExprBase {
  public:
-  BindedPathEdgesPropsExpr(const StorageReadInterface& graph, int tag,
+  BindedPathEdgesPropsExpr(const StorageReadInterface& graph,
+                           std::unique_ptr<BindedExprBase>&& path_expr,
                            const std::string& prop, const DataType& type)
       : graph_(graph),
-        tag_(tag),
+        path_expr_(std::move(path_expr)),
         prop_(prop),
-        elem_type_(ListType::GetChildType(type)) {
-    type_ = type;
-  }
+        elem_type_(ListType::GetChildType(type)),
+        type_(type) {}
+
   const DataType& type() const override { return type_; }
 
   Value eval_record(const DataChunk& chunk, size_t idx) const override {
-    Value path_val = chunk.get(tag_)->get_elem(idx);
-    const Path& path = PathValue::Get(path_val);
-    const auto& edges = path.relationships();
+    auto path_val = path_expr_->Cast<RecordExprBase>().eval_record(chunk, idx);
+    if (path_val.IsNull()) {
+      return Value(type_);
+    }
+    const auto& edges = PathValue::Get(path_val).relationships();
     std::vector<Value> prop_values;
     for (const auto& edge : edges) {
       const auto& prop_names = graph_.schema().get_edge_property_names(
           edge.label.src_label, edge.label.dst_label, edge.label.edge_label);
       auto it = std::find(prop_names.begin(), prop_names.end(), prop_);
       if (it == prop_names.end()) {
-        prop_values.push_back(Value(elem_type_));  // null value
+        prop_values.push_back(Value(elem_type_));
       } else {
-        int prop_id = std::distance(prop_names.begin(), it);
+        auto prop_id = static_cast<int>(std::distance(prop_names.begin(), it));
         const auto& accessor = graph_.GetEdgeDataAccessor(
             edge.label.src_label, edge.label.dst_label, edge.label.edge_label,
             prop_id);
-
         prop_values.emplace_back(accessor.get_data_from_ptr(edge.prop));
       }
     }
@@ -158,22 +205,21 @@ class BindedPathEdgesPropsExpr : public RecordExprBase {
 
  private:
   const StorageReadInterface& graph_;
-  int tag_;
+  std::unique_ptr<BindedExprBase> path_expr_;
   std::string prop_;
-  DataType type_;
   DataType elem_type_;
+  DataType type_;
 };
 
 std::unique_ptr<BindedExprBase> PathPropsExpr::bind(
     const IStorageInterface* storage, const ParamsMap& params) const {
   const auto* graph = dynamic_cast<const StorageReadInterface*>(storage);
   if (extract_vertex_prop_) {
-    return std::make_unique<BindedPathVerticesPropsExpr>(*graph, tag_, prop_,
-                                                         type_);
-  } else {
-    return std::make_unique<BindedPathEdgesPropsExpr>(*graph, tag_, prop_,
-                                                      type_);
+    return std::make_unique<BindedPathVerticesPropsExpr>(
+        *graph, path_expr_->bind(storage, params), prop_, type_);
   }
+  return std::make_unique<BindedPathEdgesPropsExpr>(
+      *graph, path_expr_->bind(storage, params), prop_, type_);
 }
 
 class BindedStartEndNodeExpr : public RecordExprBase {

--- a/src/execution/expression/exprs/path_expr.cc
+++ b/src/execution/expression/exprs/path_expr.cc
@@ -14,6 +14,7 @@
  */
 
 #include "neug/execution/expression/exprs/path_expr.h"
+
 #include "neug/common/types/i_context_column.h"
 #include "neug/execution/common/context.h"
 
@@ -121,6 +122,55 @@ std::unique_ptr<BindedExprBase> SingleRelationshipPathExpr::bind(
   return std::make_unique<BindedSingleRelationshipPathExpr>(
       start_expr_->bind(storage, params), rel_expr_->bind(storage, params),
       end_expr_->bind(storage, params));
+}
+
+class BindedPathConcatExpr : public RecordExprBase {
+ public:
+  BindedPathConcatExpr(std::unique_ptr<BindedExprBase>&& left_expr,
+                       std::unique_ptr<BindedExprBase>&& right_expr)
+      : left_expr_(std::move(left_expr)),
+        right_expr_(std::move(right_expr)),
+        type_(DataType::PATH) {}
+
+  const DataType& type() const override { return type_; }
+
+  Value eval_record(const DataChunk& chunk, size_t idx) const override {
+    auto left_val = left_expr_->Cast<RecordExprBase>().eval_record(chunk, idx);
+    auto right_val =
+        right_expr_->Cast<RecordExprBase>().eval_record(chunk, idx);
+    if (left_val.IsNull() || right_val.IsNull()) {
+      return Value(type_);
+    }
+
+    const auto& left_path = PathValue::Get(left_val);
+    const auto& right_path = PathValue::Get(right_val);
+    auto right_vertices = right_path.nodes();
+    if (right_vertices.empty() ||
+        !(left_path.end_node() == right_vertices.front())) {
+      THROW_INVALID_ARGUMENT_EXCEPTION(
+          "Cannot concatenate paths with different boundary vertices");
+    }
+    auto right_edges = right_path.relationships();
+    auto result = left_path;
+    for (size_t i = 0; i < right_edges.size(); ++i) {
+      const auto& edge = right_edges[i];
+      const auto& vertex = right_vertices[i + 1];
+      result = result.expand(edge.label.edge_label, vertex.label(),
+                             vertex.vid(), edge.dir, edge.prop);
+    }
+    return Value::PATH(result);
+  }
+
+ private:
+  std::unique_ptr<BindedExprBase> left_expr_;
+  std::unique_ptr<BindedExprBase> right_expr_;
+  DataType type_;
+};
+
+std::unique_ptr<BindedExprBase> PathConcatExpr::bind(
+    const IStorageInterface* storage, const ParamsMap& params) const {
+  return std::make_unique<BindedPathConcatExpr>(
+      left_expr_->bind(storage, params), right_expr_->bind(storage, params));
 }
 
 class BindedPathVerticesPropsExpr : public RecordExprBase {

--- a/src/execution/expression/exprs/path_expr.cc
+++ b/src/execution/expression/exprs/path_expr.cc
@@ -126,51 +126,57 @@ std::unique_ptr<BindedExprBase> SingleRelationshipPathExpr::bind(
 
 class BindedPathConcatExpr : public RecordExprBase {
  public:
-  BindedPathConcatExpr(std::unique_ptr<BindedExprBase>&& left_expr,
-                       std::unique_ptr<BindedExprBase>&& right_expr)
-      : left_expr_(std::move(left_expr)),
-        right_expr_(std::move(right_expr)),
-        type_(DataType::PATH) {}
+  explicit BindedPathConcatExpr(
+      std::vector<std::unique_ptr<BindedExprBase>>&& path_exprs)
+      : path_exprs_(std::move(path_exprs)), type_(DataType::PATH) {}
 
   const DataType& type() const override { return type_; }
 
   Value eval_record(const DataChunk& chunk, size_t idx) const override {
-    auto left_val = left_expr_->Cast<RecordExprBase>().eval_record(chunk, idx);
-    auto right_val =
-        right_expr_->Cast<RecordExprBase>().eval_record(chunk, idx);
-    if (left_val.IsNull() || right_val.IsNull()) {
+    auto first_val =
+        path_exprs_.front()->Cast<RecordExprBase>().eval_record(chunk, idx);
+    if (first_val.IsNull()) {
       return Value(type_);
     }
 
-    const auto& left_path = PathValue::Get(left_val);
-    const auto& right_path = PathValue::Get(right_val);
-    auto right_vertices = right_path.nodes();
-    if (right_vertices.empty() ||
-        !(left_path.end_node() == right_vertices.front())) {
-      THROW_INVALID_ARGUMENT_EXCEPTION(
-          "Cannot concatenate paths with different boundary vertices");
-    }
-    auto right_edges = right_path.relationships();
-    auto result = left_path;
-    for (size_t i = 0; i < right_edges.size(); ++i) {
-      const auto& edge = right_edges[i];
-      const auto& vertex = right_vertices[i + 1];
-      result = result.expand(edge.label.edge_label, vertex.label(),
-                             vertex.vid(), edge.dir, edge.prop);
+    auto result = PathValue::Get(first_val);
+    for (size_t path_idx = 1; path_idx < path_exprs_.size(); ++path_idx) {
+      auto path_val =
+          path_exprs_[path_idx]->Cast<RecordExprBase>().eval_record(chunk, idx);
+      if (path_val.IsNull()) {
+        return Value(type_);
+      }
+
+      const auto& path = PathValue::Get(path_val);
+      auto vertices = path.nodes();
+      if (vertices.empty() || !(result.end_node() == vertices.front())) {
+        THROW_INVALID_ARGUMENT_EXCEPTION(
+            "Cannot concatenate paths with different boundary vertices");
+      }
+      auto edges = path.relationships();
+      for (size_t i = 0; i < edges.size(); ++i) {
+        const auto& edge = edges[i];
+        const auto& vertex = vertices[i + 1];
+        result = result.expand(edge.label.edge_label, vertex.label(),
+                               vertex.vid(), edge.dir, edge.prop);
+      }
     }
     return Value::PATH(result);
   }
 
  private:
-  std::unique_ptr<BindedExprBase> left_expr_;
-  std::unique_ptr<BindedExprBase> right_expr_;
+  std::vector<std::unique_ptr<BindedExprBase>> path_exprs_;
   DataType type_;
 };
 
 std::unique_ptr<BindedExprBase> PathConcatExpr::bind(
     const IStorageInterface* storage, const ParamsMap& params) const {
-  return std::make_unique<BindedPathConcatExpr>(
-      left_expr_->bind(storage, params), right_expr_->bind(storage, params));
+  std::vector<std::unique_ptr<BindedExprBase>> bound_path_exprs;
+  bound_path_exprs.reserve(path_exprs_.size());
+  for (const auto& path_expr : path_exprs_) {
+    bound_path_exprs.emplace_back(path_expr->bind(storage, params));
+  }
+  return std::make_unique<BindedPathConcatExpr>(std::move(bound_path_exprs));
 }
 
 class BindedPathVerticesPropsExpr : public RecordExprBase {

--- a/tests/compiler/path_test.cpp
+++ b/tests/compiler/path_test.cpp
@@ -199,6 +199,36 @@ TEST_F(PathTest, Properties) {
                                       getPathResource("Properties_physical"));
 }
 
+TEST_F(PathTest, NamedPathUsesVariadicConcat) {
+  std::string query =
+      "MATCH p = (a:person)-[:knows]->(b:person)-[:knows]->(c:person)-"
+      "[:knows]->(d:person) RETURN p";
+  auto logical = planLogical(query, schemaData, statsData, rules);
+  auto physical = planPhysical(*logical);
+
+  const physical::Project* project = nullptr;
+  for (int i = 0; i < physical->plan_size(); ++i) {
+    if (physical->plan(i).opr().has_project()) {
+      project = &physical->plan(i).opr().project();
+    }
+  }
+  ASSERT_NE(project, nullptr);
+  ASSERT_EQ(project->mappings_size(), 1);
+
+  const auto& operators = project->mappings(0).expr().operators();
+  ASSERT_EQ(operators.size(), 1);
+  ASSERT_TRUE(operators.Get(0).has_udf_func());
+  const auto& concat = operators.Get(0).udf_func();
+  EXPECT_EQ(concat.name(), "gs.function.pathConcat");
+  ASSERT_EQ(concat.parameters_size(), 3);
+  for (const auto& parameter : concat.parameters()) {
+    ASSERT_EQ(parameter.operators_size(), 1);
+    ASSERT_TRUE(parameter.operators(0).has_udf_func());
+    EXPECT_EQ(parameter.operators(0).udf_func().name(),
+              "gs.function.singleRelationshipPath");
+  }
+}
+
 TEST_F(PathTest, WSHORTEST_PATH) {
   std::string query =
       "Match (p1:person {id: 123})-[knows:KNOWS* WSHORTEST(weight) "

--- a/tests/compiler/resources/path_test/Properties_physical
+++ b/tests/compiler/resources/path_test/Properties_physical
@@ -151,16 +151,69 @@
             }
            }
           },
-          "path_func": {
-           "tag": {
-            "id": 1
-           },
-           "property": {
-            "key": {
-             "name": "name"
+          "udf_func": {
+           "name": "gs.function.pathProperties",
+           "parameters": [
+            {
+             "operators": [
+              {
+               "var": {
+                "tag": {
+                 "id": 1
+                },
+                "node_type": {
+                 "graph_type": {
+                  "element_opt": "PATH",
+                  "graph_data_type": [
+                   {
+                    "label": {
+                     "label": 0,
+                     "src_label": 0,
+                     "dst_label": 0
+                    },
+                    "props": []
+                   }
+                  ]
+                 }
+                }
+               },
+               "node_type": {
+                "graph_type": {
+                 "element_opt": "PATH",
+                 "graph_data_type": [
+                  {
+                   "label": {
+                    "label": 0,
+                    "src_label": 0,
+                    "dst_label": 0
+                   },
+                   "props": []
+                  }
+                 ]
+                }
+               }
+              }
+             ]
+            },
+            {
+             "operators": [
+              {
+               "const": {
+                "str": "name"
+               }
+              }
+             ]
+            },
+            {
+             "operators": [
+              {
+               "const": {
+                "boolean": true
+               }
+              }
+             ]
             }
-           },
-           "opt": "VERTEX"
+           ]
           }
          }
         ]
@@ -181,16 +234,69 @@
             }
            }
           },
-          "path_func": {
-           "tag": {
-            "id": 1
-           },
-           "property": {
-            "key": {
-             "name": "weight"
+          "udf_func": {
+           "name": "gs.function.pathProperties",
+           "parameters": [
+            {
+             "operators": [
+              {
+               "var": {
+                "tag": {
+                 "id": 1
+                },
+                "node_type": {
+                 "graph_type": {
+                  "element_opt": "PATH",
+                  "graph_data_type": [
+                   {
+                    "label": {
+                     "label": 0,
+                     "src_label": 0,
+                     "dst_label": 0
+                    },
+                    "props": []
+                   }
+                  ]
+                 }
+                }
+               },
+               "node_type": {
+                "graph_type": {
+                 "element_opt": "PATH",
+                 "graph_data_type": [
+                  {
+                   "label": {
+                    "label": 0,
+                    "src_label": 0,
+                    "dst_label": 0
+                   },
+                   "props": []
+                  }
+                 ]
+                }
+               }
+              }
+             ]
+            },
+            {
+             "operators": [
+              {
+               "const": {
+                "str": "weight"
+               }
+              }
+             ]
+            },
+            {
+             "operators": [
+              {
+               "const": {
+                "boolean": false
+               }
+              }
+             ]
             }
-           },
-           "opt": "EDGE"
+           ]
           }
          }
         ]

--- a/tools/python_bind/tests/test_path.py
+++ b/tools/python_bind/tests/test_path.py
@@ -358,6 +358,129 @@ def test_materialized_path_returns_correct_length(path_expand_connection):
     assert "PathExpandVOpr" not in operator_names
 
 
+def test_single_relationship_named_path(modern_graph):
+    result = modern_graph.execute(
+        """
+        MATCH p = (a:person)-[]-(b:person)
+        WHERE (a.name = 'marko' AND b.name = 'vadas') OR
+              (a.name = 'vadas' AND b.name = 'marko')
+        RETURN p, length(p), nodes(p), rels(p),
+               properties(nodes(p), 'name'),
+               properties(rels(p), 'weight')
+        """
+    )
+
+    records = list(result)
+    assert len(records) == 2
+    node_name_pairs = set()
+    for path, length, nodes, rels, node_names, rel_weights in records:
+        assert length == 1
+        assert path["length"] == length
+        assert path["nodes"] == nodes
+        assert path["rels"] == rels
+        assert node_names == [node["name"] for node in nodes]
+        assert rel_weights == [0.5]
+        node_name_pairs.add(tuple(node_names))
+    assert node_name_pairs == {("marko", "vadas"), ("vadas", "marko")}
+
+
+def test_single_recursive_relationship_named_path(modern_graph):
+    result = modern_graph.execute(
+        """
+        PROFILE MATCH p = (a:person)-[:knows*1..2]->(b:person)
+        WHERE a.name = 'marko'
+        RETURN p, length(p), nodes(p), rels(p),
+               properties(nodes(p), 'name'),
+               properties(rels(p), 'weight')
+        """
+    )
+
+    records = list(result)
+    assert records
+    for path, length, nodes, rels, node_names, rel_weights in records:
+        assert path["length"] == length
+        assert path["nodes"] == nodes
+        assert path["rels"] == rels
+        assert node_names == [node["name"] for node in nodes]
+        assert rel_weights == [rel["weight"] for rel in rels]
+    operator_names = _operator_names(result)
+    assert "PathExpandOpr" in operator_names
+    assert "PathExpandVOpr" not in operator_names
+
+
+def test_named_path_with_explicit_relationship_alias(modern_graph):
+    fixed_result = modern_graph.execute(
+        """
+        MATCH p = (a:person {name: 'marko'})-[r:knows]->
+                  (b:person {name: 'vadas'})
+        RETURN p, r, length(p), nodes(p), rels(p)
+        """
+    )
+
+    fixed_records = list(fixed_result)
+    assert len(fixed_records) == 1
+    path, rel, length, nodes, rels = fixed_records[0]
+    assert length == 1
+    assert path["nodes"] == nodes
+    assert path["rels"] == rels == [rel]
+
+    recursive_result = modern_graph.execute(
+        """
+        MATCH p = (a:person {name: 'marko'})-[r:knows*1..2]->
+                  (b:person {name: 'josh'})
+        RETURN p, r, length(p), nodes(p), rels(p),
+               properties(nodes(r), 'name'),
+               properties(rels(r), 'weight')
+        """
+    )
+
+    recursive_records = list(recursive_result)
+    assert len(recursive_records) == 1
+    path, rel_path, length, nodes, rels, node_names, rel_weights = recursive_records[0]
+    assert path == rel_path
+    assert path["length"] == length
+    assert path["nodes"] == nodes
+    assert path["rels"] == rels
+    assert node_names == [node["name"] for node in nodes]
+    assert rel_weights == [rel["weight"] for rel in rels]
+
+
+def test_named_weighted_path_cost(modern_graph):
+    result = modern_graph.execute(
+        """
+        MATCH p = (a:person {name: 'marko'})
+                  -[:knows* WSHORTEST(weight)]->
+                  (b:person {name: 'josh'})
+        RETURN p, cost(p)
+        """
+    )
+
+    records = list(result)
+    assert len(records) == 1
+    assert records[0][0]["length"] == 1
+    assert records[0][1] == 1.0
+
+
+def test_named_unweighted_path_cost_is_rejected(modern_graph):
+    with pytest.raises(Exception, match="Cost function is not defined"):
+        modern_graph.execute(
+            """
+            MATCH p = (a:person)-[:knows*1..2]->(b:person)
+            RETURN cost(p)
+            """
+        )
+
+
+def test_multi_segment_named_path_return_is_not_supported(modern_graph):
+    with pytest.raises(Exception, match="exactly one relationship segment"):
+        modern_graph.execute(
+            """
+            MATCH p = (a:person)-[:knows]->(b:person)-[:knows]->(c:person)
+            RETURN p
+            """
+        )
+
+
 def test_path_expand_count_on_typed_rel_table(tmp_path):
     db_dir = tmp_path / "path_expand_typed_rel"
     db_dir.mkdir()

--- a/tools/python_bind/tests/test_path.py
+++ b/tools/python_bind/tests/test_path.py
@@ -471,12 +471,88 @@ def test_named_unweighted_path_cost_is_rejected(modern_graph):
         )
 
 
-def test_multi_segment_named_path_return_is_not_supported(modern_graph):
-    with pytest.raises(Exception, match="exactly one relationship segment"):
+def test_multi_segment_named_path(modern_graph):
+    result = modern_graph.execute(
+        """
+        MATCH p = (a:person {name: 'marko'})-[]->
+                  (b:person {name: 'josh'})-[]->
+                  (c:software {name: 'lop'})<-[]-
+                  (d:person {name: 'peter'})
+        RETURN p, length(p), nodes(p), rels(p),
+               properties(nodes(p), 'name'),
+               properties(rels(p), 'weight')
+        """
+    )
+
+    records = list(result)
+    assert len(records) == 1
+    path, length, nodes, rels, node_names, rel_weights = records[0]
+    assert length == 3
+    assert path["length"] == length
+    assert path["nodes"] == nodes
+    assert path["rels"] == rels
+    assert len(rels) == 3
+    assert node_names == ["marko", "josh", "lop", "peter"]
+    assert rel_weights == [1.0, 0.4, 0.2]
+
+
+def test_recursive_and_fixed_segments_named_path(modern_graph):
+    result = modern_graph.execute(
+        """
+        MATCH p = (a:person {name: 'marko'})-[r1:knows*1..2]-
+                  (b:person {name: 'josh'})-[r2:created]->
+                  (c:software {name: 'ripple'})
+        RETURN p, r1, r2, length(p), nodes(p), rels(p),
+               properties(nodes(p), 'name'),
+               properties(rels(p), 'weight')
+        """
+    )
+
+    records = list(result)
+    assert len(records) == 1
+    path, recursive_path, fixed_rel, length, nodes, rels, node_names, rel_weights = (
+        records[0]
+    )
+    assert recursive_path["length"] == 1
+    assert length == recursive_path["length"] + 1
+    assert path["length"] == length
+    assert path["nodes"] == nodes
+    assert path["rels"] == rels
+    assert rels == recursive_path["rels"] + [fixed_rel]
+    assert node_names == ["marko", "josh", "ripple"]
+    assert rel_weights == [1.0, 1.0]
+
+
+def test_fixed_and_recursive_segments_named_path(modern_graph):
+    result = modern_graph.execute(
+        """
+        MATCH p = (a:person {name: 'marko'})-[r1:knows]->
+                  (b:person {name: 'josh'})-[r2:created*1..2]->
+                  (c:software {name: 'ripple'})
+        RETURN p, r1, r2, length(p), nodes(p), rels(p)
+        """
+    )
+
+    records = list(result)
+    assert len(records) == 1
+    path, fixed_rel, recursive_path, length, nodes, rels = records[0]
+    assert recursive_path["length"] == 1
+    assert length == 1 + recursive_path["length"]
+    assert path["length"] == length
+    assert path["nodes"] == nodes
+    assert path["rels"] == rels
+    assert rels == [fixed_rel] + recursive_path["rels"]
+
+
+def test_multi_segment_named_path_cost_is_rejected(modern_graph):
+    with pytest.raises(Exception, match="exactly one weighted recursive relationship"):
         modern_graph.execute(
             """
-            MATCH p = (a:person)-[:knows]->(b:person)-[:knows]->(c:person)
-            RETURN p
+            MATCH p = (a:person {name: 'marko'})
+                      -[:knows* WSHORTEST(weight)]->
+                      (b:person {name: 'josh'})-[:created]->
+                      (c:software {name: 'ripple'})
+            RETURN cost(p)
             """
         )
 

--- a/tools/python_bind/tests/test_path.py
+++ b/tools/python_bind/tests/test_path.py
@@ -557,6 +557,150 @@ def test_multi_segment_named_path_cost_is_rejected(modern_graph):
         )
 
 
+def test_path_semantic_functions(modern_graph):
+    result = modern_graph.execute(
+        """
+        MATCH (a:person {name: 'marko'})-[r:knows*1..1]->
+              (b:person {name: 'josh'})
+        RETURN is_trail(r), is_acyclic(r)
+        """
+    )
+    assert list(result) == [[True, True]]
+
+    result = modern_graph.execute(
+        """
+        MATCH p = (a:person {name: 'marko'})-[:knows]->
+                  (b:person {name: 'josh'})-[:created]->
+                  (c:software {name: 'lop'})<-[:created]-(a)
+        RETURN is_trail(p), is_acyclic(p)
+        """
+    )
+    assert list(result) == [[True, False]]
+
+    result = modern_graph.execute(
+        """
+        MATCH p = (a:person {name: 'marko'})-[:knows]->
+                  (b:person {name: 'josh'})<-[:knows]-(a)
+        RETURN is_trail(p), is_acyclic(p)
+        """
+    )
+    assert list(result) == [[False, False]]
+
+
+def test_named_path_documentation_single_expand(modern_graph):
+    result = modern_graph.execute(
+        """
+        MATCH p = (a:Person {name: 'marko'})-[:KNOWS]->
+                  (b:Person {name: 'vadas'})
+        RETURN p
+        """
+    )
+    records = list(result)
+    assert len(records) == 1
+    assert records[0][0]["length"] == 1
+    assert [node["name"] for node in records[0][0]["nodes"]] == ["marko", "vadas"]
+
+
+def test_named_path_documentation_repeated_expand(modern_graph):
+    result = modern_graph.execute(
+        """
+        MATCH p = (a:Person {name: 'marko'})-[:KNOWS*1..3]->
+                  (b:Person {name: 'josh'})
+        RETURN p
+        """
+    )
+    records = list(result)
+    assert len(records) == 1
+    assert records[0][0]["length"] == 1
+    assert [node["name"] for node in records[0][0]["nodes"]] == ["marko", "josh"]
+
+
+def test_named_path_documentation_multiple_expands(modern_graph):
+    result = modern_graph.execute(
+        """
+        MATCH p = (a:Person {name: 'marko'})-[:KNOWS*1..2]->
+                  (b:Person {name: 'josh'})-[:CREATED]->
+                  (c:Software {name: 'ripple'})
+        RETURN p
+        """
+    )
+    records = list(result)
+    assert len(records) == 1
+    assert records[0][0]["length"] == 2
+    assert [node["name"] for node in records[0][0]["nodes"]] == [
+        "marko",
+        "josh",
+        "ripple",
+    ]
+
+
+def test_named_path_documentation_unnamed_second_pattern(modern_graph):
+    result = modern_graph.execute(
+        """
+        MATCH p = (a)-[:KNOWS]->(b),
+                  (a)-[:CREATED]->(c)
+        RETURN p
+        """
+    )
+    records = list(result)
+    assert len(records) == 2
+    assert all(record[0]["length"] == 1 for record in records)
+
+
+def test_named_path_documentation_multiple_named_patterns(modern_graph):
+    result = modern_graph.execute(
+        """
+        MATCH p1 = (a)-[:KNOWS]->(b),
+              p2 = (a)-[:CREATED]->(c)
+        RETURN p1, p2
+        """
+    )
+    records = list(result)
+    assert len(records) == 2
+    assert all(p1["length"] == 1 and p2["length"] == 1 for p1, p2 in records)
+
+
+def test_named_path_documentation_length_and_properties(modern_graph):
+    result = modern_graph.execute(
+        """
+        MATCH p = (a:Person {name: 'marko'})-[:KNOWS]->
+                  (b:Person {name: 'josh'})-[:CREATED]->
+                  (c:Software {name: 'lop'})
+        RETURN LENGTH(p) AS path_length,
+               PROPERTIES(NODES(p), 'name') AS node_names,
+               PROPERTIES(RELS(p), 'weight') AS rel_weights
+        """
+    )
+    assert list(result) == [[2, ["marko", "josh", "lop"], [1.0, 0.4]]]
+
+
+def test_named_path_documentation_cost(modern_graph):
+    result = modern_graph.execute(
+        """
+        MATCH p = (a:person {name: 'marko'})
+                  -[:knows* WSHORTEST(weight)]->
+                  (b:person {name: 'josh'})
+        RETURN p, COST(p) AS path_cost
+        """
+    )
+    records = list(result)
+    assert len(records) == 1
+    assert records[0][0]["length"] == 1
+    assert records[0][1] == 1.0
+
+
+def test_named_path_documentation_semantics(modern_graph):
+    result = modern_graph.execute(
+        """
+        MATCH p = (a:Person {name: 'marko'})-[:KNOWS]->
+                  (b:Person {name: 'josh'})-[:CREATED]->
+                  (c:Software {name: 'lop'})<-[:CREATED]-(a)
+        RETURN IS_TRAIL(p) AS is_trail, IS_ACYCLIC(p) AS is_acyclic
+        """
+    )
+    assert list(result) == [[True, False]]
+
+
 def test_path_expand_count_on_typed_rel_table(tmp_path):
     db_dir = tmp_path / "path_expand_typed_rel"
     db_dir.mkdir()


### PR DESCRIPTION
## Summary
- Support named paths using `p = (...)` for fixed and repeated relationship segments.
- Materialize relationship expressions when a named path is consumed while preserving endpoint-only expansion when it is unused.
- Convert each fixed relationship segment into a path and reuse repeated relationship paths directly.
- Concatenate multiple segments through `PathConcatExpr`, including fixed/fixed, repeated/fixed, and fixed/repeated combinations.
- Support returning `p` and using `LENGTH`, `NODES`, `RELS`, `PROPERTIES`, and weighted-path `COST` with named paths.
- Unify path property extraction through `gs.function.pathProperties(pathExpr, property, extractVertex)`.
- Document named-path syntax, output, supported functions, and concatenated paths.

## Scope
- A named path can contain one or more fixed or repeated relationship segments.
- Path concatenation validates the shared boundary vertex and preserves node, relationship, and traversal order.
- `COST` remains restricted to a named path containing exactly one weighted repeated relationship; it is rejected for concatenated paths.

## Testing
- Debug Python binding build with `BUILD_TEST=ON`
- `python3.9 -m pytest -q tests/test_path.py` — 17 passed, 6 skipped because LDBC data is unavailable
- `gopt_test --gtest_filter=PathTest.*` — 14 passed
- C++ and Python formatting checks

Fixes #990