### PR TITLE
docs: improve C++ API reference

### DIFF
--- a/doc/source/_scripts/cpp_key_classes.json
+++ b/doc/source/_scripts/cpp_key_classes.json
@@ -5,12 +5,12 @@
   "key_classes": [
     "neug::NeugDB",
     "neug::Connection",
-    "neug::QueryResult",
-    "neug::RecordLine",
     "neug::NeugDBService",
     "neug::ExecutionSlot",
     "neug::TpExecutionSlotPool",
-    "neug::ExecutionSlotLease"
+    "neug::ExecutionSlotLease",
+    "neug::QueryResult",
+    "neug::RecordLine"
   ],
   "class_files": {
     "neug::NeugDB": {

--- a/doc/source/reference/cpp_api/index.md
+++ b/doc/source/reference/cpp_api/index.md
@@ -14,8 +14,8 @@ The C++ API offers powerful capabilities for:
 
 - **[NeugDB](neug_db)** - The main entry point for database operations
 - **[Connection](connection)** - Execute Cypher queries against the database
-- **[QueryResult](query_result)** - Container for query results with iterator access
 - **[NeugDBService](service)** - HTTP service for high-throughput scenarios
+- **[QueryResult](query_result)** - Container for query results with iterator access
 
 ## Quick Start
 

--- a/doc/source/reference/cpp_api/index.rst
+++ b/doc/source/reference/cpp_api/index.rst
@@ -9,5 +9,5 @@ C++ API Reference
 
    Database <neug_db>
    Connection <connection>
-   Query Result <query_result>
    Service <service>
+   Query Result <query_result>

--- a/doc/source/reference/cpp_api/query_result.md
+++ b/doc/source/reference/cpp_api/query_result.md
@@ -35,8 +35,10 @@ Return the current cursor position (0-based row index).
 
 All getters read from the **current cursor row**. Each method has two overloads:
 by column index or by column name. Use `IsNull(...)` before reading a nullable
-cell. A getter throws when the cursor or column selector is invalid, or when the
-column type cannot be converted to the requested return type.
+cell. Choose a getter according to the column's underlying result type; these
+methods do not parse or coerce arbitrary source types. A getter throws
+`neug::exception::RuntimeError` when the cursor or column selector is invalid,
+or when the source column type is not listed for that getter.
 
 #### `IsNull(size_t column_index)` / `IsNull(const std::string& column_name)`
 
@@ -44,50 +46,62 @@ Check whether the cell at current row is NULL.
 
 #### `GetInt32(...)`
 
-Return the current cell as a signed 32-bit integer. This accessor accepts
-`int32` and `bool` columns; `true` is converted to `1` and `false` to `0`.
+Return the current cell as a signed 32-bit integer. Call this method only when
+the source column type is `int32` or `bool`; any other source type causes a
+`neug::exception::RuntimeError`. An `int32` value is returned unchanged, while
+`true` is converted to `1` and `false` to `0`.
 
 #### `GetUInt32(...)`
 
-Return the current cell as an unsigned 32-bit integer. This accessor accepts
-`uint32` and `bool` columns; `true` is converted to `1` and `false` to `0`.
+Return the current cell as an unsigned 32-bit integer. Call this method only
+when the source column type is `uint32` or `bool`; any other source type causes
+a `neug::exception::RuntimeError`. A `uint32` value is returned unchanged,
+while `true` is converted to `1` and `false` to `0`.
 
 #### `GetInt64(...)`
 
-Return the current cell as a signed 64-bit integer. This accessor accepts
-`int64`, `int32`, `uint32`, `bool`, `date`, and `timestamp` columns. Smaller
-integers are widened, booleans become `1` or `0`, and `date` / `timestamp`
-values are returned as the raw epoch value stored by NeuG.
+Return the current cell as a signed 64-bit integer. Call this method only when
+the source column type is `int64`, `int32`, `uint32`, `bool`, `date`, or
+`timestamp`; any other source type causes a `neug::exception::RuntimeError`.
+An `int64` value is returned unchanged, smaller integers are widened, booleans
+become `1` or `0`, and `date` / `timestamp` values are returned as the raw epoch
+value stored by NeuG.
 
 #### `GetUInt64(...)`
 
-Return the current cell as an unsigned 64-bit integer. This accessor accepts
-`uint64`, `uint32`, and `bool` columns. A `uint32` value is widened, while
-`true` and `false` are converted to `1` and `0` respectively.
+Return the current cell as an unsigned 64-bit integer. Call this method only
+when the source column type is `uint64`, `uint32`, or `bool`; any other source
+type causes a `neug::exception::RuntimeError`. A `uint64` value is returned
+unchanged, a `uint32` value is widened, and booleans become `1` or `0`.
 
 #### `GetFloat(...)`
 
-Return the current cell as a single-precision floating-point value. This
-accessor accepts `float`, `int32`, `uint32`, and `bool` columns. Integer values
-are converted to `float`; booleans become `1.0f` or `0.0f`.
+Return the current cell as a single-precision floating-point value. Call this
+method only when the source column type is `float`, `int32`, `uint32`, or
+`bool`; any other source type causes a `neug::exception::RuntimeError`. A
+`float` value is returned unchanged, integer values are converted to `float`,
+and booleans become `1.0f` or `0.0f`.
 
 #### `GetDouble(...)`
 
-Return the current cell as a double-precision floating-point value. This
-accessor accepts `double`, `float`, `int32`, `uint32`, `int64`, `uint64`, and
-`bool` columns. Numeric values are converted to `double`, and booleans become
-`1.0` or `0.0`. Large 64-bit integers may lose precision during conversion.
+Return the current cell as a double-precision floating-point value. Call this
+method only when the source column type is `double`, `float`, `int32`, `uint32`,
+`int64`, `uint64`, or `bool`; any other source type causes a
+`neug::exception::RuntimeError`. A `double` value is returned unchanged, other
+numeric values are converted to `double`, and booleans become `1.0` or `0.0`.
+Large 64-bit integers may lose precision during conversion.
 
 #### `GetString(...)`
 
-Return the current cell as a string. This accessor accepts every column type:
-string values are returned directly, while other values use NeuG's
-human-readable string representation.
+Return the current cell as a string. This is the only typed getter that can be
+called for every source column type. String values are returned directly;
+other values use NeuG's human-readable string representation.
 
 #### `GetBool(...)`
 
-Return the current cell as a Boolean value. This accessor accepts only `bool`
-columns; requesting a Boolean from any other column type throws an exception.
+Return the current cell as a Boolean value. Call this method only when the
+source column type is `bool`; any other source type causes a
+`neug::exception::RuntimeError`. The Boolean value is returned unchanged.
 
 > Temporal columns (`date`, `timestamp`, `interval`) are not exposed as
 > dedicated typed objects. Use `GetString(...)` for their canonical string form

--- a/doc/source/reference/cpp_api/query_result.md
+++ b/doc/source/reference/cpp_api/query_result.md
@@ -33,27 +33,61 @@ Return the current cursor position (0-based row index).
 
 ### Typed Value Accessors
 
-All getters read from the **current cursor row**. Each method has two overloads: by column index or by column name.
+All getters read from the **current cursor row**. Each method has two overloads:
+by column index or by column name. Use `IsNull(...)` before reading a nullable
+cell. A getter throws when the cursor or column selector is invalid, or when the
+column type cannot be converted to the requested return type.
 
 #### `IsNull(size_t column_index)` / `IsNull(const std::string& column_name)`
 
 Check whether the cell at current row is NULL.
 
-#### `GetInt32(...)` — accepts `int32`, `bool`
+#### `GetInt32(...)`
 
-#### `GetUInt32(...)` — accepts `uint32`, `bool`
+Return the current cell as a signed 32-bit integer. This accessor accepts
+`int32` and `bool` columns; `true` is converted to `1` and `false` to `0`.
 
-#### `GetInt64(...)` — accepts `int64`, `int32`, `uint32`, `bool`, `date`, `timestamp` (date/timestamp return the raw int64 epoch value)
+#### `GetUInt32(...)`
 
-#### `GetUInt64(...)` — accepts `uint64`, `uint32`, `bool`
+Return the current cell as an unsigned 32-bit integer. This accessor accepts
+`uint32` and `bool` columns; `true` is converted to `1` and `false` to `0`.
 
-#### `GetFloat(...)` — accepts `float`, `int32`, `uint32`, `bool`
+#### `GetInt64(...)`
 
-#### `GetDouble(...)` — accepts `double`, `float`, `int32`, `uint32`, `int64`, `uint64`, `bool`
+Return the current cell as a signed 64-bit integer. This accessor accepts
+`int64`, `int32`, `uint32`, `bool`, `date`, and `timestamp` columns. Smaller
+integers are widened, booleans become `1` or `0`, and `date` / `timestamp`
+values are returned as the raw epoch value stored by NeuG.
 
-#### `GetString(...)` — accepts **any type** (falls back to string representation)
+#### `GetUInt64(...)`
 
-#### `GetBool(...)` — accepts `bool` only
+Return the current cell as an unsigned 64-bit integer. This accessor accepts
+`uint64`, `uint32`, and `bool` columns. A `uint32` value is widened, while
+`true` and `false` are converted to `1` and `0` respectively.
+
+#### `GetFloat(...)`
+
+Return the current cell as a single-precision floating-point value. This
+accessor accepts `float`, `int32`, `uint32`, and `bool` columns. Integer values
+are converted to `float`; booleans become `1.0f` or `0.0f`.
+
+#### `GetDouble(...)`
+
+Return the current cell as a double-precision floating-point value. This
+accessor accepts `double`, `float`, `int32`, `uint32`, `int64`, `uint64`, and
+`bool` columns. Numeric values are converted to `double`, and booleans become
+`1.0` or `0.0`. Large 64-bit integers may lose precision during conversion.
+
+#### `GetString(...)`
+
+Return the current cell as a string. This accessor accepts every column type:
+string values are returned directly, while other values use NeuG's
+human-readable string representation.
+
+#### `GetBool(...)`
+
+Return the current cell as a Boolean value. This accessor accepts only `bool`
+columns; requesting a Boolean from any other column type throws an exception.
 
 > Temporal columns (`date`, `timestamp`, `interval`) are not exposed as
 > dedicated typed objects. Use `GetString(...)` for their canonical string form
@@ -129,4 +163,3 @@ while (result.hasNext()) {
     result.next();
 }
 ```
-

--- a/include/neug/main/query_result.h
+++ b/include/neug/main/query_result.h
@@ -110,147 +110,199 @@ class NEUG_API QueryResult {
   /**
    * @brief Return the current cell as a signed 32-bit integer.
    *
-   * Accepts int32 and bool columns. Boolean values are converted to 1 or 0.
+   * The source column must have type int32 or bool. Any other source type
+   * causes an exception. An int32 value is returned unchanged; a bool value is
+   * converted to 1 or 0.
    *
    * @param column_index Zero-based column index.
+   * @throws exception::RuntimeError If the cursor or column index is invalid,
+   * or the source column type is neither int32 nor bool.
    */
   int32_t GetInt32(size_t column_index) const;
   /**
    * @brief Return the named current cell as a signed 32-bit integer.
    *
-   * Accepts int32 and bool columns. Boolean values are converted to 1 or 0.
+   * The source column must have type int32 or bool. Any other source type
+   * causes an exception. An int32 value is returned unchanged; a bool value is
+   * converted to 1 or 0.
    *
    * @param column_name Column name from the result schema.
+   * @throws exception::RuntimeError If the cursor or column name is invalid,
+   * or the source column type is neither int32 nor bool.
    */
   int32_t GetInt32(const std::string& column_name) const;
 
   /**
    * @brief Return the current cell as an unsigned 32-bit integer.
    *
-   * Accepts uint32 and bool columns. Boolean values are converted to 1 or 0.
+   * The source column must have type uint32 or bool. Any other source type
+   * causes an exception. A uint32 value is returned unchanged; a bool value is
+   * converted to 1 or 0.
    *
    * @param column_index Zero-based column index.
+   * @throws exception::RuntimeError If the cursor or column index is invalid,
+   * or the source column type is neither uint32 nor bool.
    */
   uint32_t GetUInt32(size_t column_index) const;
   /**
    * @brief Return the named current cell as an unsigned 32-bit integer.
    *
-   * Accepts uint32 and bool columns. Boolean values are converted to 1 or 0.
+   * The source column must have type uint32 or bool. Any other source type
+   * causes an exception. A uint32 value is returned unchanged; a bool value is
+   * converted to 1 or 0.
    *
    * @param column_name Column name from the result schema.
+   * @throws exception::RuntimeError If the cursor or column name is invalid,
+   * or the source column type is neither uint32 nor bool.
    */
   uint32_t GetUInt32(const std::string& column_name) const;
 
   /**
    * @brief Return the current cell as a signed 64-bit integer.
    *
-   * Accepts int64, int32, uint32, bool, date, and timestamp columns. Date and
-   * timestamp values are returned as their raw stored epoch values.
+   * The source column must have type int64, int32, uint32, bool, date, or
+   * timestamp. Any other source type causes an exception. Smaller integers are
+   * widened, bool is converted to 1 or 0, and date and timestamp values are
+   * returned as their raw stored epoch values.
    *
    * @param column_index Zero-based column index.
+   * @throws exception::RuntimeError If the cursor or column index is invalid,
+   * or the source column type is not supported by this getter.
    */
   int64_t GetInt64(size_t column_index) const;
   /**
    * @brief Return the named current cell as a signed 64-bit integer.
    *
-   * Accepts int64, int32, uint32, bool, date, and timestamp columns. Date and
-   * timestamp values are returned as their raw stored epoch values.
+   * The source column must have type int64, int32, uint32, bool, date, or
+   * timestamp. Any other source type causes an exception. Smaller integers are
+   * widened, bool is converted to 1 or 0, and date and timestamp values are
+   * returned as their raw stored epoch values.
    *
    * @param column_name Column name from the result schema.
+   * @throws exception::RuntimeError If the cursor or column name is invalid,
+   * or the source column type is not supported by this getter.
    */
   int64_t GetInt64(const std::string& column_name) const;
 
   /**
    * @brief Return the current cell as an unsigned 64-bit integer.
    *
-   * Accepts uint64, uint32, and bool columns. Boolean values are converted to
-   * 1 or 0.
+   * The source column must have type uint64, uint32, or bool. Any other source
+   * type causes an exception. A uint32 value is widened, and bool is converted
+   * to 1 or 0.
    *
    * @param column_index Zero-based column index.
+   * @throws exception::RuntimeError If the cursor or column index is invalid,
+   * or the source column type is not supported by this getter.
    */
   uint64_t GetUInt64(size_t column_index) const;
   /**
    * @brief Return the named current cell as an unsigned 64-bit integer.
    *
-   * Accepts uint64, uint32, and bool columns. Boolean values are converted to
-   * 1 or 0.
+   * The source column must have type uint64, uint32, or bool. Any other source
+   * type causes an exception. A uint32 value is widened, and bool is converted
+   * to 1 or 0.
    *
    * @param column_name Column name from the result schema.
+   * @throws exception::RuntimeError If the cursor or column name is invalid,
+   * or the source column type is not supported by this getter.
    */
   uint64_t GetUInt64(const std::string& column_name) const;
   /**
    * @brief Return the current cell as a single-precision floating-point value.
    *
-   * Accepts float, int32, uint32, and bool columns. Boolean values are
-   * converted to 1.0 or 0.0.
+   * The source column must have type float, int32, uint32, or bool. Any other
+   * source type causes an exception. Integers are converted to float, and bool
+   * is converted to 1.0 or 0.0.
    *
    * @param column_index Zero-based column index.
+   * @throws exception::RuntimeError If the cursor or column index is invalid,
+   * or the source column type is not supported by this getter.
    */
   float GetFloat(size_t column_index) const;
   /**
    * @brief Return the named current cell as a single-precision floating-point
    * value.
    *
-   * Accepts float, int32, uint32, and bool columns. Boolean values are
-   * converted to 1.0 or 0.0.
+   * The source column must have type float, int32, uint32, or bool. Any other
+   * source type causes an exception. Integers are converted to float, and bool
+   * is converted to 1.0 or 0.0.
    *
    * @param column_name Column name from the result schema.
+   * @throws exception::RuntimeError If the cursor or column name is invalid,
+   * or the source column type is not supported by this getter.
    */
   float GetFloat(const std::string& column_name) const;
 
   /**
    * @brief Return the current cell as a double-precision floating-point value.
    *
-   * Accepts double, float, int32, uint32, int64, uint64, and bool columns.
-   * Boolean values are converted to 1.0 or 0.0.
+   * The source column must have type double, float, int32, uint32, int64,
+   * uint64, or bool. Any other source type causes an exception. Numeric values
+   * are converted to double, and bool is converted to 1.0 or 0.0. Large 64-bit
+   * integers may lose precision.
    *
    * @param column_index Zero-based column index.
+   * @throws exception::RuntimeError If the cursor or column index is invalid,
+   * or the source column type is not supported by this getter.
    */
   double GetDouble(size_t column_index) const;
   /**
    * @brief Return the named current cell as a double-precision floating-point
    * value.
    *
-   * Accepts double, float, int32, uint32, int64, uint64, and bool columns.
-   * Boolean values are converted to 1.0 or 0.0.
+   * The source column must have type double, float, int32, uint32, int64,
+   * uint64, or bool. Any other source type causes an exception. Numeric values
+   * are converted to double, and bool is converted to 1.0 or 0.0. Large 64-bit
+   * integers may lose precision.
    *
    * @param column_name Column name from the result schema.
+   * @throws exception::RuntimeError If the cursor or column name is invalid,
+   * or the source column type is not supported by this getter.
    */
   double GetDouble(const std::string& column_name) const;
 
   /**
    * @brief Return the current cell as a string.
    *
-   * Accepts every column type. String values are returned directly; all other
-   * values use their human-readable representation.
+   * This getter supports every source column type. String values are returned
+   * directly; all other values use their human-readable representation.
    *
    * @param column_index Zero-based column index.
+   * @throws exception::RuntimeError If the cursor or column index is invalid.
    */
   std::string GetString(size_t column_index) const;
   /**
    * @brief Return the named current cell as a string.
    *
-   * Accepts every column type. String values are returned directly; all other
-   * values use their human-readable representation.
+   * This getter supports every source column type. String values are returned
+   * directly; all other values use their human-readable representation.
    *
    * @param column_name Column name from the result schema.
+   * @throws exception::RuntimeError If the cursor or column name is invalid.
    */
   std::string GetString(const std::string& column_name) const;
 
   /**
    * @brief Return the current cell as a boolean value.
    *
-   * Accepts bool columns only.
+   * The source column must have type bool. Any other source type causes an
+   * exception. The bool value is returned unchanged.
    *
    * @param column_index Zero-based column index.
+   * @throws exception::RuntimeError If the cursor or column index is invalid,
+   * or the source column type is not bool.
    */
   bool GetBool(size_t column_index) const;
   /**
    * @brief Return the named current cell as a boolean value.
    *
-   * Accepts bool columns only.
+   * The source column must have type bool. Any other source type causes an
+   * exception. The bool value is returned unchanged.
    *
    * @param column_name Column name from the result schema.
+   * @throws exception::RuntimeError If the cursor or column name is invalid,
+   * or the source column type is not bool.
    */
   bool GetBool(const std::string& column_name) const;
 

--- a/include/neug/main/query_result.h
+++ b/include/neug/main/query_result.h
@@ -107,21 +107,151 @@ class NEUG_API QueryResult {
   bool IsNull(size_t column_index) const;
   bool IsNull(const std::string& column_name) const;
 
+  /**
+   * @brief Return the current cell as a signed 32-bit integer.
+   *
+   * Accepts int32 and bool columns. Boolean values are converted to 1 or 0.
+   *
+   * @param column_index Zero-based column index.
+   */
   int32_t GetInt32(size_t column_index) const;
+  /**
+   * @brief Return the named current cell as a signed 32-bit integer.
+   *
+   * Accepts int32 and bool columns. Boolean values are converted to 1 or 0.
+   *
+   * @param column_name Column name from the result schema.
+   */
   int32_t GetInt32(const std::string& column_name) const;
+
+  /**
+   * @brief Return the current cell as an unsigned 32-bit integer.
+   *
+   * Accepts uint32 and bool columns. Boolean values are converted to 1 or 0.
+   *
+   * @param column_index Zero-based column index.
+   */
   uint32_t GetUInt32(size_t column_index) const;
+  /**
+   * @brief Return the named current cell as an unsigned 32-bit integer.
+   *
+   * Accepts uint32 and bool columns. Boolean values are converted to 1 or 0.
+   *
+   * @param column_name Column name from the result schema.
+   */
   uint32_t GetUInt32(const std::string& column_name) const;
+
+  /**
+   * @brief Return the current cell as a signed 64-bit integer.
+   *
+   * Accepts int64, int32, uint32, bool, date, and timestamp columns. Date and
+   * timestamp values are returned as their raw stored epoch values.
+   *
+   * @param column_index Zero-based column index.
+   */
   int64_t GetInt64(size_t column_index) const;
+  /**
+   * @brief Return the named current cell as a signed 64-bit integer.
+   *
+   * Accepts int64, int32, uint32, bool, date, and timestamp columns. Date and
+   * timestamp values are returned as their raw stored epoch values.
+   *
+   * @param column_name Column name from the result schema.
+   */
   int64_t GetInt64(const std::string& column_name) const;
+
+  /**
+   * @brief Return the current cell as an unsigned 64-bit integer.
+   *
+   * Accepts uint64, uint32, and bool columns. Boolean values are converted to
+   * 1 or 0.
+   *
+   * @param column_index Zero-based column index.
+   */
   uint64_t GetUInt64(size_t column_index) const;
+  /**
+   * @brief Return the named current cell as an unsigned 64-bit integer.
+   *
+   * Accepts uint64, uint32, and bool columns. Boolean values are converted to
+   * 1 or 0.
+   *
+   * @param column_name Column name from the result schema.
+   */
   uint64_t GetUInt64(const std::string& column_name) const;
+  /**
+   * @brief Return the current cell as a single-precision floating-point value.
+   *
+   * Accepts float, int32, uint32, and bool columns. Boolean values are
+   * converted to 1.0 or 0.0.
+   *
+   * @param column_index Zero-based column index.
+   */
   float GetFloat(size_t column_index) const;
+  /**
+   * @brief Return the named current cell as a single-precision floating-point
+   * value.
+   *
+   * Accepts float, int32, uint32, and bool columns. Boolean values are
+   * converted to 1.0 or 0.0.
+   *
+   * @param column_name Column name from the result schema.
+   */
   float GetFloat(const std::string& column_name) const;
+
+  /**
+   * @brief Return the current cell as a double-precision floating-point value.
+   *
+   * Accepts double, float, int32, uint32, int64, uint64, and bool columns.
+   * Boolean values are converted to 1.0 or 0.0.
+   *
+   * @param column_index Zero-based column index.
+   */
   double GetDouble(size_t column_index) const;
+  /**
+   * @brief Return the named current cell as a double-precision floating-point
+   * value.
+   *
+   * Accepts double, float, int32, uint32, int64, uint64, and bool columns.
+   * Boolean values are converted to 1.0 or 0.0.
+   *
+   * @param column_name Column name from the result schema.
+   */
   double GetDouble(const std::string& column_name) const;
+
+  /**
+   * @brief Return the current cell as a string.
+   *
+   * Accepts every column type. String values are returned directly; all other
+   * values use their human-readable representation.
+   *
+   * @param column_index Zero-based column index.
+   */
   std::string GetString(size_t column_index) const;
+  /**
+   * @brief Return the named current cell as a string.
+   *
+   * Accepts every column type. String values are returned directly; all other
+   * values use their human-readable representation.
+   *
+   * @param column_name Column name from the result schema.
+   */
   std::string GetString(const std::string& column_name) const;
+
+  /**
+   * @brief Return the current cell as a boolean value.
+   *
+   * Accepts bool columns only.
+   *
+   * @param column_index Zero-based column index.
+   */
   bool GetBool(size_t column_index) const;
+  /**
+   * @brief Return the named current cell as a boolean value.
+   *
+   * Accepts bool columns only.
+   *
+   * @param column_name Column name from the result schema.
+   */
   bool GetBool(const std::string& column_name) const;
 
   /**


### PR DESCRIPTION
## Summary

- add concrete descriptions for all C++ `QueryResult` typed getters
- state each getter’s required source column types and that unsupported types throw `neug::exception::RuntimeError`
- document the supported widening and boolean conversions separately from the type preconditions
- document both column-index and column-name overloads in the public header so regenerated API docs keep the descriptions
- align C++ API navigation as Database, Connection, Service, then Query Result, including the generator source configuration

## Validation

- `make -C doc doxygen`
- `make -C doc html-only` (succeeds with pre-existing documentation warnings)
- `git diff --cached --check`