### PR TITLE
fix: validate VARCHAR maximum length

### DIFF
--- a/doc/source/cypher_manual/data_types.md
+++ b/doc/source/cypher_manual/data_types.md
@@ -71,7 +71,7 @@ The following table showcases all data types supported by NeuG and their differe
 
 ### String Types
 
-We currently support only the VARCHAR type for strings. You can specify a maximum character length using the `VARCHAR(max_length)` syntax. The default value of `max_length` is 256, and the maximum limit is 65536.
+We currently support only the VARCHAR type for strings. You can specify a maximum character length using the `VARCHAR(max_length)` syntax. The valid range of `max_length` is from 1 to 65535, and the default value is 256.
 Alternatively, you can use STRING to specify the character type directly; STRING is equivalent to VARCHAR(256), i.e., a varchar type with a default maximum length of 256 characters.
 
 #### VARCHAR

--- a/include/neug/compiler/common/types/types.h
+++ b/include/neug/compiler/common/types/types.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -251,6 +252,11 @@ struct PhysicalTypeUtils {
 PhysicalTypeID getPhysicalType(DataTypeId typeId);
 
 struct NEUG_API LogicalTypeUtils {
+  static constexpr int64_t MIN_STRING_LENGTH = 1;
+  static constexpr int64_t MAX_STRING_LENGTH =
+      std::numeric_limits<uint16_t>::max();
+
+  static void validateStringLength(int64_t length);
   static std::string toString(DataTypeId dataTypeID);
   static std::string toString(const std::vector<DataType>& dataTypes);
   static std::string toString(const std::vector<DataTypeId>& dataTypeIDs);

--- a/src/compiler/common/types/types.cpp
+++ b/src/compiler/common/types/types.cpp
@@ -39,6 +39,15 @@ using neug::function::BuiltInFunctionsUtils;
 namespace neug {
 namespace common {
 
+void LogicalTypeUtils::validateStringLength(int64_t length) {
+  if (length < MIN_STRING_LENGTH || length > MAX_STRING_LENGTH) {
+    THROW_BINDER_EXCEPTION("The length of VARCHAR/STRING must be between " +
+                           std::to_string(MIN_STRING_LENGTH) + " and " +
+                           std::to_string(MAX_STRING_LENGTH) +
+                           ". Given: " + std::to_string(length) + ".");
+  }
+}
+
 // ============================================================================
 // internalID_t implementations
 // ============================================================================
@@ -690,6 +699,7 @@ DataType parseStringType(const std::string& trimmedStr) {
         "The max length of string must be a positive integer. Given: " +
         maxLenStr);
   }
+  LogicalTypeUtils::validateStringLength(maxLen);
   return DataType::Varchar(maxLen);
 }
 

--- a/tools/python_bind/tests/test_schema.py
+++ b/tools/python_bind/tests/test_schema.py
@@ -140,6 +140,79 @@ def test_create_node_table_with_default_value(tmp_path):
     db.close()
 
 
+def test_string_type_length_boundaries(tmp_path):
+    db = Database(db_path=str(tmp_path), mode="w", checkpoint_on_close=False)
+    conn = db.connect()
+
+    conn.execute(
+        "CREATE NODE TABLE StringLengths("
+        "id INT64 PRIMARY KEY,"
+        "string_value STRING,"
+        "min_value VARCHAR(1),"
+        "max_value VARCHAR(65535));"
+    )
+    conn.execute("ALTER TABLE StringLengths ADD altered_string STRING;")
+    conn.execute("ALTER TABLE StringLengths ADD altered_min VARCHAR(1);")
+    conn.execute("ALTER TABLE StringLengths ADD altered_max VARCHAR(65535);")
+    conn.execute(
+        "CREATE (:StringLengths {"
+        "id: 1, string_value: 'string', min_value: 'm', "
+        "max_value: 'sentinel', altered_string: 'altered', "
+        "altered_min: 'a', altered_max: 'persisted'});"
+    )
+    query = (
+        "MATCH (n:StringLengths {id: 1}) "
+        "RETURN n.string_value, n.min_value, n.max_value, "
+        "n.altered_string, n.altered_min, n.altered_max;"
+    )
+    expected = [["string", "m", "sentinel", "altered", "a", "persisted"]]
+    assert list(conn.execute(query)) == expected
+
+    conn.execute("CHECKPOINT;")
+    conn.close()
+    db.close()
+
+    db = Database(db_path=str(tmp_path), mode="r", checkpoint_on_close=False)
+    conn = db.connect()
+    assert list(conn.execute(query)) == expected
+
+    conn.close()
+    db.close()
+
+
+@pytest.mark.parametrize("ddl_path", ["create", "alter"])
+@pytest.mark.parametrize(
+    "data_type",
+    [
+        "VARCHAR(0)",
+        "VARCHAR(65536)",
+        "VARCHAR(65536)[]",
+        "VARCHAR(65536)[2]",
+    ],
+)
+def test_invalid_string_type_lengths(tmp_path, ddl_path, data_type):
+    db = Database(db_path=str(tmp_path), mode="w", checkpoint_on_close=False)
+    conn = db.connect()
+
+    if ddl_path == "create":
+        ddl = (
+            "CREATE NODE TABLE InvalidStringLength("
+            f"id INT64 PRIMARY KEY, value {data_type});"
+        )
+    else:
+        conn.execute("CREATE NODE TABLE InvalidStringLength(id INT64 PRIMARY KEY);")
+        ddl = f"ALTER TABLE InvalidStringLength ADD value {data_type};"
+
+    with pytest.raises(
+        RuntimeError,
+        match="length of VARCHAR/STRING must be between 1 and 65535",
+    ):
+        conn.execute(ddl)
+
+    conn.close()
+    db.close()
+
+
 def test_create_node_table_errors(tmp_path):
     db_dir = tmp_path / "create_node_errors"
     shutil.rmtree(db_dir, ignore_errors=True)


### PR DESCRIPTION
## Summary

- reject explicit `VARCHAR` lengths outside the supported `1..65535` range during compiler type binding
- cover `STRING` and `VARCHAR` boundary behavior in CREATE/ALTER DDL, including LIST/ARRAY element types and checkpoint/reopen
- correct the documented maximum length from 65536 to 65535

## Testing

- `python3 -m pytest -q tests/test_schema.py` (37 passed)
- targeted string length and persistence tests (16 passed)
- compiler `gopt_test` suite (178 passed)

Fixes #1006