### PR TITLE
test: establish Parquet contract and isolated Carquet dependency

### DIFF
--- a/.github/workflows/neug-extension-test.yml
+++ b/.github/workflows/neug-extension-test.yml
@@ -9,7 +9,15 @@ on:
     paths:
       - '.github/workflows/neug-extension-test.yml'
       - 'CMakeLists.txt'
-      - 'cmake/neug_extension.cmake'
+      - 'cmake/**'
+      - '.gitmodules'
+      - 'third_party/carquet'
+      - 'third_party/carquet.patch'
+      - 'include/neug/common/**'
+      - 'src/common/**'
+      - 'tools/python_bind/tests/test_parquet_backend_contract.py'
+      - 'example_dataset/tinysnb/parquet/**'
+      - 'example_dataset/comprehensive_graph/parquet/**'
       - 'extension/**'
       - 'tools/python_bind/tests/test_hnsw_index.py'
       - 'tools/python_bind/tests/test_hnsw_index_tp.py'
@@ -135,7 +143,7 @@ jobs:
         export FLEX_DATA_DIR=${GITHUB_WORKSPACE}/example_dataset/modern_graph
         export TEST_PATH=${GITHUB_WORKSPACE}/tests
         cd ${GITHUB_WORKSPACE}/build
-        ctest -R parquet_extension_test -V
+        ctest --output-on-failure --no-tests=error -R '^(parquet_extension_test|parquet_carquet_.*)$'
         ctest -R httpfs_extension_test -V
         ctest -R pattern_matching_extension_test -V
         ctest -R fts_extension_test -V
@@ -152,6 +160,7 @@ jobs:
         GLOG_v=10 ${GITHUB_WORKSPACE}/build/tools/utils/bulk_loader -g ../../example_dataset/tinysnb/graph.yaml -l ../../example_dataset/tinysnb/import.yaml -d /tmp/tinysnb
         export FLEX_DATA_DIR=${GITHUB_WORKSPACE}/example_dataset/comprehensive_graph
         GLOG_v=10 ${GITHUB_WORKSPACE}/build/tools/utils/bulk_loader -g ../../example_dataset/comprehensive_graph/graph.yaml -l ../../example_dataset/comprehensive_graph/import.yaml -d /tmp/comprehensive_graph
+        NEUG_RUN_EXTENSION_TESTS=true python3 -m pytest -sv tests/test_parquet_backend_contract.py
         NEUG_RUN_EXTENSION_TESTS=true python3 -m pytest -sv tests/test_load.py -k "parquet or httpfs"
         NEUG_RUN_EXTENSION_TESTS=true python3 -m pytest -sv tests/test_load_array.py -k "parquet"
         NEUG_RUN_EXTENSION_TESTS=true python3 -m pytest -sv tests/test_export.py -k "parquet or httpfs"

--- a/.gitmodules
+++ b/.gitmodules
@@ -44,3 +44,6 @@
 [submodule "third_party/cppjieba"]
 	path = third_party/cppjieba
 	url = https://github.com/yanyiwu/cppjieba.git
+[submodule "third_party/carquet"]
+	path = third_party/carquet
+	url = https://github.com/Vitruves/carquet.git

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,5 +1,16 @@
 # Third Party Licenses
 
+## Carquet
+
+The optional Parquet backend validation target builds the
+[`third_party/carquet`](third_party/carquet) submodule from
+[Carquet](https://github.com/Vitruves/carquet) under the MIT License. The
+upstream copyright and permission notice are retained in
+[`third_party/carquet/LICENSE`](third_party/carquet/LICENSE).
+
+NeuG applies [`third_party/carquet.patch`](third_party/carquet.patch) to fix
+multi-batch BOOLEAN and BYTE_STREAM_SPLIT page encoding in the pinned version.
+
 ## Kùzu
 
 This project incorporates source code from the [Kùzu](https://github.com/kuzudb/kuzu) project under the MIT License.
@@ -193,4 +204,3 @@ express Statement of Purpose.
  d. Affirmer understands and acknowledges that Creative Commons is not a
     party to this document and has no duty or obligation with respect to
     this CC0 or use of the Work.
-

--- a/extension/parquet/CMakeLists.txt
+++ b/extension/parquet/CMakeLists.txt
@@ -66,6 +66,86 @@ target_link_libraries(neug_parquet_extension PRIVATE
 
 # Build test by compiling extension sources directly (no link to neug_parquet_extension)
 if(BUILD_TEST)
+    # Follow the same submodule + adjacent patch convention as cppjieba.
+    # Keep upstream options local to this function and use its native target.
+    function(build_carquet_as_third_party)
+        set(_carquet_source "${CMAKE_SOURCE_DIR}/third_party/carquet")
+        set(_carquet_patch "${CMAKE_SOURCE_DIR}/third_party/carquet.patch")
+        if(NOT EXISTS "${_carquet_source}/CMakeLists.txt")
+            message(FATAL_ERROR
+                "Carquet submodule is missing. Run: git submodule update --init "
+                "--recursive third_party/carquet")
+        endif()
+        # Recheck after a patch edit or a checkout that restores the source.
+        set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+            "${_carquet_patch}" "${_carquet_source}/src/writer/page_writer.c")
+        execute_process(
+            COMMAND git apply --check "${_carquet_patch}"
+            WORKING_DIRECTORY "${_carquet_source}"
+            RESULT_VARIABLE _patch_check OUTPUT_QUIET ERROR_QUIET)
+        if(_patch_check EQUAL 0)
+            execute_process(
+                COMMAND git apply "${_carquet_patch}"
+                WORKING_DIRECTORY "${_carquet_source}"
+                RESULT_VARIABLE _patch_result)
+            if(NOT _patch_result EQUAL 0)
+                message(FATAL_ERROR "Failed to apply carquet.patch")
+            endif()
+        else()
+            execute_process(
+                COMMAND git apply --reverse --check "${_carquet_patch}"
+                WORKING_DIRECTORY "${_carquet_source}"
+                RESULT_VARIABLE _patch_applied OUTPUT_QUIET ERROR_QUIET)
+            if(NOT _patch_applied EQUAL 0)
+                message(FATAL_ERROR "carquet.patch does not apply cleanly")
+            endif()
+        endif()
+
+        # Require the existing system codecs instead of fetching another copy.
+        find_package(PkgConfig REQUIRED)
+        pkg_check_modules(NEUG_CARQUET_ZSTD REQUIRED libzstd)
+        pkg_check_modules(NEUG_CARQUET_LZ4 REQUIRED IMPORTED_TARGET liblz4)
+        find_package(ZLIB REQUIRED)
+        # Upstream skips LZ4 resolution on reconfigure when LZ4_FOUND is cached,
+        # leaving a bare library name. Supply a target that retains its path.
+        set(LZ4_FOUND TRUE)
+        set(LZ4_LIBRARIES PkgConfig::NEUG_CARQUET_LZ4)
+        foreach(_option IN ITEMS BUILD_DEV BUILD_TESTS BUILD_EXAMPLES
+                BUILD_BENCHMARKS BUILD_ARROW_CPP_BENCHMARK BUILD_INTEROP
+                BUILD_CLI BUILD_SHARED BUILD_FUZZ BUILD_DOCS BUNDLE_DEPS
+                NATIVE_ARCH)
+            set(CARQUET_${_option} OFF)
+        endforeach()
+        set(CMAKE_DISABLE_FIND_PACKAGE_OpenMP TRUE)
+        add_subdirectory("${_carquet_source}"
+            "${CMAKE_BINARY_DIR}/third_party/carquet" EXCLUDE_FROM_ALL)
+        set_target_properties(carquet PROPERTIES
+            POSITION_INDEPENDENT_CODE ON COMPILE_WARNING_AS_ERROR OFF)
+        # NeuG's warning-as-error policy does not apply to upstream C sources.
+        if(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
+            target_compile_options(carquet PRIVATE -Wno-error)
+        elseif(MSVC)
+            target_compile_options(carquet PRIVATE /WX-)
+        endif()
+        add_library(neug::carquet ALIAS carquet)
+    endfunction()
+    build_carquet_as_third_party()
+
+    add_executable(parquet_carquet_smoke_test
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/carquet_smoke_test.c)
+    target_link_libraries(parquet_carquet_smoke_test PRIVATE neug::carquet)
+    add_test(NAME parquet_carquet_smoke_test COMMAND parquet_carquet_smoke_test)
+
+    add_executable(parquet_carquet_multibatch_test
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/carquet_multibatch_test.c)
+    target_link_libraries(parquet_carquet_multibatch_test PRIVATE neug::carquet)
+    add_test(NAME parquet_carquet_multibatch_test COMMAND parquet_carquet_multibatch_test)
+
+    add_executable(parquet_carquet_capabilities_test
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/carquet_capabilities_test.c)
+    target_link_libraries(parquet_carquet_capabilities_test PRIVATE neug::carquet)
+    add_test(NAME parquet_carquet_capabilities_test COMMAND parquet_carquet_capabilities_test)
+
     # arrow_dataset_objlib only exists when Arrow is built from source.
     # Under system Arrow (CI=ON), fall back to ARROW_DATASET_LIB instead.
     if(TARGET arrow_dataset_objlib)
@@ -81,4 +161,3 @@ if(BUILD_TEST)
         EXTRA_LINK_LIBS ${_parquet_test_dataset_lib} ${ARROW_PARQUET_LIB}
     )
 endif()
-

--- a/extension/parquet/tests/carquet_capabilities_test.c
+++ b/extension/parquet/tests/carquet_capabilities_test.c
@@ -1,0 +1,62 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <carquet/carquet.h>
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+int main(void) {
+  carquet_reader_options_t reader_options;
+  carquet_reader_options_init(&reader_options);
+  if (reader_options.buffer_size != 64U * 1024U ||
+      reader_options.num_threads != 0) {
+    fprintf(stderr, "unexpected Carquet reader defaults\n");
+    return 1;
+  }
+
+  carquet_batch_reader_config_t batch_config;
+  carquet_batch_reader_config_init(&batch_config);
+  if (batch_config.batch_size != 64 * 1024 || batch_config.num_threads != 0 ||
+      batch_config.column_indices != NULL || batch_config.num_columns != 0 ||
+      batch_config.row_group_filter != NULL ||
+      batch_config.thread_pool != NULL) {
+    fprintf(stderr, "unexpected Carquet batch reader defaults\n");
+    return 1;
+  }
+
+  /* Compile-time probes for the option hooks NeuG must preserve. */
+  reader_options.buffer_size = 4096;
+  reader_options.num_threads = 1;
+  batch_config.batch_size = 128;
+  batch_config.num_threads = 1;
+  batch_config.column_indices = NULL;
+  batch_config.num_columns = 0;
+  batch_config.row_group_filter = NULL;
+  batch_config.thread_pool = NULL;
+
+  carquet_status_t (*prebuffer)(carquet_reader_t*, int32_t, const int32_t*,
+                                int32_t, carquet_error_t*) =
+      carquet_reader_prebuffer;
+  carquet_batch_reader_t* (*open_batch)(
+      carquet_reader_t*, const carquet_batch_reader_config_t*,
+      carquet_error_t*) = carquet_batch_reader_create;
+  (void) prebuffer;
+  (void) open_batch;
+
+  return 0;
+}

--- a/extension/parquet/tests/carquet_multibatch_test.c
+++ b/extension/parquet/tests/carquet_multibatch_test.c
@@ -1,0 +1,182 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <carquet/carquet.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int validate_roundtrip(const char* name,
+                              carquet_physical_type_t physical_type,
+                              carquet_encoding_t encoding, const void* expected,
+                              size_t value_size, int64_t rows_per_group,
+                              int32_t num_row_groups,
+                              const int64_t* batch_sizes, size_t num_batches,
+                              int64_t max_rows_per_page) {
+  int result = 1;
+  void* parquet_buffer = NULL;
+  size_t parquet_size = 0;
+  carquet_error_t error = CARQUET_ERROR_INIT;
+  carquet_schema_t* schema = carquet_schema_create(&error);
+  carquet_writer_t* writer = NULL;
+  carquet_reader_t* reader = NULL;
+
+  if (!schema || carquet_schema_add_column(schema, "value", physical_type, NULL,
+                                           CARQUET_REPETITION_REQUIRED, 0,
+                                           0) != CARQUET_OK) {
+    fprintf(stderr, "%s: schema creation failed: %s\n", name, error.message);
+    goto cleanup;
+  }
+
+  carquet_writer_options_t options;
+  carquet_writer_options_init(&options);
+  options.compression = CARQUET_COMPRESSION_UNCOMPRESSED;
+  options.dictionary_encoding = CARQUET_ENCODING_PLAIN;
+  options.row_group_size = 1024 * 1024;
+  options.page_size = 4096;
+  options.max_rows_per_page = max_rows_per_page;
+
+  writer = carquet_writer_create_buffer(schema, &options, &error);
+  if (!writer ||
+      carquet_writer_set_column_encoding(writer, 0, encoding) != CARQUET_OK) {
+    fprintf(stderr, "%s: writer creation failed: %s\n", name, error.message);
+    goto cleanup;
+  }
+
+  for (int32_t group = 0; group < num_row_groups; ++group) {
+    int64_t group_offset = 0;
+    for (size_t batch = 0; batch < num_batches; ++batch) {
+      const int64_t count = batch_sizes[batch];
+      const uint8_t* values =
+          (const uint8_t*) expected +
+          (size_t) (group * rows_per_group + group_offset) * value_size;
+      if (carquet_writer_write_batch(writer, 0, values, count, NULL, NULL) !=
+          CARQUET_OK) {
+        fprintf(stderr, "%s: write_batch failed for group %d batch %zu\n", name,
+                group, batch);
+        goto cleanup;
+      }
+      group_offset += count;
+    }
+    if (group_offset != rows_per_group) {
+      fprintf(stderr, "%s: batch sizes do not match the row group\n", name);
+      goto cleanup;
+    }
+    if (group + 1 < num_row_groups &&
+        carquet_writer_new_row_group(writer) != CARQUET_OK) {
+      fprintf(stderr, "%s: new_row_group failed\n", name);
+      goto cleanup;
+    }
+  }
+
+  if (carquet_writer_close(writer) != CARQUET_OK ||
+      carquet_writer_get_buffer(writer, &parquet_buffer, &parquet_size) !=
+          CARQUET_OK) {
+    fprintf(stderr, "%s: writer finalization failed\n", name);
+    writer = NULL;
+    goto cleanup;
+  }
+  writer = NULL;
+
+  reader =
+      carquet_reader_open_buffer(parquet_buffer, parquet_size, NULL, &error);
+  if (!reader || carquet_reader_num_row_groups(reader) != num_row_groups) {
+    fprintf(stderr, "%s: reader creation or row-group count failed: %s\n", name,
+            error.message);
+    goto cleanup;
+  }
+
+  for (int32_t group = 0; group < num_row_groups; ++group) {
+    carquet_column_reader_t* column =
+        carquet_reader_get_column(reader, group, 0, &error);
+    void* actual = calloc((size_t) rows_per_group, value_size);
+    if (!column || !actual) {
+      fprintf(stderr, "%s: column reader allocation failed\n", name);
+      carquet_column_reader_free(column);
+      free(actual);
+      goto cleanup;
+    }
+    const int64_t count =
+        carquet_column_read_batch(column, actual, rows_per_group, NULL, NULL);
+    const uint8_t* group_expected =
+        (const uint8_t*) expected +
+        (size_t) group * rows_per_group * value_size;
+    const int mismatch = count != rows_per_group ||
+                         memcmp(actual, group_expected,
+                                (size_t) rows_per_group * value_size) != 0;
+    carquet_column_reader_free(column);
+    free(actual);
+    if (mismatch) {
+      fprintf(stderr, "%s: value mismatch in row group %d\n", name, group);
+      goto cleanup;
+    }
+  }
+
+  result = 0;
+
+cleanup:
+  if (writer) {
+    carquet_writer_abort(writer);
+  }
+  carquet_reader_close(reader);
+  carquet_schema_free(schema);
+  free(parquet_buffer);
+  return result;
+}
+
+int main(void) {
+  int failures = 0;
+
+  const int64_t boolean_batches[] = {3, 5, 4};
+  const uint8_t boolean_values[] = {1, 0, 1, 0, 1, 1, 0, 1, 1, 1, 0, 0};
+  failures += validate_roundtrip(
+      "BOOLEAN PLAIN 3/5/4", CARQUET_PHYSICAL_BOOLEAN, CARQUET_ENCODING_PLAIN,
+      boolean_values, sizeof(boolean_values[0]), 12, 1, boolean_batches,
+      sizeof(boolean_batches) / sizeof(boolean_batches[0]), 0);
+
+  const int64_t float_batches[] = {3, 5};
+  const float float_values[] = {1.25f,    -2.5f,  3.75f, 100.5f,
+                                -200.25f, 0.125f, 42.0f, -7.5f};
+  failures += validate_roundtrip(
+      "FLOAT BYTE_STREAM_SPLIT 3/5", CARQUET_PHYSICAL_FLOAT,
+      CARQUET_ENCODING_BYTE_STREAM_SPLIT, float_values, sizeof(float_values[0]),
+      8, 1, float_batches, sizeof(float_batches) / sizeof(float_batches[0]), 0);
+
+  const int64_t boundary_batches[] = {1, 7, 8, 9};
+  uint8_t boundary_booleans[50];
+  float boundary_floats[50];
+  for (size_t i = 0; i < 50; ++i) {
+    boundary_booleans[i] = (uint8_t) (((i * 5) + (i / 7)) % 3 == 0);
+    boundary_floats[i] = (float) ((int) i * 17 - 193) / 8.0f;
+  }
+  failures += validate_roundtrip(
+      "BOOLEAN PLAIN page/row-group boundaries", CARQUET_PHYSICAL_BOOLEAN,
+      CARQUET_ENCODING_PLAIN, boundary_booleans, sizeof(boundary_booleans[0]),
+      25, 2, boundary_batches,
+      sizeof(boundary_batches) / sizeof(boundary_batches[0]), 8);
+  failures += validate_roundtrip(
+      "FLOAT BYTE_STREAM_SPLIT page/row-group boundaries",
+      CARQUET_PHYSICAL_FLOAT, CARQUET_ENCODING_BYTE_STREAM_SPLIT,
+      boundary_floats, sizeof(boundary_floats[0]), 25, 2, boundary_batches,
+      sizeof(boundary_batches) / sizeof(boundary_batches[0]), 8);
+
+  if (failures != 0) {
+    fprintf(stderr, "%d Carquet multi-batch case(s) failed\n", failures);
+    return 1;
+  }
+  return 0;
+}

--- a/extension/parquet/tests/carquet_smoke_test.c
+++ b/extension/parquet/tests/carquet_smoke_test.c
@@ -1,0 +1,41 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <carquet/carquet.h>
+
+#include <stdio.h>
+#include <string.h>
+
+int main(void) {
+  int major = -1;
+  int minor = -1;
+  int patch = -1;
+  carquet_version_components(&major, &minor, &patch);
+  if (major != CARQUET_VERSION_MAJOR || minor != CARQUET_VERSION_MINOR ||
+      patch != CARQUET_VERSION_PATCH ||
+      strcmp(carquet_version(), CARQUET_VERSION_STRING) != 0) {
+    fprintf(stderr, "Carquet header/library version mismatch\n");
+    return 1;
+  }
+
+  const carquet_status_t status = carquet_init();
+  if (status != CARQUET_OK) {
+    fprintf(stderr, "Carquet initialization failed: %s\n",
+            carquet_status_string(status));
+    return 1;
+  }
+  carquet_cleanup();
+  return 0;
+}

--- a/third_party/carquet.patch
+++ b/third_party/carquet.patch
@@ -1,0 +1,322 @@
+Carquet 5c3532831090a934315abf66dddb13c3219cb4d2: fix multi-batch
+PLAIN BOOLEAN and BYTE_STREAM_SPLIT page encoding.
+Upstream issues: https://github.com/Vitruves/carquet/issues/24
+                 https://github.com/Vitruves/carquet/issues/25
+Remove after updating the submodule to an equivalent upstream fix and passing
+parquet_carquet_multibatch_test without this patch.
+
+diff --git a/src/writer/page_writer.c b/src/writer/page_writer.c
+index b95a66a..c90d2f6 100644
+--- a/src/writer/page_writer.c
++++ b/src/writer/page_writer.c
+@@ -907,30 +907,114 @@ static carquet_status_t encode_plain_double_with_stats(
+ #endif
+ }
+
++/* PLAIN BOOLEAN is one continuous bit stream per page. Appending a separately
++ * packed byte sequence would restart at bit zero and leave padding between
++ * write_batch calls, so merge new values at the existing bit offset. */
++static carquet_status_t append_plain_boolean(
++    carquet_page_writer_t* writer,
++    const uint8_t* values,
++    int64_t existing_count,
++    int64_t count) {
++
++    if (existing_count < 0 || count < 0 ||
++        (uint64_t)existing_count + (uint64_t)count > SIZE_MAX - 7) {
++        return CARQUET_ERROR_OUT_OF_MEMORY;
++    }
++
++    size_t old_size = ((size_t)existing_count + 7) / 8;
++    size_t total_count = (size_t)existing_count + (size_t)count;
++    size_t new_size = (total_count + 7) / 8;
++    if (writer->values_buffer.size != old_size) {
++        return CARQUET_ERROR_ENCODE;
++    }
++
++    carquet_status_t status =
++        carquet_buffer_resize(&writer->values_buffer, new_size);
++    if (status != CARQUET_OK) return status;
++
++    for (int64_t i = 0; i < count; i++) {
++        size_t bit = (size_t)existing_count + (size_t)i;
++        uint8_t mask = (uint8_t)(1u << (bit & 7));
++        if (values[i]) {
++            writer->values_buffer.data[bit >> 3] |= mask;
++        } else {
++            writer->values_buffer.data[bit >> 3] &= (uint8_t)~mask;
++        }
++    }
++    return CARQUET_OK;
++}
++
++/* BYTE_STREAM_SPLIT stores one byte lane for the entire page at a time. A
++ * separately encoded batch therefore cannot be appended byte-for-byte. Grow
++ * each existing lane and place the new encoded lane after it. */
++static carquet_status_t append_byte_stream_split(
++    carquet_page_writer_t* writer,
++    const uint8_t* values,
++    int64_t existing_count,
++    int64_t count,
++    int32_t type_length) {
++
++    if (existing_count < 0 || count < 0 || type_length <= 0) {
++        return CARQUET_ERROR_INVALID_ARGUMENT;
++    }
++    if ((uint64_t)existing_count + (uint64_t)count >
++        SIZE_MAX / (size_t)type_length) {
++        return CARQUET_ERROR_OUT_OF_MEMORY;
++    }
++
++    size_t old_count = (size_t)existing_count;
++    size_t new_count = (size_t)count;
++    size_t total_count = old_count + new_count;
++    size_t old_size = old_count * (size_t)type_length;
++    size_t batch_size = new_count * (size_t)type_length;
++    size_t total_size = total_count * (size_t)type_length;
++    if (writer->values_buffer.size != old_size || count == 0) {
++        return writer->values_buffer.size == old_size
++            ? CARQUET_OK : CARQUET_ERROR_ENCODE;
++    }
++
++    uint8_t* encoded = carquet_mem_malloc(batch_size);
++    if (!encoded) return CARQUET_ERROR_OUT_OF_MEMORY;
++    size_t bytes_written = 0;
++    carquet_status_t status = carquet_byte_stream_split_encode(
++        values, count, type_length, encoded, batch_size, &bytes_written);
++    if (status != CARQUET_OK || bytes_written != batch_size) {
++        carquet_mem_free(encoded);
++        return status != CARQUET_OK ? status : CARQUET_ERROR_ENCODE;
++    }
++
++    status = carquet_buffer_resize(&writer->values_buffer, total_size);
++    if (status != CARQUET_OK) {
++        carquet_mem_free(encoded);
++        return status;
++    }
++
++    for (int32_t byte = type_length; byte-- > 0;) {
++        uint8_t* lane = writer->values_buffer.data + (size_t)byte * total_count;
++        if (old_count > 0) {
++            memmove(lane, writer->values_buffer.data + (size_t)byte * old_count,
++                    old_count);
++        }
++        memcpy(lane + old_count, encoded + (size_t)byte * new_count, new_count);
++    }
++    carquet_mem_free(encoded);
++    return CARQUET_OK;
++}
++
+ static carquet_status_t encode_float_values(
+     carquet_page_writer_t* writer,
+     const float* values,
+-    int64_t count) {
++    int64_t count,
++    int64_t existing_count) {
+
+     if (count == 0) {
+         return CARQUET_OK;
+     }
+
+     if (writer->encoding == CARQUET_ENCODING_BYTE_STREAM_SPLIT) {
+-        size_t bytes_needed = (size_t)count * sizeof(float);
+-        size_t offset = writer->values_buffer.size;
+-        uint8_t* dest = carquet_buffer_advance(&writer->values_buffer, bytes_needed);
+-        size_t bytes_written = 0;
+-        if (!dest) {
+-            return CARQUET_ERROR_OUT_OF_MEMORY;
+-        }
+-        carquet_status_t status = carquet_byte_stream_split_encode_float(
+-            values, count, dest, bytes_needed, &bytes_written);
+-        if (status != CARQUET_OK || bytes_written != bytes_needed) {
+-            writer->values_buffer.size = offset;
+-            return status != CARQUET_OK ? status : CARQUET_ERROR_ENCODE;
+-        }
+-        return CARQUET_OK;
++        return append_byte_stream_split(
++            writer, (const uint8_t*)values, existing_count, count,
++            (int32_t)sizeof(float));
+     }
+
+     return carquet_encode_plain_float(values, count, &writer->values_buffer);
+@@ -939,27 +1023,17 @@ static carquet_status_t encode_float_values(
+ static carquet_status_t encode_double_values(
+     carquet_page_writer_t* writer,
+     const double* values,
+-    int64_t count) {
++    int64_t count,
++    int64_t existing_count) {
+
+     if (count == 0) {
+         return CARQUET_OK;
+     }
+
+     if (writer->encoding == CARQUET_ENCODING_BYTE_STREAM_SPLIT) {
+-        size_t bytes_needed = (size_t)count * sizeof(double);
+-        size_t offset = writer->values_buffer.size;
+-        uint8_t* dest = carquet_buffer_advance(&writer->values_buffer, bytes_needed);
+-        size_t bytes_written = 0;
+-        if (!dest) {
+-            return CARQUET_ERROR_OUT_OF_MEMORY;
+-        }
+-        carquet_status_t status = carquet_byte_stream_split_encode_double(
+-            values, count, dest, bytes_needed, &bytes_written);
+-        if (status != CARQUET_OK || bytes_written != bytes_needed) {
+-            writer->values_buffer.size = offset;
+-            return status != CARQUET_OK ? status : CARQUET_ERROR_ENCODE;
+-        }
+-        return CARQUET_OK;
++        return append_byte_stream_split(
++            writer, (const uint8_t*)values, existing_count, count,
++            (int32_t)sizeof(double));
+     }
+
+     return carquet_encode_plain_double(values, count, &writer->values_buffer);
+@@ -969,7 +1043,8 @@ static carquet_status_t encode_double_values(
+  * DELTA_BINARY_PACKED and BYTE_STREAM_SPLIT. PLAIN is handled on the
+  * fast path by the caller. */
+ static carquet_status_t encode_int32_values(
+-    carquet_page_writer_t* writer, const int32_t* values, int64_t count) {
++    carquet_page_writer_t* writer, const int32_t* values, int64_t count,
++    int64_t existing_count) {
+
+     /* DELTA_BINARY_PACKED must still emit its 4-varint header for an
+      * all-null (zero value) page, otherwise the decoder hits EOF parsing
+@@ -980,18 +1055,9 @@ static carquet_status_t encode_int32_values(
+     size_t offset = writer->values_buffer.size;
+
+     if (writer->encoding == CARQUET_ENCODING_BYTE_STREAM_SPLIT) {
+-        size_t need = (size_t)count * sizeof(int32_t);
+-        uint8_t* dest = carquet_buffer_advance(&writer->values_buffer, need);
+-        if (!dest) return CARQUET_ERROR_OUT_OF_MEMORY;
+-        size_t written = 0;
+-        carquet_status_t s = carquet_byte_stream_split_encode(
+-            (const uint8_t*)values, count, (int32_t)sizeof(int32_t),
+-            dest, need, &written);
+-        if (s != CARQUET_OK || written != need) {
+-            writer->values_buffer.size = offset;
+-            return s != CARQUET_OK ? s : CARQUET_ERROR_ENCODE;
+-        }
+-        return CARQUET_OK;
++        return append_byte_stream_split(
++            writer, (const uint8_t*)values, existing_count, count,
++            (int32_t)sizeof(int32_t));
+     }
+
+     if (writer->encoding == CARQUET_ENCODING_DELTA_BINARY_PACKED) {
+@@ -1012,7 +1078,8 @@ static carquet_status_t encode_int32_values(
+ }
+
+ static carquet_status_t encode_int64_values(
+-    carquet_page_writer_t* writer, const int64_t* values, int64_t count) {
++    carquet_page_writer_t* writer, const int64_t* values, int64_t count,
++    int64_t existing_count) {
+
+     /* DELTA_BINARY_PACKED must still emit its 4-varint header for an
+      * all-null (zero value) page, otherwise the decoder hits EOF parsing
+@@ -1023,18 +1090,9 @@ static carquet_status_t encode_int64_values(
+     size_t offset = writer->values_buffer.size;
+
+     if (writer->encoding == CARQUET_ENCODING_BYTE_STREAM_SPLIT) {
+-        size_t need = (size_t)count * sizeof(int64_t);
+-        uint8_t* dest = carquet_buffer_advance(&writer->values_buffer, need);
+-        if (!dest) return CARQUET_ERROR_OUT_OF_MEMORY;
+-        size_t written = 0;
+-        carquet_status_t s = carquet_byte_stream_split_encode(
+-            (const uint8_t*)values, count, (int32_t)sizeof(int64_t),
+-            dest, need, &written);
+-        if (s != CARQUET_OK || written != need) {
+-            writer->values_buffer.size = offset;
+-            return s != CARQUET_OK ? s : CARQUET_ERROR_ENCODE;
+-        }
+-        return CARQUET_OK;
++        return append_byte_stream_split(
++            writer, (const uint8_t*)values, existing_count, count,
++            (int32_t)sizeof(int64_t));
+     }
+
+     if (writer->encoding == CARQUET_ENCODING_DELTA_BINARY_PACKED) {
+@@ -1122,6 +1180,7 @@ carquet_status_t carquet_page_writer_add_values(
+
+     /* Count nulls and non-null values */
+     int64_t num_non_null = num_values;
++    int64_t existing_non_null = num_values_before - num_nulls_before;
+     if (def_levels && writer->max_def_level > 0) {
+         num_non_null = carquet_dispatch_count_non_nulls(def_levels, num_values,
+                                                         writer->max_def_level);
+@@ -1195,8 +1254,8 @@ carquet_status_t carquet_page_writer_add_values(
+                 }
+                 carquet_buffer_destroy(&rle);
+             } else {
+-                status = carquet_encode_plain_boolean(bools, num_non_null,
+-                                                       &writer->values_buffer);
++                status = append_plain_boolean(writer, bools, existing_non_null,
++                                              num_non_null);
+             }
+             if (status == CARQUET_OK && writer->write_statistics) {
+                 update_statistics_boolean(writer, bools, num_non_null);
+@@ -1207,7 +1266,8 @@ carquet_status_t carquet_page_writer_add_values(
+         case CARQUET_PHYSICAL_INT32: {
+             const int32_t* ints = (const int32_t*)values;
+             if (writer->encoding != CARQUET_ENCODING_PLAIN) {
+-                status = encode_int32_values(writer, ints, num_non_null);
++                status = encode_int32_values(writer, ints, num_non_null,
++                                             existing_non_null);
+                 if (status == CARQUET_OK && writer->write_statistics) {
+                     update_statistics_i32(writer, ints, num_non_null);
+                 }
+@@ -1222,7 +1282,8 @@ carquet_status_t carquet_page_writer_add_values(
+         case CARQUET_PHYSICAL_INT64: {
+             const int64_t* ints = (const int64_t*)values;
+             if (writer->encoding != CARQUET_ENCODING_PLAIN) {
+-                status = encode_int64_values(writer, ints, num_non_null);
++                status = encode_int64_values(writer, ints, num_non_null,
++                                             existing_non_null);
+                 if (status == CARQUET_OK && writer->write_statistics) {
+                     update_statistics_i64(writer, ints, num_non_null);
+                 }
+@@ -1237,7 +1298,8 @@ carquet_status_t carquet_page_writer_add_values(
+         case CARQUET_PHYSICAL_FLOAT: {
+             const float* floats = (const float*)values;
+             if (writer->encoding == CARQUET_ENCODING_BYTE_STREAM_SPLIT || !writer->write_statistics) {
+-                status = encode_float_values(writer, floats, num_non_null);
++                status = encode_float_values(writer, floats, num_non_null,
++                                             existing_non_null);
+                 if (status == CARQUET_OK && writer->write_statistics) {
+                     update_statistics_float(writer, floats, num_non_null);
+                 }
+@@ -1250,7 +1312,8 @@ carquet_status_t carquet_page_writer_add_values(
+         case CARQUET_PHYSICAL_DOUBLE: {
+             const double* doubles = (const double*)values;
+             if (writer->encoding == CARQUET_ENCODING_BYTE_STREAM_SPLIT || !writer->write_statistics) {
+-                status = encode_double_values(writer, doubles, num_non_null);
++                status = encode_double_values(writer, doubles, num_non_null,
++                                              existing_non_null);
+                 if (status == CARQUET_OK && writer->write_statistics) {
+                     update_statistics_double(writer, doubles, num_non_null);
+                 }
+@@ -1288,21 +1351,9 @@ carquet_status_t carquet_page_writer_add_values(
+         case CARQUET_PHYSICAL_FIXED_LEN_BYTE_ARRAY: {
+             const uint8_t* fixed = (const uint8_t*)values;
+             if (writer->encoding == CARQUET_ENCODING_BYTE_STREAM_SPLIT) {
+-                size_t need = (size_t)num_non_null * (size_t)writer->type_length;
+-                size_t off = writer->values_buffer.size;
+-                uint8_t* dest = carquet_buffer_advance(&writer->values_buffer, need);
+-                if (!dest) {
+-                    status = CARQUET_ERROR_OUT_OF_MEMORY;
+-                } else {
+-                    size_t written = 0;
+-                    status = carquet_byte_stream_split_encode(
+-                        fixed, num_non_null, writer->type_length,
+-                        dest, need, &written);
+-                    if (status != CARQUET_OK || written != need) {
+-                        writer->values_buffer.size = off;
+-                        if (status == CARQUET_OK) status = CARQUET_ERROR_ENCODE;
+-                    }
+-                }
++                status = append_byte_stream_split(
++                    writer, fixed, existing_non_null, num_non_null,
++                    writer->type_length);
+             } else if (writer->encoding == CARQUET_ENCODING_DELTA_BYTE_ARRAY) {
+                 /* Spec allows DELTA_BYTE_ARRAY for FLBA: present each
+                  * fixed-width value as a byte array of length type_length. */

--- a/tools/python_bind/tests/test_parquet_backend_contract.py
+++ b/tools/python_bind/tests/test_parquet_backend_contract.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+
+"""Parquet contracts through NeuG SQL, independent of the active backend.
+
+Reuse example_dataset for regular reads. PyArrow only produces temporary
+boundary/encoding inputs; it is an optional test dependency, as in test_load_array.
+Expected query results remain explicit and independent of the file producer.
+"""
+
+import os
+from datetime import date
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from neug import Database
+
+EXTENSION_TESTS_ENABLED = os.environ.get("NEUG_RUN_EXTENSION_TESTS", "").lower() in (
+    "1",
+    "true",
+    "yes",
+    "on",
+)
+pytestmark = pytest.mark.skipif(
+    not EXTENSION_TESTS_ENABLED,
+    reason="Extension tests disabled by default; set NEUG_RUN_EXTENSION_TESTS=1.",
+)
+
+DATASET_DIR = Path(__file__).resolve().parents[3] / "example_dataset"
+
+
+@pytest.fixture
+def connection(tmp_path):
+    db = Database(db_path=str(tmp_path / "parquet_backend_contract"), mode="w")
+    conn = db.connect()
+    conn.execute("LOAD PARQUET")
+    yield conn
+    conn.close()
+    db.close()
+
+
+@pytest.fixture
+def type_file(tmp_path):
+    """Generate boundary cases absent from the repository's example datasets."""
+    pa = pytest.importorskip("pyarrow")
+    pq = pytest.importorskip("pyarrow.parquet")
+    path = tmp_path / "reader_types.parquet"
+    fixed3 = pa.list_(pa.float64(), 3)
+    matrix2x2 = pa.list_(pa.list_(pa.int32(), 2), 2)
+    table = pa.table(
+        {
+            "id": pa.array([1, 2, 3, 4], pa.int64()),
+            "enabled": pa.array([True, False, None, True], pa.bool_()),
+            "signed_value": pa.array([-(2**31), 0, 2**31 - 1, None], pa.int32()),
+            "unsigned_value": pa.array([0, 2**32 - 1, None, 42], pa.uint32()),
+            "score": pa.array([1.25, -2.5, None, 4.5], pa.float64()),
+            "label": pa.array(["", "hello", None, "中文"], pa.string()),
+            "event_date": pa.array(
+                [date(1970, 1, 1), date(1969, 12, 31), None, date(2024, 2, 29)],
+                pa.date32(),
+            ),
+            "timestamp_s": pa.array(
+                [
+                    datetime(1970, 1, 1),
+                    datetime(1969, 12, 31, 23, 59, 59),
+                    None,
+                    datetime(2023, 6, 15, 12, 30, 45),
+                ],
+                pa.timestamp("s"),
+            ),
+            "timestamp_ms": pa.array(
+                [
+                    datetime(1970, 1, 1, 0, 0, 0, 123000),
+                    datetime(1969, 12, 31, 23, 59, 59),
+                    None,
+                    datetime(2023, 6, 15, 12, 30, 45, 123000),
+                ],
+                pa.timestamp("ms"),
+            ),
+            "items": pa.array([[1, None, 3], [], None, [4, 5]], pa.list_(pa.int64())),
+            "fixed3": pa.array(
+                [
+                    [1.0, None, 3.0],
+                    [4.0, 5.0, 6.0],
+                    [0.0, 0.0, 0.0],
+                    [-1.0, -2.0, -3.0],
+                ],
+                fixed3,
+            ),
+            "matrix2x2": pa.array(
+                [
+                    [[1, 2], [3, 4]],
+                    [[5, 6], [7, 8]],
+                    [[9, None], [11, 12]],
+                    [[-1, -2], [-3, -4]],
+                ],
+                matrix2x2,
+            ),
+        }
+    )
+    pq.write_table(
+        table,
+        path,
+        compression="zstd",
+        row_group_size=2,
+        data_page_size=128,
+        store_schema=True,
+    )
+
+    return path
+
+
+def test_reader_preserves_types_nulls_and_nested_values(connection, type_file):
+    path = type_file
+    rows = list(
+        connection.execute(
+            f'LOAD FROM "{path.as_posix()}" '
+            "RETURN id, enabled, signed_value, unsigned_value, score, label, "
+            "event_date, timestamp_s, timestamp_ms, items, fixed3, matrix2x2 "
+            "ORDER BY id"
+        )
+    )
+
+    assert rows == [
+        [
+            1,
+            True,
+            -(2**31),
+            0,
+            1.25,
+            "",
+            date(1970, 1, 1),
+            datetime(1970, 1, 1),
+            datetime(1970, 1, 1, 0, 0, 0, 123000),
+            [1, None, 3],
+            [1.0, None, 3.0],
+            [[1, 2], [3, 4]],
+        ],
+        [
+            2,
+            False,
+            0,
+            2**32 - 1,
+            -2.5,
+            "hello",
+            date(1969, 12, 31),
+            datetime(1969, 12, 31, 23, 59, 59),
+            datetime(1969, 12, 31, 23, 59, 59),
+            [],
+            [4.0, 5.0, 6.0],
+            [[5, 6], [7, 8]],
+        ],
+        [
+            3,
+            None,
+            2**31 - 1,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            [0.0, 0.0, 0.0],
+            [[9, None], [11, 12]],
+        ],
+        [
+            4,
+            True,
+            None,
+            42,
+            4.5,
+            "中文",
+            date(2024, 2, 29),
+            datetime(2023, 6, 15, 12, 30, 45),
+            datetime(2023, 6, 15, 12, 30, 45, 123000),
+            [4, 5],
+            [-1.0, -2.0, -3.0],
+            [[-1, -2], [-3, -4]],
+        ],
+    ]
+
+    filtered = list(
+        connection.execute(
+            f'LOAD FROM "{path.as_posix()}" WHERE score >= 0 '
+            "RETURN id, label ORDER BY id"
+        )
+    )
+    assert filtered == [[1, ""], [4, "中文"]]
+
+
+@pytest.mark.parametrize(
+    "compression,page_version",
+    [("none", "1.0"), ("snappy", "1.0"), ("gzip", "2.0"), ("zstd", "2.0")],
+)
+def test_reader_preserves_encodings_pages_and_row_groups(
+    connection, tmp_path, compression, page_version
+):
+    pa = pytest.importorskip("pyarrow")
+    pq = pytest.importorskip("pyarrow.parquet")
+    path = tmp_path / "reader_encoding.parquet"
+    table = pa.table(
+        {
+            "id": pa.array(range(1, 13), pa.int64()),
+            "flag": pa.array(
+                [
+                    True,
+                    False,
+                    True,
+                    False,
+                    True,
+                    True,
+                    False,
+                    True,
+                    True,
+                    True,
+                    False,
+                    False,
+                ],
+                pa.bool_(),
+            ),
+            "measurement": pa.array(
+                [
+                    1.25,
+                    -2.5,
+                    3.75,
+                    100.5,
+                    -200.25,
+                    0.125,
+                    42.0,
+                    -7.5,
+                    0.0,
+                    1.0,
+                    2.0,
+                    3.0,
+                ],
+                pa.float32(),
+            ),
+            "category": pa.array(
+                ["a", "b", "a", "b", "a", "c", "a", "b", "c", "a", "b", "c"],
+                pa.string(),
+            ),
+        }
+    )
+    pq.write_table(
+        table,
+        path,
+        compression=compression,
+        row_group_size=5,
+        data_page_size=64,
+        data_page_version=page_version,
+        use_dictionary=["category"],
+        use_byte_stream_split=["measurement"],
+        store_schema=True,
+    )
+    # Ensure producer upgrades do not silently remove the encoding coverage.
+    metadata = pq.read_metadata(path)
+    assert metadata.num_row_groups == 3
+    for index in range(metadata.num_row_groups):
+        group = metadata.row_group(index)
+        assert "BYTE_STREAM_SPLIT" in group.column(2).encodings
+        assert "RLE_DICTIONARY" in group.column(3).encodings
+    rows = list(
+        connection.execute(
+            f'LOAD FROM "{path.as_posix()}" '
+            "RETURN id, flag, measurement, category ORDER BY id"
+        )
+    )
+
+    assert rows == [
+        [1, True, 1.25, "a"],
+        [2, False, -2.5, "b"],
+        [3, True, 3.75, "a"],
+        [4, False, 100.5, "b"],
+        [5, True, -200.25, "a"],
+        [6, True, 0.125, "c"],
+        [7, False, 42.0, "a"],
+        [8, True, -7.5, "b"],
+        [9, True, 0.0, "c"],
+        [10, True, 1.0, "a"],
+        [11, False, 2.0, "b"],
+        [12, False, 3.0, "c"],
+    ]
+
+
+@pytest.mark.parametrize(
+    "dataset,query,expected",
+    [
+        (
+            "tinysnb/parquet/vPerson.parquet",
+            "WHERE age > 30 AND isStudent RETURN ID, fName ORDER BY ID",
+            [[0, "Alice"]],
+        ),
+        (
+            "comprehensive_graph/parquet/node_a.parquet",
+            "WHERE i64_property < 0 AND u32_property = 0 "
+            "RETURN id, i64_property, u64_property, date_property ORDER BY id",
+            [[1, -(2**63), 0, date(2023, 6, 22)]],
+        ),
+    ],
+)
+def test_reader_preserves_projection_and_filter_semantics(
+    connection, dataset, query, expected
+):
+    path = DATASET_DIR / dataset
+    rows = list(connection.execute(f'LOAD FROM "{path.as_posix()}" {query}'))
+    assert rows == expected
+
+
+def test_writer_preserves_options_and_nested_values(connection, tmp_path):
+    path = tmp_path / "writer_contract.parquet"
+    connection.execute(
+        "CREATE NODE TABLE ContractRow("
+        "id INT64, label STRING, values INT64[], PRIMARY KEY(id));"
+    )
+    connection.execute(
+        "CREATE (:ContractRow {"
+        "id: 1, label: 'alpha', values: CAST([1, 2], 'INT64[]')});"
+    )
+    connection.execute(
+        "CREATE (:ContractRow {" "id: 2, label: '中文', values: CAST([], 'INT64[]')});"
+    )
+    connection.execute(
+        f"COPY (MATCH (r:ContractRow) "
+        f"RETURN r.id, r.label, r.values ORDER BY r.id) TO '{path}' "
+        "(COMPRESSION='zstd', ROW_GROUP_SIZE=1024, "
+        "DICTIONARY_ENCODING=true)"
+    )
+
+    rows = list(connection.execute(f'LOAD FROM "{path}" RETURN * ORDER BY "r.id"'))
+    assert rows == [[1, "alpha", [1, 2]], [2, "中文", []]]


### PR DESCRIPTION
Replacing the Parquet backend requires a reproducible compatibility baseline and a way to validate Carquet independently. This PR introduces both while keeping the existing Arrow implementation as the production backend.

- Add backend-neutral Parquet fixtures and Python tests covering types, NULLs, nested values, encodings, projection/filter behavior, and export options.
- Add an isolated, test-only Carquet build with a pinned source revision, SHA256 verification, and license attribution.
- Include a focused patch for multi-batch BOOLEAN and BYTE_STREAM_SPLIT encoding, with regression tests alongside smoke and capability probes.
- Register the new tests in extension CI and document the migration boundaries and validation requirements.

Validation:
- Release build of core, Python bindings, Parquet/HTTPFS extensions, and relevant test targets passed on macOS.
- 52/52 selected CTest entries passed.
- 7/7 Python Parquet compatibility tests passed.
- Python formatting/lint, workflow YAML parsing, and diff whitespace checks passed.
- Carquet was rebuilt from the original archive with only this PR’s patch applied.