### PR TITLE
feat: read Parquet scalars through the existing chunk supplier

### DIFF
--- a/extension/parquet/CMakeLists.txt
+++ b/extension/parquet/CMakeLists.txt
@@ -154,17 +154,25 @@ if(BUILD_TEST)
     build_carquet_as_third_party()
 
     add_library(neug_parquet_carquet_impl STATIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/carquet/chunk_supplier.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/carquet/column_converter.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/src/carquet/input_adapter.cc
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/carquet/output_adapter.cc)
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/carquet/output_adapter.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/carquet/schema_converter.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/carquet/sniffer.cc)
     target_include_directories(neug_parquet_carquet_impl PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/src
         ${CMAKE_CURRENT_SOURCE_DIR}/include
         ${CMAKE_BINARY_DIR})
     target_link_libraries(neug_parquet_carquet_impl PUBLIC neug::carquet)
+    add_dependencies(neug_parquet_carquet_impl neug_proto)
 
     add_executable(parquet_carquet_test
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/carquet_chunk_supplier_test.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/carquet_input_adapter_test.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/carquet_output_adapter_test.cc)
+    target_compile_definitions(parquet_carquet_test PRIVATE
+        NEUG_PARQUET_DATASET_DIR="${CMAKE_SOURCE_DIR}/example_dataset")
     target_link_libraries(parquet_carquet_test PRIVATE
         neug::GTest
         neug_parquet_carquet_impl

--- a/extension/parquet/src/carquet/chunk_supplier.cc
+++ b/extension/parquet/src/carquet/chunk_supplier.cc
@@ -1,0 +1,197 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+#include "chunk_supplier.h"
+
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "column_converter.h"
+#include "input_adapter.h"
+#include "neug/utils/exception/exception.h"
+#include "schema_converter.h"
+
+namespace neug::parquet {
+namespace {
+
+std::string carquetMessage(const std::string& action, carquet_status_t status,
+                           const carquet_error_t& error) {
+  std::string message = action + ": " + carquet_status_string(status);
+  if (error.message[0] != '\0') {
+    message += " (" + std::string(error.message) + ")";
+  }
+  return message;
+}
+
+struct BatchDeleter {
+  void operator()(carquet_row_batch_t* batch) const {
+    carquet_row_batch_free(batch);
+  }
+};
+
+struct ArrowSchemaOwner : ArrowSchema {
+  ArrowSchemaOwner() : ArrowSchema{} {}
+  ~ArrowSchemaOwner() {
+    if (release) {
+      release(this);
+    }
+  }
+};
+
+struct ArrowArrayOwner : ArrowArray {
+  ArrowArrayOwner() : ArrowArray{} {}
+  ~ArrowArrayOwner() {
+    if (release) {
+      release(this);
+    }
+  }
+};
+
+void closeRejectedInput(std::unique_ptr<io::InputStream>& input) noexcept {
+  if (!input) {
+    return;
+  }
+  try {
+    input->Close();
+  } catch (...) {}
+}
+
+}  // namespace
+
+CarquetChunkSupplier::CarquetChunkSupplier(
+    carquet_reader_t* reader, carquet_batch_reader_t* batchReader,
+    ArrowSchema schema, std::shared_ptr<reader::EntrySchema> entrySchema,
+    int64_t rowNum)
+    : reader_(reader),
+      batchReader_(batchReader),
+      schema_(schema),
+      entrySchema_(std::move(entrySchema)),
+      rowNum_(rowNum) {}
+
+CarquetChunkSupplier::~CarquetChunkSupplier() {
+  carquet_batch_reader_free(batchReader_);
+  carquet_reader_close(reader_);
+  if (schema_.release) {
+    schema_.release(&schema_);
+  }
+}
+
+result<std::shared_ptr<CarquetChunkSupplier>> CarquetChunkSupplier::create(
+    std::unique_ptr<io::InputStream> input, CarquetReaderOptions options) {
+  if (!input) {
+    RETURN_STATUS_ERROR(StatusCode::ERR_INVALID_ARGUMENT,
+                        "Parquet input stream is null");
+  }
+  if (options.batchSize <= 0 || options.numThreads < 0) {
+    closeRejectedInput(input);
+    RETURN_STATUS_ERROR(StatusCode::ERR_INVALID_ARGUMENT,
+                        "Carquet batch size must be positive and thread count "
+                        "must be non-negative");
+  }
+
+  carquet_error_t error = CARQUET_ERROR_INIT;
+  std::unique_ptr<carquet_reader_t, decltype(&carquet_reader_close)> reader(
+      openCarquetReader(std::move(input), nullptr, &error),
+      carquet_reader_close);
+  if (!reader) {
+    RETURN_STATUS_ERROR(
+        StatusCode::ERR_IO_ERROR,
+        carquetMessage("Failed to open Parquet input", error.code, error));
+  }
+
+  ArrowSchemaOwner schema;
+  const carquet_status_t exportStatus = carquet_arrow_export_schema(
+      carquet_reader_schema(reader.get()), &schema, &error);
+  if (exportStatus != CARQUET_OK) {
+    RETURN_STATUS_ERROR(
+        StatusCode::ERR_TYPE_CONVERSION,
+        carquetMessage("Failed to export Parquet schema", exportStatus, error));
+  }
+  auto entrySchema = convertArrowCStructSchema(schema);
+  if (!entrySchema) {
+    return tl::unexpected(entrySchema.error());
+  }
+
+  carquet_batch_reader_config_t config;
+  carquet_batch_reader_config_init(&config);
+  config.batch_size = options.batchSize;
+  config.num_threads = options.numThreads;
+  config.use_mmap = false;
+  std::unique_ptr<carquet_batch_reader_t, decltype(&carquet_batch_reader_free)>
+      batchReader(carquet_batch_reader_create(reader.get(), &config, &error),
+                  carquet_batch_reader_free);
+  if (!batchReader) {
+    RETURN_STATUS_ERROR(StatusCode::ERR_IO_ERROR,
+                        carquetMessage("Failed to create Carquet batch reader",
+                                       error.code, error));
+  }
+
+  const int64_t rowNum = carquet_reader_num_rows(reader.get());
+  if (rowNum < 0) {
+    RETURN_STATUS_ERROR(StatusCode::ERR_IO_ERROR,
+                        "Carquet returned a negative row count");
+  }
+  auto supplier = std::unique_ptr<CarquetChunkSupplier>(
+      new CarquetChunkSupplier(reader.get(), batchReader.get(), schema,
+                               std::move(*entrySchema), rowNum));
+  reader.release();
+  batchReader.release();
+  schema.release = nullptr;
+  return std::shared_ptr<CarquetChunkSupplier>(std::move(supplier));
+}
+
+std::shared_ptr<DataChunk> CarquetChunkSupplier::GetNextChunk() {
+  if (finished_) {
+    return nullptr;
+  }
+
+  carquet_row_batch_t* rawBatch = nullptr;
+  const carquet_status_t status =
+      carquet_batch_reader_next(batchReader_, &rawBatch);
+  std::unique_ptr<carquet_row_batch_t, BatchDeleter> batch(rawBatch);
+  if (status == CARQUET_ERROR_END_OF_DATA) {
+    finished_ = true;
+    if (rowsRead_ != rowNum_) {
+      THROW_IO_EXCEPTION("Carquet row count mismatch: expected " +
+                         std::to_string(rowNum_) + ", read " +
+                         std::to_string(rowsRead_));
+    }
+    return nullptr;
+  }
+  if (status != CARQUET_OK || !batch) {
+    const carquet_error_t emptyError = CARQUET_ERROR_INIT;
+    THROW_IO_EXCEPTION(
+        carquetMessage("Failed to read Carquet batch", status, emptyError));
+  }
+  ArrowArrayOwner exported;
+  carquet_error_t error = CARQUET_ERROR_INIT;
+  const carquet_status_t exportStatus = carquet_arrow_export_batch(
+      batch.get(), carquet_reader_schema(reader_), nullptr, &exported, &error);
+  if (exportStatus != CARQUET_OK) {
+    THROW_IO_EXCEPTION(
+        carquetMessage("Failed to export Carquet batch", exportStatus, error));
+  }
+  batch.reset();
+
+  auto converted = convertArrowCFlatStruct(schema_, exported);
+  if (!converted) {
+    THROW_IO_EXCEPTION(converted.error().ToString());
+  }
+  const size_t chunkRows = (*converted)->row_num();
+  if (chunkRows > static_cast<size_t>(std::numeric_limits<int64_t>::max())) {
+    THROW_IO_EXCEPTION("Carquet batch row count exceeds the supported range");
+  }
+  const int64_t rows = static_cast<int64_t>(chunkRows);
+  if (rowsRead_ > rowNum_ - rows) {
+    THROW_IO_EXCEPTION("Carquet returned more rows than the file metadata");
+  }
+  rowsRead_ += rows;
+  return *converted;
+}
+
+}  // namespace neug::parquet

--- a/extension/parquet/src/carquet/chunk_supplier.h
+++ b/extension/parquet/src/carquet/chunk_supplier.h
@@ -1,0 +1,57 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+#pragma once
+
+#include <carquet/carquet.h>
+
+#include <cstdint>
+#include <memory>
+
+#include "neug/storages/loader/loader_utils.h"
+#include "neug/utils/io/read/common/schema.h"
+#include "neug/utils/io/stream/input_stream.h"
+#include "neug/utils/result.h"
+
+namespace neug::parquet {
+
+struct CarquetReaderOptions {
+  int32_t batchSize = 65536;
+  int32_t numThreads = 1;
+};
+
+class CarquetChunkSupplier final : public IDataChunkSupplier {
+ public:
+  static result<std::shared_ptr<CarquetChunkSupplier>> create(
+      std::unique_ptr<io::InputStream> input,
+      CarquetReaderOptions options = {});
+
+  ~CarquetChunkSupplier() override;
+
+  CarquetChunkSupplier(const CarquetChunkSupplier&) = delete;
+  CarquetChunkSupplier& operator=(const CarquetChunkSupplier&) = delete;
+
+  std::shared_ptr<DataChunk> GetNextChunk() override;
+  int64_t RowNum() const override { return rowNum_; }
+  const std::shared_ptr<reader::EntrySchema>& schema() const {
+    return entrySchema_;
+  }
+
+ private:
+  CarquetChunkSupplier(carquet_reader_t* reader,
+                       carquet_batch_reader_t* batchReader, ArrowSchema schema,
+                       std::shared_ptr<reader::EntrySchema> entrySchema,
+                       int64_t rowNum);
+
+  carquet_reader_t* reader_;
+  carquet_batch_reader_t* batchReader_;
+  ArrowSchema schema_;
+  std::shared_ptr<reader::EntrySchema> entrySchema_;
+  int64_t rowNum_;
+  int64_t rowsRead_ = 0;
+  bool finished_ = false;
+};
+
+}  // namespace neug::parquet

--- a/extension/parquet/src/carquet/column_converter.cc
+++ b/extension/parquet/src/carquet/column_converter.cc
@@ -1,0 +1,429 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "column_converter.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <string_view>
+
+#include "neug/common/columns/value_columns.h"
+#include "neug/utils/property/types.h"
+
+namespace neug {
+namespace parquet {
+namespace {
+
+template <typename T>
+result<T> columnError(const std::string& path, const std::string& message) {
+  return tl::unexpected(
+      Status(StatusCode::ERR_TYPE_CONVERSION,
+             "Invalid Parquet column at " + path + ": " + message));
+}
+
+result<uint64_t> validateArray(const ArrowSchema& schema,
+                               const ArrowArray& array, const std::string& path,
+                               int64_t expectedBuffers) {
+  if (!schema.format) {
+    return columnError<uint64_t>(path, "missing schema format");
+  }
+  if (schema.dictionary || array.dictionary) {
+    return columnError<uint64_t>(path, "dictionary arrays are not supported");
+  }
+  if (schema.n_children != 0 || array.n_children != 0) {
+    return columnError<uint64_t>(path, "scalar column must not have children");
+  }
+  if (array.length < 0 || array.offset < 0 || array.null_count < -1 ||
+      array.null_count > array.length) {
+    return columnError<uint64_t>(path, "invalid length, offset, or null count");
+  }
+  if (static_cast<uint64_t>(array.length) >
+      std::numeric_limits<size_t>::max()) {
+    return columnError<uint64_t>(path, "column length exceeds address space");
+  }
+  if (array.n_buffers != expectedBuffers || !array.buffers) {
+    return columnError<uint64_t>(
+        path, "expected " + std::to_string(expectedBuffers) + " buffers");
+  }
+  if (array.offset > std::numeric_limits<int64_t>::max() - array.length) {
+    return columnError<uint64_t>(path, "offset plus length overflows");
+  }
+  if (array.null_count > 0 && !array.buffers[0]) {
+    return columnError<uint64_t>(path, "null values require a validity buffer");
+  }
+  return static_cast<uint64_t>(array.offset);
+}
+
+bool isValid(const ArrowArray& array, uint64_t index) {
+  if (!array.buffers[0]) {
+    return true;
+  }
+  const auto* validity = static_cast<const uint8_t*>(array.buffers[0]);
+  return (validity[index >> 3] & static_cast<uint8_t>(1u << (index & 7))) != 0;
+}
+
+template <typename Src, typename Dst>
+result<std::shared_ptr<IContextColumn>> convertPrimitive(
+    const ArrowSchema& schema, const ArrowArray& array,
+    const std::string& path) {
+  auto offsetResult = validateArray(schema, array, path, 2);
+  if (!offsetResult) {
+    return tl::unexpected(offsetResult.error());
+  }
+  if (array.length > 0 && !array.buffers[1]) {
+    return columnError<std::shared_ptr<IContextColumn>>(
+        path, "non-empty column has no data buffer");
+  }
+
+  ValueColumnBuilder<Dst> builder;
+  builder.reserve(static_cast<size_t>(array.length));
+  const auto* data = static_cast<const Src*>(array.buffers[1]);
+  for (uint64_t i = 0; i < static_cast<uint64_t>(array.length); ++i) {
+    const uint64_t sourceIndex = *offsetResult + i;
+    if (!isValid(array, sourceIndex)) {
+      builder.push_back_null();
+    } else {
+      builder.push_back_opt(static_cast<Dst>(data[sourceIndex]));
+    }
+  }
+  return builder.finish();
+}
+
+result<std::shared_ptr<IContextColumn>> convertBoolean(
+    const ArrowSchema& schema, const ArrowArray& array,
+    const std::string& path) {
+  auto offsetResult = validateArray(schema, array, path, 2);
+  if (!offsetResult) {
+    return tl::unexpected(offsetResult.error());
+  }
+  if (array.length > 0 && !array.buffers[1]) {
+    return columnError<std::shared_ptr<IContextColumn>>(
+        path, "non-empty column has no data buffer");
+  }
+
+  ValueColumnBuilder<bool> builder;
+  builder.reserve(static_cast<size_t>(array.length));
+  const auto* data = static_cast<const uint8_t*>(array.buffers[1]);
+  for (uint64_t i = 0; i < static_cast<uint64_t>(array.length); ++i) {
+    const uint64_t sourceIndex = *offsetResult + i;
+    if (!isValid(array, sourceIndex)) {
+      builder.push_back_null();
+    } else {
+      builder.push_back_opt((data[sourceIndex >> 3] &
+                             static_cast<uint8_t>(1u << (sourceIndex & 7))) !=
+                            0);
+    }
+  }
+  return builder.finish();
+}
+
+template <typename Offset>
+result<std::shared_ptr<IContextColumn>> convertString(const ArrowSchema& schema,
+                                                      const ArrowArray& array,
+                                                      const std::string& path) {
+  auto offsetResult = validateArray(schema, array, path, 3);
+  if (!offsetResult) {
+    return tl::unexpected(offsetResult.error());
+  }
+  if (!array.buffers[1]) {
+    return columnError<std::shared_ptr<IContextColumn>>(
+        path, "string column has no offsets buffer");
+  }
+
+  const auto* offsets = static_cast<const Offset*>(array.buffers[1]);
+  const auto* data = static_cast<const char*>(array.buffers[2]);
+  const uint64_t firstIndex = *offsetResult;
+  ValueColumnBuilder<std::string> builder;
+  builder.reserve(static_cast<size_t>(array.length));
+  for (uint64_t i = 0; i < static_cast<uint64_t>(array.length); ++i) {
+    const uint64_t sourceIndex = firstIndex + i;
+    const Offset begin = offsets[sourceIndex];
+    const Offset end = offsets[sourceIndex + 1];
+    if (begin < 0 || end < begin) {
+      return columnError<std::shared_ptr<IContextColumn>>(
+          path, "string offsets are negative or decreasing");
+    }
+    if (static_cast<uint64_t>(end) >
+        static_cast<uint64_t>(std::numeric_limits<std::ptrdiff_t>::max())) {
+      return columnError<std::shared_ptr<IContextColumn>>(
+          path, "string offset exceeds addressable memory");
+    }
+    if (end > begin && !data) {
+      return columnError<std::shared_ptr<IContextColumn>>(
+          path, "non-empty string has no data buffer");
+    }
+    if (!isValid(array, sourceIndex)) {
+      builder.push_back_null();
+    } else if (begin == end) {
+      builder.push_back_opt(std::string{});
+    } else {
+      builder.push_back_opt(
+          std::string(data + static_cast<uint64_t>(begin),
+                      static_cast<size_t>(static_cast<uint64_t>(end) -
+                                          static_cast<uint64_t>(begin))));
+    }
+  }
+  return builder.finish();
+}
+
+result<std::shared_ptr<IContextColumn>> convertDate32(const ArrowSchema& schema,
+                                                      const ArrowArray& array,
+                                                      const std::string& path) {
+  auto offsetResult = validateArray(schema, array, path, 2);
+  if (!offsetResult) {
+    return tl::unexpected(offsetResult.error());
+  }
+  if (array.length > 0 && !array.buffers[1]) {
+    return columnError<std::shared_ptr<IContextColumn>>(
+        path, "non-empty date column has no data buffer");
+  }
+
+  const auto* data = static_cast<const int32_t*>(array.buffers[1]);
+  ValueColumnBuilder<Date> builder;
+  builder.reserve(static_cast<size_t>(array.length));
+  for (uint64_t i = 0; i < static_cast<uint64_t>(array.length); ++i) {
+    const uint64_t sourceIndex = *offsetResult + i;
+    if (!isValid(array, sourceIndex)) {
+      builder.push_back_null();
+    } else {
+      builder.push_back_opt(Date(data[sourceIndex]));
+    }
+  }
+  return builder.finish();
+}
+
+result<std::shared_ptr<IContextColumn>> convertDate64(const ArrowSchema& schema,
+                                                      const ArrowArray& array,
+                                                      const std::string& path) {
+  constexpr int64_t kMillisPerDay = 24LL * 60 * 60 * 1000;
+  auto offsetResult = validateArray(schema, array, path, 2);
+  if (!offsetResult) {
+    return tl::unexpected(offsetResult.error());
+  }
+  if (array.length > 0 && !array.buffers[1]) {
+    return columnError<std::shared_ptr<IContextColumn>>(
+        path, "non-empty date column has no data buffer");
+  }
+
+  const auto* data = static_cast<const int64_t*>(array.buffers[1]);
+  ValueColumnBuilder<Date> builder;
+  builder.reserve(static_cast<size_t>(array.length));
+  for (uint64_t i = 0; i < static_cast<uint64_t>(array.length); ++i) {
+    const uint64_t sourceIndex = *offsetResult + i;
+    if (!isValid(array, sourceIndex)) {
+      builder.push_back_null();
+    } else {
+      const int64_t days = data[sourceIndex] / kMillisPerDay;
+      if (days < std::numeric_limits<int32_t>::min() ||
+          days > std::numeric_limits<int32_t>::max()) {
+        return columnError<std::shared_ptr<IContextColumn>>(
+            path, "date value is outside NeuG's supported range");
+      }
+      builder.push_back_opt(Date(static_cast<int32_t>(days)));
+    }
+  }
+  return builder.finish();
+}
+
+result<std::shared_ptr<IContextColumn>> convertTimestamp(
+    const ArrowSchema& schema, const ArrowArray& array, const std::string& path,
+    char unit) {
+  auto offsetResult = validateArray(schema, array, path, 2);
+  if (!offsetResult) {
+    return tl::unexpected(offsetResult.error());
+  }
+  if (array.length > 0 && !array.buffers[1]) {
+    return columnError<std::shared_ptr<IContextColumn>>(
+        path, "non-empty timestamp column has no data buffer");
+  }
+
+  const auto* data = static_cast<const int64_t*>(array.buffers[1]);
+  ValueColumnBuilder<DateTime> builder;
+  builder.reserve(static_cast<size_t>(array.length));
+  for (uint64_t i = 0; i < static_cast<uint64_t>(array.length); ++i) {
+    const uint64_t sourceIndex = *offsetResult + i;
+    if (!isValid(array, sourceIndex)) {
+      builder.push_back_null();
+      continue;
+    }
+    int64_t millis = data[sourceIndex];
+    if (unit == 's') {
+      if (millis < std::numeric_limits<int64_t>::min() / 1000 ||
+          millis > std::numeric_limits<int64_t>::max() / 1000) {
+        return columnError<std::shared_ptr<IContextColumn>>(
+            path, "timestamp seconds overflow NeuG milliseconds");
+      }
+      millis *= 1000;
+    } else if (unit == 'u') {
+      millis /= 1000;
+    } else if (unit == 'n') {
+      millis /= 1000000;
+    }
+    builder.push_back_opt(DateTime(millis));
+  }
+  return builder.finish();
+}
+
+}  // namespace
+
+result<std::shared_ptr<IContextColumn>> convertArrowCScalarColumn(
+    const ArrowSchema& schema, const ArrowArray& array,
+    const std::string& path) {
+  auto schemaStatus = validateArrowCScalarSchema(schema, path);
+  if (!schemaStatus) {
+    return tl::unexpected(schemaStatus.error());
+  }
+  const std::string_view format(schema.format);
+  if (format == "b") {
+    return convertBoolean(schema, array, path);
+  }
+  if (format == "c") {
+    return convertPrimitive<int8_t, int32_t>(schema, array, path);
+  }
+  if (format == "s") {
+    return convertPrimitive<int16_t, int32_t>(schema, array, path);
+  }
+  if (format == "i") {
+    return convertPrimitive<int32_t, int32_t>(schema, array, path);
+  }
+  if (format == "C") {
+    return convertPrimitive<uint8_t, uint32_t>(schema, array, path);
+  }
+  if (format == "S") {
+    return convertPrimitive<uint16_t, uint32_t>(schema, array, path);
+  }
+  if (format == "I") {
+    return convertPrimitive<uint32_t, uint32_t>(schema, array, path);
+  }
+  if (format == "l") {
+    return convertPrimitive<int64_t, int64_t>(schema, array, path);
+  }
+  if (format == "L") {
+    return convertPrimitive<uint64_t, uint64_t>(schema, array, path);
+  }
+  if (format == "f") {
+    return convertPrimitive<float, float>(schema, array, path);
+  }
+  if (format == "g") {
+    return convertPrimitive<double, double>(schema, array, path);
+  }
+  if (format == "u") {
+    return convertString<int32_t>(schema, array, path);
+  }
+  if (format == "U") {
+    return convertString<int64_t>(schema, array, path);
+  }
+  if (format == "tdD") {
+    return convertDate32(schema, array, path);
+  }
+  if (format == "tdm") {
+    return convertDate64(schema, array, path);
+  }
+  if (format.size() >= 4 && format[0] == 't' && format[1] == 's' &&
+      (format[2] == 's' || format[2] == 'm' || format[2] == 'u' ||
+       format[2] == 'n') &&
+      format[3] == ':') {
+    return convertTimestamp(schema, array, path, format[2]);
+  }
+  return columnError<std::shared_ptr<IContextColumn>>(
+      path, "unsupported Arrow C format \"" + std::string(format) + "\"");
+}
+
+result<void> validateArrowCScalarSchema(const ArrowSchema& schema,
+                                        const std::string& path) {
+  if (!schema.format) {
+    return columnError<void>(path, "missing schema format");
+  }
+  if (schema.dictionary) {
+    return columnError<void>(path, "dictionary schema is not supported");
+  }
+  if (schema.n_children != 0) {
+    return columnError<void>(path, "scalar column must not have children");
+  }
+  const std::string_view format(schema.format);
+  const bool primitive = format == "b" || format == "c" || format == "s" ||
+                         format == "i" || format == "C" || format == "S" ||
+                         format == "I" || format == "l" || format == "L" ||
+                         format == "f" || format == "g" || format == "u" ||
+                         format == "U" || format == "tdD" || format == "tdm";
+  const bool timestamp = format.size() >= 4 && format[0] == 't' &&
+                         format[1] == 's' &&
+                         (format[2] == 's' || format[2] == 'm' ||
+                          format[2] == 'u' || format[2] == 'n') &&
+                         format[3] == ':';
+  if (!primitive && !timestamp) {
+    return columnError<void>(
+        path, "unsupported Arrow C format \"" + std::string(format) + "\"");
+  }
+  return {};
+}
+
+result<std::shared_ptr<DataChunk>> convertArrowCFlatStruct(
+    const ArrowSchema& schema, const ArrowArray& array) {
+  if (!schema.format || std::string_view(schema.format) != "+s") {
+    return columnError<std::shared_ptr<DataChunk>>(
+        "root", "schema must be a top-level struct");
+  }
+  if (schema.dictionary || array.dictionary) {
+    return columnError<std::shared_ptr<DataChunk>>(
+        "root", "dictionary root is not supported");
+  }
+  if (schema.n_children < 0 || array.n_children < 0 ||
+      schema.n_children != array.n_children ||
+      (schema.n_children > 0 && (!schema.children || !array.children))) {
+    return columnError<std::shared_ptr<DataChunk>>(
+        "root", "schema and array child counts do not match");
+  }
+  if (schema.n_children > (1 << 20)) {
+    return columnError<std::shared_ptr<DataChunk>>("root",
+                                                   "too many struct fields");
+  }
+  if (array.length < 0 || array.offset != 0 || array.null_count < -1 ||
+      array.null_count > array.length || array.n_buffers != 1 ||
+      !array.buffers) {
+    return columnError<std::shared_ptr<DataChunk>>(
+        "root", "invalid top-level struct layout");
+  }
+  if (array.null_count != 0 || array.buffers[0]) {
+    return columnError<std::shared_ptr<DataChunk>>(
+        "root", "nullable top-level structs are not supported");
+  }
+
+  auto chunk = std::make_shared<DataChunk>();
+  for (int64_t i = 0; i < schema.n_children; ++i) {
+    if (!schema.children[i] || !array.children[i]) {
+      return columnError<std::shared_ptr<DataChunk>>(
+          "root", "struct contains a null child");
+    }
+    if (array.children[i]->length != array.length) {
+      return columnError<std::shared_ptr<DataChunk>>(
+          "root.field[" + std::to_string(i) + "]",
+          "child length does not match the struct");
+    }
+    auto converted =
+        convertArrowCScalarColumn(*schema.children[i], *array.children[i],
+                                  "root.field[" + std::to_string(i) + "]");
+    if (!converted) {
+      return tl::unexpected(converted.error());
+    }
+    chunk->set(static_cast<int>(i), std::move(*converted));
+  }
+  return chunk;
+}
+
+}  // namespace parquet
+}  // namespace neug

--- a/extension/parquet/src/carquet/column_converter.h
+++ b/extension/parquet/src/carquet/column_converter.h
@@ -1,0 +1,44 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <carquet/carquet.h>
+
+#include "neug/common/types/data_chunk.h"
+#include "neug/utils/result.h"
+
+namespace neug {
+namespace parquet {
+
+result<void> validateArrowCScalarSchema(const ArrowSchema& schema,
+                                        const std::string& path = "column");
+
+// Converts one scalar Arrow C Data column into an owned NeuG value column.
+// The returned column never retains pointers into the ArrowArray.
+result<std::shared_ptr<IContextColumn>> convertArrowCScalarColumn(
+    const ArrowSchema& schema, const ArrowArray& array,
+    const std::string& path = "column");
+
+// Converts a flat top-level Arrow struct into an owned NeuG DataChunk.
+// The root must be non-null and all children must have the same length.
+result<std::shared_ptr<DataChunk>> convertArrowCFlatStruct(
+    const ArrowSchema& schema, const ArrowArray& array);
+
+}  // namespace parquet
+}  // namespace neug

--- a/extension/parquet/src/carquet/schema_converter.cc
+++ b/extension/parquet/src/carquet/schema_converter.cc
@@ -1,0 +1,121 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+#include "schema_converter.h"
+
+#include <string>
+#include <string_view>
+#include <unordered_set>
+
+#include "column_converter.h"
+
+namespace neug::parquet {
+namespace {
+
+constexpr int64_t kMaxSchemaColumns = 1 << 20;
+
+struct ArrowSchemaOwner : ArrowSchema {
+  ArrowSchemaOwner() : ArrowSchema{} {}
+  ~ArrowSchemaOwner() {
+    if (release) {
+      release(this);
+    }
+  }
+};
+
+template <typename T>
+result<T> schemaError(const std::string& path, const std::string& message) {
+  return tl::unexpected(
+      Status(StatusCode::ERR_TYPE_CONVERSION,
+             "Invalid Parquet schema at " + path + ": " + message));
+}
+
+}  // namespace
+
+result<std::shared_ptr<::common::DataType>> convertArrowCScalarSchemaType(
+    const ArrowSchema& schema, const std::string& path) {
+  auto valid = validateArrowCScalarSchema(schema, path);
+  if (!valid) {
+    return tl::unexpected(valid.error());
+  }
+
+  const std::string_view format(schema.format);
+  auto type = std::make_shared<::common::DataType>();
+  if (format == "b") {
+    type->set_primitive_type(::common::PrimitiveType::DT_BOOL);
+  } else if (format == "c" || format == "s" || format == "i") {
+    type->set_primitive_type(::common::PrimitiveType::DT_SIGNED_INT32);
+  } else if (format == "C" || format == "S" || format == "I") {
+    type->set_primitive_type(::common::PrimitiveType::DT_UNSIGNED_INT32);
+  } else if (format == "l") {
+    type->set_primitive_type(::common::PrimitiveType::DT_SIGNED_INT64);
+  } else if (format == "L") {
+    type->set_primitive_type(::common::PrimitiveType::DT_UNSIGNED_INT64);
+  } else if (format == "f") {
+    type->set_primitive_type(::common::PrimitiveType::DT_FLOAT);
+  } else if (format == "g") {
+    type->set_primitive_type(::common::PrimitiveType::DT_DOUBLE);
+  } else if (format == "u" || format == "U") {
+    type->mutable_string()->mutable_var_char();
+  } else if (format == "tdD" || format == "tdm") {
+    type->mutable_temporal()->mutable_date();
+  } else {
+    type->mutable_temporal()->mutable_timestamp();
+  }
+  return type;
+}
+
+result<std::shared_ptr<reader::EntrySchema>> convertArrowCStructSchema(
+    const ArrowSchema& schema) {
+  if (!schema.format || std::string_view(schema.format) != "+s" ||
+      schema.dictionary || schema.n_children < 0 ||
+      schema.n_children > kMaxSchemaColumns ||
+      (schema.n_children > 0 && !schema.children)) {
+    RETURN_STATUS_ERROR(StatusCode::ERR_TYPE_CONVERSION,
+                        "Carquet returned an invalid root schema");
+  }
+
+  auto entry = std::make_shared<reader::TableEntrySchema>();
+  entry->columnNames.reserve(static_cast<size_t>(schema.n_children));
+  entry->columnTypes.reserve(static_cast<size_t>(schema.n_children));
+  std::unordered_set<std::string> names;
+  for (int64_t i = 0; i < schema.n_children; ++i) {
+    const ArrowSchema* field = schema.children[i];
+    if (!field || !field->name || field->name[0] == '\0') {
+      return schemaError<std::shared_ptr<reader::EntrySchema>>(
+          "root", "unnamed column at index " + std::to_string(i));
+    }
+    std::string name(field->name);
+    if (!names.emplace(name).second) {
+      return schemaError<std::shared_ptr<reader::EntrySchema>>(
+          "root", "duplicate column \"" + name + "\"");
+    }
+    auto converted =
+        convertArrowCScalarSchemaType(*field, "column \"" + name + "\"");
+    if (!converted) {
+      return tl::unexpected(converted.error());
+    }
+    entry->columnNames.emplace_back(std::move(name));
+    entry->columnTypes.emplace_back(std::move(*converted));
+  }
+  return std::static_pointer_cast<reader::EntrySchema>(entry);
+}
+
+result<std::shared_ptr<reader::EntrySchema>> convertCarquetSchema(
+    const carquet_schema_t& schema) {
+  ArrowSchemaOwner exported;
+  carquet_error_t error = CARQUET_ERROR_INIT;
+  const carquet_status_t status =
+      carquet_arrow_export_schema(&schema, &exported, &error);
+  if (status != CARQUET_OK) {
+    RETURN_STATUS_ERROR(
+        StatusCode::ERR_TYPE_CONVERSION,
+        "Failed to export Carquet schema: " + std::string(error.message));
+  }
+  return convertArrowCStructSchema(exported);
+}
+
+}  // namespace neug::parquet

--- a/extension/parquet/src/carquet/schema_converter.h
+++ b/extension/parquet/src/carquet/schema_converter.h
@@ -1,0 +1,28 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+#pragma once
+
+#include <carquet/carquet.h>
+
+#include <memory>
+#include <string>
+
+#include "neug/generated/proto/plan/basic_type.pb.h"
+#include "neug/utils/io/read/common/schema.h"
+#include "neug/utils/result.h"
+
+namespace neug::parquet {
+
+result<std::shared_ptr<::common::DataType>> convertArrowCScalarSchemaType(
+    const ArrowSchema& schema, const std::string& path = "column");
+
+result<std::shared_ptr<reader::EntrySchema>> convertArrowCStructSchema(
+    const ArrowSchema& schema);
+
+result<std::shared_ptr<reader::EntrySchema>> convertCarquetSchema(
+    const carquet_schema_t& schema);
+
+}  // namespace neug::parquet

--- a/extension/parquet/src/carquet/sniffer.cc
+++ b/extension/parquet/src/carquet/sniffer.cc
@@ -1,0 +1,39 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+#include "sniffer.h"
+
+#include <string>
+
+#include "input_adapter.h"
+#include "schema_converter.h"
+
+namespace neug::parquet {
+
+result<std::shared_ptr<reader::EntrySchema>> CarquetSniffer::sniff() {
+  if (!inputFactory_) {
+    RETURN_STATUS_ERROR(StatusCode::ERR_INVALID_ARGUMENT,
+                        "Parquet input stream factory is null");
+  }
+  auto input = inputFactory_();
+  if (!input) {
+    RETURN_STATUS_ERROR(StatusCode::ERR_IO_ERROR,
+                        "Parquet input stream factory returned null");
+  }
+
+  carquet_error_t error = CARQUET_ERROR_INIT;
+  std::unique_ptr<carquet_reader_t, decltype(&carquet_reader_close)>
+      parquetReader(openCarquetReader(std::move(input), nullptr, &error),
+                    carquet_reader_close);
+  if (!parquetReader) {
+    RETURN_STATUS_ERROR(StatusCode::ERR_IO_ERROR,
+                        "Failed to open Parquet input for schema sniffing: " +
+                            std::string(error.message));
+  }
+  return convertCarquetSchema(*carquet_reader_schema(parquetReader.get()));
+}
+
+}  // namespace neug::parquet

--- a/extension/parquet/src/carquet/sniffer.h
+++ b/extension/parquet/src/carquet/sniffer.h
@@ -1,0 +1,26 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+#pragma once
+
+#include <utility>
+
+#include "neug/utils/io/read/common/sniffer.h"
+#include "neug/utils/io/stream/input_stream.h"
+
+namespace neug::parquet {
+
+class CarquetSniffer final : public reader::Sniffer {
+ public:
+  explicit CarquetSniffer(io::InputStreamFactory inputFactory)
+      : inputFactory_(std::move(inputFactory)) {}
+
+  result<std::shared_ptr<reader::EntrySchema>> sniff() override;
+
+ private:
+  io::InputStreamFactory inputFactory_;
+};
+
+}  // namespace neug::parquet

--- a/extension/parquet/tests/carquet_chunk_supplier_test.cc
+++ b/extension/parquet/tests/carquet_chunk_supplier_test.cc
@@ -1,0 +1,539 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+#include <carquet/carquet.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "carquet/chunk_supplier.h"
+#include "carquet/column_converter.h"
+#include "carquet/schema_converter.h"
+#include "carquet/sniffer.h"
+
+namespace neug::parquet {
+namespace {
+
+struct InputState {
+  std::shared_ptr<std::vector<uint8_t>> bytes;
+  bool failReads = false;
+  int readCalls = 0;
+  int closeCalls = 0;
+  int destructCalls = 0;
+};
+
+class MemoryInput final : public io::InputStream {
+ public:
+  explicit MemoryInput(std::shared_ptr<InputState> state)
+      : state_(std::move(state)) {}
+  ~MemoryInput() override { ++state_->destructCalls; }
+
+  result<int64_t> Read(void* out, int64_t nbytes) override {
+    auto read = ReadAt(position_, nbytes, out);
+    if (read) {
+      position_ += *read;
+    }
+    return read;
+  }
+
+  result<int64_t> ReadAt(int64_t position, int64_t nbytes, void* out) override {
+    ++state_->readCalls;
+    if (state_->failReads) {
+      RETURN_STATUS_ERROR(StatusCode::ERR_IO_ERROR, "injected read failure");
+    }
+    if (position < 0 || nbytes < 0 || (nbytes > 0 && !out)) {
+      RETURN_STATUS_ERROR(StatusCode::ERR_INVALID_ARGUMENT,
+                          "invalid memory read");
+    }
+    if (position >= static_cast<int64_t>(state_->bytes->size())) {
+      return int64_t{0};
+    }
+    const int64_t count = std::min(
+        nbytes, static_cast<int64_t>(state_->bytes->size()) - position);
+    if (count > 0) {
+      std::memcpy(out, state_->bytes->data() + position,
+                  static_cast<size_t>(count));
+    }
+    return count;
+  }
+
+  result<int64_t> GetSize() override {
+    return static_cast<int64_t>(state_->bytes->size());
+  }
+
+  void Close() override { ++state_->closeCalls; }
+
+ private:
+  std::shared_ptr<InputState> state_;
+  int64_t position_ = 0;
+};
+
+std::shared_ptr<InputState> fixtureState(const std::string& name) {
+  const auto path = std::filesystem::path(NEUG_PARQUET_DATASET_DIR) / name;
+  std::ifstream input(path, std::ios::binary);
+  if (!input) {
+    throw std::runtime_error("Cannot open existing Parquet dataset: " +
+                             path.string());
+  }
+  auto bytes = std::make_shared<std::vector<uint8_t>>(
+      std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>());
+  return std::make_shared<InputState>(InputState{.bytes = std::move(bytes)});
+}
+
+void checkCarquet(carquet_status_t status) {
+  if (status != CARQUET_OK) {
+    throw std::runtime_error(carquet_status_string(status));
+  }
+}
+
+// Generate only the row-group/null cases missing from the existing datasets.
+std::shared_ptr<InputState> scalarFileState(
+    int groups,
+    decltype(CARQUET_COMPRESSION_ZSTD) codec = CARQUET_COMPRESSION_ZSTD) {
+  carquet_error_t error = CARQUET_ERROR_INIT;
+  std::unique_ptr<carquet_schema_t, decltype(&carquet_schema_free)> schema(
+      carquet_schema_create(&error), carquet_schema_free);
+  if (!schema) {
+    throw std::runtime_error(error.message);
+  }
+  checkCarquet(carquet_schema_add_column(schema.get(), "id",
+                                         CARQUET_PHYSICAL_INT64, nullptr,
+                                         CARQUET_REPETITION_REQUIRED, 0, 0));
+  checkCarquet(carquet_schema_add_column(schema.get(), "flag",
+                                         CARQUET_PHYSICAL_BOOLEAN, nullptr,
+                                         CARQUET_REPETITION_OPTIONAL, 0, 0));
+  checkCarquet(carquet_schema_add_column(schema.get(), "measurement",
+                                         CARQUET_PHYSICAL_FLOAT, nullptr,
+                                         CARQUET_REPETITION_OPTIONAL, 0, 0));
+  carquet_logical_type_t stringType{};
+  stringType.id = CARQUET_LOGICAL_STRING;
+  checkCarquet(carquet_schema_add_column(
+      schema.get(), "category", CARQUET_PHYSICAL_BYTE_ARRAY, &stringType,
+      CARQUET_REPETITION_OPTIONAL, 0, 0));
+  carquet_writer_options_t options;
+  carquet_writer_options_init(&options);
+  options.compression = codec;
+  std::unique_ptr<carquet_writer_t, decltype(&carquet_writer_abort)> writer(
+      carquet_writer_create_buffer(schema.get(), &options, &error),
+      carquet_writer_abort);
+  if (!writer) {
+    throw std::runtime_error(error.message);
+  }
+  const int16_t defined[] = {1, 1, 0, 1, 1, 1};
+  const uint8_t flags[] = {1, 0, 0, 1, 0};
+  const float measurements[] = {0.5f, -1.25f, 3.5f, 4.5f, 5.5f};
+  std::string labels[] = {"", "中文", "b", "a", "c"};
+  carquet_byte_array_t strings[5];
+  for (size_t i = 0; i < 5; ++i) {
+    strings[i] = {reinterpret_cast<uint8_t*>(labels[i].data()),
+                  static_cast<int32_t>(labels[i].size())};
+  }
+  for (int group = 0; group < groups; ++group) {
+    const int64_t ids[] = {group * 6 + 1, group * 6 + 2, group * 6 + 3,
+                           group * 6 + 4, group * 6 + 5, group * 6 + 6};
+    checkCarquet(
+        carquet_writer_write_batch(writer.get(), 0, ids, 6, nullptr, nullptr));
+    checkCarquet(carquet_writer_write_batch(writer.get(), 1, flags, 6, defined,
+                                            nullptr));
+    checkCarquet(carquet_writer_write_batch(writer.get(), 2, measurements, 6,
+                                            defined, nullptr));
+    checkCarquet(carquet_writer_write_batch(writer.get(), 3, strings, 6,
+                                            defined, nullptr));
+    if (group + 1 < groups) {
+      checkCarquet(carquet_writer_new_row_group(writer.get()));
+    }
+  }
+  checkCarquet(carquet_writer_close(writer.get()));
+  void* data = nullptr;
+  size_t size = 0;
+  checkCarquet(carquet_writer_get_buffer(writer.get(), &data, &size));
+  writer.release();  // get_buffer consumes the closed buffer writer.
+  std::unique_ptr<void, decltype(&std::free)> buffer(data, std::free);
+  auto bytes = std::make_shared<std::vector<uint8_t>>(
+      static_cast<uint8_t*>(data), static_cast<uint8_t*>(data) + size);
+  return std::make_shared<InputState>(InputState{.bytes = std::move(bytes)});
+}
+
+template <typename T>
+T valueAt(const std::shared_ptr<DataChunk>& chunk, int column, size_t row) {
+  return chunk->get(column)->get_elem(row).GetValue<T>();
+}
+
+void expectPrimitive(const std::shared_ptr<::common::DataType>& type,
+                     ::common::PrimitiveType expected) {
+  ASSERT_NE(type, nullptr);
+  EXPECT_EQ(type->item_case(), ::common::DataType::kPrimitiveType);
+  EXPECT_EQ(type->primitive_type(), expected);
+}
+
+TEST(CarquetChunkSupplierTest, StreamsOwnedScalarChunksAcrossRowGroups) {
+  for (auto codec :
+       {CARQUET_COMPRESSION_UNCOMPRESSED, CARQUET_COMPRESSION_SNAPPY,
+        CARQUET_COMPRESSION_GZIP, CARQUET_COMPRESSION_ZSTD}) {
+    SCOPED_TRACE(static_cast<int>(codec));
+    auto state = scalarFileState(2, codec);
+    std::shared_ptr<DataChunk> retained;
+    std::vector<int64_t> ids;
+    std::vector<std::string> categories;
+    {
+      auto supplier =
+          CarquetChunkSupplier::create(std::make_unique<MemoryInput>(state),
+                                       {.batchSize = 3, .numThreads = 1});
+      ASSERT_TRUE(supplier) << supplier.error().ToString();
+      EXPECT_EQ((*supplier)->RowNum(), 12);
+      ASSERT_EQ(
+          (*supplier)->schema()->columnNames,
+          (std::vector<std::string>{"id", "flag", "measurement", "category"}));
+      expectPrimitive((*supplier)->schema()->columnTypes[0],
+                      ::common::DT_SIGNED_INT64);
+      expectPrimitive((*supplier)->schema()->columnTypes[1], ::common::DT_BOOL);
+      expectPrimitive((*supplier)->schema()->columnTypes[2],
+                      ::common::DT_FLOAT);
+      EXPECT_EQ((*supplier)->schema()->columnTypes[3]->item_case(),
+                ::common::DataType::kString);
+      while (auto chunk = (*supplier)->GetNextChunk()) {
+        EXPECT_GT(chunk->row_num(), 0u);
+        EXPECT_LE(chunk->row_num(), 3u);
+        ASSERT_EQ(chunk->col_num(), 4u);
+        if (!retained) {
+          retained = chunk;
+        }
+        for (size_t row = 0; row < chunk->row_num(); ++row) {
+          const int64_t id = valueAt<int64_t>(chunk, 0, row);
+          ids.push_back(id);
+          for (int col = 1; col < 4; ++col) {
+            EXPECT_EQ(chunk->get(col)->get_elem(row).IsNull(), id % 6 == 3);
+          }
+          if (id % 6 != 3) {
+            categories.push_back(valueAt<std::string>(chunk, 3, row));
+          }
+        }
+      }
+      EXPECT_EQ((*supplier)->GetNextChunk(), nullptr);
+      EXPECT_EQ((*supplier)->GetNextChunk(), nullptr);
+    }
+    EXPECT_EQ(ids,
+              (std::vector<int64_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}));
+    EXPECT_EQ(categories,
+              (std::vector<std::string>{"", "中文", "b", "a", "c", "", "中文",
+                                        "b", "a", "c"}));
+    ASSERT_NE(retained, nullptr);
+    EXPECT_EQ(valueAt<int64_t>(retained, 0, 0), 1);
+    EXPECT_TRUE(valueAt<bool>(retained, 1, 0));
+    EXPECT_FALSE(valueAt<bool>(retained, 1, 1));
+    EXPECT_FLOAT_EQ(valueAt<float>(retained, 2, 1), -1.25f);
+    EXPECT_EQ(valueAt<std::string>(retained, 3, 1), "中文");
+    EXPECT_TRUE(retained->get(3)->get_elem(2).IsNull());
+    EXPECT_EQ(state->closeCalls, 1);
+    EXPECT_EQ(state->destructCalls, 1);
+  }
+}
+
+TEST(CarquetChunkSupplierTest, ReadsExistingIndependentScalarDataset) {
+  auto state = fixtureState("comprehensive_graph/parquet/node_a.parquet");
+  auto supplier = CarquetChunkSupplier::create(
+      std::make_unique<MemoryInput>(state), {.batchSize = 3});
+  ASSERT_TRUE(supplier) << supplier.error().ToString();
+  ASSERT_EQ((*supplier)->RowNum(), 10);
+  const auto& types = (*supplier)->schema()->columnTypes;
+  ASSERT_EQ(types.size(), 11u);
+  expectPrimitive(types[1], ::common::DT_SIGNED_INT32);
+  expectPrimitive(types[3], ::common::DT_UNSIGNED_INT32);
+  expectPrimitive(types[4], ::common::DT_UNSIGNED_INT64);
+  EXPECT_TRUE(types[8]->temporal().has_date());
+  EXPECT_TRUE(types[9]->temporal().has_timestamp());
+  auto chunk = (*supplier)->GetNextChunk();
+  ASSERT_NE(chunk, nullptr);
+  ASSERT_EQ(chunk->col_num(), 11u);
+  ASSERT_EQ(chunk->row_num(), 3u);
+  EXPECT_EQ(valueAt<int32_t>(chunk, 1, 0), -123456789);
+  EXPECT_EQ(valueAt<int64_t>(chunk, 2, 0), std::numeric_limits<int64_t>::max());
+  EXPECT_EQ(valueAt<int64_t>(chunk, 2, 1), std::numeric_limits<int64_t>::min());
+  EXPECT_EQ(valueAt<uint32_t>(chunk, 3, 0),
+            std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(valueAt<uint64_t>(chunk, 4, 0),
+            std::numeric_limits<uint64_t>::max());
+  EXPECT_EQ(valueAt<uint64_t>(chunk, 4, 2), uint64_t{1} << 63);
+  EXPECT_FLOAT_EQ(valueAt<float>(chunk, 5, 0), 3.1415927f);
+  EXPECT_DOUBLE_EQ(valueAt<double>(chunk, 6, 0), 2.718281828459045);
+  EXPECT_EQ(valueAt<std::string>(chunk, 7, 0), "test_string_0");
+  EXPECT_EQ(valueAt<Date>(chunk, 8, 0).to_string(), "2023-01-15");
+  EXPECT_EQ(valueAt<DateTime>(chunk, 9, 0).milli_second, 1673740800000LL);
+  size_t rows = chunk->row_num();
+  while (auto next = (*supplier)->GetNextChunk()) {
+    rows += next->row_num();
+  }
+  EXPECT_EQ(rows, 10u);
+  supplier->reset();
+  EXPECT_EQ(valueAt<std::string>(chunk, 7, 0), "test_string_0");
+  EXPECT_EQ(state->closeCalls, 1);
+}
+
+TEST(CarquetChunkSupplierTest, SniffsMetadataThroughFreshExistingStreams) {
+  auto bytes = fixtureState("tinysnb/parquet/eMeets.parquet")->bytes;
+  std::vector<std::shared_ptr<InputState>> states;
+  CarquetSniffer sniffer([&]() {
+    auto state = std::make_shared<InputState>(InputState{.bytes = bytes});
+    states.push_back(state);
+    return std::make_unique<MemoryInput>(state);
+  });
+  for (int attempt = 0; attempt < 2; ++attempt) {
+    auto schema = sniffer.sniff();
+    ASSERT_TRUE(schema) << schema.error().ToString();
+    EXPECT_EQ(
+        (*schema)->columnNames,
+        (std::vector<std::string>{"from", "to", "location", "times", "data"}));
+  }
+  ASSERT_EQ(states.size(), 2u);
+  for (const auto& state : states) {
+    EXPECT_GT(state->readCalls, 0);
+    EXPECT_EQ(state->closeCalls, 1);
+    EXPECT_EQ(state->destructCalls, 1);
+  }
+  auto nested =
+      fixtureState("comprehensive_graph/parquet/parquet_list.parquet");
+  CarquetSniffer unsupported(
+      [nested]() { return std::make_unique<MemoryInput>(nested); });
+  auto schema = unsupported.sniff();
+  ASSERT_FALSE(schema);
+  EXPECT_EQ(schema.error().error_code(), StatusCode::ERR_TYPE_CONVERSION);
+  EXPECT_EQ(nested->closeCalls, 1);
+}
+
+TEST(CarquetChunkSupplierTest, HandlesEmptyInvalidAndMalformedInputs) {
+  auto empty = scalarFileState(0);
+  {
+    auto supplier =
+        CarquetChunkSupplier::create(std::make_unique<MemoryInput>(empty));
+    ASSERT_TRUE(supplier) << supplier.error().ToString();
+    EXPECT_EQ((*supplier)->RowNum(), 0);
+    EXPECT_EQ((*supplier)->GetNextChunk(), nullptr);
+    EXPECT_EQ((*supplier)->GetNextChunk(), nullptr);
+  }
+  EXPECT_EQ(empty->closeCalls, 1);
+  for (auto options : {CarquetReaderOptions{.batchSize = 0},
+                       CarquetReaderOptions{.numThreads = -1}}) {
+    auto rejected = scalarFileState(0);
+    auto bad = CarquetChunkSupplier::create(
+        std::make_unique<MemoryInput>(rejected), options);
+    ASSERT_FALSE(bad);
+    EXPECT_EQ(bad.error().error_code(), StatusCode::ERR_INVALID_ARGUMENT);
+    EXPECT_EQ(rejected->closeCalls, 1);
+    EXPECT_EQ(rejected->destructCalls, 1);
+  }
+  auto broken = std::make_shared<InputState>(
+      InputState{.bytes = std::make_shared<std::vector<uint8_t>>(
+                     std::initializer_list<uint8_t>{'N', 'O', 'P', 'E'})});
+  auto invalid =
+      CarquetChunkSupplier::create(std::make_unique<MemoryInput>(broken));
+  ASSERT_FALSE(invalid);
+  EXPECT_EQ(invalid.error().error_code(), StatusCode::ERR_IO_ERROR);
+  EXPECT_EQ(broken->closeCalls, 1);
+  EXPECT_EQ(broken->destructCalls, 1);
+  auto nested =
+      fixtureState("comprehensive_graph/parquet/parquet_list.parquet");
+  auto unsupported =
+      CarquetChunkSupplier::create(std::make_unique<MemoryInput>(nested));
+  ASSERT_FALSE(unsupported);
+  EXPECT_EQ(unsupported.error().error_code(), StatusCode::ERR_TYPE_CONVERSION);
+  EXPECT_EQ(nested->closeCalls, 1);
+  EXPECT_EQ(nested->destructCalls, 1);
+  EXPECT_FALSE(CarquetChunkSupplier::create(nullptr));
+  CarquetSniffer nullFactory(nullptr);
+  EXPECT_FALSE(nullFactory.sniff());
+  CarquetSniffer nullStream(
+      []() { return std::unique_ptr<io::InputStream>{}; });
+  EXPECT_FALSE(nullStream.sniff());
+}
+
+TEST(CarquetChunkSupplierTest, ReleasesInputAfterMidReadFailure) {
+  auto state = scalarFileState(2);
+  {
+    auto supplier =
+        CarquetChunkSupplier::create(std::make_unique<MemoryInput>(state));
+    ASSERT_TRUE(supplier) << supplier.error().ToString();
+    state->failReads = true;
+    EXPECT_THROW((*supplier)->GetNextChunk(), exception::IOException);
+  }
+  EXPECT_EQ(state->closeCalls, 1);
+  EXPECT_EQ(state->destructCalls, 1);
+}
+
+template <typename Source, typename Dest>
+void expectSlicedPrimitive(const char* format) {
+  SCOPED_TRACE(format);
+  const Source data[] = {0, std::numeric_limits<Source>::lowest(), 0,
+                         std::numeric_limits<Source>::max()};
+  const uint8_t validity = 0x0a;  // Indices 1 and 3 are valid.
+  const void* buffers[] = {&validity, data};
+  ArrowSchema schema{.format = format};
+  ArrowArray array{.length = 3,
+                   .null_count = -1,
+                   .offset = 1,
+                   .n_buffers = 2,
+                   .buffers = buffers};
+  auto converted = convertArrowCScalarColumn(schema, array);
+  ASSERT_TRUE(converted) << converted.error().ToString();
+  EXPECT_EQ((*converted)->get_elem(0).GetValue<Dest>(),
+            static_cast<Dest>(data[1]));
+  EXPECT_TRUE((*converted)->get_elem(1).IsNull());
+  EXPECT_EQ((*converted)->get_elem(2).GetValue<Dest>(),
+            static_cast<Dest>(data[3]));
+}
+
+TEST(CarquetScalarConverterTest, PreservesSlicedNumericValuesAndNulls) {
+  expectSlicedPrimitive<int8_t, int32_t>("c");
+  expectSlicedPrimitive<int16_t, int32_t>("s");
+  expectSlicedPrimitive<int32_t, int32_t>("i");
+  expectSlicedPrimitive<int64_t, int64_t>("l");
+  expectSlicedPrimitive<uint8_t, uint32_t>("C");
+  expectSlicedPrimitive<uint16_t, uint32_t>("S");
+  expectSlicedPrimitive<uint32_t, uint32_t>("I");
+  expectSlicedPrimitive<uint64_t, uint64_t>("L");
+  expectSlicedPrimitive<float, float>("f");
+  expectSlicedPrimitive<double, double>("g");
+}
+
+TEST(CarquetScalarConverterTest, PreservesFloatingSpecialValues) {
+  const double values[] = {std::numeric_limits<double>::quiet_NaN(),
+                           std::numeric_limits<double>::infinity(),
+                           -std::numeric_limits<double>::infinity()};
+  const void* buffers[] = {nullptr, values};
+  ArrowSchema schema{.format = "g"};
+  ArrowArray array{.length = 3, .n_buffers = 2, .buffers = buffers};
+  auto converted = convertArrowCScalarColumn(schema, array);
+  ASSERT_TRUE(converted) << converted.error().ToString();
+  EXPECT_FALSE((*converted)->get_elem(0).IsNull());
+  EXPECT_TRUE(std::isnan((*converted)->get_elem(0).GetValue<double>()));
+  EXPECT_EQ((*converted)->get_elem(1).GetValue<double>(), values[1]);
+  EXPECT_EQ((*converted)->get_elem(2).GetValue<double>(), values[2]);
+}
+
+TEST(CarquetScalarConverterTest, ConvertsTemporalUnitsAndRejectsOverflow) {
+  const int64_t ticks[] = {0, -1000000, 123000000, 0};
+  const uint8_t validity = 0x07;
+  const void* buffers[] = {&validity, ticks};
+  ArrowArray array{
+      .length = 4, .null_count = 1, .n_buffers = 2, .buffers = buffers};
+  struct TimestampCase {
+    const char* format;
+    int64_t negativeMillis;
+    int64_t positiveMillis;
+  };
+  for (const auto& test : {TimestampCase{"tss:", -1000000000, 123000000000},
+                           {"tsm:", -1000000, 123000000},
+                           {"tsu:", -1000, 123000},
+                           {"tsn:", -1, 123}}) {
+    ArrowSchema schema{.format = test.format};
+    auto converted = convertArrowCScalarColumn(schema, array);
+    ASSERT_TRUE(converted) << converted.error().ToString();
+    EXPECT_EQ((*converted)->get_elem(0).GetValue<DateTime>().milli_second, 0);
+    EXPECT_EQ((*converted)->get_elem(1).GetValue<DateTime>().milli_second,
+              test.negativeMillis);
+    EXPECT_EQ((*converted)->get_elem(2).GetValue<DateTime>().milli_second,
+              test.positiveMillis);
+    EXPECT_TRUE((*converted)->get_elem(3).IsNull());
+  }
+  const int64_t dateMillis[] = {0, -86400000, 1709164800000, 0};
+  buffers[1] = dateMillis;
+  ArrowSchema dateSchema{.format = "tdm"};
+  auto dates = convertArrowCScalarColumn(dateSchema, array);
+  ASSERT_TRUE(dates) << dates.error().ToString();
+  EXPECT_EQ((*dates)->get_elem(1).GetValue<Date>().to_num_days(), -1);
+  EXPECT_EQ((*dates)->get_elem(2).GetValue<Date>().to_string(), "2024-02-29");
+  EXPECT_TRUE((*dates)->get_elem(3).IsNull());
+  const int64_t overflow[] = {std::numeric_limits<int64_t>::min(),
+                              std::numeric_limits<int64_t>::max()};
+  array.length = 1;
+  array.null_count = 0;
+  for (const auto& value : overflow) {
+    buffers[1] = &value;
+    for (const char* format : {"tss:", "tdm"}) {
+      ArrowSchema schema{.format = format};
+      EXPECT_FALSE(convertArrowCScalarColumn(schema, array));
+    }
+  }
+}
+
+TEST(CarquetScalarConverterTest, ValidatesStringsAndOwnsLargeStringSlices) {
+  const int32_t badOffsets[] = {0, 4, 2};
+  const void* buffers[] = {nullptr, badOffsets, "abcd"};
+  ArrowSchema schema{.format = "u", .name = "label"};
+  ArrowArray array{
+      .length = 2, .null_count = 0, .n_buffers = 3, .buffers = buffers};
+  auto malformed = convertArrowCScalarColumn(schema, array);
+  ASSERT_FALSE(malformed);
+  EXPECT_NE(malformed.error().error_message().find("decreasing"),
+            std::string::npos);
+  int64_t offsets[] = {0, 4, 4, 10, 10};
+  std::string text = "skip中文";
+  const uint8_t validity = 0x07;
+  buffers[0] = &validity;
+  buffers[1] = offsets;
+  buffers[2] = text.data();
+  schema.format = "U";
+  array.length = 3;
+  array.offset = 1;
+  array.null_count = 1;
+  auto converted = convertArrowCScalarColumn(schema, array);
+  ASSERT_TRUE(converted) << converted.error().ToString();
+  text.assign(text.size(), 'x');
+  EXPECT_EQ((*converted)->get_elem(0).GetValue<std::string>(), "");
+  EXPECT_EQ((*converted)->get_elem(1).GetValue<std::string>(), "中文");
+  EXPECT_TRUE((*converted)->get_elem(2).IsNull());
+}
+
+TEST(CarquetScalarConverterTest, RejectsInvalidSchemasAndStructLayouts) {
+  ArrowSchema field{.format = "l", .name = "id"};
+  ArrowSchema* children[] = {&field, &field};
+  ArrowSchema root{.format = "+s", .n_children = 2, .children = children};
+  EXPECT_FALSE(convertArrowCStructSchema(root));  // Duplicate field names.
+  field.name = nullptr;
+  root.n_children = 1;
+  EXPECT_FALSE(convertArrowCStructSchema(root));
+  field.name = "id";
+  field.format = "z";
+  EXPECT_FALSE(convertArrowCStructSchema(root));
+  field.format = "l";
+  field.dictionary = &field;
+  EXPECT_FALSE(convertArrowCStructSchema(root));
+  field.dictionary = nullptr;
+  const int64_t value = 1;
+  const void* scalarBuffers[] = {nullptr, &value};
+  ArrowArray child{.length = 1, .n_buffers = 2, .buffers = scalarBuffers};
+  ArrowArray* arrays[] = {&child};
+  const void* rootBuffers[] = {nullptr};
+  ArrowArray array{.length = 2,
+                   .n_buffers = 1,
+                   .n_children = 1,
+                   .buffers = rootBuffers,
+                   .children = arrays};
+  EXPECT_FALSE(
+      convertArrowCFlatStruct(root, array));  // Child row count mismatch.
+  array.length = 1;
+  EXPECT_TRUE(convertArrowCFlatStruct(root, array));
+  child.offset = std::numeric_limits<int64_t>::max();
+  EXPECT_FALSE(convertArrowCScalarColumn(field, child));
+  child.offset = 0;
+  child.null_count = 1;
+  EXPECT_FALSE(convertArrowCScalarColumn(field, child));  // Missing validity.
+}
+
+}  // namespace
+}  // namespace neug::parquet


### PR DESCRIPTION
Adds the private Carquet scalar reader implementation on top of the existing I/O interfaces, preparing the Parquet extension for its backend switch. `CarquetSniffer` supplies schema metadata through `InputStreamFactory`; `CarquetChunkSupplier` implements `IDataChunkSupplier` and returns owned NeuG `DataChunk` columns.

The implementation covers scalar types, NULL values, temporal unit conversion and range checks, bounded chunk sizes, stable EOF, metadata row-count validation, and resource cleanup on failed initialization or reads. It also declares the protobuf generation dependency for the new reader target.

Tests reuse existing Parquet datasets and generate multi-row-group/NULL cases in memory. No binary fixtures or PyArrow dependency are added to the C++ tests.

Validation on macOS:

- Release build with Python, Parquet, HTTPFS, and related test targets passed.
- 57/57 CTest entries passed, including 20 Carquet tests (10 new).
- 47/47 Python contract and export regressions passed with PyArrow 24.
- clang-format 10.0.1 and diff whitespace checks passed.