### PR TITLE
docs: fix stale #543 iterator-API residue in doc sources

### DIFF
--- a/doc/source/_scripts/cpp_key_classes.json
+++ b/doc/source/_scripts/cpp_key_classes.json
@@ -9,8 +9,7 @@
     "neug::ExecutionSlot",
     "neug::TpExecutionSlotPool",
     "neug::ExecutionSlotLease",
-    "neug::QueryResult",
-    "neug::RecordLine"
+    "neug::QueryResult"
   ],
   "class_files": {
     "neug::NeugDB": {
@@ -26,8 +25,7 @@
     "neug::QueryResult": {
       "filename": "query_result",
       "title": "QueryResult",
-      "description": "Container for query results with iterator access",
-      "include_classes": ["neug::RecordLine"]
+      "description": "Container for query results with cursor-based access"
     },
     "neug::NeugDBService": {
       "filename": "service",

--- a/doc/source/_scripts/generate_cpp_docs.py
+++ b/doc/source/_scripts/generate_cpp_docs.py
@@ -1302,8 +1302,10 @@ int main() {
 
   // Process results
   if (result.has_value()) {
-    for (auto& record : result.value()) {
-      std::cout << record.ToString() << std::endl;
+    auto& qr = result.value();
+    while (qr.hasNext()) {
+      std::cout << qr.GetCurrentRowAsString() << std::endl;
+      qr.next();
     }
   }
 
@@ -1354,7 +1356,7 @@ if (!result.has_value()) {
             title = friendly_names.get(page_name, file_info["title"])
             content += f'  "{page_name}": "{title}",\n'
         
-        content += "}\n"
+        content += "};\n"
         
         with open(filename, 'w', encoding='utf-8') as f:
             f.write(content)
@@ -1471,7 +1473,7 @@ The C++ API offers powerful capabilities for:
                 elif simple_name == "Connection":
                     content += "Execute Cypher queries against the database\n"
                 elif simple_name == "QueryResult":
-                    content += "Container for query results with iterator access\n"
+                    content += "Container for query results with cursor-based access\n"
                 elif simple_name == "PropertyGraph":
                     content += "Low-level graph storage engine\n"
                 elif simple_name == "Schema":
@@ -1508,9 +1510,10 @@ int main() {
 
     // Process results
     if (result.has_value()) {
-        while (result.value().hasNext()) {
-            auto record = result.value().next();
-            std::cout << record.ToString() << std::endl;
+        auto& qr = result.value();
+        while (qr.hasNext()) {
+            std::cout << qr.GetCurrentRowAsString() << std::endl;
+            qr.next();
         }
     }
 

--- a/include/neug/main/connection.h
+++ b/include/neug/main/connection.h
@@ -47,8 +47,10 @@ class ExecutionSlot;
  *
  * // Execute a read query
  * auto result = conn->Query("MATCH (n:Person) RETURN n.name LIMIT 10", "read");
- * for (auto& record : result.value()) {
- *   // Process record...
+ * auto& qr = result.value();
+ * while (qr.hasNext()) {
+ *   std::cout << qr.GetCurrentRowAsString() << std::endl;
+ *   qr.next();
  * }
  *
  * // Execute an insert query
@@ -110,8 +112,10 @@ class NEUG_API Connection {
    *
    * // Process results
    * if (result.has_value()) {
-   *   for (auto& record : result.value()) {
-   *     // Access columns via record.entries()
+   *   auto& qr = result.value();
+   *   while (qr.hasNext()) {
+   *     std::string name = qr.GetString("n.name");
+   *     qr.next();
    *   }
    * } else {
    *   std::cerr << "Query failed: " << result.error().message() << std::endl;

--- a/include/neug/main/neug_db.h
+++ b/include/neug/main/neug_db.h
@@ -76,8 +76,10 @@ class ExtensionManager;
  * auto result = conn->Query("MATCH (n:Person) RETURN n LIMIT 10");
  *
  * // Process results
- * for (auto& record : result.value()) {
- *   std::cout << record.ToString() << std::endl;
+ * auto& qr = result.value();
+ * while (qr.hasNext()) {
+ *   std::cout << qr.GetCurrentRowAsString() << std::endl;
+ *   qr.next();
  * }
  *
  * // Close database (persists data)
@@ -99,7 +101,10 @@ class ExtensionManager;
  * Connection instances are not thread-safe.
  *
  * **Resource Management:**
- * - File locking prevents concurrent database access from multiple processes
+ * - File locking serializes write access across processes: a database opened
+ *   in read-write mode is exclusive, while multiple read-only processes (or
+ *   multiple read-only instances within one process) can share the same
+ *   database directory concurrently
  * - Automatic WAL (Write-Ahead Log) for crash recovery
  * - Configurable checkpoint on close
  *

--- a/tools/python_bind/neug/session.py
+++ b/tools/python_bind/neug/session.py
@@ -317,20 +317,21 @@ class Session:
         """
         Execute a query on the NeuG server.
 
-        :param query: The query string to be executed.
-        :param access_mode: The access mode for the query. Supported modes are:
-            - `read` or `r`: Read-only queries
-            - `insert` or `i`: Insert-only operations
-            - `update` or `u`: Update/delete operations (default)
-            - `schema` or `s`: Schema modification operations
-        :param parameters: Optional dict of query parameters.
-        :return: The result of the query execution.
-
         While an explicit transaction is active, the query runs in that
         transaction. A failure reported by the service leaves it rollback-only;
         call `rollback()` before issuing another query. Client-side validation
         errors, such as an invalid `access_mode`, do not change the transaction
         state.
+
+        :param query: The query string to be executed.
+        :param access_mode: The access mode for the query. When omitted, NeuG infers it
+            from the query text. Supported modes are:
+            - `read` or `r`: Read-only queries
+            - `insert` or `i`: Insert-only operations
+            - `update` or `u`: Update/delete operations
+            - `schema` or `s`: Schema modification operations
+        :param parameters: Optional dict of query parameters.
+        :return: The result of the query execution.
         """
         if self._closed:
             logger.error("Session is closed. Cannot execute query.")


### PR DESCRIPTION
## What do these changes do?

Fix stale documentation **sources** left behind by the #543 iterator→cursor `QueryResult` refactor. These are doc sources only (header comments, the doc generator, its config, and a Python docstring) — no functional code changes, and no generated docs are committed (rationale below).

- `include/neug/main/connection.h`, `include/neug/main/neug_db.h`: replace the pre-#543 `for (auto& record : result.value())` examples with the current cursor API (`hasNext()` / `next()` / `GetString(...)` / `GetCurrentRowAsString()`). Also expand the `neug_db.h` file-locking note to match the already-published wording: a read-write open is exclusive, while multiple read-only processes/instances can share the directory.
- `doc/source/_scripts/generate_cpp_docs.py`: update the Quick Start example templates to the cursor API and fix a struct emission bug (`content += "}"` → `"};"`, which previously produced invalid C++ in `_meta.ts`).
- `doc/source/_scripts/cpp_key_classes.json`: drop the retired `neug::RecordLine` key class and its dangling `include_classes` reference; align the `QueryResult` description to "cursor-based access".
- `tools/python_bind/neug/session.py`: correct the `Session.execute()` docstring — the default `access_mode=""` infers the mode from the query text, so remove the inaccurate "(default)" on update mode and document the inference; move the transaction-behavior note out of the `:return:` block so it renders.

## Why no generated docs are included

The published docs under `doc/source/reference/` are **hand-curated and already correct** — several were fixed directly in #573/#892/#1003/#1025 without updating the sources. Re-running the generator (`make html` / `make api-docs`) produces a **mix of catch-up and regressions**, and the regressions would ship broken docs:

- flattens the hand-curated `cpp_api/query_result.md` — #1025's five sections (`Cursor Traversal` / `Typed Value Accessors` / `Metadata` / `Other Methods` / `Example`) collapse into a single `Public Methods` list;
- deletes `cpp_api/service.md`'s hand-written `ExecutionSlot` description ("runtime-neutral execution context…"), which lives in no header and therefore cannot be reproduced by generation;
- in the Python docs, reverts #573's label casing (`Person` → `person`), breaks examples into invalid Cypher (`-[:KNOWS]->` → `-[knows]->`), and injects raw Sphinx `:meth:` roles that don't render on the docs site.

So this PR deliberately fixes the **sources only** (a strict improvement, zero published-doc regression). Bringing the generated docs back in sync — correcting the stale Python docstrings and reconciling the hand-curated C++ pages so the generator reproduces the good output — is left as a separate follow-up.

## Related issue number

N/A — follow-up cleanup to #543.
