### PR TITLE
refactor: support HNSW top-k for correlated graph patterns

### DIFF
--- a/extension/vector_search/src/hnsw_index_scan.cc
+++ b/extension/vector_search/src/hnsw_index_scan.cc
@@ -20,6 +20,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -30,10 +31,12 @@
 #include "neug/compiler/binder/expression/property_expression.h"
 #include "neug/compiler/binder/expression/scalar_function_expression.h"
 #include "neug/compiler/binder/expression/variable_expression.h"
+#include "neug/compiler/binder/expression_visitor.h"
 #include "neug/compiler/catalog/catalog_entry/function_catalog_entry.h"
 #include "neug/compiler/function/built_in_function_utils.h"
 #include "neug/compiler/function/table/bind_data.h"
 #include "neug/compiler/main/metadata_manager.h"
+#include "neug/compiler/planner/operator/logical_hash_join.h"
 #include "neug/compiler/planner/operator/logical_order_by.h"
 #include "neug/compiler/planner/operator/logical_projection.h"
 #include "neug/compiler/planner/operator/logical_table_function_call.h"
@@ -227,7 +230,7 @@ std::shared_ptr<binder::Expression> MakeScoreColumn(
   return output;
 }
 
-const binder::PropertyExpression* GetVertexOnlyOutput(
+const binder::PropertyExpression* FindIndexVertexOutput(
     const planner::LogicalOperator& input,
     const binder::PropertyExpression& distance_property) {
   const auto* schema = input.getSchema();
@@ -239,27 +242,52 @@ const binder::PropertyExpression* GetVertexOnlyOutput(
     const binder::PropertyExpression* property = nullptr;
     if (expression->expressionType == common::ExpressionType::PATTERN) {
       const auto* node = expression->constPtrCast<binder::NodeExpression>();
-      if (node == nullptr || node->getTableIDs().size() != 1 ||
-          node->getTableIDs()[0] != distance_property.getSingleTableID()) {
-        return nullptr;
+      if (node == nullptr || node->getTableIDs().size() != 1) {
+        continue;
       }
       property =
           node->getInternalIDRef()->constPtrCast<binder::PropertyExpression>();
     } else if (expression->expressionType == common::ExpressionType::PROPERTY) {
       property = expression->constPtrCast<binder::PropertyExpression>();
     } else {
-      return nullptr;
+      continue;
     }
     if (property == nullptr || !property->isInternalID() ||
         !property->isSingleLabel() ||
         property->getSingleTableID() != distance_property.getSingleTableID()) {
-      return nullptr;
+      continue;
     }
     if (property->getVariableName() == distance_property.getVariableName()) {
+      if (vertex != nullptr &&
+          vertex->getUniqueName() != property->getUniqueName()) {
+        return nullptr;
+      }
       vertex = property;
     }
   }
   return vertex;
+}
+
+bool ProjectionNeedsCorrelatedInput(
+    const planner::LogicalProjection& projection,
+    const binder::PropertyExpression& distance_property,
+    const binder::ScalarFunctionExpression& distance) {
+  std::unordered_set<std::string> direct_output_variables{
+      distance_property.getVariableName(),
+      static_cast<const binder::Expression&>(distance).getUniqueName()};
+  if (distance.hasAlias()) {
+    direct_output_variables.insert(distance.getAlias());
+  }
+  for (const auto& expression : projection.getExpressionsToProject()) {
+    binder::DependentVarNameCollector collector;
+    collector.visit(expression);
+    for (const auto& variable_name : collector.getVarNames()) {
+      if (!direct_output_variables.contains(variable_name)) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 std::unique_ptr<function::CallFuncInputBase> BindHNSWIndexScan(
@@ -480,7 +508,7 @@ HNSWIndexScanOptimizer::visitOrderByReplace(
     attach_input = scan->getPredicates() != nullptr ||
                    !scan->getPropertyPredicates().empty();
   } else {
-    vertex_output = GetVertexOnlyOutput(*input_op, *property);
+    vertex_output = FindIndexVertexOutput(*input_op, *property);
     if (vertex_output == nullptr) {
       return op;
     }
@@ -490,8 +518,8 @@ HNSWIndexScanOptimizer::visitOrderByReplace(
   if (function == nullptr) {
     return op;
   }
-  binder::expression_vector columns{MakeScanColumn(*vertex_output),
-                                    MakeScoreColumn(*distance)};
+  auto index_vertex = MakeScanColumn(*vertex_output);
+  binder::expression_vector columns{index_vertex, MakeScoreColumn(*distance)};
   auto bind_data = std::make_unique<function::IndexScanBindData>(
       columns, hnsw_index->GetMeta().name, target);
   bind_data->options["label_id"] = std::to_string(property->getSingleTableID());
@@ -499,11 +527,25 @@ HNSWIndexScanOptimizer::visitOrderByReplace(
 
   auto table_call = std::make_shared<planner::LogicalTableFunctionCall>(
       *function, std::move(bind_data));
-  if (attach_input) {
-    table_call->addChild(std::move(input_op));
+  if (ProjectionNeedsCorrelatedInput(*projection, *property, *distance)) {
+    table_call->computeFlatSchema();
+    auto left_key =
+        std::shared_ptr<binder::Expression>(vertex_output->copy().release());
+    std::vector<planner::join_condition_t> join_conditions{
+        {std::move(left_key), index_vertex}};
+    auto join = std::make_shared<planner::LogicalHashJoin>(
+        std::move(join_conditions), common::JoinType::INNER, nullptr, input_op,
+        table_call);
+    join->setPreQuery(true);
+    join->computeFlatSchema();
+    projection->setChild(0, std::move(join));
+  } else {
+    if (attach_input) {
+      table_call->addChild(std::move(input_op));
+    }
+    table_call->computeFlatSchema();
+    projection->setChild(0, std::move(table_call));
   }
-  table_call->computeFlatSchema();
-  projection->setChild(0, std::move(table_call));
   return op;
 }
 

--- a/tools/python_bind/tests/test_fts_index.py
+++ b/tools/python_bind/tests/test_fts_index.py
@@ -60,6 +60,24 @@ def search(connection, query, limit=10):
     )
 
 
+def profile_operator_names(result):
+    return [
+        operator["operator_name"]
+        for operator in result.get_profile_metrics()["operators"]
+    ]
+
+
+def add_fts_pattern_fanout(connection):
+    connection.execute(
+        "CREATE (:Article {id: 7, title: 'additional reference', "
+        "category: 'reference'});"
+    )
+    connection.execute(
+        "MATCH (article:Article {id: 1}), (cited:Article {id: 7}) "
+        "CREATE (article)-[:CITES]->(cited);"
+    )
+
+
 @pytest.fixture()
 def fts_database(tmp_path):
     db = Database(db_path=str(tmp_path / "fts_db"), mode="w")
@@ -487,6 +505,38 @@ def test_graph_candidates_receive_exact_fts_topk(fts_hybrid_database):
     )
     assert [row[0] for row in actual] == [row[0] for row in expected]
     assert [row[1] for row in actual] == pytest.approx([row[1] for row in expected])
+
+
+def test_fts_pattern_outputs_with_limit(fts_hybrid_database):
+    add_fts_pattern_fanout(fts_hybrid_database)
+    result = fts_hybrid_database.execute(
+        "PROFILE MATCH (article:Article)-[:CITES]->(cited:Article) "
+        "RETURN article.id, cited.id, "
+        "bm25(article.title, 'database') AS score LIMIT 2;"
+    )
+    rows = list(result)
+    assert {(row[0], row[1]) for row in rows} == {(1, 6), (1, 7)}
+    assert rows[0][2] == pytest.approx(rows[1][2])
+    operators = profile_operator_names(result)
+    assert "IndexScanOpr" in operators
+    assert "LimitOpr" in operators
+
+
+def test_fts_pattern_outputs_with_order_by_limit(fts_hybrid_database):
+    add_fts_pattern_fanout(fts_hybrid_database)
+    result = fts_hybrid_database.execute(
+        "PROFILE MATCH (article:Article)-[:CITES]->(cited:Article) "
+        "RETURN article.id, cited.id, "
+        "bm25(article.title, 'database') AS score "
+        "ORDER BY score ASC LIMIT 2;"
+    )
+    rows = list(result)
+    assert {(row[0], row[1]) for row in rows} == {(1, 6), (1, 7)}
+    assert rows[0][2] == pytest.approx(rows[1][2])
+    operators = profile_operator_names(result)
+    assert "IndexScanOpr" in operators
+    assert "OrderByOpr" not in operators
+    assert "LimitOpr" not in operators
 
 
 def test_show_and_drop_fts_index(fts_database):

--- a/tools/python_bind/tests/test_hnsw_index.py
+++ b/tools/python_bind/tests/test_hnsw_index.py
@@ -383,6 +383,25 @@ def test_issue_935_graph_constrained_topk_uses_hnsw_join(advanced_connection):
     assert "JoinOpr" in operators
 
 
+def test_correlated_hnsw_join_passes_scan_predicate_to_index(
+    advanced_connection,
+):
+    result = advanced_connection.execute(
+        "PROFILE MATCH (source:Source)-[:HAS_CHUNK]->(chunk:Chunk) "
+        "WHERE chunk.id = 'chunk-b' "
+        "RETURN source.id, chunk.id, "
+        "vector_distance_cosine(chunk.embedding, $embedding) AS distance "
+        "ORDER BY distance ASC LIMIT 1;",
+        parameters={"embedding": [1.0, 0.0, 0.0, 0.0]},
+    )
+    rows = list(result)
+    assert [row[:2] for row in rows] == [["source", "chunk-b"]]
+    assert rows[0][2] == pytest.approx(1.0)
+    operators = _profile_operator_names(result)
+    assert "IndexScanOpr" in operators
+    assert "JoinOpr" in operators
+
+
 def test_update_and_delete_maintain_index(advanced_connection):
     advanced_connection.execute(
         "MATCH (n:Item {id: 3}) "

--- a/tools/python_bind/tests/test_hnsw_index.py
+++ b/tools/python_bind/tests/test_hnsw_index.py
@@ -142,6 +142,22 @@ def _create_advanced_data(conn):
             f"WITH (metric = '{metric}', m = 16, ef_construction = 200);"
         )
 
+    conn.execute("CREATE NODE TABLE Source(id STRING PRIMARY KEY);")
+    conn.execute("CREATE NODE TABLE Chunk(id STRING PRIMARY KEY, embedding FLOAT[4]);")
+    conn.execute("CREATE REL TABLE HAS_CHUNK(FROM Source TO Chunk);")
+    conn.execute("CREATE (:Source {id: 'source'});")
+    conn.execute(
+        "CREATE (:Chunk {id: 'chunk-a', embedding: [1.0, 0.0, 0.0, 0.0]}), "
+        "(:Chunk {id: 'chunk-b', embedding: [0.0, 1.0, 0.0, 0.0]});"
+    )
+    conn.execute(
+        "MATCH (source:Source), (chunk:Chunk) " "CREATE (source)-[:HAS_CHUNK]->(chunk);"
+    )
+    conn.execute(
+        "CREATE INDEX chunk_hnsw ON Chunk USING HNSW (embedding) "
+        "WITH (metric = 'cosine', m = 2, ef_construction = 10);"
+    )
+
 
 @pytest.fixture(scope="module")
 def advanced_database(tmp_path_factory):
@@ -282,15 +298,30 @@ def test_hnsw_limit_above_1024(advanced_connection):
 
 
 def test_graph_filtering_during_index_scan(advanced_connection):
-    rows = list(
-        advanced_connection.execute(
-            "MATCH (source:Item)-[:NEXT]->(n:Item) RETURN n.id, "
-            f"vector_distance_l2(n.l2_vec, {_array_literal(_constant_vector(500.1))}) "
-            "AS score ORDER BY score ASC LIMIT 3;"
-        )
+    result = advanced_connection.execute(
+        "PROFILE MATCH (source:Item)-[:NEXT]->(n:Item) RETURN n.id, n.name, "
+        f"vector_distance_l2(n.l2_vec, {_array_literal(_constant_vector(500.1))}) "
+        "AS score ORDER BY score ASC LIMIT 3;"
     )
-    assert rows[0][0] == 500
-    assert {row[0] for row in rows[1:3]} == {499, 501}
+    rows = list(result)
+    assert rows[0][:2] == [500, "item_500"]
+    assert {(row[0], row[1]) for row in rows[1:3]} == {
+        (499, "item_499"),
+        (501, "item_501"),
+    }
+    operators = _profile_operator_names(result)
+    assert "IndexScanOpr" in operators
+    assert "JoinOpr" not in operators
+
+    node_result = advanced_connection.execute(
+        "PROFILE MATCH (source:Item)-[:NEXT]->(n:Item) RETURN n, "
+        f"vector_distance_l2(n.l2_vec, {_array_literal(_constant_vector(500.1))}) "
+        "AS score ORDER BY score ASC LIMIT 3;"
+    )
+    assert len(list(node_result)) == 3
+    node_operators = _profile_operator_names(node_result)
+    assert "IndexScanOpr" in node_operators
+    assert "JoinOpr" not in node_operators
 
     empty_result = advanced_connection.execute(
         "PROFILE MATCH (n:Item) WHERE n.group_id = 99 RETURN n.id, "
@@ -299,6 +330,57 @@ def test_graph_filtering_during_index_scan(advanced_connection):
     )
     assert list(empty_result) == []
     assert "IndexScanOpr" in _profile_operator_names(empty_result)
+
+
+def test_correlated_pattern_outputs_use_hnsw_join(advanced_connection):
+    result = advanced_connection.execute(
+        "PROFILE MATCH (n:Item)-[:NEXT]->(e:Item) RETURN n.id, e.id, "
+        f"vector_distance_l2(n.l2_vec, {_array_literal(_constant_vector(500.1))}) "
+        "AS score ORDER BY score ASC LIMIT 3;"
+    )
+    rows = list(result)
+    assert [(row[0], row[1]) for row in rows] == [
+        (500, 501),
+        (501, 502),
+        (499, 500),
+    ]
+    operators = _profile_operator_names(result)
+    assert "IndexScanOpr" in operators
+    assert "JoinOpr" in operators
+
+
+def test_correlated_hnsw_join_applies_final_limit_after_fanout(
+    advanced_connection,
+):
+    result = advanced_connection.execute(
+        "PROFILE MATCH (n:Item)-[:NEXT]-(e:Item) RETURN n.id, e.id, "
+        f"vector_distance_l2(n.l2_vec, {_array_literal(_constant_vector(500.1))}) "
+        "AS score ORDER BY score ASC LIMIT 3;"
+    )
+    rows = list(result)
+    assert len(rows) == 3
+    assert [row[0] for row in rows[:2]] == [500, 500]
+    assert {row[1] for row in rows[:2]} == {499, 501}
+    assert rows[2][0] == 501
+    operators = _profile_operator_names(result)
+    assert "IndexScanOpr" in operators
+    assert "JoinOpr" in operators
+
+
+def test_issue_935_graph_constrained_topk_uses_hnsw_join(advanced_connection):
+    result = advanced_connection.execute(
+        "PROFILE MATCH (source:Source)-[:HAS_CHUNK]->(chunk:Chunk) "
+        "RETURN source.id, chunk.id, "
+        "vector_distance_cosine(chunk.embedding, $embedding) AS distance "
+        "ORDER BY distance ASC LIMIT 1;",
+        parameters={"embedding": [1.0, 0.0, 0.0, 0.0]},
+    )
+    rows = list(result)
+    assert [row[:2] for row in rows] == [["source", "chunk-a"]]
+    assert rows[0][2] == pytest.approx(0.0)
+    operators = _profile_operator_names(result)
+    assert "IndexScanOpr" in operators
+    assert "JoinOpr" in operators
 
 
 def test_update_and_delete_maintain_index(advanced_connection):


### PR DESCRIPTION
## Summary

- preserve correlated pattern outputs when rewriting graph-constrained vector Top-K queries to HNSW IndexScan
- keep the existing direct IndexScan path when projection only depends on the indexed vertex, its properties, and the distance score
- add regression coverage for graph fan-out, final row-level LIMIT semantics, and the exact Source-to-Chunk cosine query reported in the issue
- add FTS pattern-output coverage for LIMIT and ORDER BY LIMIT behavior

## Implementation

When projection needs variables outside the indexed vertex and score, the optimizer now builds a pre-query INNER hash join:

- left: the original pattern input
- right: a childless HNSW IndexScan returning the indexed vertex and score
- join key: the indexed vertex internal identity

The original projection, ordering, and limit remain above the join so pattern fan-out is sorted and limited at the final row level. Queries that only return the indexed vertex or its properties continue using the direct path and avoid the join overhead.

## Tests

- NEUG_RUN_EXTENSION_TESTS=1 python3.9 -m pytest -q tests/test_hnsw_index.py -k "not parquet"
  - 29 passed, 1 deselected
- NEUG_RUN_EXTENSION_TESTS=1 python3.9 -m pytest -q tests/test_fts_index.py
  - 71 passed

Fixes #935