### PR TITLE
feat: add Carquet reads through the existing IO interfaces

### DIFF
--- a/doc/source/extensions/_meta.ts
+++ b/doc/source/extensions/_meta.ts
@@ -5,6 +5,7 @@ export default {
   develop_extension: "Developing Out-of-Tree Extensions",
   load_json: "JSON Extension",
   load_parquet: "Parquet Extension",
+  carquet_reader: "Carquet Reader Implementation",
   load_httpfs: "HTTPFS Extension",
   load_gds: "GDS Extension",
   pattern_match: "Pattern Match Extension",

--- a/doc/source/extensions/carquet_reader.md
+++ b/doc/source/extensions/carquet_reader.md
@@ -1,0 +1,89 @@
+# Carquet reader implementation
+
+NeuG's Parquet extension includes a Carquet reader that implements the existing
+input-stream and data-chunk interfaces. This is a preparation step for replacing
+the Arrow backend. It is currently built with the extension tests; `LOAD PARQUET`
+and `LOAD FROM` continue to use the existing Arrow reader. There is no SQL option
+to select Carquet yet.
+
+## Reading and filtering
+
+`CarquetSniffer` obtains the schema through an `InputStreamFactory`.
+`CarquetChunkSupplier` implements `IDataChunkSupplier` and returns NeuG-owned
+`DataChunk` columns. Returned values remain valid after subsequent reads or
+supplier destruction. The private `scanCarquet` entry point coordinates these
+suppliers for one or more files with compatible schemas.
+
+The scan reads the union of requested output columns and all columns referenced
+by the predicate, including nested expressions. It passes the complete predicate
+and current query parameters to NeuG's shared chunk filter, then restores the
+requested output column order and removes filter-only columns. Repeated output
+columns are preserved. An empty projection means all columns.
+
+Before decoding, the reader may skip row groups using scalar min/max and NULL
+statistics. Comparisons, reversed comparisons, `IS NULL`, and Boolean combinations
+are handled conservatively. Missing or incompatible statistics and unsupported
+expressions keep the affected groups. A supported condition in an `AND` may still
+prove that a group cannot match when another condition is unsupported. The
+complete predicate is evaluated on decoded rows in all cases; statistics never
+replace exact filtering. Parameters, casts and complex functions currently use
+this exact-filtering path without native statistics evaluation.
+
+## Supported values
+
+| Parquet values | NeuG representation |
+| --- | --- |
+| Boolean, signed/unsigned integers, float and double | Corresponding scalar type; narrow integers widen to INT32/UINT32 |
+| UTF-8 strings, including large strings | VARCHAR |
+| Dates and timestamps | DATE and millisecond TIMESTAMP, with unit and overflow checks |
+| LIST and LARGE_LIST | LIST, preserving NULL lists, empty lists and NULL elements |
+| Fixed-size lists with Arrow schema metadata | ARRAY with the recorded length |
+| Supported lists and arrays nested inside one another | Nested LIST/ARRAY values |
+
+MAP schemas can be inspected, but MAP and general STRUCT value columns are not
+supported by this reader. INTERVAL values retain their textual storage for
+downstream conversion. Unsupported schemas or invalid layouts report errors.
+
+Carquet's `ArrowSchema` and `ArrowArray` structures are the C Data interchange
+ABI declared by Carquet; these adapters do not link against Arrow to convert
+values. The existing production backend still requires Arrow at this stage.
+
+## Batching, concurrency and memory
+
+The private scan accepts the existing `batch_read`, `parallel`, `BATCH_SIZE`,
+`BUFFERED_STREAM`, `PRE_BUFFER` and `ENABLE_IO_COALESCING` options.
+`PARQUET_BATCH_ROWS` controls the maximum rows returned in each supplier chunk
+(default 65,536). Full reads merge the resulting chunks with the shared helper.
+Parallel scans use independent streams for row-group tasks and preserve file and
+row-group order when collecting results.
+
+Chunk size is **not a decoder memory limit**. The simple scalar path can use
+Carquet's batch reader. Nested values, physical projection, selected row groups,
+pruning and prebuffering use its row-group API, which decodes a complete selected
+row group before splitting it into chunks. Parallel tasks can hold several row
+groups simultaneously, and full reads retain the complete result.
+
+Local and remote streams use the same interface. Projection and pruning can
+reduce remote range reads, although buffering and footer inspection may fetch
+additional bytes. The HTTPFS integration test measures actual HTTP response
+bytes against the same projected read with pruning disabled.
+
+## Building and testing
+
+Enable `BUILD_TEST=ON` and include `parquet` in `BUILD_EXTENSIONS`, then run:
+
+```sh
+cmake --build build --target parquet_carquet_test -j2
+ctest --test-dir build -R '^parquet_carquet' --output-on-failure
+```
+
+With `httpfs` also enabled, `httpfs_extension_test` includes a local HTTP Range
+integration test. Tests reuse the repository's datasets and generate additional
+files in memory; the C++ suite does not require PyArrow.
+
+Carquet remains a pinned submodule with its local changes in the adjacent
+`third_party/carquet.patch`. Reader changes add recursive fixed-size-list metadata
+restoration and selection of top-level fields before nested decoding. The patch
+also retains the existing callback IO and page-encoding fixes. Backend-specific
+code stays inside the Parquet extension, allowing a later replacement without
+changing the public supplier or stream interfaces.

--- a/doc/source/extensions/load_parquet.md
+++ b/doc/source/extensions/load_parquet.md
@@ -87,6 +87,10 @@ by the filter, including references inside nested expressions. Filter-only colum
 are removed from the result after filtering. This applies to both batch and full
 reads. In this fallback path, the predicate does not prune Parquet row groups.
 
+For the upcoming backend's implementation status and supported read paths, see
+[Carquet reader implementation](carquet_reader.md). The current SQL backend is
+unchanged by that preparation work.
+
 ## Export to Parquet
 
 NeuG supports exporting query results to Parquet files using the `COPY TO` command. This is useful for:

--- a/extension/httpfs/CMakeLists.txt
+++ b/extension/httpfs/CMakeLists.txt
@@ -84,4 +84,8 @@ if(BUILD_TEST)
         EXTRA_LINK_LIBS ${CURL_LIBRARIES}
         EXTRA_INCLUDE_DIRS ${CURL_INCLUDE_DIRS}
     )
+    if(TARGET neug_parquet_carquet_impl)
+        target_link_libraries(httpfs_extension_test PRIVATE neug_parquet_carquet_impl)
+        target_compile_definitions(httpfs_extension_test PRIVATE NEUG_HTTPFS_CARQUET_TEST=1)
+    endif()
 endif()

--- a/extension/httpfs/tests/http_test.cc
+++ b/extension/httpfs/tests/http_test.cc
@@ -30,8 +30,81 @@
 #include "../include/http_options.h"
 #include "neug/compiler/common/case_insensitive_map.h"
 #include "neug/utils/exception/exception.h"
+#ifdef NEUG_HTTPFS_CARQUET_TEST
+#include "carquet/chunk_supplier.h"
+#include "carquet/output_adapter.h"
+#include "neug/compiler/function/import/import_stream.h"
+#endif
 
 using namespace neug::extension::http;
+
+#ifdef NEUG_HTTPFS_CARQUET_TEST
+class HttpMemoryOutput final : public neug::io::OutputStream {
+ public:
+  explicit HttpMemoryOutput(std::shared_ptr<std::string> bytes)
+      : bytes_(std::move(bytes)) {}
+
+  neug::Status Write(const uint8_t* data, int64_t nbytes) override {
+    bytes_->append(reinterpret_cast<const char*>(data),
+                   static_cast<size_t>(nbytes));
+    return neug::Status::OK();
+  }
+  neug::Status Close() override { return neug::Status::OK(); }
+  void Abort() override { bytes_->clear(); }
+
+ private:
+  std::shared_ptr<std::string> bytes_;
+};
+
+std::string makeHttpPruningFixture() {
+  constexpr int64_t kRowsPerGroup = 300000;
+  carquet_error_t error = CARQUET_ERROR_INIT;
+  std::unique_ptr<carquet_schema_t, decltype(&carquet_schema_free)> schema(
+      carquet_schema_create(&error), carquet_schema_free);
+  EXPECT_NE(schema, nullptr) << error.message;
+  for (const char* name : {"selected", "unselected"}) {
+    EXPECT_EQ(
+        carquet_schema_add_column(schema.get(), name, CARQUET_PHYSICAL_INT64,
+                                  nullptr, CARQUET_REPETITION_REQUIRED, 0, 0),
+        CARQUET_OK);
+  }
+  carquet_writer_options_t options;
+  carquet_writer_options_init(&options);
+  options.compression = CARQUET_COMPRESSION_UNCOMPRESSED;
+  options.dictionary_encoding = CARQUET_ENCODING_PLAIN;
+  options.page_size = 64 * 1024;
+
+  auto bytes = std::make_shared<std::string>();
+  auto* writer = neug::parquet::createCarquetWriter(
+      std::make_unique<HttpMemoryOutput>(bytes), schema.get(), &options,
+      &error);
+  EXPECT_NE(writer, nullptr) << error.message;
+  std::vector<int64_t> values(static_cast<size_t>(kRowsPerGroup));
+  for (int64_t i = 0; i < kRowsPerGroup; ++i) {
+    values[static_cast<size_t>(i)] = i * 23 + 5;
+  }
+  for (int group = 0; writer && group < 2; ++group) {
+    if (group == 1) {
+      for (auto& value : values) {
+        value += 10000000;
+      }
+    }
+    for (int column = 0; column < 2; ++column) {
+      EXPECT_EQ(carquet_writer_write_batch(writer, column, values.data(),
+                                           kRowsPerGroup, nullptr, nullptr),
+                CARQUET_OK);
+    }
+    if (group == 0) {
+      EXPECT_EQ(carquet_writer_new_row_group(writer), CARQUET_OK);
+    }
+  }
+  if (writer) {
+    EXPECT_EQ(carquet_writer_close(writer), CARQUET_OK);
+  }
+  EXPECT_GT(bytes->size(), 8u * 1024u * 1024u);
+  return std::move(*bytes);
+}
+#endif
 
 class HTTPFileSystemTest : public ::testing::Test {
  protected:
@@ -743,6 +816,7 @@ class RangeKeepAliveHTTPServer {
   int port() const { return port_; }
   int connections() const { return connections_.load(); }
   int requests() const { return requests_.load(); }
+  int64_t bodyBytesSent() const { return body_bytes_sent_.load(); }
 
  private:
   void serve() {
@@ -813,6 +887,7 @@ class RangeKeepAliveHTTPServer {
                                       static_cast<size_t>(slice_len)))) {
           return;
         }
+        body_bytes_sent_.fetch_add(slice_len);
         continue;
       } else {
         response = "HTTP/1.1 200 OK\r\nContent-Length: " +
@@ -844,7 +919,56 @@ class RangeKeepAliveHTTPServer {
   std::atomic<int> connections_{0};
   std::atomic<int> requests_{0};
   std::atomic<int> active_fd_{-1};
+  std::atomic<int64_t> body_bytes_sent_{0};
 };
+
+#ifdef NEUG_HTTPFS_CARQUET_TEST
+TEST_F(HTTPFileSystemTest, CarquetPrunesRowGroupOverActualRangeTransport) {
+  const std::string body = makeHttpPruningFixture();
+  RangeKeepAliveHTTPServer server(body);
+  ASSERT_TRUE(server.start());
+
+  neug::common::case_insensitive_map_t<std::string> httpOptions;
+  HTTPFileSystem fs(httpOptions);
+  const std::string url =
+      "http://127.0.0.1:" + std::to_string(server.port()) + "/types.parquet";
+  auto opener = neug::function::makeImportStreamOpener(fs);
+  ASSERT_TRUE(opener);
+
+  auto filter = std::make_shared<::common::Expression>();
+  filter->add_operators()->mutable_var()->mutable_tag()->set_name("selected");
+  filter->add_operators()->set_logical(::common::Logical::GT);
+  filter->add_operators()->mutable_const_()->set_i64(8000000);
+  neug::parquet::CarquetReaderOptions readerOptions;
+  readerOptions.bufferedStream = false;
+  readerOptions.preBuffer = true;
+  readerOptions.topLevelFields = {0};
+  readerOptions.rowGroupFilter = std::move(filter);
+  auto supplier =
+      neug::parquet::CarquetChunkSupplier::create(opener(url), readerOptions);
+  ASSERT_TRUE(supplier) << supplier.error().ToString();
+  while ((*supplier)->GetNextChunk()) {}
+
+  EXPECT_EQ((*supplier)->selectedRowGroups(), (std::vector<int32_t>{1}));
+  EXPECT_EQ((*supplier)->rowGroupsRead(), 1u);
+  EXPECT_EQ((*supplier)->rowGroupsSkipped(), 1u);
+  EXPECT_GT(server.bodyBytesSent(), 0);
+  server.stop();
+
+  RangeKeepAliveHTTPServer fullServer(body);
+  ASSERT_TRUE(fullServer.start());
+  const std::string fullUrl =
+      "http://127.0.0.1:" + std::to_string(fullServer.port()) +
+      "/types.parquet";
+  readerOptions.rowGroupFilter.reset();
+  auto full = neug::parquet::CarquetChunkSupplier::create(opener(fullUrl),
+                                                          readerOptions);
+  ASSERT_TRUE(full) << full.error().ToString();
+  while ((*full)->GetNextChunk()) {}
+  EXPECT_LT(server.bodyBytesSent(), fullServer.bodyBytesSent());
+  fullServer.stop();
+}
+#endif
 
 TEST_F(HTTPFileSystemTest, ReadaheadAndConnectionReuse) {
   // 8 MiB body with a verifiable repeating pattern.

--- a/extension/parquet/CMakeLists.txt
+++ b/extension/parquet/CMakeLists.txt
@@ -81,6 +81,10 @@ if(BUILD_TEST)
             "${_carquet_patch}"
             "${_carquet_source}/include/carquet/carquet.h"
             "${_carquet_source}/src/reader/file_reader.c"
+            "${_carquet_source}/src/reader/arrow_c_export.c"
+            "${_carquet_source}/src/reader/arrow_c_read.c"
+            "${_carquet_source}/src/reader/arrow_schema_read.c"
+            "${_carquet_source}/src/thrift/parquet_types.h"
             "${_carquet_source}/src/reader/page_reader.c"
             "${_carquet_source}/src/reader/reader_internal.h"
             "${_carquet_source}/src/writer/file_writer.c"
@@ -154,6 +158,13 @@ if(BUILD_TEST)
     build_carquet_as_third_party()
 
     add_library(neug_parquet_carquet_impl STATIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/carquet/chunk_supplier.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/carquet/column_converter.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/carquet/nested_converter.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/carquet/row_group_pruner.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/carquet/scan.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/carquet/schema_converter.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/carquet/sniffer.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/src/carquet/input_adapter.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/src/carquet/output_adapter.cc)
     target_include_directories(neug_parquet_carquet_impl PUBLIC
@@ -165,8 +176,12 @@ if(BUILD_TEST)
     add_dependencies(neug_parquet_carquet_impl neug_proto)
 
     add_executable(parquet_carquet_test
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/carquet_chunk_supplier_test.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/carquet_scan_test.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/carquet_input_adapter_test.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/carquet_output_adapter_test.cc)
+    target_compile_definitions(parquet_carquet_test PRIVATE
+        NEUG_PARQUET_DATASET_DIR="${CMAKE_SOURCE_DIR}/example_dataset")
     target_link_libraries(parquet_carquet_test PRIVATE
         neug::GTest
         neug_parquet_carquet_impl

--- a/extension/parquet/include/carquet/chunk_supplier.h
+++ b/extension/parquet/include/carquet/chunk_supplier.h
@@ -1,0 +1,89 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+#pragma once
+
+#include <carquet/carquet.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "neug/generated/proto/plan/expr.pb.h"
+#include "neug/storages/loader/loader_utils.h"
+#include "neug/utils/io/read/common/schema.h"
+#include "neug/utils/io/stream/input_stream.h"
+#include "neug/utils/result.h"
+
+namespace neug::parquet {
+
+struct CarquetReaderOptions {
+  int32_t batchSize = 65536;
+  int32_t numThreads = 1;
+  int64_t bufferSize = 1 << 20;
+  bool bufferedStream = true;
+  bool preBuffer = false;
+  std::vector<int32_t> topLevelFields;
+  std::vector<int32_t> rowGroups;
+  std::shared_ptr<::common::Expression> rowGroupFilter;
+};
+
+// The only Carquet-to-NeuG supplier. Flat files use Carquet's bounded batch
+// reader; files containing LIST or ARRAY values use its nested row-group API.
+class CarquetChunkSupplier final : public IDataChunkSupplier {
+ public:
+  static result<std::shared_ptr<CarquetChunkSupplier>> create(
+      std::unique_ptr<io::InputStream> input,
+      CarquetReaderOptions options = {});
+
+  ~CarquetChunkSupplier() override;
+
+  CarquetChunkSupplier(const CarquetChunkSupplier&) = delete;
+  CarquetChunkSupplier& operator=(const CarquetChunkSupplier&) = delete;
+
+  std::shared_ptr<DataChunk> GetNextChunk() override;
+  int64_t RowNum() const override { return rowNum_; }
+  const std::shared_ptr<reader::EntrySchema>& schema() const {
+    return entrySchema_;
+  }
+  size_t rowGroupCount() const { return allRowGroupCount_; }
+  const std::vector<int32_t>& selectedRowGroups() const { return rowGroups_; }
+  size_t rowGroupsRead() const { return nextRowGroup_; }
+  size_t rowGroupsSkipped() const { return rowGroupsSkipped_; }
+
+ private:
+  CarquetChunkSupplier(
+      carquet_reader_t* reader, carquet_batch_reader_t* batchReader,
+      ArrowSchema flatSchema, std::shared_ptr<reader::EntrySchema> entrySchema,
+      std::vector<int32_t> rowGroups, std::vector<int64_t> rowGroupRows,
+      std::vector<int32_t> topLevelFields, std::vector<int32_t> prebufferLeaves,
+      int32_t batchSize, bool preBuffer, size_t allRowGroupCount,
+      size_t rowGroupsSkipped, int64_t rowNum);
+
+  std::shared_ptr<DataChunk> readFlatChunk();
+  std::shared_ptr<DataChunk> readNestedChunk();
+  std::shared_ptr<DataChunk> slicePendingChunk();
+
+  carquet_reader_t* reader_;
+  carquet_batch_reader_t* batchReader_;
+  ArrowSchema flatSchema_;
+  std::shared_ptr<reader::EntrySchema> entrySchema_;
+  std::vector<int32_t> rowGroups_;
+  std::vector<int64_t> rowGroupRows_;
+  std::vector<int32_t> topLevelFields_;
+  std::vector<int32_t> prebufferLeaves_;
+  std::shared_ptr<DataChunk> pendingChunk_;
+  size_t pendingOffset_ = 0;
+  int32_t batchSize_;
+  bool preBuffer_;
+  size_t allRowGroupCount_;
+  size_t rowGroupsSkipped_;
+  int64_t rowNum_;
+  int64_t rowsRead_ = 0;
+  size_t nextRowGroup_ = 0;
+  bool finished_ = false;
+};
+
+}  // namespace neug::parquet

--- a/extension/parquet/include/carquet/column_converter.h
+++ b/extension/parquet/include/carquet/column_converter.h
@@ -1,0 +1,44 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <carquet/carquet.h>
+
+#include "neug/common/types/data_chunk.h"
+#include "neug/utils/result.h"
+
+namespace neug {
+namespace parquet {
+
+result<void> validateArrowCScalarSchema(const ArrowSchema& schema,
+                                        const std::string& path = "column");
+
+// Converts one scalar Arrow C Data column into an owned NeuG value column.
+// The returned column never retains pointers into the ArrowArray.
+result<std::shared_ptr<IContextColumn>> convertArrowCScalarColumn(
+    const ArrowSchema& schema, const ArrowArray& array,
+    const std::string& path = "column");
+
+// Converts a flat top-level Arrow struct into an owned NeuG DataChunk.
+// The root must be non-null and all children must have the same length.
+result<std::shared_ptr<DataChunk>> convertArrowCFlatStruct(
+    const ArrowSchema& schema, const ArrowArray& array);
+
+}  // namespace parquet
+}  // namespace neug

--- a/extension/parquet/include/carquet/nested_converter.h
+++ b/extension/parquet/include/carquet/nested_converter.h
@@ -1,0 +1,27 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+#pragma once
+
+#include <carquet/carquet.h>
+
+#include <memory>
+#include <string>
+
+#include "neug/common/types/data_chunk.h"
+#include "neug/utils/result.h"
+
+namespace neug::parquet {
+
+// Converts scalar, LIST, LARGE_LIST and fixed ARRAY data recursively into
+// owned NeuG columns. MAP and general STRUCT fields remain unsupported.
+result<std::shared_ptr<IContextColumn>> convertArrowCColumn(
+    const ArrowSchema& schema, const ArrowArray& array,
+    const std::string& path = "column");
+
+result<std::shared_ptr<DataChunk>> convertArrowCStruct(
+    const ArrowSchema& schema, const ArrowArray& array);
+
+}  // namespace neug::parquet

--- a/extension/parquet/include/carquet/row_group_pruner.h
+++ b/extension/parquet/include/carquet/row_group_pruner.h
@@ -1,0 +1,44 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+#pragma once
+
+#include <carquet/carquet.h>
+
+#include <memory>
+
+#include "neug/generated/proto/plan/expr.pb.h"
+#include "neug/utils/io/read/common/schema.h"
+
+namespace neug::parquet {
+
+// Compiles a scan filter into conservative row-group decisions. A true result
+// only means that the group may match; the shared row filter remains the source
+// of exact SQL semantics.
+class CarquetRowGroupPruner final {
+ public:
+  struct Node;
+
+  static std::unique_ptr<CarquetRowGroupPruner> create(
+      const carquet_reader_t* reader, const reader::EntrySchema& schema,
+      const ::common::Expression* filter);
+
+  ~CarquetRowGroupPruner();
+
+  CarquetRowGroupPruner(const CarquetRowGroupPruner&) = delete;
+  CarquetRowGroupPruner& operator=(const CarquetRowGroupPruner&) = delete;
+
+  bool mightMatch(int32_t rowGroup) const;
+
+ private:
+  CarquetRowGroupPruner(const carquet_reader_t* reader,
+                        std::unique_ptr<Node> root);
+
+  const carquet_reader_t* reader_;
+  std::unique_ptr<Node> root_;
+};
+
+}  // namespace neug::parquet

--- a/extension/parquet/include/carquet/scan.h
+++ b/extension/parquet/include/carquet/scan.h
@@ -1,0 +1,23 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+#pragma once
+
+#include <memory>
+
+#include "neug/execution/common/context.h"
+#include "neug/utils/io/read/common/read_state.h"
+#include "neug/utils/io/stream/input_stream.h"
+#include "neug/utils/result.h"
+
+namespace neug::parquet {
+
+result<std::shared_ptr<reader::EntrySchema>> sniffCarquet(
+    io::InputStreamFactory inputFactory);
+
+void scanCarquet(const std::shared_ptr<reader::ReadSharedState>& state,
+                 execution::Context& output);
+
+}  // namespace neug::parquet

--- a/extension/parquet/include/carquet/schema_converter.h
+++ b/extension/parquet/include/carquet/schema_converter.h
@@ -1,0 +1,28 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+#pragma once
+
+#include <carquet/carquet.h>
+
+#include <memory>
+#include <string>
+
+#include "neug/generated/proto/plan/basic_type.pb.h"
+#include "neug/utils/io/read/common/schema.h"
+#include "neug/utils/result.h"
+
+namespace neug::parquet {
+
+result<std::shared_ptr<::common::DataType>> convertArrowCScalarSchemaType(
+    const ArrowSchema& schema, const std::string& path = "column");
+
+result<std::shared_ptr<reader::EntrySchema>> convertArrowCStructSchema(
+    const ArrowSchema& schema);
+
+result<std::shared_ptr<reader::EntrySchema>> convertCarquetSchema(
+    const carquet_schema_t& schema);
+
+}  // namespace neug::parquet

--- a/extension/parquet/include/carquet/sniffer.h
+++ b/extension/parquet/include/carquet/sniffer.h
@@ -1,0 +1,26 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+#pragma once
+
+#include <utility>
+
+#include "neug/utils/io/read/common/sniffer.h"
+#include "neug/utils/io/stream/input_stream.h"
+
+namespace neug::parquet {
+
+class CarquetSniffer final : public reader::Sniffer {
+ public:
+  explicit CarquetSniffer(io::InputStreamFactory inputFactory)
+      : inputFactory_(std::move(inputFactory)) {}
+
+  result<std::shared_ptr<reader::EntrySchema>> sniff() override;
+
+ private:
+  io::InputStreamFactory inputFactory_;
+};
+
+}  // namespace neug::parquet

--- a/extension/parquet/src/carquet/chunk_supplier.cc
+++ b/extension/parquet/src/carquet/chunk_supplier.cc
@@ -1,0 +1,507 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+#include "carquet/chunk_supplier.h"
+
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+#include <utility>
+
+#include "carquet/column_converter.h"
+#include "carquet/nested_converter.h"
+#include "carquet/row_group_pruner.h"
+#include "carquet/schema_converter.h"
+#include "input_adapter.h"
+#include "neug/utils/exception/exception.h"
+
+namespace neug::parquet {
+namespace {
+
+std::string carquetMessage(const std::string& action, carquet_status_t status,
+                           const carquet_error_t& error) {
+  std::string message = action + ": " + carquet_status_string(status);
+  if (error.message[0] != '\0') {
+    message += " (" + std::string(error.message) + ")";
+  }
+  return message;
+}
+
+struct BatchDeleter {
+  void operator()(carquet_row_batch_t* batch) const {
+    carquet_row_batch_free(batch);
+  }
+};
+
+struct ArrowArrayOwner : ArrowArray {
+  ArrowArrayOwner() : ArrowArray{} {}
+  ~ArrowArrayOwner() {
+    if (release) {
+      release(this);
+    }
+  }
+};
+
+struct ArrowSchemaOwner : ArrowSchema {
+  ArrowSchemaOwner() : ArrowSchema{} {}
+  ~ArrowSchemaOwner() {
+    if (release) {
+      release(this);
+    }
+  }
+};
+
+struct ArrowPairOwner {
+  ~ArrowPairOwner() {
+    if (array.release) {
+      array.release(&array);
+    }
+    if (schema.release) {
+      schema.release(&schema);
+    }
+  }
+
+  ArrowSchema schema{};
+  ArrowArray array{};
+};
+
+void closeRejectedInput(std::unique_ptr<io::InputStream>& input) noexcept {
+  if (!input) {
+    return;
+  }
+  try {
+    input->Close();
+  } catch (...) {}
+}
+
+bool containsNestedType(const ::common::DataType& type) {
+  return type.item_case() == ::common::DataType::kList ||
+         type.item_case() == ::common::DataType::kArray;
+}
+
+result<std::vector<int64_t>> readRowGroupRows(carquet_reader_t* reader,
+                                              int64_t totalRows) {
+  const int32_t count = carquet_reader_num_row_groups(reader);
+  if (count < 0) {
+    RETURN_STATUS_ERROR(StatusCode::ERR_IO_ERROR,
+                        "Carquet returned a negative row-group count");
+  }
+
+  std::vector<int64_t> rows;
+  rows.reserve(static_cast<size_t>(count));
+  int64_t sum = 0;
+  for (int32_t group = 0; group < count; ++group) {
+    carquet_row_group_metadata_t metadata{};
+    const carquet_status_t status =
+        carquet_reader_row_group_metadata(reader, group, &metadata);
+    if (status != CARQUET_OK || metadata.num_rows < 0 ||
+        sum > std::numeric_limits<int64_t>::max() - metadata.num_rows) {
+      RETURN_STATUS_ERROR(StatusCode::ERR_IO_ERROR,
+                          "Carquet returned invalid row-group metadata");
+    }
+    sum += metadata.num_rows;
+    rows.emplace_back(metadata.num_rows);
+  }
+  if (sum != totalRows) {
+    RETURN_STATUS_ERROR(StatusCode::ERR_IO_ERROR,
+                        "Carquet file and row-group counts do not match");
+  }
+  return rows;
+}
+
+result<void> validateTopLevelFields(
+    const std::vector<int32_t>& fields,
+    const std::shared_ptr<reader::EntrySchema>& schema) {
+  if (fields.size() > schema->columnNames.size()) {
+    RETURN_STATUS_ERROR(StatusCode::ERR_INVALID_ARGUMENT,
+                        "Too many projected Carquet fields");
+  }
+  std::vector<bool> selected(schema->columnNames.size(), false);
+  for (const int32_t field : fields) {
+    if (field < 0 || static_cast<size_t>(field) >= selected.size() ||
+        selected[static_cast<size_t>(field)]) {
+      RETURN_STATUS_ERROR(StatusCode::ERR_INVALID_ARGUMENT,
+                          "Invalid projected Carquet field index");
+    }
+    selected[static_cast<size_t>(field)] = true;
+  }
+  return {};
+}
+
+result<std::vector<int32_t>> selectRowGroups(
+    const std::vector<int32_t>& requested,
+    const std::vector<int64_t>& allRows) {
+  if (requested.empty()) {
+    std::vector<int32_t> result(allRows.size());
+    std::iota(result.begin(), result.end(), 0);
+    return result;
+  }
+  if (requested.size() > allRows.size()) {
+    RETURN_STATUS_ERROR(StatusCode::ERR_INVALID_ARGUMENT,
+                        "Too many selected Carquet row groups");
+  }
+  std::vector<bool> selected(allRows.size(), false);
+  for (const int32_t group : requested) {
+    if (group < 0 || static_cast<size_t>(group) >= selected.size() ||
+        selected[static_cast<size_t>(group)]) {
+      RETURN_STATUS_ERROR(StatusCode::ERR_INVALID_ARGUMENT,
+                          "Invalid selected Carquet row-group index");
+    }
+    selected[static_cast<size_t>(group)] = true;
+  }
+  return requested;
+}
+
+result<std::vector<int32_t>> projectedLeafFields(
+    const carquet_schema_t& schema,
+    const std::shared_ptr<reader::EntrySchema>& entrySchema,
+    const std::vector<int32_t>& topLevelFields) {
+  if (topLevelFields.empty()) {
+    return std::vector<int32_t>{};
+  }
+  std::unordered_set<std::string_view> selectedNames;
+  selectedNames.reserve(topLevelFields.size());
+  for (const int32_t field : topLevelFields) {
+    selectedNames.emplace(entrySchema->columnNames[static_cast<size_t>(field)]);
+  }
+
+  const int32_t leafCount = carquet_schema_num_columns(&schema);
+  if (leafCount < 0) {
+    RETURN_STATUS_ERROR(StatusCode::ERR_IO_ERROR,
+                        "Carquet returned a negative leaf-column count");
+  }
+  std::vector<int32_t> leaves;
+  const char* path[64];
+  for (int32_t leaf = 0; leaf < leafCount; ++leaf) {
+    const int32_t depth = carquet_schema_column_path(&schema, leaf, path, 64);
+    if (depth <= 0 || !path[0]) {
+      RETURN_STATUS_ERROR(StatusCode::ERR_IO_ERROR,
+                          "Carquet returned an invalid leaf-column path");
+    }
+    if (selectedNames.contains(path[0])) {
+      leaves.emplace_back(leaf);
+    }
+  }
+  if (leaves.empty() && !topLevelFields.empty()) {
+    RETURN_STATUS_ERROR(StatusCode::ERR_IO_ERROR,
+                        "Projected Parquet fields contain no leaf columns");
+  }
+  return leaves;
+}
+
+}  // namespace
+
+CarquetChunkSupplier::CarquetChunkSupplier(
+    carquet_reader_t* reader, carquet_batch_reader_t* batchReader,
+    ArrowSchema flatSchema, std::shared_ptr<reader::EntrySchema> entrySchema,
+    std::vector<int32_t> rowGroups, std::vector<int64_t> rowGroupRows,
+    std::vector<int32_t> topLevelFields, std::vector<int32_t> prebufferLeaves,
+    int32_t batchSize, bool preBuffer, size_t allRowGroupCount,
+    size_t rowGroupsSkipped, int64_t rowNum)
+    : reader_(reader),
+      batchReader_(batchReader),
+      flatSchema_(flatSchema),
+      entrySchema_(std::move(entrySchema)),
+      rowGroups_(std::move(rowGroups)),
+      rowGroupRows_(std::move(rowGroupRows)),
+      topLevelFields_(std::move(topLevelFields)),
+      prebufferLeaves_(std::move(prebufferLeaves)),
+      batchSize_(batchSize),
+      preBuffer_(preBuffer),
+      allRowGroupCount_(allRowGroupCount),
+      rowGroupsSkipped_(rowGroupsSkipped),
+      rowNum_(rowNum) {}
+
+CarquetChunkSupplier::~CarquetChunkSupplier() {
+  carquet_batch_reader_free(batchReader_);
+  carquet_reader_close(reader_);
+  if (flatSchema_.release) {
+    flatSchema_.release(&flatSchema_);
+  }
+}
+
+result<std::shared_ptr<CarquetChunkSupplier>> CarquetChunkSupplier::create(
+    std::unique_ptr<io::InputStream> input, CarquetReaderOptions options) {
+  if (!input) {
+    RETURN_STATUS_ERROR(StatusCode::ERR_INVALID_ARGUMENT,
+                        "Parquet input stream is null");
+  }
+  if (options.batchSize <= 0 || options.numThreads < 0 ||
+      options.bufferSize <= 0 ||
+      static_cast<uint64_t>(options.bufferSize) >
+          std::numeric_limits<size_t>::max()) {
+    closeRejectedInput(input);
+    RETURN_STATUS_ERROR(StatusCode::ERR_INVALID_ARGUMENT,
+                        "Carquet batch and buffer sizes must be positive and "
+                        "thread count must be non-negative");
+  }
+
+  carquet_reader_options_t readerOptions;
+  carquet_reader_options_init(&readerOptions);
+  readerOptions.buffer_size =
+      options.bufferedStream ? static_cast<size_t>(options.bufferSize) : 0;
+  readerOptions.num_threads = options.numThreads;
+  carquet_error_t error = CARQUET_ERROR_INIT;
+  std::unique_ptr<carquet_reader_t, decltype(&carquet_reader_close)> reader(
+      openCarquetReader(std::move(input), &readerOptions, &error),
+      carquet_reader_close);
+  if (!reader) {
+    RETURN_STATUS_ERROR(
+        StatusCode::ERR_IO_ERROR,
+        carquetMessage("Failed to open Parquet input", error.code, error));
+  }
+
+  auto entrySchema = convertCarquetSchema(*carquet_reader_schema(reader.get()));
+  if (!entrySchema) {
+    return tl::unexpected(entrySchema.error());
+  }
+  auto validFields =
+      validateTopLevelFields(options.topLevelFields, *entrySchema);
+  if (!validFields) {
+    return tl::unexpected(validFields.error());
+  }
+
+  const int64_t fileRows = carquet_reader_num_rows(reader.get());
+  if (fileRows < 0) {
+    RETURN_STATUS_ERROR(StatusCode::ERR_IO_ERROR,
+                        "Carquet returned a negative row count");
+  }
+  auto allRowGroupRows = readRowGroupRows(reader.get(), fileRows);
+  if (!allRowGroupRows) {
+    return tl::unexpected(allRowGroupRows.error());
+  }
+  auto rowGroups = selectRowGroups(options.rowGroups, *allRowGroupRows);
+  if (!rowGroups) {
+    return tl::unexpected(rowGroups.error());
+  }
+  const size_t candidateRowGroups = rowGroups->size();
+  if (options.rowGroupFilter) {
+    auto pruner = CarquetRowGroupPruner::create(reader.get(), **entrySchema,
+                                                options.rowGroupFilter.get());
+    rowGroups->erase(std::remove_if(rowGroups->begin(), rowGroups->end(),
+                                    [&](int32_t group) {
+                                      return !pruner->mightMatch(group);
+                                    }),
+                     rowGroups->end());
+  }
+  const size_t rowGroupsSkipped = candidateRowGroups - rowGroups->size();
+  std::vector<int64_t> rowGroupRows;
+  rowGroupRows.reserve(rowGroups->size());
+  int64_t rowNum = 0;
+  for (const int32_t group : *rowGroups) {
+    const int64_t rows = (*allRowGroupRows)[static_cast<size_t>(group)];
+    if (rowNum > std::numeric_limits<int64_t>::max() - rows) {
+      RETURN_STATUS_ERROR(StatusCode::ERR_IO_ERROR,
+                          "Selected Carquet row count overflows");
+    }
+    rowNum += rows;
+    rowGroupRows.emplace_back(rows);
+  }
+
+  bool nested = false;
+  for (const auto& type : (*entrySchema)->columnTypes) {
+    if (!type) {
+      RETURN_STATUS_ERROR(StatusCode::ERR_TYPE_CONVERSION,
+                          "Carquet returned a null column type");
+    }
+    nested |= containsNestedType(*type);
+  }
+
+  const bool needsRowGroupApi = nested || !options.topLevelFields.empty() ||
+                                !options.rowGroups.empty() ||
+                                options.preBuffer || options.rowGroupFilter;
+  ArrowSchemaOwner flatSchema;
+  std::unique_ptr<carquet_batch_reader_t, decltype(&carquet_batch_reader_free)>
+      batchReader(nullptr, carquet_batch_reader_free);
+  std::vector<int32_t> prebufferLeaves;
+  if (needsRowGroupApi && options.preBuffer) {
+    auto leaves = projectedLeafFields(*carquet_reader_schema(reader.get()),
+                                      *entrySchema, options.topLevelFields);
+    if (!leaves) {
+      return tl::unexpected(leaves.error());
+    }
+    prebufferLeaves = std::move(*leaves);
+  }
+  if (!needsRowGroupApi) {
+    const carquet_status_t exportStatus = carquet_arrow_export_schema(
+        carquet_reader_schema(reader.get()), &flatSchema, &error);
+    if (exportStatus != CARQUET_OK) {
+      RETURN_STATUS_ERROR(StatusCode::ERR_TYPE_CONVERSION,
+                          carquetMessage("Failed to export Parquet schema",
+                                         exportStatus, error));
+    }
+
+    carquet_batch_reader_config_t config;
+    carquet_batch_reader_config_init(&config);
+    config.batch_size = options.batchSize;
+    config.num_threads = options.numThreads;
+    config.use_mmap = false;
+    batchReader.reset(
+        carquet_batch_reader_create(reader.get(), &config, &error));
+    if (!batchReader) {
+      RETURN_STATUS_ERROR(
+          StatusCode::ERR_IO_ERROR,
+          carquetMessage("Failed to create Carquet batch reader", error.code,
+                         error));
+    }
+  }
+
+  auto supplier =
+      std::unique_ptr<CarquetChunkSupplier>(new CarquetChunkSupplier(
+          reader.get(), batchReader.get(), flatSchema, std::move(*entrySchema),
+          std::move(*rowGroups), std::move(rowGroupRows),
+          std::move(options.topLevelFields), std::move(prebufferLeaves),
+          options.batchSize, options.preBuffer, allRowGroupRows->size(),
+          rowGroupsSkipped, rowNum));
+  reader.release();
+  batchReader.release();
+  flatSchema.release = nullptr;
+  return std::shared_ptr<CarquetChunkSupplier>(std::move(supplier));
+}
+
+std::shared_ptr<DataChunk> CarquetChunkSupplier::GetNextChunk() {
+  if (finished_) {
+    return nullptr;
+  }
+  if (pendingChunk_) {
+    return slicePendingChunk();
+  }
+  auto chunk = batchReader_ ? readFlatChunk() : readNestedChunk();
+  if (!chunk || chunk->row_num() <= static_cast<size_t>(batchSize_)) {
+    return chunk;
+  }
+  pendingChunk_ = std::move(chunk);
+  pendingOffset_ = 0;
+  return slicePendingChunk();
+}
+
+std::shared_ptr<DataChunk> CarquetChunkSupplier::readFlatChunk() {
+  carquet_row_batch_t* rawBatch = nullptr;
+  const carquet_status_t status =
+      carquet_batch_reader_next(batchReader_, &rawBatch);
+  std::unique_ptr<carquet_row_batch_t, BatchDeleter> batch(rawBatch);
+  if (status == CARQUET_ERROR_END_OF_DATA) {
+    finished_ = true;
+    if (rowsRead_ != rowNum_) {
+      THROW_IO_EXCEPTION("Carquet row count mismatch: expected " +
+                         std::to_string(rowNum_) + ", read " +
+                         std::to_string(rowsRead_));
+    }
+    return nullptr;
+  }
+  if (status != CARQUET_OK || !rawBatch) {
+    const carquet_error_t emptyError = CARQUET_ERROR_INIT;
+    THROW_IO_EXCEPTION(
+        carquetMessage("Failed to read Carquet batch", status, emptyError));
+  }
+  ArrowArrayOwner exported;
+  carquet_error_t error = CARQUET_ERROR_INIT;
+  const carquet_status_t exportStatus = carquet_arrow_export_batch(
+      batch.get(), carquet_reader_schema(reader_), nullptr, &exported, &error);
+  if (exportStatus != CARQUET_OK) {
+    THROW_IO_EXCEPTION(
+        carquetMessage("Failed to export Carquet batch", exportStatus, error));
+  }
+  batch.reset();
+
+  auto converted = convertArrowCFlatStruct(flatSchema_, exported);
+  if (!converted) {
+    THROW_IO_EXCEPTION(converted.error().ToString());
+  }
+  const size_t chunkRows = (*converted)->row_num();
+  if (chunkRows > static_cast<size_t>(std::numeric_limits<int64_t>::max())) {
+    THROW_IO_EXCEPTION("Carquet batch row count exceeds the supported range");
+  }
+  const int64_t rows = static_cast<int64_t>(chunkRows);
+  if (rowsRead_ > rowNum_ - rows) {
+    THROW_IO_EXCEPTION("Carquet returned more rows than the file metadata");
+  }
+  rowsRead_ += rows;
+  return *converted;
+}
+
+std::shared_ptr<DataChunk> CarquetChunkSupplier::readNestedChunk() {
+  if (nextRowGroup_ == rowGroupRows_.size()) {
+    finished_ = true;
+    if (rowsRead_ != rowNum_) {
+      THROW_IO_EXCEPTION("Carquet row count mismatch: expected " +
+                         std::to_string(rowNum_) + ", read " +
+                         std::to_string(rowsRead_));
+    }
+    return nullptr;
+  }
+
+  const int32_t rowGroup = rowGroups_[nextRowGroup_];
+  if (preBuffer_) {
+    carquet_error_t prebufferError = CARQUET_ERROR_INIT;
+    const carquet_status_t prebufferStatus = carquet_reader_prebuffer(
+        reader_, rowGroup, prebufferLeaves_.data(),
+        static_cast<int32_t>(prebufferLeaves_.size()), &prebufferError);
+    if (prebufferStatus != CARQUET_OK) {
+      THROW_IO_EXCEPTION(carquetMessage("Failed to prebuffer Carquet row group",
+                                        prebufferStatus, prebufferError));
+    }
+  }
+
+  ArrowPairOwner exported;
+  carquet_error_t error = CARQUET_ERROR_INIT;
+  const carquet_status_t status = carquet_reader_read_arrow_columns(
+      reader_, rowGroup, topLevelFields_.data(),
+      static_cast<int32_t>(topLevelFields_.size()), &exported.schema,
+      &exported.array, &error);
+  if (preBuffer_) {
+    carquet_reader_release_prebuffer(reader_);
+  }
+  if (status != CARQUET_OK) {
+    THROW_IO_EXCEPTION(
+        carquetMessage("Failed to read Carquet row group", status, error));
+  }
+
+  auto converted = convertArrowCStruct(exported.schema, exported.array);
+  if (!converted) {
+    THROW_IO_EXCEPTION(converted.error().ToString());
+  }
+  const size_t chunkRows = (*converted)->row_num();
+  if (chunkRows > static_cast<size_t>(std::numeric_limits<int64_t>::max())) {
+    THROW_IO_EXCEPTION("Carquet row-group count exceeds the supported range");
+  }
+  const int64_t rows = static_cast<int64_t>(chunkRows);
+  if (rows != rowGroupRows_[nextRowGroup_]) {
+    THROW_IO_EXCEPTION(
+        "Carquet row-group data does not match its metadata: expected " +
+        std::to_string(rowGroupRows_[nextRowGroup_]) + ", read " +
+        std::to_string(rows));
+  }
+  if (rowsRead_ > rowNum_ - rows) {
+    THROW_IO_EXCEPTION("Carquet returned more rows than the file metadata");
+  }
+  rowsRead_ += rows;
+  ++nextRowGroup_;
+  return *converted;
+}
+
+std::shared_ptr<DataChunk> CarquetChunkSupplier::slicePendingChunk() {
+  const size_t remaining = pendingChunk_->row_num() - pendingOffset_;
+  const size_t count = std::min(remaining, static_cast<size_t>(batchSize_));
+  sel_vec_t offsets(count);
+  std::iota(offsets.begin(), offsets.end(), pendingOffset_);
+  // DataChunk copies only shared column pointers. reshuffle materializes the
+  // selected rows (LIST columns share their child storage), not the full group.
+  auto output = std::make_shared<DataChunk>(*pendingChunk_);
+  output->reshuffle(offsets);
+  pendingOffset_ += count;
+  if (pendingOffset_ == pendingChunk_->row_num()) {
+    pendingChunk_.reset();
+    pendingOffset_ = 0;
+  }
+  return output;
+}
+
+}  // namespace neug::parquet

--- a/extension/parquet/src/carquet/column_converter.cc
+++ b/extension/parquet/src/carquet/column_converter.cc
@@ -1,0 +1,429 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "carquet/column_converter.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <string_view>
+
+#include "neug/common/columns/value_columns.h"
+#include "neug/utils/property/types.h"
+
+namespace neug {
+namespace parquet {
+namespace {
+
+template <typename T>
+result<T> columnError(const std::string& path, const std::string& message) {
+  return tl::unexpected(
+      Status(StatusCode::ERR_TYPE_CONVERSION,
+             "Invalid Parquet column at " + path + ": " + message));
+}
+
+result<uint64_t> validateArray(const ArrowSchema& schema,
+                               const ArrowArray& array, const std::string& path,
+                               int64_t expectedBuffers) {
+  if (!schema.format) {
+    return columnError<uint64_t>(path, "missing schema format");
+  }
+  if (schema.dictionary || array.dictionary) {
+    return columnError<uint64_t>(path, "dictionary arrays are not supported");
+  }
+  if (schema.n_children != 0 || array.n_children != 0) {
+    return columnError<uint64_t>(path, "scalar column must not have children");
+  }
+  if (array.length < 0 || array.offset < 0 || array.null_count < -1 ||
+      array.null_count > array.length) {
+    return columnError<uint64_t>(path, "invalid length, offset, or null count");
+  }
+  if (static_cast<uint64_t>(array.length) >
+      std::numeric_limits<size_t>::max()) {
+    return columnError<uint64_t>(path, "column length exceeds address space");
+  }
+  if (array.n_buffers != expectedBuffers || !array.buffers) {
+    return columnError<uint64_t>(
+        path, "expected " + std::to_string(expectedBuffers) + " buffers");
+  }
+  if (array.offset > std::numeric_limits<int64_t>::max() - array.length) {
+    return columnError<uint64_t>(path, "offset plus length overflows");
+  }
+  if (array.null_count > 0 && !array.buffers[0]) {
+    return columnError<uint64_t>(path, "null values require a validity buffer");
+  }
+  return static_cast<uint64_t>(array.offset);
+}
+
+bool isValid(const ArrowArray& array, uint64_t index) {
+  if (!array.buffers[0]) {
+    return true;
+  }
+  const auto* validity = static_cast<const uint8_t*>(array.buffers[0]);
+  return (validity[index >> 3] & static_cast<uint8_t>(1u << (index & 7))) != 0;
+}
+
+template <typename Src, typename Dst>
+result<std::shared_ptr<IContextColumn>> convertPrimitive(
+    const ArrowSchema& schema, const ArrowArray& array,
+    const std::string& path) {
+  auto offsetResult = validateArray(schema, array, path, 2);
+  if (!offsetResult) {
+    return tl::unexpected(offsetResult.error());
+  }
+  if (array.length > 0 && !array.buffers[1]) {
+    return columnError<std::shared_ptr<IContextColumn>>(
+        path, "non-empty column has no data buffer");
+  }
+
+  ValueColumnBuilder<Dst> builder;
+  builder.reserve(static_cast<size_t>(array.length));
+  const auto* data = static_cast<const Src*>(array.buffers[1]);
+  for (uint64_t i = 0; i < static_cast<uint64_t>(array.length); ++i) {
+    const uint64_t sourceIndex = *offsetResult + i;
+    if (!isValid(array, sourceIndex)) {
+      builder.push_back_null();
+    } else {
+      builder.push_back_opt(static_cast<Dst>(data[sourceIndex]));
+    }
+  }
+  return builder.finish();
+}
+
+result<std::shared_ptr<IContextColumn>> convertBoolean(
+    const ArrowSchema& schema, const ArrowArray& array,
+    const std::string& path) {
+  auto offsetResult = validateArray(schema, array, path, 2);
+  if (!offsetResult) {
+    return tl::unexpected(offsetResult.error());
+  }
+  if (array.length > 0 && !array.buffers[1]) {
+    return columnError<std::shared_ptr<IContextColumn>>(
+        path, "non-empty column has no data buffer");
+  }
+
+  ValueColumnBuilder<bool> builder;
+  builder.reserve(static_cast<size_t>(array.length));
+  const auto* data = static_cast<const uint8_t*>(array.buffers[1]);
+  for (uint64_t i = 0; i < static_cast<uint64_t>(array.length); ++i) {
+    const uint64_t sourceIndex = *offsetResult + i;
+    if (!isValid(array, sourceIndex)) {
+      builder.push_back_null();
+    } else {
+      builder.push_back_opt((data[sourceIndex >> 3] &
+                             static_cast<uint8_t>(1u << (sourceIndex & 7))) !=
+                            0);
+    }
+  }
+  return builder.finish();
+}
+
+template <typename Offset>
+result<std::shared_ptr<IContextColumn>> convertString(const ArrowSchema& schema,
+                                                      const ArrowArray& array,
+                                                      const std::string& path) {
+  auto offsetResult = validateArray(schema, array, path, 3);
+  if (!offsetResult) {
+    return tl::unexpected(offsetResult.error());
+  }
+  if (!array.buffers[1]) {
+    return columnError<std::shared_ptr<IContextColumn>>(
+        path, "string column has no offsets buffer");
+  }
+
+  const auto* offsets = static_cast<const Offset*>(array.buffers[1]);
+  const auto* data = static_cast<const char*>(array.buffers[2]);
+  const uint64_t firstIndex = *offsetResult;
+  ValueColumnBuilder<std::string> builder;
+  builder.reserve(static_cast<size_t>(array.length));
+  for (uint64_t i = 0; i < static_cast<uint64_t>(array.length); ++i) {
+    const uint64_t sourceIndex = firstIndex + i;
+    const Offset begin = offsets[sourceIndex];
+    const Offset end = offsets[sourceIndex + 1];
+    if (begin < 0 || end < begin) {
+      return columnError<std::shared_ptr<IContextColumn>>(
+          path, "string offsets are negative or decreasing");
+    }
+    if (static_cast<uint64_t>(end) >
+        static_cast<uint64_t>(std::numeric_limits<std::ptrdiff_t>::max())) {
+      return columnError<std::shared_ptr<IContextColumn>>(
+          path, "string offset exceeds addressable memory");
+    }
+    if (end > begin && !data) {
+      return columnError<std::shared_ptr<IContextColumn>>(
+          path, "non-empty string has no data buffer");
+    }
+    if (!isValid(array, sourceIndex)) {
+      builder.push_back_null();
+    } else if (begin == end) {
+      builder.push_back_opt(std::string{});
+    } else {
+      builder.push_back_opt(
+          std::string(data + static_cast<uint64_t>(begin),
+                      static_cast<size_t>(static_cast<uint64_t>(end) -
+                                          static_cast<uint64_t>(begin))));
+    }
+  }
+  return builder.finish();
+}
+
+result<std::shared_ptr<IContextColumn>> convertDate32(const ArrowSchema& schema,
+                                                      const ArrowArray& array,
+                                                      const std::string& path) {
+  auto offsetResult = validateArray(schema, array, path, 2);
+  if (!offsetResult) {
+    return tl::unexpected(offsetResult.error());
+  }
+  if (array.length > 0 && !array.buffers[1]) {
+    return columnError<std::shared_ptr<IContextColumn>>(
+        path, "non-empty date column has no data buffer");
+  }
+
+  const auto* data = static_cast<const int32_t*>(array.buffers[1]);
+  ValueColumnBuilder<Date> builder;
+  builder.reserve(static_cast<size_t>(array.length));
+  for (uint64_t i = 0; i < static_cast<uint64_t>(array.length); ++i) {
+    const uint64_t sourceIndex = *offsetResult + i;
+    if (!isValid(array, sourceIndex)) {
+      builder.push_back_null();
+    } else {
+      builder.push_back_opt(Date(data[sourceIndex]));
+    }
+  }
+  return builder.finish();
+}
+
+result<std::shared_ptr<IContextColumn>> convertDate64(const ArrowSchema& schema,
+                                                      const ArrowArray& array,
+                                                      const std::string& path) {
+  constexpr int64_t kMillisPerDay = 24LL * 60 * 60 * 1000;
+  auto offsetResult = validateArray(schema, array, path, 2);
+  if (!offsetResult) {
+    return tl::unexpected(offsetResult.error());
+  }
+  if (array.length > 0 && !array.buffers[1]) {
+    return columnError<std::shared_ptr<IContextColumn>>(
+        path, "non-empty date column has no data buffer");
+  }
+
+  const auto* data = static_cast<const int64_t*>(array.buffers[1]);
+  ValueColumnBuilder<Date> builder;
+  builder.reserve(static_cast<size_t>(array.length));
+  for (uint64_t i = 0; i < static_cast<uint64_t>(array.length); ++i) {
+    const uint64_t sourceIndex = *offsetResult + i;
+    if (!isValid(array, sourceIndex)) {
+      builder.push_back_null();
+    } else {
+      const int64_t days = data[sourceIndex] / kMillisPerDay;
+      if (days < std::numeric_limits<int32_t>::min() ||
+          days > std::numeric_limits<int32_t>::max()) {
+        return columnError<std::shared_ptr<IContextColumn>>(
+            path, "date value is outside NeuG's supported range");
+      }
+      builder.push_back_opt(Date(static_cast<int32_t>(days)));
+    }
+  }
+  return builder.finish();
+}
+
+result<std::shared_ptr<IContextColumn>> convertTimestamp(
+    const ArrowSchema& schema, const ArrowArray& array, const std::string& path,
+    char unit) {
+  auto offsetResult = validateArray(schema, array, path, 2);
+  if (!offsetResult) {
+    return tl::unexpected(offsetResult.error());
+  }
+  if (array.length > 0 && !array.buffers[1]) {
+    return columnError<std::shared_ptr<IContextColumn>>(
+        path, "non-empty timestamp column has no data buffer");
+  }
+
+  const auto* data = static_cast<const int64_t*>(array.buffers[1]);
+  ValueColumnBuilder<DateTime> builder;
+  builder.reserve(static_cast<size_t>(array.length));
+  for (uint64_t i = 0; i < static_cast<uint64_t>(array.length); ++i) {
+    const uint64_t sourceIndex = *offsetResult + i;
+    if (!isValid(array, sourceIndex)) {
+      builder.push_back_null();
+      continue;
+    }
+    int64_t millis = data[sourceIndex];
+    if (unit == 's') {
+      if (millis < std::numeric_limits<int64_t>::min() / 1000 ||
+          millis > std::numeric_limits<int64_t>::max() / 1000) {
+        return columnError<std::shared_ptr<IContextColumn>>(
+            path, "timestamp seconds overflow NeuG milliseconds");
+      }
+      millis *= 1000;
+    } else if (unit == 'u') {
+      millis /= 1000;
+    } else if (unit == 'n') {
+      millis /= 1000000;
+    }
+    builder.push_back_opt(DateTime(millis));
+  }
+  return builder.finish();
+}
+
+}  // namespace
+
+result<std::shared_ptr<IContextColumn>> convertArrowCScalarColumn(
+    const ArrowSchema& schema, const ArrowArray& array,
+    const std::string& path) {
+  auto schemaStatus = validateArrowCScalarSchema(schema, path);
+  if (!schemaStatus) {
+    return tl::unexpected(schemaStatus.error());
+  }
+  const std::string_view format(schema.format);
+  if (format == "b") {
+    return convertBoolean(schema, array, path);
+  }
+  if (format == "c") {
+    return convertPrimitive<int8_t, int32_t>(schema, array, path);
+  }
+  if (format == "s") {
+    return convertPrimitive<int16_t, int32_t>(schema, array, path);
+  }
+  if (format == "i") {
+    return convertPrimitive<int32_t, int32_t>(schema, array, path);
+  }
+  if (format == "C") {
+    return convertPrimitive<uint8_t, uint32_t>(schema, array, path);
+  }
+  if (format == "S") {
+    return convertPrimitive<uint16_t, uint32_t>(schema, array, path);
+  }
+  if (format == "I") {
+    return convertPrimitive<uint32_t, uint32_t>(schema, array, path);
+  }
+  if (format == "l") {
+    return convertPrimitive<int64_t, int64_t>(schema, array, path);
+  }
+  if (format == "L") {
+    return convertPrimitive<uint64_t, uint64_t>(schema, array, path);
+  }
+  if (format == "f") {
+    return convertPrimitive<float, float>(schema, array, path);
+  }
+  if (format == "g") {
+    return convertPrimitive<double, double>(schema, array, path);
+  }
+  if (format == "u") {
+    return convertString<int32_t>(schema, array, path);
+  }
+  if (format == "U") {
+    return convertString<int64_t>(schema, array, path);
+  }
+  if (format == "tdD") {
+    return convertDate32(schema, array, path);
+  }
+  if (format == "tdm") {
+    return convertDate64(schema, array, path);
+  }
+  if (format.size() >= 4 && format[0] == 't' && format[1] == 's' &&
+      (format[2] == 's' || format[2] == 'm' || format[2] == 'u' ||
+       format[2] == 'n') &&
+      format[3] == ':') {
+    return convertTimestamp(schema, array, path, format[2]);
+  }
+  return columnError<std::shared_ptr<IContextColumn>>(
+      path, "unsupported Arrow C format \"" + std::string(format) + "\"");
+}
+
+result<void> validateArrowCScalarSchema(const ArrowSchema& schema,
+                                        const std::string& path) {
+  if (!schema.format) {
+    return columnError<void>(path, "missing schema format");
+  }
+  if (schema.dictionary) {
+    return columnError<void>(path, "dictionary schema is not supported");
+  }
+  if (schema.n_children != 0) {
+    return columnError<void>(path, "scalar column must not have children");
+  }
+  const std::string_view format(schema.format);
+  const bool primitive = format == "b" || format == "c" || format == "s" ||
+                         format == "i" || format == "C" || format == "S" ||
+                         format == "I" || format == "l" || format == "L" ||
+                         format == "f" || format == "g" || format == "u" ||
+                         format == "U" || format == "tdD" || format == "tdm";
+  const bool timestamp = format.size() >= 4 && format[0] == 't' &&
+                         format[1] == 's' &&
+                         (format[2] == 's' || format[2] == 'm' ||
+                          format[2] == 'u' || format[2] == 'n') &&
+                         format[3] == ':';
+  if (!primitive && !timestamp) {
+    return columnError<void>(
+        path, "unsupported Arrow C format \"" + std::string(format) + "\"");
+  }
+  return {};
+}
+
+result<std::shared_ptr<DataChunk>> convertArrowCFlatStruct(
+    const ArrowSchema& schema, const ArrowArray& array) {
+  if (!schema.format || std::string_view(schema.format) != "+s") {
+    return columnError<std::shared_ptr<DataChunk>>(
+        "root", "schema must be a top-level struct");
+  }
+  if (schema.dictionary || array.dictionary) {
+    return columnError<std::shared_ptr<DataChunk>>(
+        "root", "dictionary root is not supported");
+  }
+  if (schema.n_children < 0 || array.n_children < 0 ||
+      schema.n_children != array.n_children ||
+      (schema.n_children > 0 && (!schema.children || !array.children))) {
+    return columnError<std::shared_ptr<DataChunk>>(
+        "root", "schema and array child counts do not match");
+  }
+  if (schema.n_children > (1 << 20)) {
+    return columnError<std::shared_ptr<DataChunk>>("root",
+                                                   "too many struct fields");
+  }
+  if (array.length < 0 || array.offset != 0 || array.null_count < -1 ||
+      array.null_count > array.length || array.n_buffers != 1 ||
+      !array.buffers) {
+    return columnError<std::shared_ptr<DataChunk>>(
+        "root", "invalid top-level struct layout");
+  }
+  if (array.null_count != 0 || array.buffers[0]) {
+    return columnError<std::shared_ptr<DataChunk>>(
+        "root", "nullable top-level structs are not supported");
+  }
+
+  auto chunk = std::make_shared<DataChunk>();
+  for (int64_t i = 0; i < schema.n_children; ++i) {
+    if (!schema.children[i] || !array.children[i]) {
+      return columnError<std::shared_ptr<DataChunk>>(
+          "root", "struct contains a null child");
+    }
+    if (array.children[i]->length != array.length) {
+      return columnError<std::shared_ptr<DataChunk>>(
+          "root.field[" + std::to_string(i) + "]",
+          "child length does not match the struct");
+    }
+    auto converted =
+        convertArrowCScalarColumn(*schema.children[i], *array.children[i],
+                                  "root.field[" + std::to_string(i) + "]");
+    if (!converted) {
+      return tl::unexpected(converted.error());
+    }
+    chunk->set(static_cast<int>(i), std::move(*converted));
+  }
+  return chunk;
+}
+
+}  // namespace parquet
+}  // namespace neug

--- a/extension/parquet/src/carquet/input_adapter.cc
+++ b/extension/parquet/src/carquet/input_adapter.cc
@@ -6,20 +6,29 @@
 
 #include "input_adapter.h"
 
+#include <algorithm>
 #include <cstdint>
+#include <cstring>
 #include <limits>
 #include <memory>
+#include <mutex>
 #include <new>
 #include <utility>
+#include <vector>
 
 namespace neug::parquet {
 namespace {
 
 struct InputContext {
-  explicit InputContext(std::unique_ptr<io::InputStream> value)
-      : input(std::move(value)) {}
+  InputContext(std::unique_ptr<io::InputStream> value, size_t bufferSize)
+      : input(std::move(value)), bufferSize(bufferSize) {}
 
   std::unique_ptr<io::InputStream> input;
+  size_t bufferSize;
+  std::vector<uint8_t> buffer;
+  int64_t bufferOffset = 0;
+  size_t bufferedBytes = 0;
+  std::mutex mutex;
 };
 
 carquet_status_t getSize(void* opaque, int64_t* size) noexcept {
@@ -44,12 +53,51 @@ carquet_status_t readAt(void* opaque, int64_t offset, void* buffer, size_t size,
   }
   *bytesRead = 0;
   try {
-    auto value = static_cast<InputContext*>(opaque)->input->ReadAt(
-        offset, static_cast<int64_t>(size), buffer);
-    if (!value || *value < 0 || *value > static_cast<int64_t>(size)) {
+    auto& context = *static_cast<InputContext*>(opaque);
+    // InputStream does not guarantee concurrent ReadAt calls: local streams
+    // seek/read a shared std::ifstream. Protect both the stream and the cache;
+    // parallel row-group tasks each open an independent stream.
+    std::lock_guard<std::mutex> guard(context.mutex);
+    if (size == 0) {
+      return CARQUET_OK;
+    }
+    if (context.buffer.empty() && context.bufferSize > 0) {
+      context.buffer.resize(context.bufferSize);
+    }
+    if (!context.buffer.empty() && offset >= context.bufferOffset) {
+      const uint64_t relative =
+          static_cast<uint64_t>(offset - context.bufferOffset);
+      if (relative <= context.bufferedBytes &&
+          size <= context.bufferedBytes - relative) {
+        std::memcpy(buffer, context.buffer.data() + relative, size);
+        *bytesRead = size;
+        return CARQUET_OK;
+      }
+    }
+
+    if (context.buffer.empty() || size >= context.buffer.size()) {
+      auto value =
+          context.input->ReadAt(offset, static_cast<int64_t>(size), buffer);
+      if (!value || *value < 0 || *value > static_cast<int64_t>(size)) {
+        return CARQUET_ERROR_FILE_READ;
+      }
+      *bytesRead = static_cast<size_t>(*value);
+      return CARQUET_OK;
+    }
+
+    auto value = context.input->ReadAt(
+        offset, static_cast<int64_t>(context.buffer.size()),
+        context.buffer.data());
+    if (!value || *value < 0 ||
+        *value > static_cast<int64_t>(context.buffer.size())) {
       return CARQUET_ERROR_FILE_READ;
     }
-    *bytesRead = static_cast<size_t>(*value);
+    context.bufferOffset = offset;
+    context.bufferedBytes = static_cast<size_t>(*value);
+    *bytesRead = std::min(size, context.bufferedBytes);
+    if (*bytesRead > 0) {
+      std::memcpy(buffer, context.buffer.data(), *bytesRead);
+    }
     return CARQUET_OK;
   } catch (...) { return CARQUET_ERROR_FILE_READ; }
 }
@@ -79,7 +127,8 @@ carquet_reader_t* openCarquetReader(std::unique_ptr<io::InputStream> input,
     return nullptr;
   }
 
-  auto* context = new (std::nothrow) InputContext(nullptr);
+  const size_t bufferSize = options ? options->buffer_size : 0;
+  auto* context = new (std::nothrow) InputContext(nullptr, bufferSize);
   if (!context) {
     try {
       input->Close();

--- a/extension/parquet/src/carquet/nested_converter.cc
+++ b/extension/parquet/src/carquet/nested_converter.cc
@@ -1,0 +1,365 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "carquet/nested_converter.h"
+
+#include <charconv>
+#include <cstdint>
+#include <limits>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "carquet/column_converter.h"
+#include "neug/common/columns/array_columns.h"
+#include "neug/common/columns/list_columns.h"
+
+namespace neug {
+namespace parquet {
+namespace {
+
+constexpr int kMaxNestedDepth = 64;
+constexpr int64_t kMaxChildren = 1 << 20;
+
+template <typename T>
+result<T> nestedError(const std::string& path, const std::string& message) {
+  return tl::unexpected(
+      Status(StatusCode::ERR_TYPE_CONVERSION,
+             "Invalid nested Parquet column at " + path + ": " + message));
+}
+
+bool isValid(const ArrowArray& array, uint64_t physicalIndex) {
+  if (!array.buffers[0]) {
+    return true;
+  }
+  const auto* validity = static_cast<const uint8_t*>(array.buffers[0]);
+  return (validity[physicalIndex >> 3] &
+          static_cast<uint8_t>(1u << (physicalIndex & 7))) != 0;
+}
+
+result<uint64_t> validateLayout(const ArrowSchema& schema,
+                                const ArrowArray& array,
+                                const std::string& path, uint64_t start,
+                                uint64_t count, int64_t expectedBuffers,
+                                int64_t expectedChildren) {
+  if (!schema.format) {
+    return nestedError<uint64_t>(path, "missing schema format");
+  }
+  if (schema.dictionary || array.dictionary) {
+    return nestedError<uint64_t>(path, "dictionary arrays are not supported");
+  }
+  if (array.length < 0 || array.offset < 0 || array.null_count < -1 ||
+      array.null_count > array.length) {
+    return nestedError<uint64_t>(path, "invalid length, offset, or null count");
+  }
+  const auto length = static_cast<uint64_t>(array.length);
+  if (length > std::numeric_limits<size_t>::max()) {
+    return nestedError<uint64_t>(path, "array length exceeds address space");
+  }
+  if (start > length || count > length - start) {
+    return nestedError<uint64_t>(path,
+                                 "requested range exceeds the child array");
+  }
+  const auto offset = static_cast<uint64_t>(array.offset);
+  if (offset >
+      static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) - length) {
+    return nestedError<uint64_t>(path, "offset plus length overflows");
+  }
+  if (schema.n_children != expectedChildren ||
+      array.n_children != expectedChildren) {
+    return nestedError<uint64_t>(
+        path, "expected " + std::to_string(expectedChildren) + " children");
+  }
+  if (expectedChildren > 0 && (!schema.children || !array.children)) {
+    return nestedError<uint64_t>(path, "missing child pointer array");
+  }
+  for (int64_t i = 0; i < expectedChildren; ++i) {
+    if (!schema.children[i] || !array.children[i]) {
+      return nestedError<uint64_t>(path, "contains a null child pointer");
+    }
+  }
+  if (array.n_buffers != expectedBuffers || !array.buffers) {
+    return nestedError<uint64_t>(
+        path, "expected " + std::to_string(expectedBuffers) + " buffers");
+  }
+  if (array.null_count > 0 && !array.buffers[0]) {
+    return nestedError<uint64_t>(path, "null values require a validity buffer");
+  }
+  return offset + start;
+}
+
+result<uint64_t> parseFixedLength(std::string_view format,
+                                  const std::string& path) {
+  constexpr std::string_view prefix = "+w:";
+  const auto text = format.substr(prefix.size());
+  uint64_t length = 0;
+  const auto parsed =
+      std::from_chars(text.data(), text.data() + text.size(), length);
+  if (text.empty() || parsed.ec != std::errc{} ||
+      parsed.ptr != text.data() + text.size() || length == 0 ||
+      length > std::numeric_limits<uint32_t>::max()) {
+    return nestedError<uint64_t>(
+        path, "invalid fixed-size list format \"" + std::string(format) + "\"");
+  }
+  return length;
+}
+
+result<std::shared_ptr<IContextColumn>> convertRange(
+    const ArrowSchema& schema, const ArrowArray& array, uint64_t start,
+    uint64_t count, const std::string& path, int depth);
+
+template <typename Offset>
+result<std::vector<uint64_t>> readOffsets(const ArrowArray& array,
+                                          uint64_t physicalStart,
+                                          uint64_t count,
+                                          const std::string& path) {
+  if (!array.buffers[1]) {
+    return nestedError<std::vector<uint64_t>>(path, "missing offsets buffer");
+  }
+  const auto* offsets = static_cast<const Offset*>(array.buffers[1]);
+  std::vector<uint64_t> result;
+  result.reserve(static_cast<size_t>(count + 1));
+  for (uint64_t i = 0; i <= count; ++i) {
+    const Offset raw = offsets[physicalStart + i];
+    if (raw < 0) {
+      return nestedError<std::vector<uint64_t>>(path,
+                                                "offsets must be non-negative");
+    }
+    const auto value = static_cast<uint64_t>(raw);
+    if (!result.empty() && value < result.back()) {
+      return nestedError<std::vector<uint64_t>>(path,
+                                                "offsets must be monotonic");
+    }
+    result.push_back(value);
+  }
+  return result;
+}
+
+template <typename Offset>
+result<std::shared_ptr<IContextColumn>> convertList(
+    const ArrowSchema& schema, const ArrowArray& array, uint64_t start,
+    uint64_t count, const std::string& path, int depth) {
+  auto physicalResult = validateLayout(schema, array, path, start, count, 2, 1);
+  if (!physicalResult) {
+    return tl::unexpected(physicalResult.error());
+  }
+  auto offsetsResult = readOffsets<Offset>(array, *physicalResult, count, path);
+  if (!offsetsResult) {
+    return tl::unexpected(offsetsResult.error());
+  }
+  const auto& offsets = *offsetsResult;
+  const uint64_t first = offsets.front();
+  const uint64_t childCount = offsets.back() - first;
+  auto childResult =
+      convertRange(*schema.children[0], *array.children[0], first, childCount,
+                   path + ".element", depth + 1);
+  if (!childResult) {
+    return tl::unexpected(childResult.error());
+  }
+
+  const auto& child = *childResult;
+  const auto& childType = child->elem_type();
+  ListColumnBuilder builder(childType);
+  builder.reserve(static_cast<size_t>(count));
+  for (uint64_t row = 0; row < count; ++row) {
+    if (!isValid(array, *physicalResult + row)) {
+      builder.push_back_null();
+      continue;
+    }
+    std::vector<Value> values;
+    const uint64_t localBegin = offsets[row] - first;
+    const uint64_t localEnd = offsets[row + 1] - first;
+    values.reserve(static_cast<size_t>(localEnd - localBegin));
+    for (uint64_t i = localBegin; i < localEnd; ++i) {
+      values.emplace_back(child->get_elem(static_cast<size_t>(i)));
+    }
+    builder.push_back_elem(Value::LIST(childType, std::move(values)));
+  }
+  return builder.finish();
+}
+
+result<std::shared_ptr<IContextColumn>> convertFixedList(
+    const ArrowSchema& schema, const ArrowArray& array, uint64_t start,
+    uint64_t count, const std::string& path, int depth, uint64_t fixedLength) {
+  if (array.n_buffers != 1 && array.n_buffers != 2) {
+    return nestedError<std::shared_ptr<IContextColumn>>(
+        path,
+        "fixed-size list expects one standard buffer or Carquet's "
+        "two-buffer compact layout");
+  }
+  auto physicalResult =
+      validateLayout(schema, array, path, start, count, array.n_buffers, 1);
+  if (!physicalResult) {
+    return tl::unexpected(physicalResult.error());
+  }
+
+  std::vector<uint64_t> offsets;
+  if (array.n_buffers == 2) {
+    auto offsetsResult =
+        readOffsets<int32_t>(array, *physicalResult, count, path);
+    if (!offsetsResult) {
+      return tl::unexpected(offsetsResult.error());
+    }
+    offsets = std::move(*offsetsResult);
+    for (uint64_t row = 0; row < count; ++row) {
+      const uint64_t length = offsets[row + 1] - offsets[row];
+      const bool valid = isValid(array, *physicalResult + row);
+      if ((valid && length != fixedLength) || (!valid && length != 0)) {
+        return nestedError<std::shared_ptr<IContextColumn>>(
+            path + ".row[" + std::to_string(row) + "]",
+            valid ? "value length does not match the fixed-size schema"
+                  : "null value contains compact child elements");
+      }
+    }
+  } else {
+    if (*physicalResult > std::numeric_limits<uint64_t>::max() / fixedLength ||
+        count > std::numeric_limits<uint64_t>::max() / fixedLength -
+                    *physicalResult) {
+      return nestedError<std::shared_ptr<IContextColumn>>(
+          path, "fixed-size child range overflows");
+    }
+    offsets.reserve(static_cast<size_t>(count + 1));
+    const uint64_t first = *physicalResult * fixedLength;
+    for (uint64_t row = 0; row <= count; ++row) {
+      offsets.push_back(first + row * fixedLength);
+    }
+  }
+
+  const uint64_t childStart = offsets.front();
+  const uint64_t childCount = offsets.back() - childStart;
+  auto childResult =
+      convertRange(*schema.children[0], *array.children[0], childStart,
+                   childCount, path + ".element", depth + 1);
+  if (!childResult) {
+    return tl::unexpected(childResult.error());
+  }
+
+  const auto& child = *childResult;
+  const auto arrayType = DataType::Array(child->elem_type(), fixedLength);
+  ContextArrayColumnBuilder builder(arrayType);
+  builder.reserve(static_cast<size_t>(count));
+  for (uint64_t row = 0; row < count; ++row) {
+    if (!isValid(array, *physicalResult + row)) {
+      builder.push_back_null();
+      continue;
+    }
+    std::vector<Value> values;
+    values.reserve(static_cast<size_t>(fixedLength));
+    const uint64_t localBegin = offsets[row] - childStart;
+    const uint64_t localEnd = offsets[row + 1] - childStart;
+    for (uint64_t i = localBegin; i < localEnd; ++i) {
+      values.emplace_back(child->get_elem(static_cast<size_t>(i)));
+    }
+    builder.push_back_elem(Value::ARRAY(arrayType, std::move(values)));
+  }
+  return builder.finish();
+}
+
+result<std::shared_ptr<IContextColumn>> convertRange(
+    const ArrowSchema& schema, const ArrowArray& array, uint64_t start,
+    uint64_t count, const std::string& path, int depth) {
+  if (depth > kMaxNestedDepth) {
+    return nestedError<std::shared_ptr<IContextColumn>>(
+        path, "nesting exceeds 64 levels");
+  }
+  if (!schema.format) {
+    return nestedError<std::shared_ptr<IContextColumn>>(
+        path, "missing schema format");
+  }
+  const std::string_view format(schema.format);
+  if (format == "+l") {
+    return convertList<int32_t>(schema, array, start, count, path, depth);
+  }
+  if (format == "+L") {
+    return convertList<int64_t>(schema, array, start, count, path, depth);
+  }
+  if (format.starts_with("+w:")) {
+    auto lengthResult = parseFixedLength(format, path);
+    if (!lengthResult) {
+      return tl::unexpected(lengthResult.error());
+    }
+    return convertFixedList(schema, array, start, count, path, depth,
+                            *lengthResult);
+  }
+
+  auto physicalResult =
+      validateLayout(schema, array, path, start, count, array.n_buffers, 0);
+  if (!physicalResult) {
+    return tl::unexpected(physicalResult.error());
+  }
+  ArrowArray slice = array;
+  slice.length = static_cast<int64_t>(count);
+  slice.offset = static_cast<int64_t>(*physicalResult);
+  slice.null_count = -1;
+  return convertArrowCScalarColumn(schema, slice, path);
+}
+
+}  // namespace
+
+result<std::shared_ptr<IContextColumn>> convertArrowCColumn(
+    const ArrowSchema& schema, const ArrowArray& array,
+    const std::string& path) {
+  if (array.length < 0) {
+    return nestedError<std::shared_ptr<IContextColumn>>(path,
+                                                        "negative length");
+  }
+  return convertRange(schema, array, 0, static_cast<uint64_t>(array.length),
+                      path, 0);
+}
+
+result<std::shared_ptr<DataChunk>> convertArrowCStruct(
+    const ArrowSchema& schema, const ArrowArray& array) {
+  if (!schema.format || std::string_view(schema.format) != "+s") {
+    return nestedError<std::shared_ptr<DataChunk>>(
+        "root", "schema must be a top-level struct");
+  }
+  if (schema.n_children < 0 || schema.n_children > kMaxChildren) {
+    return nestedError<std::shared_ptr<DataChunk>>("root",
+                                                   "invalid field count");
+  }
+  auto physicalResult =
+      validateLayout(schema, array, "root", 0,
+                     array.length < 0 ? 0 : static_cast<uint64_t>(array.length),
+                     1, schema.n_children);
+  if (!physicalResult) {
+    return tl::unexpected(physicalResult.error());
+  }
+  if (array.length > 0 && schema.n_children == 0) {
+    return nestedError<std::shared_ptr<DataChunk>>(
+        "root", "non-empty record batch must have at least one field");
+  }
+  for (uint64_t row = 0; row < static_cast<uint64_t>(array.length); ++row) {
+    if (!isValid(array, *physicalResult + row)) {
+      return nestedError<std::shared_ptr<DataChunk>>(
+          "root", "top-level struct rows must not be null");
+    }
+  }
+
+  auto chunk = std::make_shared<DataChunk>();
+  for (int64_t i = 0; i < schema.n_children; ++i) {
+    auto converted =
+        convertRange(*schema.children[i], *array.children[i], *physicalResult,
+                     static_cast<uint64_t>(array.length),
+                     "root.field[" + std::to_string(i) + "]", 0);
+    if (!converted) {
+      return tl::unexpected(converted.error());
+    }
+    chunk->set(static_cast<int>(i), std::move(*converted));
+  }
+  return chunk;
+}
+
+}  // namespace parquet
+}  // namespace neug

--- a/extension/parquet/src/carquet/row_group_pruner.cc
+++ b/extension/parquet/src/carquet/row_group_pruner.cc
@@ -1,0 +1,538 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+#include "carquet/row_group_pruner.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <stack>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+#include "neug/utils/io/read/common/operator_precedence.h"
+
+namespace neug::parquet {
+namespace {
+
+enum Truth : uint8_t { kFalse = 1, kTrue = 2, kUnknown = 4, kAny = 7 };
+
+using Scalar = std::variant<bool, int32_t, uint32_t, int64_t, uint64_t, float,
+                            double, std::string>;
+
+struct ColumnRef {
+  int32_t leaf = -1;
+  ::common::DataType type;
+};
+
+uint8_t negate(uint8_t input) {
+  uint8_t output = 0;
+  if (input & kFalse) {
+    output |= kTrue;
+  }
+  if (input & kTrue) {
+    output |= kFalse;
+  }
+  if (input & kUnknown) {
+    output |= kUnknown;
+  }
+  return output;
+}
+
+Truth andValue(Truth left, Truth right) {
+  if (left == kFalse || right == kFalse) {
+    return kFalse;
+  }
+  if (left == kTrue && right == kTrue) {
+    return kTrue;
+  }
+  return kUnknown;
+}
+
+Truth orValue(Truth left, Truth right) {
+  if (left == kTrue || right == kTrue) {
+    return kTrue;
+  }
+  if (left == kFalse && right == kFalse) {
+    return kFalse;
+  }
+  return kUnknown;
+}
+
+template <typename Operation>
+uint8_t combine(uint8_t left, uint8_t right, Operation operation) {
+  uint8_t output = 0;
+  for (const auto leftValue : {kFalse, kTrue, kUnknown}) {
+    if (!(left & leftValue)) {
+      continue;
+    }
+    for (const auto rightValue : {kFalse, kTrue, kUnknown}) {
+      if (right & rightValue) {
+        output |= operation(leftValue, rightValue);
+      }
+    }
+  }
+  return output;
+}
+
+std::optional<Scalar> constantForType(const ::common::Value& value,
+                                      const ::common::DataType& type) {
+  if (type.item_case() == ::common::DataType::kString &&
+      value.item_case() == ::common::Value::kStr) {
+    return Scalar(value.str());
+  }
+  if (type.item_case() != ::common::DataType::kPrimitiveType) {
+    return std::nullopt;
+  }
+  switch (type.primitive_type()) {
+  case ::common::PrimitiveType::DT_BOOL:
+    if (value.item_case() == ::common::Value::kBoolean) {
+      return Scalar(value.boolean());
+    }
+    break;
+  case ::common::PrimitiveType::DT_SIGNED_INT32:
+    if (value.item_case() == ::common::Value::kI32) {
+      return Scalar(value.i32());
+    }
+    break;
+  case ::common::PrimitiveType::DT_UNSIGNED_INT32:
+    if (value.item_case() == ::common::Value::kU32) {
+      return Scalar(value.u32());
+    }
+    break;
+  case ::common::PrimitiveType::DT_SIGNED_INT64:
+    if (value.item_case() == ::common::Value::kI64) {
+      return Scalar(value.i64());
+    }
+    break;
+  case ::common::PrimitiveType::DT_UNSIGNED_INT64:
+    if (value.item_case() == ::common::Value::kU64) {
+      return Scalar(value.u64());
+    }
+    break;
+  case ::common::PrimitiveType::DT_FLOAT:
+    if (value.item_case() == ::common::Value::kF32 &&
+        std::isfinite(value.f32())) {
+      return Scalar(value.f32());
+    }
+    break;
+  case ::common::PrimitiveType::DT_DOUBLE:
+    if (value.item_case() == ::common::Value::kF64 &&
+        std::isfinite(value.f64())) {
+      return Scalar(value.f64());
+    }
+    break;
+  default:
+    break;
+  }
+  return std::nullopt;
+}
+
+template <typename T>
+std::optional<Scalar> decodeFixed(const void* data, int32_t size) {
+  if (!data || size != static_cast<int32_t>(sizeof(T))) {
+    return std::nullopt;
+  }
+  if constexpr (std::is_same_v<T, bool>) {
+    const auto byte = *static_cast<const uint8_t*>(data);
+    if (byte > 1) {
+      return std::nullopt;
+    }
+    return Scalar(byte != 0);
+  }
+  T value;
+  std::memcpy(&value, data, sizeof(value));
+  if constexpr (std::is_floating_point_v<T>) {
+    if (!std::isfinite(value)) {
+      return std::nullopt;
+    }
+  }
+  return Scalar(value);
+}
+
+std::optional<Scalar> decodeStat(const void* data, int32_t size,
+                                 const ::common::DataType& type) {
+  if (type.item_case() == ::common::DataType::kString) {
+    if (size < 0 || (size > 0 && !data)) {
+      return std::nullopt;
+    }
+    if (size == 0) {
+      return Scalar(std::string{});
+    }
+    return Scalar(
+        std::string(static_cast<const char*>(data), static_cast<size_t>(size)));
+  }
+  if (type.item_case() != ::common::DataType::kPrimitiveType) {
+    return std::nullopt;
+  }
+  switch (type.primitive_type()) {
+  case ::common::PrimitiveType::DT_BOOL:
+    return decodeFixed<bool>(data, size);
+  case ::common::PrimitiveType::DT_SIGNED_INT32:
+    return decodeFixed<int32_t>(data, size);
+  case ::common::PrimitiveType::DT_UNSIGNED_INT32:
+    return decodeFixed<uint32_t>(data, size);
+  case ::common::PrimitiveType::DT_SIGNED_INT64:
+    return decodeFixed<int64_t>(data, size);
+  case ::common::PrimitiveType::DT_UNSIGNED_INT64:
+    return decodeFixed<uint64_t>(data, size);
+  case ::common::PrimitiveType::DT_FLOAT:
+    return decodeFixed<float>(data, size);
+  case ::common::PrimitiveType::DT_DOUBLE:
+    return decodeFixed<double>(data, size);
+  default:
+    return std::nullopt;
+  }
+}
+
+std::optional<int> compareScalar(const Scalar& left, const Scalar& right) {
+  if (left.index() != right.index()) {
+    return std::nullopt;
+  }
+  return std::visit(
+      [](const auto& lhs, const auto& rhs) -> std::optional<int> {
+        using Left = std::decay_t<decltype(lhs)>;
+        using Right = std::decay_t<decltype(rhs)>;
+        if constexpr (!std::is_same_v<Left, Right>) {
+          return std::nullopt;
+        } else {
+          return (lhs > rhs) - (lhs < rhs);
+        }
+      },
+      left, right);
+}
+
+std::optional<::common::Logical> reverseComparison(::common::Logical op) {
+  switch (op) {
+  case ::common::Logical::EQ:
+  case ::common::Logical::NE:
+    return op;
+  case ::common::Logical::LT:
+    return ::common::Logical::GT;
+  case ::common::Logical::LE:
+    return ::common::Logical::GE;
+  case ::common::Logical::GT:
+    return ::common::Logical::LT;
+  case ::common::Logical::GE:
+    return ::common::Logical::LE;
+  default:
+    return std::nullopt;
+  }
+}
+
+bool comparisonMightMatch(::common::Logical op, int valueVsMin,
+                          int valueVsMax) {
+  switch (op) {
+  case ::common::Logical::EQ:
+    return valueVsMin >= 0 && valueVsMax <= 0;
+  case ::common::Logical::NE:
+    return valueVsMin != 0 || valueVsMax != 0;
+  case ::common::Logical::LT:
+    return valueVsMin > 0;
+  case ::common::Logical::LE:
+    return valueVsMin >= 0;
+  case ::common::Logical::GT:
+    return valueVsMax < 0;
+  case ::common::Logical::GE:
+    return valueVsMax <= 0;
+  default:
+    return true;
+  }
+}
+
+std::optional<ColumnRef> findColumn(const carquet_reader_t* reader,
+                                    const reader::EntrySchema& schema,
+                                    const std::string& name) {
+  const auto iter =
+      std::find(schema.columnNames.begin(), schema.columnNames.end(), name);
+  if (iter == schema.columnNames.end()) {
+    return std::nullopt;
+  }
+  const size_t schemaIndex =
+      static_cast<size_t>(std::distance(schema.columnNames.begin(), iter));
+  if (schemaIndex >= schema.columnTypes.size() ||
+      !schema.columnTypes[schemaIndex]) {
+    return std::nullopt;
+  }
+
+  const carquet_schema_t* carquetSchema = carquet_reader_schema(reader);
+  const int32_t leaves = carquet_schema_num_columns(carquetSchema);
+  for (int32_t leaf = 0; leaf < leaves; ++leaf) {
+    const char* path[2] = {nullptr, nullptr};
+    const int32_t depth =
+        carquet_schema_column_path(carquetSchema, leaf, path, 2);
+    if (depth == 1 && path[0] && name == path[0]) {
+      return ColumnRef{leaf, *schema.columnTypes[schemaIndex]};
+    }
+  }
+  return std::nullopt;
+}
+
+}  // namespace
+
+struct CarquetRowGroupPruner::Node {
+  enum class Kind { kUnsupported, kColumn, kConstant, kOperation };
+
+  Kind kind = Kind::kUnsupported;
+  ColumnRef column;
+  ::common::Value constant;
+  ::common::ExprOpr operation;
+  std::unique_ptr<Node> left;
+  std::unique_ptr<Node> right;
+
+  uint8_t possible(const carquet_reader_t* reader, int32_t rowGroup,
+                   int64_t rowCount) const {
+    if (kind != Kind::kOperation ||
+        operation.item_case() != ::common::ExprOpr::kLogical) {
+      return kAny;
+    }
+
+    const auto op = operation.logical();
+    if (op == ::common::Logical::NOT) {
+      return right ? negate(right->possible(reader, rowGroup, rowCount)) : kAny;
+    }
+    if (op == ::common::Logical::AND || op == ::common::Logical::OR) {
+      if (!left || !right) {
+        return kAny;
+      }
+      const auto leftValues = left->possible(reader, rowGroup, rowCount);
+      const auto rightValues = right->possible(reader, rowGroup, rowCount);
+      return op == ::common::Logical::AND
+                 ? combine(leftValues, rightValues, andValue)
+                 : combine(leftValues, rightValues, orValue);
+    }
+    if (op == ::common::Logical::ISNULL) {
+      if (!right || right->kind != Kind::kColumn) {
+        return kAny;
+      }
+      carquet_column_statistics_t stats;
+      if (carquet_reader_column_statistics(reader, rowGroup, right->column.leaf,
+                                           &stats) != CARQUET_OK ||
+          !stats.has_null_count || stats.num_values != rowCount ||
+          stats.null_count < 0 || stats.null_count > stats.num_values) {
+        return kAny;
+      }
+      if (stats.null_count == 0) {
+        return kFalse;
+      }
+      if (stats.null_count == stats.num_values) {
+        return kTrue;
+      }
+      return kFalse | kTrue;
+    }
+
+    const Node* columnNode = nullptr;
+    const Node* constantNode = nullptr;
+    auto comparison = reverseComparison(op);
+    if (!comparison || !left || !right) {
+      return kAny;
+    }
+    if (left->kind == Kind::kColumn && right->kind == Kind::kConstant) {
+      columnNode = left.get();
+      constantNode = right.get();
+      comparison = op;
+    } else if (left->kind == Kind::kConstant && right->kind == Kind::kColumn) {
+      columnNode = right.get();
+      constantNode = left.get();
+    } else {
+      return kAny;
+    }
+
+    carquet_column_statistics_t stats;
+    if (carquet_reader_column_statistics(
+            reader, rowGroup, columnNode->column.leaf, &stats) != CARQUET_OK ||
+        stats.num_values != rowCount ||
+        (stats.has_null_count &&
+         (stats.null_count < 0 || stats.null_count > stats.num_values))) {
+      return kAny;
+    }
+    if (stats.has_null_count && stats.null_count == stats.num_values) {
+      return kUnknown;
+    }
+    if (!stats.has_min_max) {
+      return kAny;
+    }
+
+    // Finite min/max do not prove that a floating-point group has no NaNs.
+    // NaN matches NE even when every finite value equals the constant.
+    const auto primitive = columnNode->column.type.primitive_type();
+    if ((primitive == ::common::PrimitiveType::DT_FLOAT ||
+         primitive == ::common::PrimitiveType::DT_DOUBLE) &&
+        *comparison == ::common::Logical::NE) {
+      return kAny;
+    }
+
+    const auto value =
+        constantForType(constantNode->constant, columnNode->column.type);
+    const auto minimum = decodeStat(stats.min_value, stats.min_value_size,
+                                    columnNode->column.type);
+    const auto maximum = decodeStat(stats.max_value, stats.max_value_size,
+                                    columnNode->column.type);
+    if (!value || !minimum || !maximum) {
+      return kAny;
+    }
+    const auto minVsMax = compareScalar(*minimum, *maximum);
+    const auto valueVsMin = compareScalar(*value, *minimum);
+    const auto valueVsMax = compareScalar(*value, *maximum);
+    if (!minVsMax || *minVsMax > 0 || !valueVsMin || !valueVsMax) {
+      return kAny;
+    }
+    if (comparisonMightMatch(*comparison, *valueVsMin, *valueVsMax)) {
+      return kAny;
+    }
+    return stats.has_null_count && stats.null_count == 0 ? kFalse
+                                                         : kFalse | kUnknown;
+  }
+};
+
+namespace {
+
+std::unique_ptr<CarquetRowGroupPruner::Node> makeUnsupported() {
+  return std::make_unique<CarquetRowGroupPruner::Node>();
+}
+
+std::unique_ptr<CarquetRowGroupPruner::Node> compile(
+    const carquet_reader_t* reader, const reader::EntrySchema& schema,
+    const ::common::Expression* filter) {
+  if (!filter || filter->operators().empty()) {
+    return makeUnsupported();
+  }
+  using Node = CarquetRowGroupPruner::Node;
+  std::stack<std::unique_ptr<Node>> values;
+  std::stack<::common::ExprOpr> operators;
+
+  auto apply = [&]() -> bool {
+    if (operators.empty()) {
+      return false;
+    }
+    auto operation = operators.top();
+    operators.pop();
+    const bool unary = operation.item_case() == ::common::ExprOpr::kLogical &&
+                       (operation.logical() == ::common::Logical::NOT ||
+                        operation.logical() == ::common::Logical::ISNULL);
+    if (values.empty() || (!unary && values.size() < 2)) {
+      return false;
+    }
+    auto node = std::make_unique<Node>();
+    node->kind = Node::Kind::kOperation;
+    node->operation = std::move(operation);
+    node->right = std::move(values.top());
+    values.pop();
+    if (!unary) {
+      node->left = std::move(values.top());
+      values.pop();
+    }
+    values.push(std::move(node));
+    return true;
+  };
+
+  for (const auto& token : filter->operators()) {
+    if (token.item_case() == ::common::ExprOpr::kVar) {
+      auto node = std::make_unique<Node>();
+      auto column = token.var().tag().has_name() && !token.var().has_property()
+                        ? findColumn(reader, schema, token.var().tag().name())
+                        : std::nullopt;
+      if (column) {
+        node->kind = Node::Kind::kColumn;
+        node->column = std::move(*column);
+      }
+      values.push(std::move(node));
+    } else if (token.item_case() == ::common::ExprOpr::kConst) {
+      auto node = std::make_unique<Node>();
+      node->kind = Node::Kind::kConstant;
+      node->constant = token.const_();
+      values.push(std::move(node));
+    } else if (token.item_case() == ::common::ExprOpr::kBrace) {
+      if (token.brace() == ::common::ExprOpr::LEFT_BRACE) {
+        operators.push(token);
+      } else {
+        while (!operators.empty() &&
+               operators.top().item_case() != ::common::ExprOpr::kBrace) {
+          if (!apply()) {
+            return makeUnsupported();
+          }
+        }
+        if (operators.empty()) {
+          return makeUnsupported();
+        }
+        operators.pop();
+      }
+    } else if (token.item_case() == ::common::ExprOpr::kLogical ||
+               token.item_case() == ::common::ExprOpr::kArith) {
+      // Prefix unary operators bind to the following operand, including another
+      // unary operator. Keep this private parser aligned with exact evaluation.
+      const auto precedenceOf = [](const ::common::ExprOpr& op) {
+        if (op.has_logical() && (op.logical() == ::common::Logical::ISNULL ||
+                                 op.logical() == ::common::Logical::NOT)) {
+          return 2;
+        }
+        return reader::OperatorPrecedence::getPrecedence(op);
+      };
+      if (token.has_logical() &&
+          (token.logical() == ::common::Logical::NOT ||
+           token.logical() == ::common::Logical::ISNULL)) {
+        operators.push(token);
+        continue;
+      }
+      const int precedence = precedenceOf(token);
+      while (!operators.empty() &&
+             operators.top().item_case() != ::common::ExprOpr::kBrace &&
+             precedenceOf(operators.top()) <= precedence) {
+        if (!apply()) {
+          return makeUnsupported();
+        }
+      }
+      operators.push(token);
+    } else {
+      values.push(makeUnsupported());
+    }
+  }
+  while (!operators.empty()) {
+    if (operators.top().item_case() == ::common::ExprOpr::kBrace || !apply()) {
+      return makeUnsupported();
+    }
+  }
+  if (values.size() != 1) {
+    return makeUnsupported();
+  }
+  return std::move(values.top());
+}
+
+}  // namespace
+
+CarquetRowGroupPruner::CarquetRowGroupPruner(const carquet_reader_t* reader,
+                                             std::unique_ptr<Node> root)
+    : reader_(reader), root_(std::move(root)) {}
+
+CarquetRowGroupPruner::~CarquetRowGroupPruner() = default;
+
+std::unique_ptr<CarquetRowGroupPruner> CarquetRowGroupPruner::create(
+    const carquet_reader_t* reader, const reader::EntrySchema& schema,
+    const ::common::Expression* filter) {
+  return std::unique_ptr<CarquetRowGroupPruner>(
+      new CarquetRowGroupPruner(reader, compile(reader, schema, filter)));
+}
+
+bool CarquetRowGroupPruner::mightMatch(int32_t rowGroup) const {
+  if (!reader_ || !root_) {
+    return true;
+  }
+  carquet_row_group_metadata_t metadata;
+  if (carquet_reader_row_group_metadata(reader_, rowGroup, &metadata) !=
+      CARQUET_OK) {
+    return true;
+  }
+  if (metadata.num_rows == 0) {
+    return false;
+  }
+  return (root_->possible(reader_, rowGroup, metadata.num_rows) & kTrue) != 0;
+}
+
+}  // namespace neug::parquet

--- a/extension/parquet/src/carquet/scan.cc
+++ b/extension/parquet/src/carquet/scan.cc
@@ -1,0 +1,393 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+#include "carquet/scan.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <functional>
+#include <future>
+#include <limits>
+#include <memory>
+#include <string>
+#include <thread>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "carquet/chunk_supplier.h"
+#include "carquet/sniffer.h"
+#include "neug/utils/exception/exception.h"
+#include "neug/utils/io/read/common/options.h"
+#include "neug/utils/io/read/common/row_expression_filter.h"
+
+namespace neug::parquet {
+namespace {
+
+struct ScanOptions {
+  bool batchRead;
+  bool parallel;
+  bool bufferedStream;
+  bool preBuffer;
+  bool enableIoCoalescing;
+  int32_t rowBatchSize;
+  int64_t bufferSize;
+};
+
+struct PhysicalProjection {
+  std::vector<std::string> columnNames;
+  std::vector<int32_t> topLevelFields;
+};
+
+struct RowGroupTask {
+  std::string path;
+  int32_t rowGroup;
+};
+
+using ChunkConsumer = std::function<void(std::shared_ptr<DataChunk>)>;
+
+ScanOptions parseOptions(const reader::options_t& values) {
+  reader::ReadOptions common;
+  reader::Option<bool> buffered =
+      reader::Option<bool>::BoolOption("BUFFERED_STREAM", true);
+  reader::Option<bool> prebuffer =
+      reader::Option<bool>::BoolOption("PRE_BUFFER", false);
+  reader::Option<bool> coalescing =
+      reader::Option<bool>::BoolOption("ENABLE_IO_COALESCING", true);
+  reader::Option<int64_t> rowBatch =
+      reader::Option<int64_t>::Int64Option("PARQUET_BATCH_ROWS", 65536);
+
+  const int64_t rowBatchSize = rowBatch.get(values);
+  const int64_t bufferSize = common.batch_size.get(values);
+  if (rowBatchSize <= 0 || rowBatchSize > std::numeric_limits<int32_t>::max()) {
+    THROW_INVALID_ARGUMENT_EXCEPTION(
+        "PARQUET_BATCH_ROWS must be between 1 and INT32_MAX");
+  }
+  if (bufferSize <= 0) {
+    THROW_INVALID_ARGUMENT_EXCEPTION("BATCH_SIZE must be positive");
+  }
+  return {
+      .batchRead = common.batch_read.get(values),
+      .parallel = common.use_threads.get(values),
+      .bufferedStream = buffered.get(values),
+      .preBuffer = prebuffer.get(values),
+      .enableIoCoalescing = coalescing.get(values),
+      .rowBatchSize = static_cast<int32_t>(rowBatchSize),
+      .bufferSize = bufferSize,
+  };
+}
+
+std::unique_ptr<io::InputStream> openInput(const reader::ReadSharedState& state,
+                                           const std::string& path) {
+  auto input = state.stream_opener ? state.stream_opener(path)
+                                   : io::openLocalInputStream(path);
+  if (!input) {
+    THROW_IO_EXCEPTION("Failed to open Parquet input: " + path);
+  }
+  return input;
+}
+
+bool sameType(const ::common::DataType& expected,
+              const ::common::DataType& actual) {
+  // INTERVAL is stored as text and converted by the downstream loader.
+  if (expected.has_temporal() && expected.temporal().has_interval() &&
+      actual.has_string()) {
+    return true;
+  }
+  if (expected.item_case() != actual.item_case()) {
+    return false;
+  }
+  switch (expected.item_case()) {
+  case ::common::DataType::kPrimitiveType:
+    return expected.primitive_type() == actual.primitive_type();
+  case ::common::DataType::kString:
+    return true;
+  case ::common::DataType::kTemporal: {
+    const auto expectedCase = expected.temporal().item_case();
+    const auto actualCase = actual.temporal().item_case();
+    const bool expectedDate = expectedCase == ::common::Temporal::kDate ||
+                              expectedCase == ::common::Temporal::kDate32;
+    const bool actualDate = actualCase == ::common::Temporal::kDate ||
+                            actualCase == ::common::Temporal::kDate32;
+    const bool expectedTimestamp =
+        expectedCase == ::common::Temporal::kDateTime ||
+        expectedCase == ::common::Temporal::kTimestamp;
+    const bool actualTimestamp = actualCase == ::common::Temporal::kDateTime ||
+                                 actualCase == ::common::Temporal::kTimestamp;
+    return (expectedDate && actualDate) ||
+           (expectedTimestamp && actualTimestamp) || expectedCase == actualCase;
+  }
+  case ::common::DataType::kArray:
+    return expected.array().fixed_length() == actual.array().fixed_length() &&
+           sameType(expected.array().component_type(),
+                    actual.array().component_type());
+  case ::common::DataType::kList:
+    return sameType(expected.list().component_type(),
+                    actual.list().component_type());
+  default:
+    return expected.SerializeAsString() == actual.SerializeAsString();
+  }
+}
+
+bool sameSchema(const reader::EntrySchema& expected,
+                const reader::EntrySchema& actual) {
+  if (expected.columnNames != actual.columnNames ||
+      expected.columnTypes.size() != actual.columnTypes.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < expected.columnTypes.size(); ++i) {
+    if (!expected.columnTypes[i] || !actual.columnTypes[i] ||
+        !sameType(*expected.columnTypes[i], *actual.columnTypes[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+PhysicalProjection buildPhysicalProjection(
+    const reader::EntrySchema& schema,
+    const std::vector<std::string>& projection,
+    const std::shared_ptr<::common::Expression>& filter) {
+  std::unordered_set<std::string> required;
+  if (projection.empty()) {
+    required.insert(schema.columnNames.begin(), schema.columnNames.end());
+  } else {
+    required.insert(projection.begin(), projection.end());
+  }
+  std::vector<const ::common::Expression*> pending{filter.get()};
+  while (!pending.empty()) {
+    const auto* expression = pending.back();
+    pending.pop_back();
+    if (!expression) {
+      continue;
+    }
+    for (const auto& operation : expression->operators()) {
+      switch (operation.item_case()) {
+      case ::common::ExprOpr::kVar:
+        if (!operation.var().tag().has_name() ||
+            operation.var().has_property()) {
+          THROW_INVALID_ARGUMENT_EXCEPTION(
+              "File filter requires a column name without a graph property");
+        }
+        required.insert(operation.var().tag().name());
+        break;
+      case ::common::ExprOpr::kCase:
+        for (const auto& branch : operation.case_().when_then_expressions()) {
+          pending.push_back(&branch.when_expression());
+          pending.push_back(&branch.then_result_expression());
+        }
+        pending.push_back(&operation.case_().else_result_expression());
+        break;
+      case ::common::ExprOpr::kScalarFunc:
+        for (const auto& child : operation.scalar_func().parameters()) {
+          pending.push_back(&child);
+        }
+        break;
+      case ::common::ExprOpr::kUdfFunc:
+        for (const auto& child : operation.udf_func().parameters()) {
+          pending.push_back(&child);
+        }
+        break;
+      case ::common::ExprOpr::kToTuple:
+        for (const auto& child : operation.to_tuple().fields()) {
+          pending.push_back(&child);
+        }
+        break;
+      case ::common::ExprOpr::kToList:
+        for (const auto& child : operation.to_list().fields()) {
+          pending.push_back(&child);
+        }
+        break;
+      case ::common::ExprOpr::kToArray:
+        for (const auto& child : operation.to_array().fields()) {
+          pending.push_back(&child);
+        }
+        break;
+      default:
+        break;
+      }
+    }
+  }
+
+  PhysicalProjection physical;
+  for (size_t i = 0; i < schema.columnNames.size(); ++i) {
+    if (required.erase(schema.columnNames[i]) > 0) {
+      physical.columnNames.emplace_back(schema.columnNames[i]);
+      physical.topLevelFields.emplace_back(static_cast<int32_t>(i));
+    }
+  }
+  if (!required.empty()) {
+    std::vector<std::string> missing(required.begin(), required.end());
+    std::sort(missing.begin(), missing.end());
+    std::string message = "Parquet columns not found:";
+    for (size_t i = 0; i < missing.size(); ++i) {
+      message += (i == 0 ? " " : ", ") + missing[i];
+    }
+    THROW_INVALID_ARGUMENT_EXCEPTION(message);
+  }
+  if (physical.topLevelFields.size() == schema.columnNames.size()) {
+    physical.topLevelFields.clear();
+  }
+  return physical;
+}
+
+CarquetReaderOptions supplierOptions(
+    const ScanOptions& options, const PhysicalProjection& projection,
+    std::shared_ptr<::common::Expression> rowGroupFilter = nullptr) {
+  return {
+      .batchSize = options.rowBatchSize,
+      .numThreads = options.parallel ? 0 : 1,
+      .bufferSize = options.bufferSize,
+      .bufferedStream = options.bufferedStream,
+      .preBuffer = options.preBuffer || !options.enableIoCoalescing,
+      .topLevelFields = projection.topLevelFields,
+      .rowGroupFilter = std::move(rowGroupFilter),
+  };
+}
+
+std::shared_ptr<CarquetChunkSupplier> openSupplier(
+    const reader::ReadSharedState& state, const std::string& path,
+    CarquetReaderOptions options) {
+  auto supplier =
+      CarquetChunkSupplier::create(openInput(state, path), std::move(options));
+  if (!supplier) {
+    THROW_IO_EXCEPTION("Failed to read Parquet input " + path + ": " +
+                       supplier.error().ToString());
+  }
+  return std::move(*supplier);
+}
+
+std::shared_ptr<DataChunk> transformChunk(
+    const std::shared_ptr<DataChunk>& chunk,
+    const reader::ReadSharedState& state, const PhysicalProjection& physical) {
+  auto transformed = reader::filter_chunk(
+      *chunk, state.skipRows, physical.columnNames, state.parameters);
+  transformed = reader::project_chunk(transformed, physical.columnNames,
+                                      state.projectColumns);
+  return std::make_shared<DataChunk>(std::move(transformed));
+}
+
+std::vector<std::shared_ptr<DataChunk>> readSupplier(
+    const std::shared_ptr<CarquetChunkSupplier>& supplier,
+    const reader::ReadSharedState& state, const PhysicalProjection& physical) {
+  std::vector<std::shared_ptr<DataChunk>> chunks;
+  while (auto chunk = supplier->GetNextChunk()) {
+    chunks.emplace_back(transformChunk(chunk, state, physical));
+  }
+  return chunks;
+}
+
+void readSequential(const reader::ReadSharedState& state,
+                    const ScanOptions& options,
+                    const PhysicalProjection& physical,
+                    const ChunkConsumer& consume) {
+  for (const auto& path : state.schema.file.paths) {
+    auto supplier = openSupplier(
+        state, path, supplierOptions(options, physical, state.skipRows));
+    if (!sameSchema(*state.schema.entry, *supplier->schema())) {
+      THROW_SCHEMA_MISMATCH("Parquet schema does not match declared schema: " +
+                            path);
+    }
+    while (auto chunk = supplier->GetNextChunk()) {
+      consume(transformChunk(chunk, state, physical));
+    }
+  }
+}
+
+std::vector<RowGroupTask> inspectParallelTasks(
+    const reader::ReadSharedState& state, const ScanOptions& options,
+    const PhysicalProjection& physical) {
+  std::vector<RowGroupTask> tasks;
+  for (const auto& path : state.schema.file.paths) {
+    auto probe = openSupplier(
+        state, path, supplierOptions(options, physical, state.skipRows));
+    if (!sameSchema(*state.schema.entry, *probe->schema())) {
+      THROW_SCHEMA_MISMATCH("Parquet schema does not match declared schema: " +
+                            path);
+    }
+    if (probe->rowGroupCount() >
+        static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
+      THROW_IO_EXCEPTION("Parquet row-group count exceeds INT32_MAX");
+    }
+    for (const int32_t group : probe->selectedRowGroups()) {
+      tasks.push_back({path, group});
+    }
+  }
+  return tasks;
+}
+
+void readParallel(const reader::ReadSharedState& state,
+                  const ScanOptions& options,
+                  const PhysicalProjection& physical,
+                  const ChunkConsumer& consume) {
+  const auto tasks = inspectParallelTasks(state, options, physical);
+  if (tasks.empty()) {
+    return;
+  }
+  const size_t concurrency = std::max<size_t>(
+      1, std::min<size_t>(tasks.size(), std::thread::hardware_concurrency()));
+  for (size_t begin = 0; begin < tasks.size(); begin += concurrency) {
+    const size_t end = std::min(tasks.size(), begin + concurrency);
+    std::vector<std::future<std::vector<std::shared_ptr<DataChunk>>>> futures;
+    futures.reserve(end - begin);
+    for (size_t i = begin; i < end; ++i) {
+      futures.emplace_back(std::async(std::launch::async, [&, task = tasks[i]] {
+        auto taskOptions = supplierOptions(options, physical);
+        taskOptions.numThreads = 1;
+        taskOptions.rowGroups = {task.rowGroup};
+        auto supplier = openSupplier(state, task.path, std::move(taskOptions));
+        return readSupplier(supplier, state, physical);
+      }));
+    }
+    for (auto& future : futures) {
+      auto taskChunks = future.get();
+      for (auto& chunk : taskChunks) {
+        consume(std::move(chunk));
+      }
+    }
+  }
+}
+
+}  // namespace
+
+result<std::shared_ptr<reader::EntrySchema>> sniffCarquet(
+    io::InputStreamFactory inputFactory) {
+  return CarquetSniffer(std::move(inputFactory)).sniff();
+}
+
+void scanCarquet(const std::shared_ptr<reader::ReadSharedState>& state,
+                 execution::Context& output) {
+  if (!state || !state->schema.entry) {
+    THROW_INVALID_ARGUMENT_EXCEPTION(
+        "Carquet scan state and entry schema must be set");
+  }
+  if (state->schema.file.paths.empty()) {
+    THROW_INVALID_ARGUMENT_EXCEPTION("No Parquet input paths provided");
+  }
+
+  const auto options = parseOptions(state->schema.file.options);
+  const auto physical = buildPhysicalProjection(
+      *state->schema.entry, state->projectColumns, state->skipRows);
+  output.clear();
+  std::vector<std::shared_ptr<DataChunk>> chunks;
+  const ChunkConsumer consume = [&](std::shared_ptr<DataChunk> chunk) {
+    if (options.batchRead) {
+      output.append_chunk(std::move(*chunk));
+    } else {
+      chunks.emplace_back(std::move(chunk));
+    }
+  };
+  if (options.parallel) {
+    readParallel(*state, options, physical, consume);
+  } else {
+    readSequential(*state, options, physical, consume);
+  }
+  if (!options.batchRead && !chunks.empty()) {
+    output.append_chunk(reader::merge_chunks(std::move(chunks)));
+  }
+}
+
+}  // namespace neug::parquet

--- a/extension/parquet/src/carquet/schema_converter.cc
+++ b/extension/parquet/src/carquet/schema_converter.cc
@@ -1,0 +1,208 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+#include "carquet/schema_converter.h"
+
+#include <charconv>
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+
+#include "carquet/column_converter.h"
+
+namespace neug::parquet {
+namespace {
+
+constexpr int kMaxSchemaDepth = 64;
+constexpr int64_t kMaxSchemaColumns = 1 << 20;
+
+struct ArrowSchemaOwner : ArrowSchema {
+  ArrowSchemaOwner() : ArrowSchema{} {}
+  ~ArrowSchemaOwner() {
+    if (release) {
+      release(this);
+    }
+  }
+};
+
+template <typename T>
+result<T> schemaError(const std::string& path, const std::string& message) {
+  return tl::unexpected(
+      Status(StatusCode::ERR_TYPE_CONVERSION,
+             "Invalid Parquet schema at " + path + ": " + message));
+}
+
+result<uint32_t> parseFixedLength(std::string_view format,
+                                  const std::string& path) {
+  constexpr std::string_view prefix = "+w:";
+  const std::string_view text = format.substr(prefix.size());
+  uint64_t value = 0;
+  const auto parsed =
+      std::from_chars(text.data(), text.data() + text.size(), value);
+  if (text.empty() || parsed.ec != std::errc{} ||
+      parsed.ptr != text.data() + text.size() || value == 0 ||
+      value > std::numeric_limits<uint32_t>::max()) {
+    return schemaError<uint32_t>(
+        path, "invalid fixed-size list format \"" + std::string(format) + "\"");
+  }
+  return static_cast<uint32_t>(value);
+}
+
+result<std::shared_ptr<::common::DataType>> convertType(
+    const ArrowSchema& schema, const std::string& path, int depth) {
+  if (depth > kMaxSchemaDepth) {
+    return schemaError<std::shared_ptr<::common::DataType>>(
+        path, "nesting exceeds 64 levels");
+  }
+  if (!schema.format) {
+    return schemaError<std::shared_ptr<::common::DataType>>(path,
+                                                            "missing format");
+  }
+
+  const std::string_view format(schema.format);
+  if (format == "+l" || format == "+L" || format.starts_with("+w:")) {
+    if (schema.dictionary || schema.n_children != 1 || !schema.children ||
+        !schema.children[0]) {
+      return schemaError<std::shared_ptr<::common::DataType>>(
+          path, "list type must have exactly one child");
+    }
+    auto child = convertType(*schema.children[0], path + ".element", depth + 1);
+    if (!child) {
+      return tl::unexpected(child.error());
+    }
+
+    auto type = std::make_shared<::common::DataType>();
+    if (format.starts_with("+w:")) {
+      auto fixedLength = parseFixedLength(format, path);
+      if (!fixedLength) {
+        return tl::unexpected(fixedLength.error());
+      }
+      auto* array = type->mutable_array();
+      *array->mutable_component_type() = **child;
+      array->set_fixed_length(*fixedLength);
+    } else {
+      *type->mutable_list()->mutable_component_type() = **child;
+    }
+    return type;
+  }
+  if (format == "+m") {
+    if (schema.dictionary || schema.n_children != 1 || !schema.children ||
+        !schema.children[0]) {
+      return schemaError<std::shared_ptr<::common::DataType>>(
+          path, "MAP must have one entries child");
+    }
+    const auto& entries = *schema.children[0];
+    if (!entries.format || std::string_view(entries.format) != "+s" ||
+        entries.n_children != 2 || !entries.children || !entries.children[0] ||
+        !entries.children[1]) {
+      return schemaError<std::shared_ptr<::common::DataType>>(
+          path, "MAP entries must contain key and value fields");
+    }
+    auto key = convertType(*entries.children[0], path + ".key", depth + 1);
+    auto value = convertType(*entries.children[1], path + ".value", depth + 1);
+    if (!key || !value) {
+      return tl::unexpected(!key ? key.error() : value.error());
+    }
+    // Preserve schema sniffing without introducing MAP value columns.
+    auto type = std::make_shared<::common::DataType>();
+    *type->mutable_map()->mutable_key_type() = **key;
+    *type->mutable_map()->mutable_value_type() = **value;
+    return type;
+  }
+  if (format == "+s") {
+    return schemaError<std::shared_ptr<::common::DataType>>(
+        path, "STRUCT fields are not supported");
+  }
+  return convertArrowCScalarSchemaType(schema, path);
+}
+
+}  // namespace
+
+result<std::shared_ptr<::common::DataType>> convertArrowCScalarSchemaType(
+    const ArrowSchema& schema, const std::string& path) {
+  auto valid = validateArrowCScalarSchema(schema, path);
+  if (!valid) {
+    return tl::unexpected(valid.error());
+  }
+
+  const std::string_view format(schema.format);
+  auto type = std::make_shared<::common::DataType>();
+  if (format == "b") {
+    type->set_primitive_type(::common::PrimitiveType::DT_BOOL);
+  } else if (format == "c" || format == "s" || format == "i") {
+    type->set_primitive_type(::common::PrimitiveType::DT_SIGNED_INT32);
+  } else if (format == "C" || format == "S" || format == "I") {
+    type->set_primitive_type(::common::PrimitiveType::DT_UNSIGNED_INT32);
+  } else if (format == "l") {
+    type->set_primitive_type(::common::PrimitiveType::DT_SIGNED_INT64);
+  } else if (format == "L") {
+    type->set_primitive_type(::common::PrimitiveType::DT_UNSIGNED_INT64);
+  } else if (format == "f") {
+    type->set_primitive_type(::common::PrimitiveType::DT_FLOAT);
+  } else if (format == "g") {
+    type->set_primitive_type(::common::PrimitiveType::DT_DOUBLE);
+  } else if (format == "u" || format == "U") {
+    type->mutable_string()->mutable_var_char();
+  } else if (format == "tdD" || format == "tdm") {
+    type->mutable_temporal()->mutable_date();
+  } else {
+    type->mutable_temporal()->mutable_timestamp();
+  }
+  return type;
+}
+
+result<std::shared_ptr<reader::EntrySchema>> convertArrowCStructSchema(
+    const ArrowSchema& schema) {
+  if (!schema.format || std::string_view(schema.format) != "+s" ||
+      schema.dictionary || schema.n_children < 0 ||
+      schema.n_children > kMaxSchemaColumns ||
+      (schema.n_children > 0 && !schema.children)) {
+    RETURN_STATUS_ERROR(StatusCode::ERR_TYPE_CONVERSION,
+                        "Carquet returned an invalid root schema");
+  }
+
+  auto entry = std::make_shared<reader::TableEntrySchema>();
+  entry->columnNames.reserve(static_cast<size_t>(schema.n_children));
+  entry->columnTypes.reserve(static_cast<size_t>(schema.n_children));
+  std::unordered_set<std::string> names;
+  for (int64_t i = 0; i < schema.n_children; ++i) {
+    const ArrowSchema* field = schema.children[i];
+    if (!field || !field->name || field->name[0] == '\0') {
+      return schemaError<std::shared_ptr<reader::EntrySchema>>(
+          "root", "unnamed column at index " + std::to_string(i));
+    }
+    std::string name(field->name);
+    if (!names.emplace(name).second) {
+      return schemaError<std::shared_ptr<reader::EntrySchema>>(
+          "root", "duplicate column \"" + name + "\"");
+    }
+    auto converted = convertType(*field, "column \"" + name + "\"", 0);
+    if (!converted) {
+      return tl::unexpected(converted.error());
+    }
+    entry->columnNames.emplace_back(std::move(name));
+    entry->columnTypes.emplace_back(std::move(*converted));
+  }
+  return std::static_pointer_cast<reader::EntrySchema>(entry);
+}
+
+result<std::shared_ptr<reader::EntrySchema>> convertCarquetSchema(
+    const carquet_schema_t& schema) {
+  ArrowSchemaOwner exported;
+  carquet_error_t error = CARQUET_ERROR_INIT;
+  const carquet_status_t status =
+      carquet_arrow_export_schema(&schema, &exported, &error);
+  if (status != CARQUET_OK) {
+    RETURN_STATUS_ERROR(
+        StatusCode::ERR_TYPE_CONVERSION,
+        "Failed to export Carquet schema: " + std::string(error.message));
+  }
+  return convertArrowCStructSchema(exported);
+}
+
+}  // namespace neug::parquet

--- a/extension/parquet/src/carquet/sniffer.cc
+++ b/extension/parquet/src/carquet/sniffer.cc
@@ -1,0 +1,39 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+#include "carquet/sniffer.h"
+
+#include <string>
+
+#include "carquet/schema_converter.h"
+#include "input_adapter.h"
+
+namespace neug::parquet {
+
+result<std::shared_ptr<reader::EntrySchema>> CarquetSniffer::sniff() {
+  if (!inputFactory_) {
+    RETURN_STATUS_ERROR(StatusCode::ERR_INVALID_ARGUMENT,
+                        "Parquet input stream factory is null");
+  }
+  auto input = inputFactory_();
+  if (!input) {
+    RETURN_STATUS_ERROR(StatusCode::ERR_IO_ERROR,
+                        "Parquet input stream factory returned null");
+  }
+
+  carquet_error_t error = CARQUET_ERROR_INIT;
+  std::unique_ptr<carquet_reader_t, decltype(&carquet_reader_close)>
+      parquetReader(openCarquetReader(std::move(input), nullptr, &error),
+                    carquet_reader_close);
+  if (!parquetReader) {
+    RETURN_STATUS_ERROR(StatusCode::ERR_IO_ERROR,
+                        "Failed to open Parquet input for schema sniffing: " +
+                            std::string(error.message));
+  }
+  return convertCarquetSchema(*carquet_reader_schema(parquetReader.get()));
+}
+
+}  // namespace neug::parquet

--- a/extension/parquet/tests/carquet_chunk_supplier_test.cc
+++ b/extension/parquet/tests/carquet_chunk_supplier_test.cc
@@ -1,0 +1,912 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+#include <carquet/carquet.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "carquet/chunk_supplier.h"
+#include "carquet/column_converter.h"
+#include "carquet/nested_converter.h"
+#include "carquet/schema_converter.h"
+#include "carquet/sniffer.h"
+#include "carquet_test_data.h"
+
+namespace neug::parquet {
+namespace {
+
+struct InputState {
+  std::shared_ptr<std::vector<uint8_t>> bytes;
+  bool failReads = false;
+  int readCalls = 0;
+  int closeCalls = 0;
+  int destructCalls = 0;
+};
+
+class MemoryInput final : public io::InputStream {
+ public:
+  explicit MemoryInput(std::shared_ptr<InputState> state)
+      : state_(std::move(state)) {}
+  ~MemoryInput() override { ++state_->destructCalls; }
+
+  result<int64_t> Read(void* out, int64_t nbytes) override {
+    auto read = ReadAt(position_, nbytes, out);
+    if (read) {
+      position_ += *read;
+    }
+    return read;
+  }
+
+  result<int64_t> ReadAt(int64_t position, int64_t nbytes, void* out) override {
+    ++state_->readCalls;
+    if (state_->failReads) {
+      RETURN_STATUS_ERROR(StatusCode::ERR_IO_ERROR, "injected read failure");
+    }
+    if (position < 0 || nbytes < 0 || (nbytes > 0 && !out)) {
+      RETURN_STATUS_ERROR(StatusCode::ERR_INVALID_ARGUMENT,
+                          "invalid memory read");
+    }
+    if (position >= static_cast<int64_t>(state_->bytes->size())) {
+      return int64_t{0};
+    }
+    const int64_t count = std::min(
+        nbytes, static_cast<int64_t>(state_->bytes->size()) - position);
+    if (count > 0) {
+      std::memcpy(out, state_->bytes->data() + position,
+                  static_cast<size_t>(count));
+    }
+    return count;
+  }
+
+  result<int64_t> GetSize() override {
+    return static_cast<int64_t>(state_->bytes->size());
+  }
+
+  void Close() override { ++state_->closeCalls; }
+
+ private:
+  std::shared_ptr<InputState> state_;
+  int64_t position_ = 0;
+};
+
+std::shared_ptr<InputState> fixtureState(const std::string& name) {
+  const auto path = std::filesystem::path(NEUG_PARQUET_DATASET_DIR) / name;
+  std::ifstream input(path, std::ios::binary);
+  if (!input) {
+    throw std::runtime_error("Cannot open existing Parquet dataset: " +
+                             path.string());
+  }
+  auto bytes = std::make_shared<std::vector<uint8_t>>(
+      std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>());
+  return std::make_shared<InputState>(InputState{.bytes = std::move(bytes)});
+}
+
+void checkCarquet(carquet_status_t status) {
+  if (status != CARQUET_OK) {
+    throw std::runtime_error(carquet_status_string(status));
+  }
+}
+
+// Generate only the row-group/null cases missing from the existing datasets.
+std::shared_ptr<InputState> scalarFileState(
+    int groups,
+    decltype(CARQUET_COMPRESSION_ZSTD) codec = CARQUET_COMPRESSION_ZSTD) {
+  carquet_error_t error = CARQUET_ERROR_INIT;
+  std::unique_ptr<carquet_schema_t, decltype(&carquet_schema_free)> schema(
+      carquet_schema_create(&error), carquet_schema_free);
+  if (!schema) {
+    throw std::runtime_error(error.message);
+  }
+  checkCarquet(carquet_schema_add_column(schema.get(), "id",
+                                         CARQUET_PHYSICAL_INT64, nullptr,
+                                         CARQUET_REPETITION_REQUIRED, 0, 0));
+  checkCarquet(carquet_schema_add_column(schema.get(), "flag",
+                                         CARQUET_PHYSICAL_BOOLEAN, nullptr,
+                                         CARQUET_REPETITION_OPTIONAL, 0, 0));
+  checkCarquet(carquet_schema_add_column(schema.get(), "measurement",
+                                         CARQUET_PHYSICAL_FLOAT, nullptr,
+                                         CARQUET_REPETITION_OPTIONAL, 0, 0));
+  carquet_logical_type_t stringType{};
+  stringType.id = CARQUET_LOGICAL_STRING;
+  checkCarquet(carquet_schema_add_column(
+      schema.get(), "category", CARQUET_PHYSICAL_BYTE_ARRAY, &stringType,
+      CARQUET_REPETITION_OPTIONAL, 0, 0));
+  carquet_writer_options_t options;
+  carquet_writer_options_init(&options);
+  options.compression = codec;
+  std::unique_ptr<carquet_writer_t, decltype(&carquet_writer_abort)> writer(
+      carquet_writer_create_buffer(schema.get(), &options, &error),
+      carquet_writer_abort);
+  if (!writer) {
+    throw std::runtime_error(error.message);
+  }
+  const int16_t defined[] = {1, 1, 0, 1, 1, 1};
+  const uint8_t flags[] = {1, 0, 0, 1, 0};
+  const float measurements[] = {0.5f, -1.25f, 3.5f, 4.5f, 5.5f};
+  std::string labels[] = {"", "中文", "b", "a", "c"};
+  carquet_byte_array_t strings[5];
+  for (size_t i = 0; i < 5; ++i) {
+    strings[i] = {reinterpret_cast<uint8_t*>(labels[i].data()),
+                  static_cast<int32_t>(labels[i].size())};
+  }
+  for (int group = 0; group < groups; ++group) {
+    const int64_t ids[] = {group * 6 + 1, group * 6 + 2, group * 6 + 3,
+                           group * 6 + 4, group * 6 + 5, group * 6 + 6};
+    checkCarquet(
+        carquet_writer_write_batch(writer.get(), 0, ids, 6, nullptr, nullptr));
+    checkCarquet(carquet_writer_write_batch(writer.get(), 1, flags, 6, defined,
+                                            nullptr));
+    checkCarquet(carquet_writer_write_batch(writer.get(), 2, measurements, 6,
+                                            defined, nullptr));
+    checkCarquet(carquet_writer_write_batch(writer.get(), 3, strings, 6,
+                                            defined, nullptr));
+    if (group + 1 < groups) {
+      checkCarquet(carquet_writer_new_row_group(writer.get()));
+    }
+  }
+  checkCarquet(carquet_writer_close(writer.get()));
+  void* data = nullptr;
+  size_t size = 0;
+  checkCarquet(carquet_writer_get_buffer(writer.get(), &data, &size));
+  writer.release();  // get_buffer consumes the closed buffer writer.
+  std::unique_ptr<void, decltype(&std::free)> buffer(data, std::free);
+  auto bytes = std::make_shared<std::vector<uint8_t>>(
+      static_cast<uint8_t*>(data), static_cast<uint8_t*>(data) + size);
+  return std::make_shared<InputState>(InputState{.bytes = std::move(bytes)});
+}
+
+template <typename T>
+T valueAt(const std::shared_ptr<DataChunk>& chunk, int column, size_t row) {
+  return chunk->get(column)->get_elem(row).GetValue<T>();
+}
+
+void expectPrimitive(const std::shared_ptr<::common::DataType>& type,
+                     ::common::PrimitiveType expected) {
+  ASSERT_NE(type, nullptr);
+  EXPECT_EQ(type->item_case(), ::common::DataType::kPrimitiveType);
+  EXPECT_EQ(type->primitive_type(), expected);
+}
+
+struct NarrowIntegerType {
+  const char* name;
+  int8_t bits;
+  bool isSigned;
+  int32_t minimum;
+  int32_t maximum;
+};
+
+constexpr NarrowIntegerType kNarrowIntegers[] = {
+    {"i8", 8, true, INT8_MIN, INT8_MAX},
+    {"u8", 8, false, 0, UINT8_MAX},
+    {"i16", 16, true, INT16_MIN, INT16_MAX},
+    {"u16", 16, false, 0, UINT16_MAX},
+};
+
+std::shared_ptr<InputState> narrowIntegerFile(bool nested, bool dictionary) {
+  carquet_error_t error = CARQUET_ERROR_INIT;
+  std::unique_ptr<carquet_schema_t, decltype(&carquet_schema_free)> schema(
+      carquet_schema_create(&error), carquet_schema_free);
+  if (!schema) {
+    throw std::runtime_error(error.message);
+  }
+  for (const auto& type : kNarrowIntegers) {
+    carquet_logical_type_t logical{};
+    logical.id = CARQUET_LOGICAL_INTEGER;
+    logical.params.integer = {.bit_width = type.bits,
+                              .is_signed = type.isSigned};
+    const int32_t parent =
+        nested ? carquet_schema_add_list_group(schema.get(), type.name,
+                                               CARQUET_REPETITION_OPTIONAL, 0)
+               : 0;
+    if (parent < 0) {
+      throw std::runtime_error("Failed to create narrow integer list schema");
+    }
+    checkCarquet(carquet_schema_add_column(
+        schema.get(), nested ? "element" : type.name, CARQUET_PHYSICAL_INT32,
+        &logical, CARQUET_REPETITION_OPTIONAL, 0, parent));
+  }
+  carquet_writer_options_t options;
+  carquet_writer_options_init(&options);
+  options.dictionary_encoding =
+      dictionary ? CARQUET_ENCODING_RLE_DICTIONARY : CARQUET_ENCODING_PLAIN;
+  test::BufferWriter writer(
+      carquet_writer_create_buffer(schema.get(), &options, &error),
+      carquet_writer_abort);
+  if (!writer) {
+    throw std::runtime_error(error.message);
+  }
+  if (dictionary) {
+    for (int column = 0; column < 4; ++column) {
+      checkCarquet(carquet_writer_set_column_encoding(
+          writer.get(), column, CARQUET_ENCODING_RLE_DICTIONARY));
+    }
+  }
+  for (int group = 0; group < 2; ++group) {
+    for (int column = 0; column < 4; ++column) {
+      const auto& type = kNarrowIntegers[column];
+      // Parquet stores all four logical integer types as physical INT32.
+      // Avoid the C Data writer here so it cannot conceal a reader ABI bug.
+      const int32_t values[] = {type.minimum,     type.maximum,    0, 1, 42,
+                                type.minimum + 1, type.maximum - 1};
+      const int16_t flatDefined[] = {1, 1, 0, 1, 1, 1, 1, 1};
+      // [min, NULL, max], [], NULL, [0], [1, 42], [min+1, max-1].
+      const int16_t nestedDefined[] = {3, 2, 3, 1, 0, 3, 3, 3, 3, 3};
+      const int16_t repeated[] = {0, 1, 1, 0, 0, 0, 0, 1, 0, 1};
+      checkCarquet(carquet_writer_write_batch(
+          writer.get(), column, values, nested ? 10 : 8,
+          nested ? nestedDefined : flatDefined, nested ? repeated : nullptr));
+    }
+    if (group == 0) {
+      checkCarquet(carquet_writer_new_row_group(writer.get()));
+    }
+  }
+  return std::make_shared<InputState>(
+      InputState{.bytes = test::finish(std::move(writer))});
+}
+
+void expectNarrowInteger(const Value& value, int32_t expected,
+                         const NarrowIntegerType& type) {
+  ASSERT_FALSE(value.IsNull());
+  if (type.isSigned) {
+    EXPECT_EQ(value.GetValue<int32_t>(), expected);
+  } else {
+    EXPECT_EQ(value.GetValue<uint32_t>(), static_cast<uint32_t>(expected));
+  }
+}
+
+TEST(CarquetChunkSupplierTest, ReadsNarrowIntegersThroughBothExportPaths) {
+  for (bool dictionary : {false, true}) {
+    for (bool projected : {false, true}) {
+      SCOPED_TRACE(dictionary);
+      SCOPED_TRACE(projected);
+      auto state = narrowIntegerFile(false, dictionary);
+      // Full flat scans export row batches; projection selects the row-group
+      // C Data path. Both must use the width declared by the ArrowSchema.
+      const std::vector<int32_t> columns =
+          projected ? std::vector<int32_t>{3, 1, 2, 0}
+                    : std::vector<int32_t>{0, 1, 2, 3};
+      auto supplier = CarquetChunkSupplier::create(
+          std::make_unique<MemoryInput>(state),
+          {.batchSize = 3,
+           .topLevelFields = projected ? columns : std::vector<int32_t>{}});
+      ASSERT_TRUE(supplier) << supplier.error().ToString();
+      ASSERT_EQ((*supplier)->RowNum(), 16);
+      size_t rowIndex = 0;
+      while (auto chunk = (*supplier)->GetNextChunk()) {
+        ASSERT_EQ(chunk->col_num(), 4u);
+        ASSERT_LE(chunk->row_num(), 3u);
+        for (size_t row = 0; row < chunk->row_num(); ++row, ++rowIndex) {
+          for (size_t column = 0; column < columns.size(); ++column) {
+            const auto& type = kNarrowIntegers[columns[column]];
+            const auto value = chunk->get(column)->get_elem(row);
+            if (rowIndex % 8 == 2) {
+              EXPECT_TRUE(value.IsNull());
+            } else {
+              const int32_t expected[] = {
+                  type.minimum,     type.maximum,    0, 0, 1, 42,
+                  type.minimum + 1, type.maximum - 1};
+              expectNarrowInteger(value, expected[rowIndex % 8], type);
+            }
+          }
+        }
+      }
+      EXPECT_EQ(rowIndex, 16u);
+    }
+  }
+}
+
+TEST(CarquetChunkSupplierTest, ReadsNarrowIntegerListsWithParentAndChildNulls) {
+  for (bool dictionary : {false, true}) {
+    auto state = narrowIntegerFile(true, dictionary);
+    auto supplier = CarquetChunkSupplier::create(
+        std::make_unique<MemoryInput>(state), {.batchSize = 2});
+    ASSERT_TRUE(supplier) << supplier.error().ToString();
+    ASSERT_EQ((*supplier)->RowNum(), 12);
+    size_t rowIndex = 0;
+    while (auto chunk = (*supplier)->GetNextChunk()) {
+      ASSERT_EQ(chunk->col_num(), 4u);
+      for (size_t row = 0; row < chunk->row_num(); ++row, ++rowIndex) {
+        for (size_t column = 0; column < 4; ++column) {
+          const auto& type = kNarrowIntegers[column];
+          const auto value = chunk->get(column)->get_elem(row);
+          if (rowIndex % 6 == 2) {
+            EXPECT_TRUE(value.IsNull());
+            continue;
+          }
+          ASSERT_FALSE(value.IsNull());
+          const std::vector<std::vector<std::optional<int32_t>>> expected = {
+              {type.minimum, std::nullopt, type.maximum}, {}, {}, {0}, {1, 42},
+              {type.minimum + 1, type.maximum - 1}};
+          const auto& values = expected[rowIndex % 6];
+          const auto& children = ListValue::GetChildren(value);
+          ASSERT_EQ(children.size(), values.size());
+          for (size_t child = 0; child < values.size(); ++child) {
+            if (values[child]) {
+              expectNarrowInteger(children[child], *values[child], type);
+            } else {
+              EXPECT_TRUE(children[child].IsNull());
+            }
+          }
+        }
+      }
+    }
+    EXPECT_EQ(rowIndex, 12u);
+  }
+}
+
+TEST(CarquetChunkSupplierTest, StreamsOwnedScalarChunksAcrossRowGroups) {
+  for (auto codec :
+       {CARQUET_COMPRESSION_UNCOMPRESSED, CARQUET_COMPRESSION_SNAPPY,
+        CARQUET_COMPRESSION_GZIP, CARQUET_COMPRESSION_ZSTD}) {
+    SCOPED_TRACE(static_cast<int>(codec));
+    auto state = scalarFileState(2, codec);
+    std::shared_ptr<DataChunk> retained;
+    std::vector<int64_t> ids;
+    std::vector<std::string> categories;
+    {
+      auto supplier =
+          CarquetChunkSupplier::create(std::make_unique<MemoryInput>(state),
+                                       {.batchSize = 3, .numThreads = 1});
+      ASSERT_TRUE(supplier) << supplier.error().ToString();
+      EXPECT_EQ((*supplier)->RowNum(), 12);
+      ASSERT_EQ(
+          (*supplier)->schema()->columnNames,
+          (std::vector<std::string>{"id", "flag", "measurement", "category"}));
+      expectPrimitive((*supplier)->schema()->columnTypes[0],
+                      ::common::DT_SIGNED_INT64);
+      expectPrimitive((*supplier)->schema()->columnTypes[1], ::common::DT_BOOL);
+      expectPrimitive((*supplier)->schema()->columnTypes[2],
+                      ::common::DT_FLOAT);
+      EXPECT_EQ((*supplier)->schema()->columnTypes[3]->item_case(),
+                ::common::DataType::kString);
+      while (auto chunk = (*supplier)->GetNextChunk()) {
+        EXPECT_GT(chunk->row_num(), 0u);
+        EXPECT_LE(chunk->row_num(), 3u);
+        ASSERT_EQ(chunk->col_num(), 4u);
+        if (!retained) {
+          retained = chunk;
+        }
+        for (size_t row = 0; row < chunk->row_num(); ++row) {
+          const int64_t id = valueAt<int64_t>(chunk, 0, row);
+          ids.push_back(id);
+          for (int col = 1; col < 4; ++col) {
+            EXPECT_EQ(chunk->get(col)->get_elem(row).IsNull(), id % 6 == 3);
+          }
+          if (id % 6 != 3) {
+            categories.push_back(valueAt<std::string>(chunk, 3, row));
+          }
+        }
+      }
+      EXPECT_EQ((*supplier)->GetNextChunk(), nullptr);
+      EXPECT_EQ((*supplier)->GetNextChunk(), nullptr);
+    }
+    EXPECT_EQ(ids,
+              (std::vector<int64_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}));
+    EXPECT_EQ(categories,
+              (std::vector<std::string>{"", "中文", "b", "a", "c", "", "中文",
+                                        "b", "a", "c"}));
+    ASSERT_NE(retained, nullptr);
+    EXPECT_EQ(valueAt<int64_t>(retained, 0, 0), 1);
+    EXPECT_TRUE(valueAt<bool>(retained, 1, 0));
+    EXPECT_FALSE(valueAt<bool>(retained, 1, 1));
+    EXPECT_FLOAT_EQ(valueAt<float>(retained, 2, 1), -1.25f);
+    EXPECT_EQ(valueAt<std::string>(retained, 3, 1), "中文");
+    EXPECT_TRUE(retained->get(3)->get_elem(2).IsNull());
+    EXPECT_EQ(state->closeCalls, 1);
+    EXPECT_EQ(state->destructCalls, 1);
+  }
+}
+
+TEST(CarquetChunkSupplierTest, ReadsExistingIndependentScalarDataset) {
+  auto state = fixtureState("comprehensive_graph/parquet/node_a.parquet");
+  auto supplier = CarquetChunkSupplier::create(
+      std::make_unique<MemoryInput>(state), {.batchSize = 3});
+  ASSERT_TRUE(supplier) << supplier.error().ToString();
+  ASSERT_EQ((*supplier)->RowNum(), 10);
+  const auto& types = (*supplier)->schema()->columnTypes;
+  ASSERT_EQ(types.size(), 11u);
+  expectPrimitive(types[1], ::common::DT_SIGNED_INT32);
+  expectPrimitive(types[3], ::common::DT_UNSIGNED_INT32);
+  expectPrimitive(types[4], ::common::DT_UNSIGNED_INT64);
+  EXPECT_TRUE(types[8]->temporal().has_date());
+  EXPECT_TRUE(types[9]->temporal().has_timestamp());
+  auto chunk = (*supplier)->GetNextChunk();
+  ASSERT_NE(chunk, nullptr);
+  ASSERT_EQ(chunk->col_num(), 11u);
+  ASSERT_EQ(chunk->row_num(), 3u);
+  EXPECT_EQ(valueAt<int32_t>(chunk, 1, 0), -123456789);
+  EXPECT_EQ(valueAt<int64_t>(chunk, 2, 0), std::numeric_limits<int64_t>::max());
+  EXPECT_EQ(valueAt<int64_t>(chunk, 2, 1), std::numeric_limits<int64_t>::min());
+  EXPECT_EQ(valueAt<uint32_t>(chunk, 3, 0),
+            std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(valueAt<uint64_t>(chunk, 4, 0),
+            std::numeric_limits<uint64_t>::max());
+  EXPECT_EQ(valueAt<uint64_t>(chunk, 4, 2), uint64_t{1} << 63);
+  EXPECT_FLOAT_EQ(valueAt<float>(chunk, 5, 0), 3.1415927f);
+  EXPECT_DOUBLE_EQ(valueAt<double>(chunk, 6, 0), 2.718281828459045);
+  EXPECT_EQ(valueAt<std::string>(chunk, 7, 0), "test_string_0");
+  EXPECT_EQ(valueAt<Date>(chunk, 8, 0).to_string(), "2023-01-15");
+  EXPECT_EQ(valueAt<DateTime>(chunk, 9, 0).milli_second, 1673740800000LL);
+  size_t rows = chunk->row_num();
+  while (auto next = (*supplier)->GetNextChunk()) {
+    rows += next->row_num();
+  }
+  EXPECT_EQ(rows, 10u);
+  supplier->reset();
+  EXPECT_EQ(valueAt<std::string>(chunk, 7, 0), "test_string_0");
+  EXPECT_EQ(state->closeCalls, 1);
+}
+
+TEST(CarquetChunkSupplierTest, SniffsMetadataThroughFreshExistingStreams) {
+  auto bytes = fixtureState("tinysnb/parquet/eMeets.parquet")->bytes;
+  std::vector<std::shared_ptr<InputState>> states;
+  CarquetSniffer sniffer([&]() {
+    auto state = std::make_shared<InputState>(InputState{.bytes = bytes});
+    states.push_back(state);
+    return std::make_unique<MemoryInput>(state);
+  });
+  for (int attempt = 0; attempt < 2; ++attempt) {
+    auto schema = sniffer.sniff();
+    ASSERT_TRUE(schema) << schema.error().ToString();
+    EXPECT_EQ(
+        (*schema)->columnNames,
+        (std::vector<std::string>{"from", "to", "location", "times", "data"}));
+  }
+  ASSERT_EQ(states.size(), 2u);
+  for (const auto& state : states) {
+    EXPECT_GT(state->readCalls, 0);
+    EXPECT_EQ(state->closeCalls, 1);
+    EXPECT_EQ(state->destructCalls, 1);
+  }
+  auto nested =
+      fixtureState("comprehensive_graph/parquet/parquet_list.parquet");
+  CarquetSniffer nestedSniffer(
+      [nested]() { return std::make_unique<MemoryInput>(nested); });
+  auto schema = nestedSniffer.sniff();
+  ASSERT_TRUE(schema) << schema.error().ToString();
+  EXPECT_EQ(nested->closeCalls, 1);
+}
+
+TEST(CarquetChunkSupplierTest, HandlesEmptyInvalidAndMalformedInputs) {
+  auto empty = scalarFileState(0);
+  {
+    auto supplier =
+        CarquetChunkSupplier::create(std::make_unique<MemoryInput>(empty));
+    ASSERT_TRUE(supplier) << supplier.error().ToString();
+    EXPECT_EQ((*supplier)->RowNum(), 0);
+    EXPECT_EQ((*supplier)->GetNextChunk(), nullptr);
+    EXPECT_EQ((*supplier)->GetNextChunk(), nullptr);
+  }
+  EXPECT_EQ(empty->closeCalls, 1);
+  for (auto options : {CarquetReaderOptions{.batchSize = 0},
+                       CarquetReaderOptions{.numThreads = -1}}) {
+    auto rejected = scalarFileState(0);
+    auto bad = CarquetChunkSupplier::create(
+        std::make_unique<MemoryInput>(rejected), options);
+    ASSERT_FALSE(bad);
+    EXPECT_EQ(bad.error().error_code(), StatusCode::ERR_INVALID_ARGUMENT);
+    EXPECT_EQ(rejected->closeCalls, 1);
+    EXPECT_EQ(rejected->destructCalls, 1);
+  }
+  auto broken = std::make_shared<InputState>(
+      InputState{.bytes = std::make_shared<std::vector<uint8_t>>(
+                     std::initializer_list<uint8_t>{'N', 'O', 'P', 'E'})});
+  auto invalid =
+      CarquetChunkSupplier::create(std::make_unique<MemoryInput>(broken));
+  ASSERT_FALSE(invalid);
+  EXPECT_EQ(invalid.error().error_code(), StatusCode::ERR_IO_ERROR);
+  EXPECT_EQ(broken->closeCalls, 1);
+  EXPECT_EQ(broken->destructCalls, 1);
+  EXPECT_FALSE(CarquetChunkSupplier::create(nullptr));
+  CarquetSniffer nullFactory(nullptr);
+  EXPECT_FALSE(nullFactory.sniff());
+  CarquetSniffer nullStream(
+      []() { return std::unique_ptr<io::InputStream>{}; });
+  EXPECT_FALSE(nullStream.sniff());
+}
+
+TEST(CarquetChunkSupplierTest, ReleasesInputAfterMidReadFailure) {
+  auto state = scalarFileState(2);
+  {
+    auto supplier = CarquetChunkSupplier::create(
+        std::make_unique<MemoryInput>(state), {.bufferedStream = false});
+    ASSERT_TRUE(supplier) << supplier.error().ToString();
+    state->failReads = true;
+    EXPECT_THROW((*supplier)->GetNextChunk(), exception::IOException);
+  }
+  EXPECT_EQ(state->closeCalls, 1);
+  EXPECT_EQ(state->destructCalls, 1);
+}
+
+template <typename Source, typename Dest>
+void expectSlicedPrimitive(const char* format) {
+  SCOPED_TRACE(format);
+  const Source data[] = {0, std::numeric_limits<Source>::lowest(), 0,
+                         std::numeric_limits<Source>::max()};
+  const uint8_t validity = 0x0a;  // Indices 1 and 3 are valid.
+  const void* buffers[] = {&validity, data};
+  ArrowSchema schema{.format = format};
+  ArrowArray array{.length = 3,
+                   .null_count = -1,
+                   .offset = 1,
+                   .n_buffers = 2,
+                   .buffers = buffers};
+  auto converted = convertArrowCScalarColumn(schema, array);
+  ASSERT_TRUE(converted) << converted.error().ToString();
+  EXPECT_EQ((*converted)->get_elem(0).GetValue<Dest>(),
+            static_cast<Dest>(data[1]));
+  EXPECT_TRUE((*converted)->get_elem(1).IsNull());
+  EXPECT_EQ((*converted)->get_elem(2).GetValue<Dest>(),
+            static_cast<Dest>(data[3]));
+}
+
+TEST(CarquetScalarConverterTest, PreservesSlicedNumericValuesAndNulls) {
+  expectSlicedPrimitive<int8_t, int32_t>("c");
+  expectSlicedPrimitive<int16_t, int32_t>("s");
+  expectSlicedPrimitive<int32_t, int32_t>("i");
+  expectSlicedPrimitive<int64_t, int64_t>("l");
+  expectSlicedPrimitive<uint8_t, uint32_t>("C");
+  expectSlicedPrimitive<uint16_t, uint32_t>("S");
+  expectSlicedPrimitive<uint32_t, uint32_t>("I");
+  expectSlicedPrimitive<uint64_t, uint64_t>("L");
+  expectSlicedPrimitive<float, float>("f");
+  expectSlicedPrimitive<double, double>("g");
+}
+
+TEST(CarquetScalarConverterTest, PreservesFloatingSpecialValues) {
+  const double values[] = {std::numeric_limits<double>::quiet_NaN(),
+                           std::numeric_limits<double>::infinity(),
+                           -std::numeric_limits<double>::infinity()};
+  const void* buffers[] = {nullptr, values};
+  ArrowSchema schema{.format = "g"};
+  ArrowArray array{.length = 3, .n_buffers = 2, .buffers = buffers};
+  auto converted = convertArrowCScalarColumn(schema, array);
+  ASSERT_TRUE(converted) << converted.error().ToString();
+  EXPECT_FALSE((*converted)->get_elem(0).IsNull());
+  EXPECT_TRUE(std::isnan((*converted)->get_elem(0).GetValue<double>()));
+  EXPECT_EQ((*converted)->get_elem(1).GetValue<double>(), values[1]);
+  EXPECT_EQ((*converted)->get_elem(2).GetValue<double>(), values[2]);
+}
+
+TEST(CarquetScalarConverterTest, ConvertsTemporalUnitsAndRejectsOverflow) {
+  const int64_t ticks[] = {0, -1000000, 123000000, 0};
+  const uint8_t validity = 0x07;
+  const void* buffers[] = {&validity, ticks};
+  ArrowArray array{
+      .length = 4, .null_count = 1, .n_buffers = 2, .buffers = buffers};
+  struct TimestampCase {
+    const char* format;
+    int64_t negativeMillis;
+    int64_t positiveMillis;
+  };
+  for (const auto& test : {TimestampCase{"tss:", -1000000000, 123000000000},
+                           {"tsm:", -1000000, 123000000},
+                           {"tsu:", -1000, 123000},
+                           {"tsn:", -1, 123}}) {
+    ArrowSchema schema{.format = test.format};
+    auto converted = convertArrowCScalarColumn(schema, array);
+    ASSERT_TRUE(converted) << converted.error().ToString();
+    EXPECT_EQ((*converted)->get_elem(0).GetValue<DateTime>().milli_second, 0);
+    EXPECT_EQ((*converted)->get_elem(1).GetValue<DateTime>().milli_second,
+              test.negativeMillis);
+    EXPECT_EQ((*converted)->get_elem(2).GetValue<DateTime>().milli_second,
+              test.positiveMillis);
+    EXPECT_TRUE((*converted)->get_elem(3).IsNull());
+  }
+  const int64_t dateMillis[] = {0, -86400000, 1709164800000, 0};
+  buffers[1] = dateMillis;
+  ArrowSchema dateSchema{.format = "tdm"};
+  auto dates = convertArrowCScalarColumn(dateSchema, array);
+  ASSERT_TRUE(dates) << dates.error().ToString();
+  EXPECT_EQ((*dates)->get_elem(1).GetValue<Date>().to_num_days(), -1);
+  EXPECT_EQ((*dates)->get_elem(2).GetValue<Date>().to_string(), "2024-02-29");
+  EXPECT_TRUE((*dates)->get_elem(3).IsNull());
+  const int64_t overflow[] = {std::numeric_limits<int64_t>::min(),
+                              std::numeric_limits<int64_t>::max()};
+  array.length = 1;
+  array.null_count = 0;
+  for (const auto& value : overflow) {
+    buffers[1] = &value;
+    for (const char* format : {"tss:", "tdm"}) {
+      ArrowSchema schema{.format = format};
+      EXPECT_FALSE(convertArrowCScalarColumn(schema, array));
+    }
+  }
+}
+
+TEST(CarquetScalarConverterTest, ValidatesStringsAndOwnsLargeStringSlices) {
+  const int32_t badOffsets[] = {0, 4, 2};
+  const void* buffers[] = {nullptr, badOffsets, "abcd"};
+  ArrowSchema schema{.format = "u", .name = "label"};
+  ArrowArray array{
+      .length = 2, .null_count = 0, .n_buffers = 3, .buffers = buffers};
+  auto malformed = convertArrowCScalarColumn(schema, array);
+  ASSERT_FALSE(malformed);
+  EXPECT_NE(malformed.error().error_message().find("decreasing"),
+            std::string::npos);
+  int64_t offsets[] = {0, 4, 4, 10, 10};
+  std::string text = "skip中文";
+  const uint8_t validity = 0x07;
+  buffers[0] = &validity;
+  buffers[1] = offsets;
+  buffers[2] = text.data();
+  schema.format = "U";
+  array.length = 3;
+  array.offset = 1;
+  array.null_count = 1;
+  auto converted = convertArrowCScalarColumn(schema, array);
+  ASSERT_TRUE(converted) << converted.error().ToString();
+  text.assign(text.size(), 'x');
+  EXPECT_EQ((*converted)->get_elem(0).GetValue<std::string>(), "");
+  EXPECT_EQ((*converted)->get_elem(1).GetValue<std::string>(), "中文");
+  EXPECT_TRUE((*converted)->get_elem(2).IsNull());
+}
+
+TEST(CarquetScalarConverterTest, RejectsInvalidSchemasAndStructLayouts) {
+  ArrowSchema field{.format = "l", .name = "id"};
+  ArrowSchema* children[] = {&field, &field};
+  ArrowSchema root{.format = "+s", .n_children = 2, .children = children};
+  EXPECT_FALSE(convertArrowCStructSchema(root));  // Duplicate field names.
+  field.name = nullptr;
+  root.n_children = 1;
+  EXPECT_FALSE(convertArrowCStructSchema(root));
+  field.name = "id";
+  field.format = "z";
+  EXPECT_FALSE(convertArrowCStructSchema(root));
+  field.format = "l";
+  field.dictionary = &field;
+  EXPECT_FALSE(convertArrowCStructSchema(root));
+  field.dictionary = nullptr;
+  const int64_t value = 1;
+  const void* scalarBuffers[] = {nullptr, &value};
+  ArrowArray child{.length = 1, .n_buffers = 2, .buffers = scalarBuffers};
+  ArrowArray* arrays[] = {&child};
+  const void* rootBuffers[] = {nullptr};
+  ArrowArray array{.length = 2,
+                   .n_buffers = 1,
+                   .n_children = 1,
+                   .buffers = rootBuffers,
+                   .children = arrays};
+  EXPECT_FALSE(
+      convertArrowCFlatStruct(root, array));  // Child row count mismatch.
+  array.length = 1;
+  EXPECT_TRUE(convertArrowCFlatStruct(root, array));
+  child.offset = std::numeric_limits<int64_t>::max();
+  EXPECT_FALSE(convertArrowCScalarColumn(field, child));
+  child.offset = 0;
+  child.null_count = 1;
+  EXPECT_FALSE(convertArrowCScalarColumn(field, child));  // Missing validity.
+}
+
+void expectIntList(const Value& value,
+                   const std::vector<std::optional<int64_t>>& expected) {
+  ASSERT_FALSE(value.IsNull());
+  const auto& children = ListValue::GetChildren(value);
+  ASSERT_EQ(children.size(), expected.size());
+  for (size_t i = 0; i < expected.size(); ++i) {
+    if (expected[i]) {
+      EXPECT_EQ(children[i].GetValue<int64_t>(), *expected[i]) << i;
+    } else {
+      EXPECT_TRUE(children[i].IsNull()) << i;
+    }
+  }
+}
+
+TEST(CarquetChunkSupplierTest, ReadsListsAndFixedArraysThroughSameSupplier) {
+  auto state =
+      std::make_shared<InputState>(InputState{.bytes = test::nestedFile()});
+  std::shared_ptr<DataChunk> retained;
+  size_t globalRow = 0;
+  {
+    auto supplier = CarquetChunkSupplier::create(
+        std::make_unique<MemoryInput>(state), {.batchSize = 2});
+    ASSERT_TRUE(supplier) << supplier.error().ToString();
+    EXPECT_EQ((*supplier)->RowNum(), 4);
+    ASSERT_EQ((*supplier)->schema()->columnTypes.size(), 3u);
+    EXPECT_EQ((*supplier)->schema()->columnTypes[0]->item_case(),
+              ::common::DataType::kList);
+    ASSERT_EQ((*supplier)->schema()->columnTypes[1]->item_case(),
+              ::common::DataType::kArray);
+    EXPECT_EQ((*supplier)->schema()->columnTypes[1]->array().fixed_length(),
+              3u);
+    ASSERT_EQ((*supplier)->schema()->columnTypes[2]->item_case(),
+              ::common::DataType::kArray);
+    EXPECT_EQ((*supplier)
+                  ->schema()
+                  ->columnTypes[2]
+                  ->array()
+                  .component_type()
+                  .array()
+                  .fixed_length(),
+              2u);
+
+    while (auto chunk = (*supplier)->GetNextChunk()) {
+      EXPECT_EQ(chunk->row_num(), 2u);
+      ASSERT_EQ(chunk->col_num(), 3u);
+      if (!retained) {
+        retained = chunk;
+      }
+      for (size_t row = 0; row < chunk->row_num(); ++row, ++globalRow) {
+        const Value items = chunk->get(0)->get_elem(row);
+        if (globalRow == 0) {
+          expectIntList(items, {1, std::nullopt, 3});
+        } else if (globalRow == 1) {
+          expectIntList(items, {});
+        } else if (globalRow == 2) {
+          EXPECT_TRUE(items.IsNull());
+        } else {
+          expectIntList(items, {4, 5});
+        }
+
+        const Value fixed = chunk->get(1)->get_elem(row);
+        ASSERT_EQ(ArrayValue::GetChildren(fixed).size(), 3u);
+        const Value matrix = chunk->get(2)->get_elem(row);
+        ASSERT_EQ(ArrayValue::GetChildren(matrix).size(), 2u);
+        ASSERT_EQ(
+            ArrayValue::GetChildren(ArrayValue::GetChildren(matrix)[0]).size(),
+            2u);
+      }
+    }
+    EXPECT_EQ((*supplier)->GetNextChunk(), nullptr);
+  }
+
+  EXPECT_EQ(globalRow, 4u);
+  EXPECT_EQ(state->closeCalls, 1);
+  EXPECT_EQ(state->destructCalls, 1);
+  ASSERT_NE(retained, nullptr);
+  expectIntList(retained->get(0)->get_elem(0), {1, std::nullopt, 3});
+  const Value fixedValue = retained->get(1)->get_elem(0);
+  const auto& fixed = ArrayValue::GetChildren(fixedValue);
+  EXPECT_DOUBLE_EQ(fixed[0].GetValue<double>(), 1.0);
+  EXPECT_TRUE(fixed[1].IsNull());
+  EXPECT_DOUBLE_EQ(fixed[2].GetValue<double>(), 3.0);
+
+  auto projectedState =
+      std::make_shared<InputState>(InputState{.bytes = state->bytes});
+  auto projected = CarquetChunkSupplier::create(
+      std::make_unique<MemoryInput>(projectedState),
+      {.batchSize = 1, .topLevelFields = {2, 0}});
+  ASSERT_TRUE(projected) << projected.error().ToString();
+  auto first = (*projected)->GetNextChunk();
+  ASSERT_NE(first, nullptr);
+  ASSERT_EQ(first->col_num(), 2u);
+  ASSERT_EQ(first->row_num(), 1u);
+  const auto matrix = first->get(0)->get_elem(0);
+  EXPECT_EQ(ArrayValue::GetChildren(ArrayValue::GetChildren(matrix)[0])[0]
+                .GetValue<int32_t>(),
+            1);
+  expectIntList(first->get(1)->get_elem(0), {1, std::nullopt, 3});
+  size_t projectedRows = first->row_num();
+  while (auto chunk = (*projected)->GetNextChunk()) {
+    EXPECT_EQ(chunk->col_num(), 2u);
+    EXPECT_LE(chunk->row_num(), 1u);
+    projectedRows += chunk->row_num();
+  }
+  EXPECT_EQ(projectedRows, 4u);
+  projected->reset();
+  EXPECT_EQ(projectedState->closeCalls, 1);
+}
+
+TEST(CarquetChunkSupplierTest, RejectsInvalidNestedRangesAndArrayLengths) {
+  const int64_t values[] = {1, 2, 3};
+  const void* childBuffers[] = {nullptr, values};
+  ArrowSchema childSchema = {.format = "l", .name = "element"};
+  ArrowArray childArray = {.length = 3,
+                           .null_count = 0,
+                           .offset = 0,
+                           .n_buffers = 2,
+                           .buffers = childBuffers};
+  ArrowSchema* schemaChildren[] = {&childSchema};
+  ArrowArray* arrayChildren[] = {&childArray};
+
+  const int32_t decreasingOffsets[] = {0, 3, 2};
+  const void* listBuffers[] = {nullptr, decreasingOffsets};
+  ArrowSchema listSchema = {.format = "+l",
+                            .name = "items",
+                            .n_children = 1,
+                            .children = schemaChildren};
+  ArrowArray listArray = {.length = 2,
+                          .null_count = 0,
+                          .offset = 0,
+                          .n_buffers = 2,
+                          .n_children = 1,
+                          .buffers = listBuffers,
+                          .children = arrayChildren};
+  auto converted = convertArrowCColumn(listSchema, listArray);
+  ASSERT_FALSE(converted);
+  EXPECT_NE(converted.error().error_message().find("monotonic"),
+            std::string::npos);
+
+  const uint8_t validity[] = {0b00000010};
+  const int32_t compactOffsets[] = {0, 2, 4};
+  const void* arrayBuffers[] = {validity, compactOffsets};
+  ArrowSchema fixedSchema = {.format = "+w:2",
+                             .name = "fixed",
+                             .n_children = 1,
+                             .children = schemaChildren};
+  ArrowArray fixedArray = {.length = 2,
+                           .null_count = 1,
+                           .offset = 0,
+                           .n_buffers = 2,
+                           .n_children = 1,
+                           .buffers = arrayBuffers,
+                           .children = arrayChildren};
+  converted = convertArrowCColumn(fixedSchema, fixedArray);
+  ASSERT_FALSE(converted);
+  EXPECT_NE(converted.error().error_message().find(
+                "null value contains compact child elements"),
+            std::string::npos);
+}
+
+TEST(CarquetChunkSupplierTest, PreservesMapSchemaWithoutAddingMapValues) {
+  ArrowSchema key{.format = "u", .name = "key"};
+  ArrowSchema value{.format = "l", .name = "value"};
+  ArrowSchema* entriesFields[] = {&key, &value};
+  ArrowSchema entries{
+      .format = "+s", .n_children = 2, .children = entriesFields};
+  ArrowSchema* mapFields[] = {&entries};
+  ArrowSchema map{.format = "+m",
+                  .name = "attributes",
+                  .n_children = 1,
+                  .children = mapFields};
+  ArrowSchema* fields[] = {&map};
+  ArrowSchema root{.format = "+s", .n_children = 1, .children = fields};
+  auto converted = convertArrowCStructSchema(root);
+  ASSERT_TRUE(converted) << converted.error().ToString();
+  const auto& type = (*converted)->columnTypes.front()->map();
+  EXPECT_TRUE(type.key_type().has_string());
+  EXPECT_EQ(type.value_type().primitive_type(),
+            ::common::PrimitiveType::DT_SIGNED_INT64);
+  ArrowArray array{};
+  EXPECT_FALSE(convertArrowCColumn(map, array));
+  entries.n_children = 1;
+  EXPECT_FALSE(convertArrowCStructSchema(root));
+}
+
+TEST(CarquetChunkSupplierTest, ReadsExistingListValuesAndValidatesSelections) {
+  auto input = fixtureState("comprehensive_graph/parquet/parquet_list.parquet");
+  auto supplier =
+      CarquetChunkSupplier::create(std::make_unique<MemoryInput>(input));
+  ASSERT_TRUE(supplier) << supplier.error().ToString();
+  auto chunk = (*supplier)->GetNextChunk();
+  ASSERT_NE(chunk, nullptr);
+  ASSERT_EQ(chunk->row_num(), 1u);
+  ASSERT_EQ(chunk->col_num(), 1u);
+  supplier->reset();
+  expectIntList(chunk->get(0)->get_elem(0), {1, 2, 3});
+  EXPECT_EQ(input->closeCalls, 1);
+  for (const auto& options : {CarquetReaderOptions{.topLevelFields = {-1}},
+                              CarquetReaderOptions{.topLevelFields = {4}},
+                              CarquetReaderOptions{.topLevelFields = {0, 0}},
+                              CarquetReaderOptions{.rowGroups = {-1}},
+                              CarquetReaderOptions{.rowGroups = {2}},
+                              CarquetReaderOptions{.rowGroups = {0, 0}}}) {
+    auto state = scalarFileState(2);
+    EXPECT_FALSE(CarquetChunkSupplier::create(
+        std::make_unique<MemoryInput>(state), options));
+    EXPECT_EQ(state->closeCalls, 1);
+    EXPECT_EQ(state->destructCalls, 1);
+  }
+}
+
+}  // namespace
+
+}  // namespace neug::parquet

--- a/extension/parquet/tests/carquet_scan_test.cc
+++ b/extension/parquet/tests/carquet_scan_test.cc
@@ -1,0 +1,840 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <atomic>
+#include <barrier>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <limits>
+#include <map>
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "carquet/chunk_supplier.h"
+#include "carquet/output_adapter.h"
+#include "carquet/row_group_pruner.h"
+#include "carquet/scan.h"
+#include "carquet_test_data.h"
+#include "neug/generated/proto/plan/expr.pb.h"
+#include "neug/utils/exception/exception.h"
+#include "neug/utils/io/read/common/row_expression_filter.h"
+
+namespace neug::parquet {
+namespace {
+
+struct StreamStats {
+  std::atomic<int> opens = 0;
+  std::atomic<int> closes = 0;
+  std::atomic<int> readCalls = 0;
+  std::atomic<int64_t> requestedBytes = 0;
+  std::atomic<int> activeReads = 0;
+  std::atomic<int> maxActiveReads = 0;
+  std::shared_ptr<std::barrier<>> firstReadBarrier;
+
+  void reset() {
+    opens = 0;
+    closes = 0;
+    readCalls = 0;
+    requestedBytes = 0;
+    activeReads = 0;
+    maxActiveReads = 0;
+  }
+};
+
+class MemoryInput final : public io::InputStream {
+ public:
+  MemoryInput(std::shared_ptr<std::vector<uint8_t>> bytes,
+              std::shared_ptr<StreamStats> stats, bool synchronizeFirstRead)
+      : bytes_(std::move(bytes)),
+        stats_(std::move(stats)),
+        synchronizeFirstRead_(synchronizeFirstRead) {}
+
+  result<int64_t> Read(void* out, int64_t nbytes) override {
+    auto read = ReadAt(position_, nbytes, out);
+    if (read) {
+      position_ += *read;
+    }
+    return read;
+  }
+
+  result<int64_t> ReadAt(int64_t position, int64_t nbytes, void* out) override {
+    ++stats_->readCalls;
+    stats_->requestedBytes += nbytes;
+    if (synchronizeFirstRead_ && !synchronized_) {
+      synchronized_ = true;
+      const int active = ++stats_->activeReads;
+      int maximum = stats_->maxActiveReads.load();
+      while (active > maximum &&
+             !stats_->maxActiveReads.compare_exchange_weak(maximum, active)) {}
+      stats_->firstReadBarrier->arrive_and_wait();
+      --stats_->activeReads;
+    }
+    if (position < 0 || nbytes < 0 || (nbytes > 0 && !out)) {
+      RETURN_STATUS_ERROR(StatusCode::ERR_INVALID_ARGUMENT,
+                          "invalid memory read");
+    }
+    if (position >= static_cast<int64_t>(bytes_->size())) {
+      return int64_t{0};
+    }
+    const int64_t count =
+        std::min(nbytes, static_cast<int64_t>(bytes_->size()) - position);
+    if (count > 0) {
+      std::memcpy(out, bytes_->data() + position, static_cast<size_t>(count));
+    }
+    return count;
+  }
+
+  result<int64_t> GetSize() override {
+    return static_cast<int64_t>(bytes_->size());
+  }
+
+  void Close() override { ++stats_->closes; }
+
+ private:
+  std::shared_ptr<std::vector<uint8_t>> bytes_;
+  std::shared_ptr<StreamStats> stats_;
+  bool synchronizeFirstRead_;
+  bool synchronized_ = false;
+  int64_t position_ = 0;
+};
+
+class MemoryOutput final : public io::OutputStream {
+ public:
+  explicit MemoryOutput(std::shared_ptr<std::vector<uint8_t>> bytes)
+      : bytes_(std::move(bytes)) {}
+
+  Status Write(const uint8_t* data, int64_t nbytes) override {
+    bytes_->insert(bytes_->end(), data, data + nbytes);
+    return Status::OK();
+  }
+  Status Close() override { return Status::OK(); }
+  void Abort() override { bytes_->clear(); }
+
+ private:
+  std::shared_ptr<std::vector<uint8_t>> bytes_;
+};
+
+class MemoryFiles {
+ public:
+  void add(std::string path, bool idOnly = false) {
+    files_.emplace(std::move(path), test::scanFile(idOnly));
+  }
+
+  void addBytes(std::string path, std::shared_ptr<std::vector<uint8_t>> bytes) {
+    files_.emplace(std::move(path), std::move(bytes));
+  }
+
+  io::InputStreamOpener opener(bool parallelBarrier = false) {
+    return [this, parallelBarrier](const std::string& path) {
+      const auto iter = files_.find(path);
+      if (iter == files_.end()) {
+        return std::unique_ptr<io::InputStream>{};
+      }
+      const int open = ++stats_->opens;
+      const bool synchronize = parallelBarrier && open > 1;
+      return std::unique_ptr<io::InputStream>(
+          new MemoryInput(iter->second, stats_, synchronize));
+    };
+  }
+
+  std::shared_ptr<StreamStats> stats() const { return stats_; }
+
+ private:
+  std::map<std::string, std::shared_ptr<std::vector<uint8_t>>> files_;
+  std::shared_ptr<StreamStats> stats_ = std::make_shared<StreamStats>();
+};
+
+std::shared_ptr<reader::ReadSharedState> makeState(
+    MemoryFiles& files, std::vector<std::string> paths,
+    const std::string& firstPath) {
+  auto state = std::make_shared<reader::ReadSharedState>();
+  state->schema.file.paths = std::move(paths);
+  state->schema.file.format = "parquet";
+  state->stream_opener = files.opener();
+  auto schema =
+      sniffCarquet(io::bindInputStream(state->stream_opener, firstPath));
+  EXPECT_TRUE(schema) << schema.error().ToString();
+  if (schema) {
+    state->schema.entry = std::move(*schema);
+  }
+  return state;
+}
+
+std::shared_ptr<::common::Expression> compareDouble(const std::string& column,
+                                                    ::common::Logical op,
+                                                    double value) {
+  auto expression = std::make_shared<::common::Expression>();
+  expression->add_operators()->mutable_var()->mutable_tag()->set_name(column);
+  expression->add_operators()->set_logical(op);
+  expression->add_operators()->mutable_const_()->set_f64(value);
+  return expression;
+}
+
+std::shared_ptr<::common::Expression> compareDoubleFromLeft(
+    double value, ::common::Logical op, const std::string& column) {
+  auto expression = std::make_shared<::common::Expression>();
+  expression->add_operators()->mutable_const_()->set_f64(value);
+  expression->add_operators()->set_logical(op);
+  expression->add_operators()->mutable_var()->mutable_tag()->set_name(column);
+  return expression;
+}
+
+std::shared_ptr<::common::Expression> compareString(const std::string& column,
+                                                    ::common::Logical op,
+                                                    std::string value) {
+  auto expression = std::make_shared<::common::Expression>();
+  expression->add_operators()->mutable_var()->mutable_tag()->set_name(column);
+  expression->add_operators()->set_logical(op);
+  expression->add_operators()->mutable_const_()->set_str(std::move(value));
+  return expression;
+}
+
+std::shared_ptr<::common::Expression> isNull(const std::string& column) {
+  auto expression = std::make_shared<::common::Expression>();
+  expression->add_operators()->set_logical(::common::Logical::ISNULL);
+  expression->add_operators()->mutable_var()->mutable_tag()->set_name(column);
+  return expression;
+}
+
+void appendExpression(::common::Expression& target,
+                      const ::common::Expression& source) {
+  for (const auto& operation : source.operators()) {
+    *target.add_operators() = operation;
+  }
+}
+
+std::shared_ptr<::common::Expression> combineExpressions(
+    const ::common::Expression& left, ::common::Logical op,
+    const ::common::Expression& right) {
+  auto expression = std::make_shared<::common::Expression>();
+  expression->add_operators()->set_brace(::common::ExprOpr::LEFT_BRACE);
+  appendExpression(*expression, left);
+  expression->add_operators()->set_brace(::common::ExprOpr::RIGHT_BRACE);
+  expression->add_operators()->set_logical(op);
+  expression->add_operators()->set_brace(::common::ExprOpr::LEFT_BRACE);
+  appendExpression(*expression, right);
+  expression->add_operators()->set_brace(::common::ExprOpr::RIGHT_BRACE);
+  return expression;
+}
+
+std::shared_ptr<::common::Expression> negateExpression(
+    const ::common::Expression& operand) {
+  auto expression = std::make_shared<::common::Expression>();
+  expression->add_operators()->set_logical(::common::Logical::NOT);
+  expression->add_operators()->set_brace(::common::ExprOpr::LEFT_BRACE);
+  appendExpression(*expression, operand);
+  expression->add_operators()->set_brace(::common::ExprOpr::RIGHT_BRACE);
+  return expression;
+}
+
+std::shared_ptr<std::vector<uint8_t>> makeDoubleFile(
+    const std::vector<std::vector<double>>& rowGroups, bool writeStatistics) {
+  carquet_error_t error = CARQUET_ERROR_INIT;
+  std::unique_ptr<carquet_schema_t, decltype(&carquet_schema_free)> schema(
+      carquet_schema_create(&error), carquet_schema_free);
+  EXPECT_NE(schema, nullptr) << error.message;
+  EXPECT_EQ(
+      carquet_schema_add_column(schema.get(), "score", CARQUET_PHYSICAL_DOUBLE,
+                                nullptr, CARQUET_REPETITION_REQUIRED, 0, 0),
+      CARQUET_OK);
+  carquet_writer_options_t options;
+  carquet_writer_options_init(&options);
+  options.write_statistics = writeStatistics;
+  auto bytes = std::make_shared<std::vector<uint8_t>>();
+  auto* writer = createCarquetWriter(std::make_unique<MemoryOutput>(bytes),
+                                     schema.get(), &options, &error);
+  EXPECT_NE(writer, nullptr) << error.message;
+  for (size_t group = 0; writer && group < rowGroups.size(); ++group) {
+    EXPECT_EQ(
+        carquet_writer_write_batch(
+            writer, 0, rowGroups[group].data(),
+            static_cast<int64_t>(rowGroups[group].size()), nullptr, nullptr),
+        CARQUET_OK);
+    if (group + 1 < rowGroups.size()) {
+      EXPECT_EQ(carquet_writer_new_row_group(writer), CARQUET_OK);
+    }
+  }
+  if (writer) {
+    EXPECT_EQ(carquet_writer_close(writer), CARQUET_OK);
+  }
+  return bytes;
+}
+
+std::shared_ptr<std::vector<uint8_t>> makeStringFile(
+    const std::vector<std::vector<std::string>>& rowGroups) {
+  carquet_error_t error = CARQUET_ERROR_INIT;
+  std::unique_ptr<carquet_schema_t, decltype(&carquet_schema_free)> schema(
+      carquet_schema_create(&error), carquet_schema_free);
+  carquet_logical_type_t stringType{};
+  stringType.id = CARQUET_LOGICAL_STRING;
+  EXPECT_EQ(carquet_schema_add_column(schema.get(), "label",
+                                      CARQUET_PHYSICAL_BYTE_ARRAY, &stringType,
+                                      CARQUET_REPETITION_REQUIRED, 0, 0),
+            CARQUET_OK);
+  carquet_writer_options_t options;
+  carquet_writer_options_init(&options);
+  auto bytes = std::make_shared<std::vector<uint8_t>>();
+  auto* writer = createCarquetWriter(std::make_unique<MemoryOutput>(bytes),
+                                     schema.get(), &options, &error);
+  EXPECT_NE(writer, nullptr) << error.message;
+  for (size_t group = 0; writer && group < rowGroups.size(); ++group) {
+    std::vector<carquet_byte_array_t> values;
+    values.reserve(rowGroups[group].size());
+    for (const auto& value : rowGroups[group]) {
+      values.push_back(
+          {reinterpret_cast<uint8_t*>(const_cast<char*>(value.data())),
+           static_cast<int32_t>(value.size())});
+    }
+    EXPECT_EQ(carquet_writer_write_batch(writer, 0, values.data(),
+                                         static_cast<int64_t>(values.size()),
+                                         nullptr, nullptr),
+              CARQUET_OK);
+    if (group + 1 < rowGroups.size()) {
+      EXPECT_EQ(carquet_writer_new_row_group(writer), CARQUET_OK);
+    }
+  }
+  if (writer) {
+    EXPECT_EQ(carquet_writer_close(writer), CARQUET_OK);
+  }
+  return bytes;
+}
+
+std::vector<int64_t> collectIds(const execution::Context& context) {
+  std::vector<int64_t> ids;
+  for (const auto& chunk : context.chunks()) {
+    for (size_t row = 0; row < chunk.row_num(); ++row) {
+      ids.emplace_back(chunk.get(0)->get_elem(row).GetValue<int64_t>());
+    }
+  }
+  return ids;
+}
+
+TEST(CarquetScanTest, ReadsProjectedMultiFileBatchesAndMergesFullResults) {
+  MemoryFiles files;
+  files.add("first");
+  files.add("second");
+  auto state = makeState(files, {"first", "second"}, "first");
+  ASSERT_NE(state->schema.entry, nullptr);
+  state->projectColumns = {"id", "label"};
+  state->schema.file.options["PARQUET_BATCH_ROWS"] = "1";
+
+  execution::Context batches;
+  scanCarquet(state, batches);
+  EXPECT_EQ(batches.chunk_num(), 8u);
+  EXPECT_EQ(batches.col_num(), 2u);
+  EXPECT_EQ(collectIds(batches),
+            (std::vector<int64_t>{1, 2, 3, 4, 1, 2, 3, 4}));
+
+  state->schema.file.options["batch_read"] = "false";
+  execution::Context full;
+  scanCarquet(state, full);
+  ASSERT_EQ(full.chunk_num(), 1u);
+  EXPECT_EQ(full.col_num(), 2u);
+  EXPECT_EQ(collectIds(full), collectIds(batches));
+}
+
+TEST(CarquetScanTest, ReadsFilterColumnsBeforeApplyingOutputProjection) {
+  MemoryFiles files;
+  files.add("types");
+  auto state = makeState(files, {"types"}, "types");
+  ASSERT_NE(state->schema.entry, nullptr);
+  state->projectColumns = {"id", "label"};
+  state->skipRows = compareDouble("score", ::common::Logical::GE, 0.0);
+  state->schema.file.options["batch_read"] = "false";
+
+  execution::Context output;
+  scanCarquet(state, output);
+  ASSERT_EQ(output.chunk_num(), 1u);
+  EXPECT_EQ(output.col_num(), 2u);
+  EXPECT_EQ(collectIds(output), (std::vector<int64_t>{1, 4}));
+}
+
+TEST(CarquetScanTest, KeepsIntervalStorageAsStringForDownstreamCast) {
+  MemoryFiles files;
+  files.add("types");
+  auto state = makeState(files, {"types"}, "types");
+  ASSERT_NE(state->schema.entry, nullptr);
+  ASSERT_EQ(state->schema.entry->columnNames[5], "label");
+  state->schema.entry->columnTypes[5]->Clear();
+  state->schema.entry->columnTypes[5]->mutable_temporal()->mutable_interval();
+  state->projectColumns = {"label"};
+  state->schema.file.options["batch_read"] = "false";
+
+  execution::Context output;
+  scanCarquet(state, output);
+  ASSERT_EQ(output.chunk_num(), 1u);
+  ASSERT_EQ(output.col_num(), 1u);
+  const auto& column = output.chunk(0).get(0);
+  ASSERT_EQ(column->size(), 4u);
+  EXPECT_EQ(column->get_elem(0).GetValue<std::string>(), "");
+  EXPECT_EQ(column->get_elem(1).GetValue<std::string>(), "hello");
+  EXPECT_TRUE(column->get_elem(2).IsNull());
+  EXPECT_EQ(column->get_elem(3).GetValue<std::string>(), "中文");
+}
+
+TEST(CarquetScanTest, ParallelRowGroupsUseIndependentStreamsInStableOrder) {
+  if (std::thread::hardware_concurrency() < 2) {
+    GTEST_SKIP() << "parallel overlap requires two hardware threads";
+  }
+  MemoryFiles files;
+  files.add("types");
+  auto state = makeState(files, {"types"}, "types");
+  ASSERT_NE(state->schema.entry, nullptr);
+  files.stats()->reset();
+  files.stats()->firstReadBarrier = std::make_shared<std::barrier<>>(2);
+  state->stream_opener = files.opener(true);
+  state->projectColumns = {"id"};
+  state->schema.file.options["parallel"] = "true";
+  state->schema.file.options["PARQUET_BATCH_ROWS"] = "1";
+
+  execution::Context output;
+  scanCarquet(state, output);
+  EXPECT_EQ(collectIds(output), (std::vector<int64_t>{1, 2, 3, 4}));
+  EXPECT_EQ(output.chunk_num(), 4u);
+  EXPECT_GE(files.stats()->maxActiveReads.load(), 2);
+  EXPECT_EQ(files.stats()->opens.load(), 3);
+  EXPECT_EQ(files.stats()->closes.load(), 3);
+}
+
+TEST(CarquetScanTest, ProjectionReducesPhysicalRangeReads) {
+  const auto bytes = test::scanFile();
+  auto fullStats = std::make_shared<StreamStats>();
+  auto projectedStats = std::make_shared<StreamStats>();
+
+  CarquetReaderOptions options;
+  options.bufferedStream = false;
+  auto full = CarquetChunkSupplier::create(
+      std::make_unique<MemoryInput>(bytes, fullStats, false), options);
+  ASSERT_TRUE(full) << full.error().ToString();
+  while ((*full)->GetNextChunk()) {}
+
+  options.topLevelFields = {0};
+  auto projected = CarquetChunkSupplier::create(
+      std::make_unique<MemoryInput>(bytes, projectedStats, false), options);
+  ASSERT_TRUE(projected) << projected.error().ToString();
+  while (auto chunk = (*projected)->GetNextChunk()) {
+    EXPECT_EQ(chunk->col_num(), 1u);
+  }
+  EXPECT_LT(projectedStats->requestedBytes.load(),
+            fullStats->requestedBytes.load());
+  EXPECT_LT(projectedStats->readCalls.load(), fullStats->readCalls.load());
+}
+
+TEST(CarquetScanTest, PreservesResultsAcrossBufferAndPrebufferModes) {
+  MemoryFiles files;
+  files.add("types");
+  auto state = makeState(files, {"types"}, "types");
+  ASSERT_NE(state->schema.entry, nullptr);
+  state->projectColumns = {"id"};
+  state->schema.file.options["BATCH_SIZE"] = "32";
+  state->schema.file.options["BUFFERED_STREAM"] = "true";
+  state->schema.file.options["PRE_BUFFER"] = "true";
+
+  execution::Context explicitPrebuffer;
+  scanCarquet(state, explicitPrebuffer);
+  EXPECT_EQ(collectIds(explicitPrebuffer), (std::vector<int64_t>{1, 2, 3, 4}));
+
+  state->schema.file.options["BUFFERED_STREAM"] = "false";
+  state->schema.file.options["PRE_BUFFER"] = "false";
+  state->schema.file.options["ENABLE_IO_COALESCING"] = "false";
+  execution::Context eagerCoalescing;
+  scanCarquet(state, eagerCoalescing);
+  EXPECT_EQ(collectIds(eagerCoalescing), collectIds(explicitPrebuffer));
+}
+
+TEST(CarquetScanTest, PrunesOnlyProvenNonMatchingGroupsBeforeReadingData) {
+  const auto bytes = test::scanFile();
+  auto fullStats = std::make_shared<StreamStats>();
+  auto prunedStats = std::make_shared<StreamStats>();
+  CarquetReaderOptions options;
+  options.bufferedStream = false;
+  options.preBuffer = true;
+  options.topLevelFields = {0, 4};
+
+  auto full = CarquetChunkSupplier::create(
+      std::make_unique<MemoryInput>(bytes, fullStats, false), options);
+  ASSERT_TRUE(full) << full.error().ToString();
+  while ((*full)->GetNextChunk()) {}
+  EXPECT_EQ((*full)->rowGroupsRead(), 2u);
+
+  options.rowGroupFilter = compareDouble("score", ::common::Logical::GT, 2.0);
+  auto pruned = CarquetChunkSupplier::create(
+      std::make_unique<MemoryInput>(bytes, prunedStats, false), options);
+  ASSERT_TRUE(pruned) << pruned.error().ToString();
+  EXPECT_EQ((*pruned)->selectedRowGroups(), (std::vector<int32_t>{1}));
+  while ((*pruned)->GetNextChunk()) {}
+  EXPECT_EQ((*pruned)->rowGroupsRead(), 1u);
+  EXPECT_EQ((*pruned)->rowGroupsSkipped(), 1u);
+  EXPECT_LT(prunedStats->requestedBytes.load(),
+            fullStats->requestedBytes.load());
+  EXPECT_LT(prunedStats->readCalls.load(), fullStats->readCalls.load());
+
+  MemoryFiles files;
+  files.addBytes("types", bytes);
+  auto state = makeState(files, {"types"}, "types");
+  state->projectColumns = {"id"};
+  state->skipRows = options.rowGroupFilter;
+  state->schema.file.options["parallel"] = "true";
+  state->schema.file.options["PRE_BUFFER"] = "true";
+  files.stats()->reset();
+  state->stream_opener = files.opener();
+  execution::Context output;
+  scanCarquet(state, output);
+  EXPECT_EQ(collectIds(output), (std::vector<int64_t>{4}));
+  EXPECT_EQ(files.stats()->opens.load(), 2);
+}
+
+TEST(CarquetScanTest, CombinesReversedAndThreeValuedPredicatesSafely) {
+  MemoryFiles files;
+  files.add("types");
+  auto state = makeState(files, {"types"}, "types");
+  state->projectColumns = {"id"};
+  execution::Context output;
+
+  state->skipRows = compareDoubleFromLeft(2.0, ::common::Logical::LT, "score");
+  scanCarquet(state, output);
+  EXPECT_EQ(collectIds(output), (std::vector<int64_t>{4}));
+
+  const auto aboveZero = compareDouble("score", ::common::Logical::GT, 0.0);
+  const auto belowTwo = compareDouble("score", ::common::Logical::LT, 2.0);
+  state->skipRows =
+      combineExpressions(*aboveZero, ::common::Logical::AND, *belowTwo);
+  scanCarquet(state, output);
+  EXPECT_EQ(collectIds(output), (std::vector<int64_t>{1}));
+
+  const auto belowMinusThree =
+      compareDouble("score", ::common::Logical::LT, -3.0);
+  state->skipRows =
+      combineExpressions(*compareDouble("score", ::common::Logical::GT, 2.0),
+                         ::common::Logical::OR, *belowMinusThree);
+  scanCarquet(state, output);
+  EXPECT_EQ(collectIds(output), (std::vector<int64_t>{4}));
+
+  state->skipRows = isNull("score");
+  scanCarquet(state, output);
+  EXPECT_EQ(collectIds(output), (std::vector<int64_t>{3}));
+
+  state->skipRows =
+      negateExpression(*compareDouble("score", ::common::Logical::LE, 2.0));
+  scanCarquet(state, output);
+  EXPECT_EQ(collectIds(output), (std::vector<int64_t>{4}));
+}
+
+TEST(CarquetScanTest, KeepsGroupsWithMissingOrNanStatistics) {
+  auto missingBytes = makeDoubleFile({{-2.0, -1.0}, {1.0, 2.0}}, false);
+  auto missingStats = std::make_shared<StreamStats>();
+  CarquetReaderOptions options;
+  options.bufferedStream = false;
+  options.rowGroupFilter = compareDouble("score", ::common::Logical::GT, 0.0);
+  auto missing = CarquetChunkSupplier::create(
+      std::make_unique<MemoryInput>(missingBytes, missingStats, false),
+      options);
+  ASSERT_TRUE(missing) << missing.error().ToString();
+  while ((*missing)->GetNextChunk()) {}
+  EXPECT_EQ((*missing)->rowGroupsRead(), 2u);
+  EXPECT_EQ((*missing)->rowGroupsSkipped(), 0u);
+
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  auto onlyNanBytes = makeDoubleFile({{nan, nan}}, true);
+  auto onlyNan = CarquetChunkSupplier::create(
+      std::make_unique<MemoryInput>(onlyNanBytes,
+                                    std::make_shared<StreamStats>(), false),
+      options);
+  ASSERT_TRUE(onlyNan) << onlyNan.error().ToString();
+  while ((*onlyNan)->GetNextChunk()) {}
+  EXPECT_EQ((*onlyNan)->rowGroupsRead(), 1u);
+  EXPECT_EQ((*onlyNan)->rowGroupsSkipped(), 0u);
+
+  auto finiteAndNanBytes = makeDoubleFile({{0.0, nan, 0.0}}, true);
+  for (const auto op :
+       {::common::Logical::NE, ::common::Logical::LE, ::common::Logical::GE}) {
+    options.rowGroupFilter = compareDouble(
+        "score", op,
+        op == ::common::Logical::LE ? -1.0
+                                    : op == ::common::Logical::GE ? 1.0 : 0.0);
+    auto supplier = CarquetChunkSupplier::create(
+        std::make_unique<MemoryInput>(finiteAndNanBytes,
+                                      std::make_shared<StreamStats>(), false),
+        options);
+    ASSERT_TRUE(supplier) << supplier.error().ToString();
+    while ((*supplier)->GetNextChunk()) {}
+    EXPECT_EQ((*supplier)->rowGroupsSkipped(),
+              op == ::common::Logical::NE ? 0u : 1u)
+        << op;
+  }
+
+  auto stringBytes = makeStringFile({{"", ""}, {"b", "c"}});
+  options.rowGroupFilter = compareString("label", ::common::Logical::GT, "a");
+  auto strings = CarquetChunkSupplier::create(
+      std::make_unique<MemoryInput>(stringBytes,
+                                    std::make_shared<StreamStats>(), false),
+      options);
+  ASSERT_TRUE(strings) << strings.error().ToString();
+  EXPECT_EQ((*strings)->selectedRowGroups(), (std::vector<int32_t>{0, 1}));
+  while ((*strings)->GetNextChunk()) {}
+  EXPECT_EQ((*strings)->rowGroupsSkipped(), 0u);
+}
+
+TEST(CarquetScanTest, RejectsInvalidOptionsColumnsAndCrossFileSchema) {
+  MemoryFiles files;
+  files.add("types");
+  files.add("flat", true);
+  auto state = makeState(files, {"types"}, "types");
+  ASSERT_NE(state->schema.entry, nullptr);
+  execution::Context output;
+
+  state->schema.file.options["PARQUET_BATCH_ROWS"] = "0";
+  EXPECT_THROW(scanCarquet(state, output), exception::InvalidArgumentException);
+  state->schema.file.options["PARQUET_BATCH_ROWS"] = "1";
+  state->schema.file.options["BATCH_SIZE"] = "0";
+  EXPECT_THROW(scanCarquet(state, output), exception::InvalidArgumentException);
+
+  state->schema.file.options["BATCH_SIZE"] = "1024";
+  state->projectColumns = {"missing"};
+  EXPECT_THROW(scanCarquet(state, output), exception::InvalidArgumentException);
+
+  state->projectColumns = {"z_missing", "id", "a_missing", "z_missing"};
+  state->skipRows = isNull("m_missing");
+  for (int attempt = 0; attempt < 2; ++attempt) {
+    try {
+      scanCarquet(state, output);
+      FAIL() << "Expected missing projection and filter columns to be rejected";
+    } catch (const exception::InvalidArgumentException& error) {
+      EXPECT_NE(
+          std::string(error.what())
+              .find(
+                  "Parquet columns not found: a_missing, m_missing, z_missing"),
+          std::string::npos);
+    }
+    std::reverse(state->projectColumns.begin(), state->projectColumns.end());
+  }
+  state->skipRows.reset();
+  state->projectColumns.clear();
+  state->schema.file.paths = {"types", "flat"};
+  EXPECT_THROW(scanCarquet(state, output), exception::SchemaMismatchException);
+}
+
+TEST(CarquetScanTest, RebindsNestedParametersBeforeFinalProjection) {
+  MemoryFiles files;
+  files.add("first");
+  files.add("second");
+  auto state = makeState(files, {"first", "second"}, "first");
+  // CASE WHEN score > $minimum THEN true ELSE false END
+  auto predicate = std::make_shared<::common::Expression>();
+  auto* cases = predicate->add_operators()->mutable_case_();
+  auto* branch = cases->add_when_then_expressions();
+  auto* condition = branch->mutable_when_expression();
+  condition->add_operators()->mutable_var()->mutable_tag()->set_name("score");
+  condition->add_operators()->set_logical(::common::Logical::GT);
+  auto* parameter = condition->add_operators()->mutable_param();
+  parameter->set_name("minimum");
+  parameter->mutable_data_type()->mutable_data_type()->set_primitive_type(
+      ::common::PrimitiveType::DT_DOUBLE);
+  branch->mutable_then_result_expression()
+      ->add_operators()
+      ->mutable_const_()
+      ->set_boolean(true);
+  cases->mutable_else_result_expression()
+      ->add_operators()
+      ->mutable_const_()
+      ->set_boolean(false);
+  state->skipRows = predicate;
+  state->projectColumns = {"id", "label", "id"};
+  const auto original = predicate->SerializeAsString();
+  for (const auto* parallel : {"false", "true"}) {
+    for (const auto* batch : {"false", "true"}) {
+      state->schema.file.options = {{"parallel", parallel},
+                                    {"batch_read", batch},
+                                    {"PARQUET_BATCH_ROWS", "1"}};
+      for (const double minimum : {0.0, 3.0, 10.0, -3.0}) {
+        SCOPED_TRACE(std::string(parallel) + "/" + batch + "/" +
+                     std::to_string(minimum));
+        state->parameters = {{"minimum", Value::DOUBLE(minimum)}};
+        execution::Context output;
+        scanCarquet(state, output);
+        std::vector<int64_t> expected;
+        for (int file = 0; file < 2; ++file) {
+          if (1.25 > minimum)
+            expected.push_back(1);
+          if (-2.5 > minimum)
+            expected.push_back(2);
+          if (4.5 > minimum)
+            expected.push_back(4);
+        }
+        EXPECT_EQ(collectIds(output), expected);
+        EXPECT_EQ(output.col_num(), 3u);
+        for (const auto& chunk : output.chunks()) {
+          for (size_t row = 0; row < chunk.row_num(); ++row) {
+            EXPECT_EQ(chunk.get(0)->get_elem(row), chunk.get(2)->get_elem(row));
+          }
+        }
+        EXPECT_EQ(predicate->SerializeAsString(), original);
+      }
+    }
+  }
+  state->parameters.clear();
+  execution::Context output;
+  EXPECT_THROW(scanCarquet(state, output), exception::InvalidArgumentException);
+  EXPECT_EQ(predicate->SerializeAsString(), original);
+}
+
+TEST(CarquetScanTest, PruningNeverDropsRowsAcceptedByCompleteEvaluation) {
+  const auto bytes = test::scanFile();
+  carquet_error_t error = CARQUET_ERROR_INIT;
+  std::unique_ptr<carquet_reader_t, decltype(&carquet_reader_close)> reader(
+      carquet_reader_open_buffer(bytes->data(), bytes->size(), nullptr, &error),
+      carquet_reader_close);
+  ASSERT_NE(reader, nullptr) << error.message;
+  MemoryFiles files;
+  files.addBytes("types", bytes);
+  auto state = makeState(files, {"types"}, "types");
+  std::vector<std::shared_ptr<::common::Expression>> predicates;
+  for (const auto op :
+       {::common::Logical::EQ, ::common::Logical::NE, ::common::Logical::LT,
+        ::common::Logical::LE, ::common::Logical::GT, ::common::Logical::GE}) {
+    for (const double threshold : {-3.0, -2.5, 0.0, 1.25, 4.5, 5.0}) {
+      predicates.push_back(compareDouble("score", op, threshold));
+      predicates.push_back(compareDoubleFromLeft(threshold, op, "score"));
+    }
+  }
+  predicates.push_back(isNull("score"));
+  auto prefix = std::make_shared<::common::Expression>();
+  prefix->add_operators()->set_logical(::common::Logical::NOT);
+  appendExpression(*prefix, *isNull("score"));
+  predicates.push_back(prefix);
+  auto doublePrefix = std::make_shared<::common::Expression>();
+  doublePrefix->add_operators()->set_logical(::common::Logical::NOT);
+  appendExpression(*doublePrefix, *prefix);
+  predicates.push_back(doublePrefix);
+  const size_t simpleCount = predicates.size();
+  for (size_t i = 0; i < simpleCount; ++i) {
+    predicates.push_back(negateExpression(*predicates[i]));
+    for (const auto op : {::common::Logical::AND, ::common::Logical::OR}) {
+      // No additional parentheses around NOT/ISNULL: exercise precedence.
+      auto combined = std::make_shared<::common::Expression>(*prefix);
+      combined->add_operators()->set_logical(op);
+      appendExpression(*combined, *predicates[i]);
+      predicates.push_back(std::move(combined));
+    }
+  }
+  for (int32_t group = 0; group < 2; ++group) {
+    auto supplier = CarquetChunkSupplier::create(
+        std::make_unique<MemoryInput>(bytes, std::make_shared<StreamStats>(),
+                                      false),
+        {.rowGroups = {group}});
+    ASSERT_TRUE(supplier) << supplier.error().ToString();
+    const auto chunk = (*supplier)->GetNextChunk();
+    ASSERT_NE(chunk, nullptr);
+    for (size_t index = 0; index < predicates.size(); ++index) {
+      SCOPED_TRACE(index);
+      const auto& predicate = predicates[index];
+      auto exact = reader::filter_chunk(*chunk, predicate,
+                                        state->schema.entry->columnNames);
+      auto pruner = CarquetRowGroupPruner::create(
+          reader.get(), *state->schema.entry, predicate.get());
+      if (exact.row_num() > 0) {
+        EXPECT_TRUE(pruner->mightMatch(group)) << "row group " << group;
+      }
+    }
+  }
+}
+
+TEST(CarquetScanTest, PrunesNullGroupsWithAdjacentUnaryOperators) {
+  carquet_error_t error = CARQUET_ERROR_INIT;
+  std::unique_ptr<carquet_schema_t, decltype(&carquet_schema_free)> schema(
+      carquet_schema_create(&error), carquet_schema_free);
+  ASSERT_NE(schema, nullptr);
+  test::check(carquet_schema_add_column(schema.get(), "score",
+                                        CARQUET_PHYSICAL_DOUBLE, nullptr,
+                                        CARQUET_REPETITION_OPTIONAL, 0, 0));
+  auto writer = test::writerFor(schema.get());
+  const double value = 2.0;
+  const int16_t nulls[] = {0, 0}, mixed[] = {1, 0};
+  test::check(
+      carquet_writer_write_batch(writer.get(), 0, &value, 2, nulls, nullptr));
+  test::check(carquet_writer_new_row_group(writer.get()));
+  test::check(
+      carquet_writer_write_batch(writer.get(), 0, &value, 2, mixed, nullptr));
+  const auto bytes = test::finish(std::move(writer));
+  auto predicate = std::make_shared<::common::Expression>();
+  predicate->add_operators()->set_logical(::common::Logical::NOT);
+  appendExpression(*predicate, *isNull("score"));
+  CarquetReaderOptions options{.rowGroupFilter = predicate};
+  auto supplier = CarquetChunkSupplier::create(
+      std::make_unique<MemoryInput>(bytes, std::make_shared<StreamStats>(),
+                                    false),
+      options);
+  ASSERT_TRUE(supplier) << supplier.error().ToString();
+  EXPECT_EQ((*supplier)->selectedRowGroups(), (std::vector<int32_t>{1}));
+  MemoryFiles files;
+  files.addBytes("nulls", bytes);
+  auto state = makeState(files, {"nulls"}, "nulls");
+  state->skipRows = predicate;
+  execution::Context output;
+  scanCarquet(state, output);
+  ASSERT_EQ(output.row_num(), 1u);
+  EXPECT_DOUBLE_EQ(output.chunk(0).get(0)->get_elem(0).GetValue<double>(), 2.0);
+}
+
+TEST(CarquetScanTest, PreservesParametersNestedInsideListAndArrayPredicates) {
+  MemoryFiles files;
+  files.add("types");
+  auto state = makeState(files, {"types"}, "types");
+  state->projectColumns = {"label"};
+  for (const bool asArray : {false, true}) {
+    auto predicate = std::make_shared<::common::Expression>();
+    predicate->add_operators()->mutable_var()->mutable_tag()->set_name("id");
+    predicate->add_operators()->set_logical(::common::Logical::WITHIN);
+    auto* container = predicate->add_operators();
+    auto* fields = asArray ? container->mutable_to_array()->mutable_fields()
+                           : container->mutable_to_list()->mutable_fields();
+    if (asArray) {
+      auto* type =
+          container->mutable_node_type()->mutable_data_type()->mutable_array();
+      type->set_fixed_length(1);
+      type->mutable_component_type()->set_primitive_type(
+          ::common::PrimitiveType::DT_SIGNED_INT64);
+    }
+    auto* parameter = fields->Add()->add_operators()->mutable_param();
+    parameter->set_name("selected");
+    parameter->mutable_data_type()->mutable_data_type()->set_primitive_type(
+        ::common::PrimitiveType::DT_SIGNED_INT64);
+    state->skipRows = predicate;
+    const auto original = predicate->SerializeAsString();
+    for (const auto* parallel : {"false", "true"}) {
+      for (const auto* batch : {"false", "true"}) {
+        state->schema.file.options = {{"parallel", parallel},
+                                      {"batch_read", batch},
+                                      {"PARQUET_BATCH_ROWS", "1"}};
+        for (const int64_t selected : {2, 4}) {
+          state->parameters = {{"selected", Value::INT64(selected)}};
+          execution::Context output;
+          scanCarquet(state, output);
+          ASSERT_EQ(output.row_num(), 1u);
+          ASSERT_EQ(output.col_num(), 1u);
+          for (const auto& chunk : output.chunks()) {
+            if (chunk.row_num())
+              EXPECT_EQ(chunk.get(0)->get_elem(0).GetValue<std::string>(),
+                        selected == 2 ? "hello" : "中文");
+          }
+          EXPECT_EQ(predicate->SerializeAsString(), original);
+        }
+      }
+    }
+  }
+}
+
+}  // namespace
+}  // namespace neug::parquet

--- a/extension/parquet/tests/carquet_test_data.h
+++ b/extension/parquet/tests/carquet_test_data.h
@@ -1,0 +1,224 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+#pragma once
+
+#include <carquet/carquet.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace neug::parquet::test {
+
+inline void check(carquet_status_t status) {
+  if (status != CARQUET_OK) {
+    throw std::runtime_error(carquet_status_string(status));
+  }
+}
+
+using BufferWriter =
+    std::unique_ptr<carquet_writer_t, decltype(&carquet_writer_abort)>;
+
+inline BufferWriter writerFor(const carquet_schema_t* schema,
+                              bool writeSchema = true) {
+  carquet_writer_options_t options;
+  carquet_writer_options_init(&options);
+  options.compression = CARQUET_COMPRESSION_ZSTD;
+  options.write_arrow_schema = writeSchema;
+  carquet_error_t error = CARQUET_ERROR_INIT;
+  BufferWriter writer(carquet_writer_create_buffer(schema, &options, &error),
+                      carquet_writer_abort);
+  if (!writer) {
+    throw std::runtime_error(error.message);
+  }
+  return writer;
+}
+
+inline std::shared_ptr<std::vector<uint8_t>> finish(BufferWriter writer) {
+  check(carquet_writer_close(writer.get()));
+  void* data = nullptr;
+  size_t size = 0;
+  check(carquet_writer_get_buffer(writer.get(), &data, &size));
+  writer.release();  // get_buffer consumes the closed buffer writer.
+  std::unique_ptr<void, decltype(&std::free)> buffer(data, std::free);
+  return std::make_shared<std::vector<uint8_t>>(
+      static_cast<uint8_t*>(data), static_cast<uint8_t*>(data) + size);
+}
+
+// Two row groups with independent expected values for filtering and projection.
+inline std::shared_ptr<std::vector<uint8_t>> scanFile(bool idOnly = false) {
+  carquet_error_t error = CARQUET_ERROR_INIT;
+  std::unique_ptr<carquet_schema_t, decltype(&carquet_schema_free)> schema(
+      carquet_schema_create(&error), carquet_schema_free);
+  if (!schema) {
+    throw std::runtime_error(error.message);
+  }
+  check(carquet_schema_add_column(schema.get(), "id", CARQUET_PHYSICAL_INT64,
+                                  nullptr, CARQUET_REPETITION_REQUIRED, 0, 0));
+  if (!idOnly) {
+    for (const auto* name : {"enabled", "signed_value", "unsigned_value"}) {
+      check(carquet_schema_add_column(schema.get(), name,
+                                      CARQUET_PHYSICAL_INT32, nullptr,
+                                      CARQUET_REPETITION_REQUIRED, 0, 0));
+    }
+    check(carquet_schema_add_column(schema.get(), "score",
+                                    CARQUET_PHYSICAL_DOUBLE, nullptr,
+                                    CARQUET_REPETITION_OPTIONAL, 0, 0));
+    carquet_logical_type_t stringType{};
+    stringType.id = CARQUET_LOGICAL_STRING;
+    check(carquet_schema_add_column(schema.get(), "label",
+                                    CARQUET_PHYSICAL_BYTE_ARRAY, &stringType,
+                                    CARQUET_REPETITION_OPTIONAL, 0, 0));
+  }
+  auto writer = writerFor(schema.get());
+  for (int64_t group = 0; group < 2; ++group) {
+    const int64_t ids[] = {group * 2 + 1, group * 2 + 2};
+    check(
+        carquet_writer_write_batch(writer.get(), 0, ids, 2, nullptr, nullptr));
+    if (!idOnly) {
+      const int32_t values[] = {1, 0};
+      for (int column = 1; column < 4; ++column) {
+        check(carquet_writer_write_batch(writer.get(), column, values, 2,
+                                         nullptr, nullptr));
+      }
+      const int16_t defined[] = {static_cast<int16_t>(group == 0), 1};
+      const double scores[] = {group == 0 ? 1.25 : 4.5, -2.5};
+      check(carquet_writer_write_batch(writer.get(), 4, scores, 2, defined,
+                                       nullptr));
+      std::string labels[] = {group == 0 ? "" : "中文", "hello"};
+      carquet_byte_array_t strings[2];
+      for (size_t i = 0; i < 2; ++i) {
+        strings[i] = {reinterpret_cast<uint8_t*>(labels[i].data()),
+                      static_cast<int32_t>(labels[i].size())};
+      }
+      check(carquet_writer_write_batch(writer.get(), 5, strings, 2, defined,
+                                       nullptr));
+    }
+    if (group == 0) {
+      check(carquet_writer_new_row_group(writer.get()));
+    }
+  }
+  return finish(std::move(writer));
+}
+
+// C Data is an interchange ABI; this fixture needs no Arrow library or PyArrow.
+inline std::shared_ptr<std::vector<uint8_t>> nestedFile() {
+  ArrowSchema item{
+      .format = "l", .name = "element", .flags = ARROW_FLAG_NULLABLE};
+  ArrowSchema fixedItem{
+      .format = "g", .name = "element", .flags = ARROW_FLAG_NULLABLE};
+  ArrowSchema matrixItem{
+      .format = "i", .name = "element", .flags = ARROW_FLAG_NULLABLE};
+  ArrowSchema* itemChildren[] = {&item};
+  ArrowSchema* fixedChildren[] = {&fixedItem};
+  ArrowSchema* matrixChildren[] = {&matrixItem};
+  ArrowSchema items{.format = "+l",
+                    .name = "items",
+                    .flags = ARROW_FLAG_NULLABLE,
+                    .n_children = 1,
+                    .children = itemChildren};
+  ArrowSchema fixed{.format = "+l",
+                    .name = "fixed3",
+                    .n_children = 1,
+                    .children = fixedChildren};
+  ArrowSchema inner{.format = "+l",
+                    .name = "element",
+                    .n_children = 1,
+                    .children = matrixChildren};
+  ArrowSchema* innerChildren[] = {&inner};
+  ArrowSchema matrix{.format = "+l",
+                     .name = "matrix2x2",
+                     .n_children = 1,
+                     .children = innerChildren};
+  ArrowSchema* fields[] = {&items, &fixed, &matrix};
+  ArrowSchema root{.format = "+s", .n_children = 3, .children = fields};
+  carquet_error_t error = CARQUET_ERROR_INIT;
+  carquet_schema_t* raw = nullptr;
+  check(carquet_arrow_import_schema(&root, &raw, &error));
+  std::unique_ptr<carquet_schema_t, decltype(&carquet_schema_free)> schema(
+      raw, carquet_schema_free);
+  auto writer = writerFor(schema.get(), false);
+  // Fixed-size lists use the same Parquet LIST layout. Supply independently
+  // serialized IPC schema metadata to exercise the reader's refinement parser.
+  // Generated with base64.b64encode(pa.schema([
+  //   pa.field("items", pa.list_(pa.int64())),
+  //   pa.field("fixed3", pa.list_(pa.float64(), 3), nullable=False),
+  //   pa.field("matrix2x2", pa.list_(pa.list_(pa.int32(), 2), 2),
+  //   nullable=False)
+  // ]).serialize().to_pybytes()).decode(). This is schema-only test data.
+  constexpr const char* arrowSchema =
+      "/////8ABAAAQAAAAAAAKAAwABgAFAAgACgAAAAABBAAMAAAACAAIAAAABAAIAAAABAAAAAMA"
+      "AAAYAQAArAAAAAQAAABs////AAAAEBQAAAAgAAAABAAAAAEAAAAcAAAACQAAAG1hdHJpeDJ4"
+      "MgAAAF7///8CAAAA+P7//wAAARAUAAAAHAAAAAQAAAABAAAAGAAAAAQAAABpdGVtAAAAAI7/"
+      "//8CAAAAKP///wAAAQIQAAAAGAAAAAQAAAAAAAAABAAAAGl0ZW0AAAAAGP///wAAAAEgAAAA"
+      "EAAUAAgAAAAHAAwAAAAQABAAAAAAAAAQFAAAACQAAAAEAAAAAQAAACAAAAAGAAAAZml4ZWQz"
+      "AAAAAAYACAAEAAYAAAADAAAAoP///wAAAQMQAAAAHAAAAAQAAAAAAAAABAAAAGl0ZW0AAAYA"
+      "CAAGAAYAAAAAAAIA0P///wAAAQwUAAAAIAAAAAQAAAABAAAAKAAAAAUAAABpdGVtcwAAAAQA"
+      "BAAEAAAAEAAUAAgABgAHAAwAAAAQABAAAAAAAAECEAAAACAAAAAEAAAAAAAAAAQAAABpdGVt"
+      "AAAAAAgADAAIAAcACAAAAAAAAAFAAAAA";
+  check(carquet_writer_add_metadata(writer.get(), "ARROW:schema", arrowSchema));
+  const int64_t values[] = {1, 0, 3, 4, 5};
+  const double fixedValues[] = {1, 0, 3, 4, 5, 6, 0, 0, 0, -1, -2, -3};
+  const int32_t matrixValues[] = {1, 2, 3,  4,  5,  6,  7,  8,
+                                  9, 0, 11, 12, -1, -2, -3, -4};
+  const uint8_t validItems = 0x1d, validLists = 0x0b;
+  const uint8_t validFixed[] = {0xfd, 0x0f}, validMatrix[] = {0xff, 0xfd};
+  const int32_t offsets[] = {0, 3, 3, 3, 5};
+  const void* itemBuffers[] = {&validItems, values};
+  const void* listBuffers[] = {&validLists, offsets};
+  const void* fixedBuffers[] = {validFixed, fixedValues};
+  const void* matrixBuffers[] = {validMatrix, matrixValues};
+  const void* containerBuffers[] = {nullptr};
+  const int32_t fixedOffsets[] = {0, 3, 6, 9, 12};
+  const int32_t innerOffsets[] = {0, 2, 4, 6, 8, 10, 12, 14, 16};
+  const int32_t outerOffsets[] = {0, 2, 4, 6, 8};
+  const void* fixedListBuffers[] = {nullptr, fixedOffsets};
+  const void* innerListBuffers[] = {nullptr, innerOffsets};
+  const void* outerListBuffers[] = {nullptr, outerOffsets};
+  ArrowArray itemArray{
+      .length = 5, .null_count = 1, .n_buffers = 2, .buffers = itemBuffers};
+  ArrowArray fixedArray{
+      .length = 12, .null_count = 1, .n_buffers = 2, .buffers = fixedBuffers};
+  ArrowArray matrixArray{
+      .length = 16, .null_count = 1, .n_buffers = 2, .buffers = matrixBuffers};
+  ArrowArray* itemArrays[] = {&itemArray};
+  ArrowArray* fixedArrays[] = {&fixedArray};
+  ArrowArray* matrixArrays[] = {&matrixArray};
+  ArrowArray listArray{.length = 4,
+                       .null_count = 1,
+                       .n_buffers = 2,
+                       .n_children = 1,
+                       .buffers = listBuffers,
+                       .children = itemArrays};
+  ArrowArray fixedList{.length = 4,
+                       .n_buffers = 2,
+                       .n_children = 1,
+                       .buffers = fixedListBuffers,
+                       .children = fixedArrays};
+  ArrowArray innerArray{.length = 8,
+                        .n_buffers = 2,
+                        .n_children = 1,
+                        .buffers = innerListBuffers,
+                        .children = matrixArrays};
+  ArrowArray* innerArrays[] = {&innerArray};
+  ArrowArray matrixList{.length = 4,
+                        .n_buffers = 2,
+                        .n_children = 1,
+                        .buffers = outerListBuffers,
+                        .children = innerArrays};
+  ArrowArray* columns[] = {&listArray, &fixedList, &matrixList};
+  ArrowArray array{.length = 4,
+                   .n_buffers = 1,
+                   .n_children = 3,
+                   .buffers = containerBuffers,
+                   .children = columns};
+  check(carquet_writer_write_arrow(writer.get(), &array, &root, &error));
+  return finish(std::move(writer));
+}
+
+}  // namespace neug::parquet::test

--- a/third_party/carquet.patch
+++ b/third_party/carquet.patch
@@ -7,8 +7,16 @@ NeuG InputStream/OutputStream, with exactly-once close or abort ownership.
 Remove each change when the pinned upstream version provides its equivalent
 and the multibatch and I/O adapter regression tests pass without that change.
 
+Reader additions preserve fixed-size list metadata recursively and select
+top-level fields before decoding nested row groups. The scalar/nested reader
+and scan regression tests cover these changes.
+
+Both C Data export paths pack INT8/UINT8 and INT16/UINT16 values to their
+logical width instead of exposing physical INT32 buffers. Real-file narrow
+integer supplier regressions cover batch, projected and nested reads.
+
 diff --git a/include/carquet/carquet.h b/include/carquet/carquet.h
-index 8080d27..05eca3d 100644
+index 8080d27..bf1b1db 100644
 --- a/include/carquet/carquet.h
 +++ b/include/carquet/carquet.h
 @@ -572,6 +572,30 @@ typedef struct carquet_row_batch carquet_row_batch_t;
@@ -107,6 +115,627 @@ index 8080d27..05eca3d 100644
  /**
   * @brief Create a writer to a FILE handle.
   *
+@@ -3855,6 +3923,38 @@ carquet_status_t carquet_reader_read_arrow(
+     struct ArrowArray* out_array,
+     carquet_error_t* error);
+
++/**
++ * @brief Read selected top-level fields from one row group into Arrow C Data.
++ *
++ * This is the projected counterpart to @ref carquet_reader_read_arrow. The
++ * field indices address the top-level children of the file schema, and the
++ * output children follow the requested order. Every leaf below each selected
++ * field is read so arbitrarily nested fields remain intact. Unselected leaf
++ * column chunks are not read.
++ *
++ * Passing zero columns selects every top-level field. Duplicate or out-of-range
++ * indices are rejected.
++ *
++ * @param[in] reader Open reader.
++ * @param[in] row_group_index Row group to read (0-based).
++ * @param[in] field_indices Top-level field indices, or NULL when num_fields is
++ *                          zero.
++ * @param[in] num_fields Number of requested top-level fields, or zero for all.
++ * @param[out] out_schema Optional projected ArrowSchema (may be NULL).
++ * @param[out] out_array Projected ArrowArray; caller must release.
++ * @param[out] error Error details (may be NULL).
++ * @return CARQUET_OK or an error. On error nothing is left owned by the caller.
++ */
++CARQUET_API CARQUET_WARN_UNUSED_RESULT
++carquet_status_t carquet_reader_read_arrow_columns(
++    carquet_reader_t* reader,
++    int32_t row_group_index,
++    const int32_t* field_indices,
++    int32_t num_fields,
++    struct ArrowSchema* out_schema,
++    struct ArrowArray* out_array,
++    carquet_error_t* error);
++
+ /* ============================================================================
+  * C++ Compatibility - End
+  * ============================================================================ */
+diff --git a/src/reader/arrow_c_export.c b/src/reader/arrow_c_export.c
+index f651483..e76bcd0 100644
+--- a/src/reader/arrow_c_export.c
++++ b/src/reader/arrow_c_export.c
+@@ -328,7 +328,8 @@ static carquet_status_t export_child_array(
+     const uint8_t* validity,
+     int64_t n,
+     carquet_physical_type_t pt,
+-    int32_t type_length) {
++    int32_t type_length,
++    const carquet_logical_type_t* logical_type) {
+
+     memset(child, 0, sizeof(*child));
+     child->length = n;
+@@ -390,6 +391,21 @@ static carquet_status_t export_child_array(
+         for (int64_t i = 0; i < n; i++) {
+             if (src[i]) out_data[i >> 3] |= (uint8_t)(1u << (i & 7));
+         }
++    } else if (pt == CARQUET_PHYSICAL_INT32 && logical_type &&
++               logical_type->id == CARQUET_LOGICAL_INTEGER &&
++               (logical_type->params.integer.bit_width == 8 ||
++                logical_type->params.integer.bit_width == 16)) {
++        /* Parquet uses INT32 storage, but Arrow's c/C/s/S buffers are packed
++         * at the logical width. Preserve signed values as their bit pattern. */
++        size_t stride = (size_t)logical_type->params.integer.bit_width / 8;
++        out_data = (uint8_t*)calloc(n > 0 ? (size_t)n : 1, stride);
++        if (!out_data) { free(val); return CARQUET_ERROR_OUT_OF_MEMORY; }
++        const int32_t* src = (const int32_t*)data;
++        for (int64_t i = 0; i < n; i++) {
++            if (validity && !(validity[i >> 3] & (uint8_t)(1u << (i & 7)))) continue;
++            if (stride == 1) out_data[i] = (uint8_t)src[i];
++            else ((uint16_t*)out_data)[i] = (uint16_t)src[i];
++        }
+     } else {
+         size_t stride;
+         switch (pt) {
+@@ -477,7 +493,9 @@ static carquet_status_t build_leaf_child(struct ArrowArray* child,
+                                          const void* values, const uint8_t* validity,
+                                          int64_t n) {
+     return export_child_array(child, values, validity, n,
+-                              cs->elements[e].type, cs->elements[e].type_length);
++                              cs->elements[e].type, cs->elements[e].type_length,
++                              cs->elements[e].has_logical_type
++                                  ? &cs->elements[e].logical_type : NULL);
+ }
+
+ /* Export a single top-level field `e` (leaf / single-level LIST / MAP) into a
+diff --git a/src/reader/arrow_c_read.c b/src/reader/arrow_c_read.c
+index 1ceec37..1b46bf1 100644
+--- a/src/reader/arrow_c_read.c
++++ b/src/reader/arrow_c_read.c
+@@ -218,7 +218,12 @@ static carquet_status_t schema_node(const carquet_schema_t* cs, int32_t e,
+     }
+     case K_LIST: {
+         /* list group -> repeated "list" group -> element */
+-        out->format = c_strdup("+l");
++        char fmt[32];
++        if (el->arrow_fixed_size_list_length > 0)
++            snprintf(fmt, sizeof(fmt), "+w:%d", el->arrow_fixed_size_list_length);
++        else
++            snprintf(fmt, sizeof(fmt), "+l");
++        out->format = c_strdup(fmt);
+         if (!out->format) { release_schema(out); return CARQUET_ERROR_OUT_OF_MEMORY; }
+         int32_t rep[4]; int32_t nr = elem_children(cs, e, rep, 4);
+         if (nr != 1) { release_schema(out); return CARQUET_ERROR_INVALID_ARGUMENT; }
+@@ -265,8 +270,37 @@ static carquet_status_t schema_node(const carquet_schema_t* cs, int32_t e,
+     return CARQUET_ERROR_INTERNAL;
+ }
+
+-carquet_status_t carquet_arrow_build_schema_tree(
+-    const carquet_schema_t* cs, struct ArrowSchema* out, carquet_error_t* error) {
++static carquet_status_t validate_field_indices(
++    const int32_t* field_indices, int32_t num_fields, int32_t num_top,
++    carquet_error_t* error) {
++
++    if (num_fields < 0 || (num_fields > 0 && !field_indices)) {
++        CARQUET_SET_ERROR(error, CARQUET_ERROR_INVALID_ARGUMENT,
++                          "field_indices is NULL or num_fields is negative");
++        return CARQUET_ERROR_INVALID_ARGUMENT;
++    }
++    for (int32_t i = 0; i < num_fields; i++) {
++        if (field_indices[i] < 0 || field_indices[i] >= num_top) {
++            CARQUET_SET_ERROR(error, CARQUET_ERROR_INVALID_ARGUMENT,
++                              "top-level field index %d is out of range",
++                              field_indices[i]);
++            return CARQUET_ERROR_INVALID_ARGUMENT;
++        }
++        for (int32_t j = 0; j < i; j++) {
++            if (field_indices[j] == field_indices[i]) {
++                CARQUET_SET_ERROR(error, CARQUET_ERROR_INVALID_ARGUMENT,
++                                  "duplicate top-level field index %d",
++                                  field_indices[i]);
++                return CARQUET_ERROR_INVALID_ARGUMENT;
++            }
++        }
++    }
++    return CARQUET_OK;
++}
++
++static carquet_status_t carquet_arrow_build_projected_schema_tree(
++    const carquet_schema_t* cs, const int32_t* field_indices,
++    int32_t num_fields, struct ArrowSchema* out, carquet_error_t* error) {
+
+     memset(out, 0, sizeof(*out));
+     out->format = c_strdup("+s");
+@@ -276,16 +310,25 @@ carquet_status_t carquet_arrow_build_schema_tree(
+
+     int32_t top[1024]; int32_t nt = elem_children(cs, 0, top, 1024);
+     if (nt > 1024) { release_schema(out); CARQUET_SET_ERROR(error, CARQUET_ERROR_INVALID_ARGUMENT, "too many fields"); return CARQUET_ERROR_INVALID_ARGUMENT; }
+-    if (schema_alloc_children(out, nt) != CARQUET_OK) { release_schema(out); CARQUET_SET_ERROR(error, CARQUET_ERROR_OUT_OF_MEMORY, "alloc"); return CARQUET_ERROR_OUT_OF_MEMORY; }
+-    for (int32_t i = 0; i < nt; i++) {
++    carquet_status_t valid = validate_field_indices(field_indices, num_fields, nt, error);
++    if (valid != CARQUET_OK) { release_schema(out); return valid; }
++    int32_t output_fields = num_fields > 0 ? num_fields : nt;
++    if (schema_alloc_children(out, output_fields) != CARQUET_OK) { release_schema(out); CARQUET_SET_ERROR(error, CARQUET_ERROR_OUT_OF_MEMORY, "alloc"); return CARQUET_ERROR_OUT_OF_MEMORY; }
++    for (int32_t i = 0; i < output_fields; i++) {
++        int32_t field = num_fields > 0 ? field_indices[i] : i;
+         out->children[i] = new_schema_child();
+         if (!out->children[i]) { release_schema(out); CARQUET_SET_ERROR(error, CARQUET_ERROR_OUT_OF_MEMORY, "alloc"); return CARQUET_ERROR_OUT_OF_MEMORY; }
+-        carquet_status_t st = schema_node(cs, top[i], NULL, false, out->children[i]);
+-        if (st != CARQUET_OK) { release_schema(out); CARQUET_SET_ERROR(error, st, "Arrow export: field %d", i); return st; }
++        carquet_status_t st = schema_node(cs, top[field], NULL, false, out->children[i]);
++        if (st != CARQUET_OK) { release_schema(out); CARQUET_SET_ERROR(error, st, "Arrow export: field %d", field); return st; }
+     }
+     return CARQUET_OK;
+ }
+
++carquet_status_t carquet_arrow_build_schema_tree(
++    const carquet_schema_t* cs, struct ArrowSchema* out, carquet_error_t* error) {
++    return carquet_arrow_build_projected_schema_tree(cs, NULL, 0, out, error);
++}
++
+ /* ============================================================================
+  * Leaf reading
+  * ============================================================================
+@@ -395,13 +438,31 @@ static carquet_status_t build_leaf(rctx_t* ctx, int32_t leaf_col, int16_t exist_
+         a->n_buffers = 2; a->buffers = bufs;
+     } else {
+         size_t stride = L->stride;
++        const parquet_schema_element_t* element =
++            &ctx->cs->elements[ctx->cs->leaf_indices[leaf_col]];
++        if (L->pt == CARQUET_PHYSICAL_INT32 && element->has_logical_type &&
++            element->logical_type.id == CARQUET_LOGICAL_INTEGER) {
++            int bits = element->logical_type.params.integer.bit_width;
++            if (bits == 8 || bits == 16) stride = (size_t)bits / 8;
++        }
+         uint8_t* data = (uint8_t*)calloc((size_t)(len > 0 ? len : 1) * stride, 1);
+         const void** bufs = (const void**)malloc(2 * sizeof(void*));
+         if (!data || !bufs) { free(data); free(bufs); rc = CARQUET_ERROR_OUT_OF_MEMORY; goto fail; }
+         const uint8_t* src = (const uint8_t*)L->values;
+         int64_t vc = 0;
+         for (int64_t i = 0; i < len; i++) {
+-            if (present[i]) { memcpy(data + (size_t)i * stride, src + (size_t)vc * stride, stride); vc++; }
++            if (!present[i]) continue;
++            /* Source values retain their physical width; Arrow output must
++             * match the logical c/C/s/S format declared by the schema. */
++            if (stride < L->stride) {
++                int32_t value;
++                memcpy(&value, src + (size_t)vc * L->stride, sizeof(value));
++                if (stride == 1) data[i] = (uint8_t)value;
++                else ((uint16_t*)data)[i] = (uint16_t)value;
++            } else {
++                memcpy(data + (size_t)i * stride, src + (size_t)vc * L->stride, stride);
++            }
++            vc++;
+         }
+         bufs[0] = validity; bufs[1] = data;
+         a->n_buffers = 2; a->buffers = bufs;
+@@ -588,9 +649,11 @@ static carquet_status_t build_node(rctx_t* ctx, int32_t e, int16_t def_in,
+  * Public entry point
+  * ============================================================================
+  */
+-carquet_status_t carquet_reader_read_arrow(
++carquet_status_t carquet_reader_read_arrow_columns(
+     carquet_reader_t* reader,
+     int32_t row_group_index,
++    const int32_t* field_indices,
++    int32_t num_fields,
+     struct ArrowSchema* out_schema,
+     struct ArrowArray* out_array,
+     carquet_error_t* error) {
+@@ -606,15 +669,55 @@ carquet_status_t carquet_reader_read_arrow(
+     }
+     const carquet_schema_t* cs = reader->schema;
+     int32_t num_leaves = cs->num_leaves;
++    int32_t top[1024]; int32_t nt = elem_children(cs, 0, top, 1024);
++    if (nt > 1024) {
++        CARQUET_SET_ERROR(error, CARQUET_ERROR_INVALID_ARGUMENT, "too many fields");
++        return CARQUET_ERROR_INVALID_ARGUMENT;
++    }
++    carquet_status_t rc = validate_field_indices(
++        field_indices, num_fields, nt, error);
++    if (rc != CARQUET_OK) return rc;
++    int32_t output_fields = num_fields > 0 ? num_fields : nt;
++
++    bool* read_leaves = (bool*)calloc(
++        (size_t)(num_leaves > 0 ? num_leaves : 1), sizeof(bool));
++    if (!read_leaves) {
++        CARQUET_SET_ERROR(error, CARQUET_ERROR_OUT_OF_MEMORY, "alloc");
++        return CARQUET_ERROR_OUT_OF_MEMORY;
++    }
++    int32_t top_base[1024];
++    int32_t next_base = 0;
++    for (int32_t i = 0; i < nt; i++) {
++        top_base[i] = next_base;
++        int32_t leaves = count_leaves(cs, top[i]);
++        if (leaves < 0 || next_base > num_leaves - leaves) {
++            free(read_leaves);
++            CARQUET_SET_ERROR(error, CARQUET_ERROR_INVALID_ARGUMENT,
++                              "invalid top-level field tree");
++            return CARQUET_ERROR_INVALID_ARGUMENT;
++        }
++        next_base += leaves;
++    }
++    if (next_base != num_leaves) {
++        free(read_leaves);
++        CARQUET_SET_ERROR(error, CARQUET_ERROR_INVALID_ARGUMENT,
++                          "top-level fields do not cover every leaf");
++        return CARQUET_ERROR_INVALID_ARGUMENT;
++    }
++    for (int32_t i = 0; i < output_fields; i++) {
++        int32_t field = num_fields > 0 ? field_indices[i] : i;
++        int32_t base = top_base[field];
++        int32_t leaves = count_leaves(cs, top[field]);
++        for (int32_t l = 0; l < leaves; l++) read_leaves[base + l] = true;
++    }
+
+     rctx_t ctx = { cs, NULL, num_leaves, error };
+     ctx.leaves = (rleaf_t*)calloc((size_t)(num_leaves > 0 ? num_leaves : 1), sizeof(rleaf_t));
+-    if (!ctx.leaves) { CARQUET_SET_ERROR(error, CARQUET_ERROR_OUT_OF_MEMORY, "alloc"); return CARQUET_ERROR_OUT_OF_MEMORY; }
++    if (!ctx.leaves) { free(read_leaves); CARQUET_SET_ERROR(error, CARQUET_ERROR_OUT_OF_MEMORY, "alloc"); return CARQUET_ERROR_OUT_OF_MEMORY; }
+
+-    carquet_status_t rc = CARQUET_OK;
+-
+-    /* Read every leaf column's full (rep, def, value) stream. */
++    /* Read every leaf below each selected top-level field. */
+     for (int32_t l = 0; l < num_leaves; l++) {
++        if (!read_leaves[l]) continue;
+         rleaf_t* L = &ctx.leaves[l];
+         int32_t elem = cs->leaf_indices[l];
+         const parquet_schema_element_t* el = &cs->elements[elem];
+@@ -686,8 +789,6 @@ carquet_status_t carquet_reader_read_arrow(
+
+     /* Assemble the top-level struct array. */
+     {
+-        int32_t top[1024]; int32_t nt = elem_children(cs, 0, top, 1024);
+-        if (nt > 1024) { rc = CARQUET_ERROR_INVALID_ARGUMENT; goto cleanup; }
+         int64_t num_rows = reader->metadata.row_groups[row_group_index].num_rows;
+
+         memset(out_array, 0, sizeof(*out_array));
+@@ -696,20 +797,20 @@ carquet_status_t carquet_reader_read_arrow(
+         out_array->offset = 0;
+         out_array->n_buffers = 1;
+         out_array->buffers = (const void**)calloc(1, sizeof(void*));  /* struct validity (absent) */
+-        out_array->n_children = nt;
+-        out_array->children = nt ? (struct ArrowArray**)calloc((size_t)nt, sizeof(void*)) : NULL;
++        out_array->n_children = output_fields;
++        out_array->children = output_fields ? (struct ArrowArray**)calloc((size_t)output_fields, sizeof(void*)) : NULL;
+         out_array->release = release_array;
+-        if (!out_array->buffers || (nt && !out_array->children)) {
++        if (!out_array->buffers || (output_fields && !out_array->children)) {
+             release_array(out_array); rc = CARQUET_ERROR_OUT_OF_MEMORY;
+             CARQUET_SET_ERROR(error, rc, "alloc"); goto cleanup;
+         }
+
+-        int32_t base = 0;
+-        for (int32_t i = 0; i < nt; i++) {
+-            rc = build_node(&ctx, top[i], 0, 0, 0, base, &out_array->children[i]);
++        for (int32_t i = 0; i < output_fields; i++) {
++            int32_t field = num_fields > 0 ? field_indices[i] : i;
++            rc = build_node(&ctx, top[field], 0, 0, 0, top_base[field], &out_array->children[i]);
+             if (rc != CARQUET_OK) {
+                 release_array(out_array);
+-                CARQUET_SET_ERROR(error, rc, "Arrow read: failed to assemble field %d", i);
++                CARQUET_SET_ERROR(error, rc, "Arrow read: failed to assemble field %d", field);
+                 goto cleanup;
+             }
+             int64_t got_len = out_array->children[i]->length;
+@@ -717,15 +818,15 @@ carquet_status_t carquet_reader_read_arrow(
+                 release_array(out_array);
+                 CARQUET_SET_ERROR(error, CARQUET_ERROR_INTERNAL,
+                     "Arrow read: field %d length %lld != %lld rows",
+-                    i, (long long)got_len, (long long)num_rows);
++                    field, (long long)got_len, (long long)num_rows);
+                 rc = CARQUET_ERROR_INTERNAL; goto cleanup;
+             }
+-            base += count_leaves(cs, top[i]);
+         }
+     }
+
+     if (out_schema) {
+-        rc = carquet_arrow_build_schema_tree(cs, out_schema, error);
++        rc = carquet_arrow_build_projected_schema_tree(
++            cs, field_indices, num_fields, out_schema, error);
+         if (rc != CARQUET_OK) { release_array(out_array); goto cleanup; }
+     }
+
+@@ -737,5 +838,16 @@ cleanup:
+         if (ctx.leaves[l].cr) carquet_column_reader_free(ctx.leaves[l].cr);
+     }
+     free(ctx.leaves);
++    free(read_leaves);
+     return rc;
+ }
++
++carquet_status_t carquet_reader_read_arrow(
++    carquet_reader_t* reader,
++    int32_t row_group_index,
++    struct ArrowSchema* out_schema,
++    struct ArrowArray* out_array,
++    carquet_error_t* error) {
++    return carquet_reader_read_arrow_columns(
++        reader, row_group_index, NULL, 0, out_schema, out_array, error);
++}
+diff --git a/src/reader/arrow_schema_read.c b/src/reader/arrow_schema_read.c
+index d0d225f..4b933b7 100644
+--- a/src/reader/arrow_schema_read.c
++++ b/src/reader/arrow_schema_read.c
+@@ -21,12 +21,17 @@ enum { MSG_HEADER_SLOT = 2 };      /* Message.header (union value) */
+ enum { SCHEMA_FIELDS_SLOT = 1 };   /* Schema.fields */
+ enum { FIELD_NAME_SLOT = 0 };      /* Field.name */
+ enum { FIELD_TYPETYPE_SLOT = 2 };  /* Field.type_type (union tag, u8) */
++enum { FIELD_TYPE_SLOT = 3 };      /* Field.type (union value table) */
++enum { FIELD_CHILDREN_SLOT = 5 };  /* Field.children */
+ enum { FIELD_META_SLOT = 6 };      /* Field.custom_metadata */
+ enum { KV_KEY_SLOT = 0, KV_VALUE_SLOT = 1 };
+
+ /* Arrow Type union tags for the 64-bit-offset variants Parquet can't express
+  * (format/Type.fbs). Kept in sync with carquet_arrow_type_refinement_t. */
+-enum { AT_LARGEBINARY = 19, AT_LARGEUTF8 = 20, AT_LARGELIST = 21 };
++enum {
++    AT_LIST = 12, AT_STRUCT = 13, AT_FIXED_SIZE_LIST = 16, AT_MAP = 17,
++    AT_LARGEBINARY = 19, AT_LARGEUTF8 = 20, AT_LARGELIST = 21
++};
+
+ /* Sanity cap on vector element counts from crafted input. */
+ enum { MAX_VECTOR_ELEMS = 1 << 20 };
+@@ -187,25 +192,186 @@ static int32_t field_type_refinement(const fbr* r, size_t field_tbl) {
+     }
+ }
+
+-/* ---- attach metadata to the matching top-level schema element ---- */
++/* ---- recursively attach Arrow-only information to the Parquet tree ---- */
+
+-static int32_t match_element(const char* name,
+-                             parquet_schema_element_t* elements,
+-                             int32_t num_elements,
+-                             const int32_t* parent_indices,
+-                             const uint8_t* used) {
++enum { ARROW_MAX_NEST_DEPTH = 100 };
++
++static int32_t match_child(const char* name, int32_t parquet_parent,
++                           parquet_schema_element_t* elements,
++                           int32_t num_elements,
++                           const int32_t* parent_indices,
++                           const uint8_t* used) {
+     if (!name) return -1;
+-    /* Match by name among direct children of the root that have no metadata
+-     * yet (used[] guards against duplicate names being over-written). */
+     for (int32_t i = 1; i < num_elements; i++) {
+-        int32_t parent = parent_indices ? parent_indices[i] : 0;
+-        if (parent != 0) continue;
+-        if (used[i]) continue;
++        if (parent_indices[i] != parquet_parent || used[i]) continue;
+         if (elements[i].name && strcmp(elements[i].name, name) == 0) return i;
+     }
+     return -1;
+ }
+
++static int32_t only_child(int32_t parquet_parent, int32_t num_elements,
++                          const int32_t* parent_indices) {
++    int32_t child = -1;
++    for (int32_t i = 1; i < num_elements; i++) {
++        if (parent_indices[i] != parquet_parent) continue;
++        if (child >= 0) return -1;
++        child = i;
++    }
++    return child;
++}
++
++static int element_is_list(const parquet_schema_element_t* e) {
++    return (e->has_logical_type &&
++            e->logical_type.id == CARQUET_LOGICAL_LIST) ||
++           (e->has_converted_type &&
++            e->converted_type == CARQUET_CONVERTED_LIST);
++}
++
++static int element_is_map(const parquet_schema_element_t* e) {
++    return (e->has_logical_type &&
++            e->logical_type.id == CARQUET_LOGICAL_MAP) ||
++           (e->has_converted_type &&
++            (e->converted_type == CARQUET_CONVERTED_MAP ||
++             e->converted_type == CARQUET_CONVERTED_MAP_KEY_VALUE));
++}
++
++static uint8_t field_type_tag(const fbr* r, size_t field_tbl) {
++    size_t f;
++    uint8_t tag = 0;
++    if (!fbr_field(r, field_tbl, FIELD_TYPETYPE_SLOT, &f) || f == 0 ||
++        !fbr_u8(r, f, &tag)) return 0;
++    return tag;
++}
++
++static int32_t fixed_size_list_length(const fbr* r, size_t field_tbl) {
++    if (field_type_tag(r, field_tbl) != AT_FIXED_SIZE_LIST) return 0;
++    size_t f, type_tbl, length_field;
++    int32_t length;
++    if (!fbr_field(r, field_tbl, FIELD_TYPE_SLOT, &f) || f == 0 ||
++        !fbr_indirect(r, f, &type_tbl) ||
++        !fbr_field(r, type_tbl, 0, &length_field) || length_field == 0 ||
++        !fbr_i32(r, length_field, &length) || length <= 0) return 0;
++    return length;
++}
++
++static void attach_custom_metadata(const fbr* r, size_t field_tbl,
++                                   parquet_schema_element_t* element,
++                                   carquet_arena_t* arena) {
++    size_t meta_data;
++    uint32_t nmeta;
++    if (!fbr_field_vector(r, field_tbl, FIELD_META_SLOT, 4,
++                          &meta_data, &nmeta) || nmeta == 0) return;
++
++    parquet_key_value_t* kvs = (parquet_key_value_t*)carquet_arena_calloc(
++        arena, nmeta, sizeof(parquet_key_value_t));
++    if (!kvs) return;
++
++    int32_t got = 0;
++    for (uint32_t k = 0; k < nmeta; k++) {
++        size_t kv_tbl;
++        if (!fbr_indirect(r, meta_data + (size_t)k * 4, &kv_tbl)) continue;
++        char* key = fbr_field_string(r, kv_tbl, KV_KEY_SLOT, arena);
++        if (!key) continue;
++        kvs[got].key = key;
++        kvs[got].value = fbr_field_string(r, kv_tbl, KV_VALUE_SLOT, arena);
++        got++;
++    }
++    if (got > 0) {
++        element->field_metadata = kvs;
++        element->num_field_metadata = got;
++    }
++}
++
++static void apply_field(const fbr* r, size_t field_tbl, int32_t element_index,
++                        parquet_schema_element_t* elements,
++                        int32_t num_elements, const int32_t* parent_indices,
++                        uint8_t* used, carquet_arena_t* arena, int depth);
++
++static void apply_children(const fbr* r, size_t field_tbl,
++                           int32_t parquet_parent,
++                           parquet_schema_element_t* elements,
++                           int32_t num_elements,
++                           const int32_t* parent_indices, uint8_t* used,
++                           carquet_arena_t* arena, int depth) {
++    size_t children_data;
++    uint32_t nchildren;
++    if (!fbr_field_vector(r, field_tbl, FIELD_CHILDREN_SLOT, 4,
++                          &children_data, &nchildren)) return;
++    for (uint32_t i = 0; i < nchildren; i++) {
++        size_t child_tbl;
++        if (!fbr_indirect(r, children_data + (size_t)i * 4, &child_tbl)) continue;
++        char* name = fbr_field_string(r, child_tbl, FIELD_NAME_SLOT, arena);
++        int32_t child = match_child(name, parquet_parent, elements,
++                                    num_elements, parent_indices, used);
++        if (child < 0) continue;
++        used[child] = 1;
++        apply_field(r, child_tbl, child, elements, num_elements,
++                    parent_indices, used, arena, depth + 1);
++    }
++}
++
++static void apply_field(const fbr* r, size_t field_tbl, int32_t element_index,
++                        parquet_schema_element_t* elements,
++                        int32_t num_elements, const int32_t* parent_indices,
++                        uint8_t* used, carquet_arena_t* arena, int depth) {
++    if (depth > ARROW_MAX_NEST_DEPTH || element_index <= 0 ||
++        element_index >= num_elements) return;
++
++    parquet_schema_element_t* element = &elements[element_index];
++    uint8_t tag = field_type_tag(r, field_tbl);
++    int32_t refine = field_type_refinement(r, field_tbl);
++    if (refine != 0) element->arrow_type_refinement = refine;
++    attach_custom_metadata(r, field_tbl, element, arena);
++
++    if (element_is_list(element)) {
++        if (tag != AT_LIST && tag != AT_LARGELIST &&
++            tag != AT_FIXED_SIZE_LIST) return;
++        size_t children_data;
++        uint32_t nchildren;
++        if (!fbr_field_vector(r, field_tbl, FIELD_CHILDREN_SLOT, 4,
++                              &children_data, &nchildren) || nchildren != 1)
++            return;
++        int32_t repeated_group = only_child(element_index, num_elements,
++                                            parent_indices);
++        int32_t parquet_element = repeated_group < 0 ? -1 :
++            only_child(repeated_group, num_elements, parent_indices);
++        size_t child_tbl;
++        if (parquet_element < 0 ||
++            !fbr_indirect(r, children_data, &child_tbl)) return;
++
++        int32_t fixed_length = fixed_size_list_length(r, field_tbl);
++        if (tag != AT_FIXED_SIZE_LIST || fixed_length > 0)
++            element->arrow_fixed_size_list_length = fixed_length;
++        used[parquet_element] = 1;
++        apply_field(r, child_tbl, parquet_element, elements, num_elements,
++                    parent_indices, used, arena, depth + 1);
++        return;
++    }
++
++    if (element_is_map(element)) {
++        if (tag != AT_MAP) return;
++        size_t children_data;
++        uint32_t nchildren;
++        if (!fbr_field_vector(r, field_tbl, FIELD_CHILDREN_SLOT, 4,
++                              &children_data, &nchildren) || nchildren != 1)
++            return;
++        size_t entries_tbl;
++        if (!fbr_indirect(r, children_data, &entries_tbl) ||
++            field_type_tag(r, entries_tbl) != AT_STRUCT) return;
++        int32_t kv_group = only_child(element_index, num_elements,
++                                      parent_indices);
++        if (kv_group < 0) return;
++        apply_children(r, entries_tbl, kv_group, elements, num_elements,
++                       parent_indices, used, arena, depth + 1);
++        return;
++    }
++
++    if (!element->has_type && tag == AT_STRUCT) {
++        apply_children(r, field_tbl, element_index, elements, num_elements,
++                       parent_indices, used, arena, depth + 1);
++    }
++}
++
+ void carquet_apply_arrow_field_metadata(
+     const char* b64_value,
+     parquet_schema_element_t* elements,
+@@ -251,42 +417,12 @@ void carquet_apply_arrow_field_metadata(
+
+         char* name = fbr_field_string(&r, field_tbl, FIELD_NAME_SLOT, arena);
+
+-        /* Match the Arrow field to its Parquet element up front so both the
+-         * type refinement and the custom_metadata can be attached, even when
+-         * the field carries no metadata. */
+-        int32_t idx = match_element(name, elements, num_elements,
+-                                    parent_indices, used);
++        int32_t idx = match_child(name, 0, elements, num_elements,
++                                  parent_indices, used);
+         if (idx < 0) continue;
+         used[idx] = 1;
+-
+-        /* Type refinement: a 64-bit-offset Arrow type Parquet can't express. */
+-        int32_t refine = field_type_refinement(&r, field_tbl);
+-        if (refine != 0) elements[idx].arrow_type_refinement = refine;
+-
+-        /* custom_metadata (variable labels/descriptions). */
+-        size_t meta_data;
+-        uint32_t nmeta;
+-        if (!fbr_field_vector(&r, field_tbl, FIELD_META_SLOT, 4,
+-                              &meta_data, &nmeta) || nmeta == 0) continue;
+-
+-        parquet_key_value_t* kvs = (parquet_key_value_t*)carquet_arena_calloc(
+-            arena, nmeta, sizeof(parquet_key_value_t));
+-        if (!kvs) continue;
+-
+-        int32_t got = 0;
+-        for (uint32_t k = 0; k < nmeta; k++) {
+-            size_t kv_tbl;
+-            if (!fbr_indirect(&r, meta_data + (size_t)k * 4, &kv_tbl)) continue;
+-            char* key = fbr_field_string(&r, kv_tbl, KV_KEY_SLOT, arena);
+-            if (!key) continue;  /* KeyValue.key is required to be useful */
+-            kvs[got].key = key;
+-            kvs[got].value = fbr_field_string(&r, kv_tbl, KV_VALUE_SLOT, arena);
+-            got++;
+-        }
+-        if (got == 0) continue;
+-
+-        elements[idx].field_metadata = kvs;
+-        elements[idx].num_field_metadata = got;
++        apply_field(&r, field_tbl, idx, elements, num_elements,
++                    parent_indices, used, arena, 0);
+     }
+
+ done:
 diff --git a/src/reader/file_reader.c b/src/reader/file_reader.c
 index 93ca8c0..2d88cc1 100644
 --- a/src/reader/file_reader.c
@@ -414,6 +1043,22 @@ index 22ad65f..977470b 100644
  /**
   * Open file with memory mapping.
   * Returns mmap_info on success, NULL on failure (fallback to fread).
+diff --git a/src/thrift/parquet_types.h b/src/thrift/parquet_types.h
+index 66b549c..45be575 100644
+--- a/src/thrift/parquet_types.h
++++ b/src/thrift/parquet_types.h
+@@ -97,6 +97,11 @@ struct parquet_schema_element {
+      * Values mirror carquet_arrow_type_refinement_t. Read-only: never written
+      * to the Parquet schema. */
+     int32_t arrow_type_refinement;
++
++    /* Carquet extension: FixedSizeList length recovered from, or to be
++     * emitted into, the "ARROW:schema" footer blob. Parquet's LIST logical
++     * type does not carry this value. Zero means a variable-length list. */
++    int32_t arrow_fixed_size_list_length;
+ };
+
+ /* ============================================================================
 diff --git a/src/writer/file_writer.c b/src/writer/file_writer.c
 index 2ae7880..142e87a 100644
 --- a/src/writer/file_writer.c

--- a/tools/python_bind/tests/test_load_array.py
+++ b/tools/python_bind/tests/test_load_array.py
@@ -22,6 +22,7 @@ import json
 import os
 import shutil
 import sys
+from collections import Counter
 from datetime import date
 from datetime import datetime
 from pathlib import Path
@@ -752,11 +753,10 @@ class TestLoadArray:
 
         rows = list(
             self.conn.execute(
-                f'LOAD FROM "{list_path}" '
-                "UNWIND values AS value RETURN value ORDER BY value"
+                f'LOAD FROM "{list_path}" ' "UNWIND values AS value RETURN value"
             )
         )
-        assert rows == [[1], [None], [3], [4], [5]]
+        assert Counter(row[0] for row in rows) == Counter([1, None, 3, 4, 5])
 
         rows = list(
             self.conn.execute(f'LOAD FROM "{array_path}" RETURN id, vec ORDER BY id')


### PR DESCRIPTION
Adds the private Carquet reading path in the Parquet extension. CarquetSniffer and CarquetChunkSupplier reuse InputStreamFactory and IDataChunkSupplier and return NeuG-owned DataChunk columns. The scan handles scalar/NULL/temporal values, LIST and ARRAY nesting, projection, complete predicates with runtime parameters, multiple files, batch/full reads and ordered parallel row-group tasks.

The reader selects output columns plus all predicate dependencies before decoding, applies conservative row-group pruning, evaluates the complete predicate using the shared R5 filter and restores the requested output projection. Reader, schema and batch ownership use RAII, including failed initialization and reads. The existing callback input adapter adds bounded caching. Carquet remains a pinned submodule with an adjacent patch; the additions restore fixed-size-list metadata and select nested top-level fields before decoding.

Production Parquet registration still uses Arrow. No public IO, compiler, execution, CSV/JSON or existing Arrow-reader behavior is changed. The new implementation remains in the test build until the backend-switch PR. MAP schema inspection is supported, but general MAP/STRUCT values are outside this reader's supported scope. Chunk size bounds returned chunks; nested/projected/pruned paths may decode a whole row group and full reads retain their complete result.

## Review map

- schema_converter and column_converter/nested_converter: scalar, temporal and nested layout conversion.
- chunk_supplier and input_adapter: ownership, chunk slicing, physical column/row-group selection and caching.
- scan and row_group_pruner: schema checks, complete predicates, parameter rebinding, projection and conservative statistics.
- Carquet supplier/scan tests and HTTPFS test: independent expected results, temporary in-memory data, resource lifetime, actual HTTP Range bytes. Existing datasets are reused; no Parquet binaries or PyArrow dependency are added to C++ tests. Fixed-size-list metadata uses a documented schema-only IPC test value.
- doc/source/extensions/carquet_reader.md: feature status, type coverage, options, memory constraints and test instructions, linked from Parquet documentation and navigation.

## Validation

- Debug and Release: 38/38 Carquet tests, 46/46 production Parquet tests.
- Debug and Release: 88 Python Parquet/export tests passed, 6 existing comprehensive_graph tests skipped; 6 credential-dependent HTTPFS export tests deselected.
- The five Parquet CTest entries selected by extension_tests_default passed, including existing page-encoding and callback tests.
- 22 HTTPFS tests passed with local loopback-server access. Range integration compares the same physical projection with pruning enabled/disabled and verifies lower actual HTTP response bytes.
- ASan/UBSan: all 38 tests passed with all 48 Carquet C sources, 9 C++ adapter sources and 4 test sources instrumented. Existing core/dependency libraries are uninstrumented; leak detection is disabled on macOS.
- 600 predicate/row-group combinations checked against exact evaluation; separate all-NULL/adjacent-NOT-ISNULL, nested CASE/ARRAY/LIST parameters, duplicate outputs and reordered nested projection regressions passed.
- Debug with only parquet enabled (HTTPFS disabled) configured, built and passed Carquet tests. Existing build configuration restored afterward.
- A fresh pinned Carquet source archive plus the adjacent patch configured and built with pkg-config disabled. Live patched files equal this fresh application. All 9 private C++ sources separately compile without Arrow include directories.
- clang-format 10 and git diff --check passed. No submodule gitlink or local design documents are included.

These are local macOS results. Linux runners and the system-Arrow configuration still require PR CI; no local system Arrow installation is available. No push or PR creation was performed.

Base: upstream/main fc9096bb (R5 merged as #1023). Branch: codex/carquet-r03-complete-reader. One cohesive feature commit: 25 files, +5397/-8 (5405 changed lines). Logs: build/review-r03-expanded-mdfpz1ah/.