### PR TITLE
docs: reconcile API doc sources so regeneration is stable

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,9 @@ jobs:
       env:
         DOXYGEN_VERSION: '1.13.2'
       run: |
-        set -euo pipefail
+        # The container runs steps under sh (dash), which lacks `pipefail`;
+        # stick to POSIX `set -eu` so this works regardless of the shell.
+        set -eu
         sudo apt update
         sudo apt install -y curl graphviz
         INSTALL_DIR="${HOME}/doxygen-${DOXYGEN_VERSION}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,8 @@ on:
         - main
       paths:
         - 'doc/**'
+        - 'include/neug/**'            # C++ API doc sources (parsed by Doxygen)
+        - 'tools/python_bind/neug/**'  # Python API doc sources (parsed by pydoc-markdown)
         - '.github/workflows/docs.yml'
 
 
@@ -32,14 +34,46 @@ jobs:
       with:
         python-version: '3.10'
 
+    - name: Install pinned Doxygen
+      # Pinned to the exact version that generated the committed docs under
+      # doc/source/reference. Doxygen's XML output changes across versions, so an
+      # unpinned `apt install doxygen` would make the freshness guard below fail
+      # on version drift instead of on genuinely stale docs.
+      env:
+        DOXYGEN_VERSION: '1.13.2'
+      run: |
+        set -euo pipefail
+        sudo apt update
+        sudo apt install -y curl graphviz
+        INSTALL_DIR="${HOME}/doxygen-${DOXYGEN_VERSION}"
+        curl -fsSL -o /tmp/doxygen.tar.gz \
+          "https://sourceforge.net/projects/doxygen/files/rel-${DOXYGEN_VERSION}/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz/download"
+        mkdir -p "${INSTALL_DIR}"
+        tar -xzf /tmp/doxygen.tar.gz -C "${INSTALL_DIR}" --strip-components=1
+        "${INSTALL_DIR}/bin/doxygen" --version
+        echo "DOXYGEN_BIN=${INSTALL_DIR}/bin/doxygen" >> "${GITHUB_ENV}"
+
     - name: Build Documentation
       run: |
-        sudo apt update
-        sudo apt install -y doxygen graphviz
         cd ${GITHUB_WORKSPACE}/tools/python_bind
         python3 -m pip  install -r requirements.txt
         python3 -m pip  install -r requirements_dev.txt
         cd ${GITHUB_WORKSPACE}/doc
         . /home/neug/.neug_env
         make dependencies
-        make html
+        make html DOXYGEN="${DOXYGEN_BIN}"
+
+    - name: Verify committed API docs are up to date
+      # Hard guard: `make html` above regenerated doc/source/reference from the
+      # current sources. If the committed docs differ (modified, added, or
+      # removed), the contributor changed API sources without committing the
+      # regenerated docs, so fail the check.
+      run: |
+        cd "${GITHUB_WORKSPACE}"
+        if [ -n "$(git status --porcelain -- doc/source/reference)" ]; then
+          echo "::error::Committed API reference docs are stale. Sources under include/neug or tools/python_bind/neug changed but doc/source/reference was not regenerated. Run 'cd doc && make api-docs' (Doxygen 1.13.2, pydoc-markdown 4.8.2) and commit the result."
+          git --no-pager status --porcelain -- doc/source/reference
+          git --no-pager diff --stat -- doc/source/reference
+          exit 1
+        fi
+        echo "Committed API reference docs match the sources."

--- a/doc/docs-requirements.txt
+++ b/doc/docs-requirements.txt
@@ -7,4 +7,4 @@ sphinx-panels
 sphinxemoji
 sphinxext-opengraph
 breathe
-pydoc-markdown  # for Python API documentation generation
+pydoc-markdown==4.8.2  # pinned to match the docs committed under doc/source/reference (see .github/workflows/docs.yml)

--- a/doc/source/reference/cpp_api/connection.md
+++ b/doc/source/reference/cpp_api/connection.md
@@ -4,9 +4,9 @@
 
 Database connection for executing Cypher queries.
 
-`Connection` is the primary interface for interacting with a NeuG database. It provides methods to execute Cypher queries, retrieve schema information, and manage the connection lifecycle.
+`Connection` is the primary embedded-mode interface for interacting with a NeuG database. It provides methods to execute Cypher queries, retrieve schema information, manage a programmatic AP explicit transaction, and manage the connection lifecycle.
 
-**Usage Example:**
+**Usage Example:** 
 ```cpp
 // Get connection from database
 auto conn = db.Connect();
@@ -29,9 +29,7 @@ conn->Close();
 - `"update"` or `"u"`: Update/delete operations (SET, DELETE, MERGE)
 - `"schema"` or `"s"`: `Schema` modification operations (CREATE/DROP labels)
 
-**Thread Safety:** This class is NOT thread-safe. Do not call `Query()`,
-`GetSchema()`, or `Close()` concurrently on the same connection. Use a separate
-connection per thread.
+**Thread Safety:** This class is NOT thread-safe. A `Connection` and its owned `ExecutionSlot` must be used by only one thread at a time. Use a separate `Connection` per thread.
 
 **Lifecycle:**
 - Created via `NeugDB::Connect()`
@@ -47,28 +45,28 @@ connection per thread.
 Query(
     const std::string &query_string,
     const std::string &access_mode="",
-    const execution::ParamsMap &parameters={}
+    const rapidjson::Value &parameters=rapidjson::Value{rapidjson::kObjectType}
 )
 ```
 
 Execute a Cypher query and return results.
 
-Compiles and executes a Cypher query string against the database. The query is processed through the planner for optimization, then executed by the query processor.
+Compiles and executes a Cypher query string against the database. The query is processed through the planner for optimization, then executed by the connection-owned execution slot.
 
-**Usage Example:**
+**Usage Example:** 
 ```cpp
 // Simple read query
 auto result = conn->Query("MATCH (n:Person) RETURN n.name", "read");
 // Query with parameters
-neug::execution::ParamsMap params;
-params["min_age"] = neug::Value(18);
+rapidjson::Document params(rapidjson::kObjectType);
+params.AddMember("min_age", 18, params.GetAllocator());
 result = conn->Query("MATCH (p:Person) WHERE p.age > $min_age RETURN p",
 "read", params);
 // Process results
 if (result.has_value()) {
   auto& qr = result.value();
   while (qr.hasNext()) {
-    // Access columns via qr.GetString(0), qr.GetInt32(1), etc.
+    std::string name = qr.GetString("n.name");
     qr.next();
   }
 } else {
@@ -84,12 +82,13 @@ if (result.has_value()) {
 - `"insert"` or `"i"`: Insert-only operations (CREATE)
 - `"update"` or `"u"`: Update/delete operations
 - `"schema"` or `"s"`: `Schema` modification operations
-- Empty string: Infer the access mode from the query text
+- empty string: Infer access mode from query text
   - `parameters`: Named parameters for parameterized queries. Keys are parameter names (without `$`), values are parameter values.
 
 - **Notes:**
   - Use parameterized queries for dynamic values to prevent injection.
   - Specifying correct access_mode ensures proper transaction handling.
+  - Within an active explicit transaction, this query uses the connection-owned pinned read view or private COW write view. Cypher BEGIN/COMMIT/ROLLBACK statements are not supported; use the programmatic control methods below.
 
 - **Returns:** `result<QueryResult>` containing either:
 
@@ -98,69 +97,44 @@ if (result.has_value()) {
 
 - **Since:** v0.1.0
 
-#### `Query(...)`
+#### `BeginTransaction(TransactionMode mode=TransactionMode::kReadWrite)`
 
-```cpp
-Query(
-    const std::string &query_string,
-    const std::string &access_mode,
-    const rapidjson::Value &parameters_json
-)
-```
+Begin a Connection-owned embedded AP explicit transaction.
 
-Execute a Cypher query with JSON parameters.
-
-The parameter values are provided as a JSON object.
+A read-only transaction pins one published read view across `Query()` calls. A read-write transaction owns one private COW view; successful writes are visible to later queries on this `Connection` and are published together by `Commit()`. Read-write AP transactions hold exclusive AP admission until a terminal operation.
 
 - **Parameters:**
-  - `query_string`
-  - `access_mode`
-  - `parameters_json`
+  - `mode`
 
-#### `BeginTransaction(...)`
+- **Notes:**
+  - This API is not a Cypher BEGIN statement and does not support nested transactions or read-to-write upgrades.
 
-```cpp
-Status BeginTransaction(
-    TransactionMode mode = TransactionMode::kReadWrite
-)
-```
+- **Returns:** `Status::OK` on success. Otherwise:
 
-Begin an explicit embedded transaction owned by this connection. A read-only
-transaction pins one published view. A read-write transaction uses a private
-copy-on-write view and publishes all successful writes together on `Commit()`.
-Nested transactions and read-to-write upgrades are not supported.
-
-- **Parameters:**
-  - `mode`: `TransactionMode::kReadWrite` or `TransactionMode::kReadOnly`
-- **Returns:** `Status::OK` on success, otherwise a connection, state, argument,
-  or unsupported-mode error
+- ERR_CONNECTION_CLOSED if this `Connection` is closed
+- ERR_TX_STATE_CONFLICT if a transaction is already active
+- ERR_INVALID_ARGUMENT if the requested mode is invalid or a read-write transaction is requested on a read-only database
+- ERR_NOT_SUPPORTED if the execution mode does not support embedded explicit transactions
 
 #### `Commit()`
 
-```cpp
-Status Commit()
-```
+Commit the active explicit transaction.
 
-Commit the active explicit transaction. A failed commit leaves the connection
-rollback-only; call `Rollback()` before reusing it.
+A read-write transaction appends and publishes its accumulated logical redo once. A read-only transaction only releases its pinned read view.
+
+- **Returns:** A transaction-state error if no transaction is active or it is rollback-only. A failed commit leaves the `Connection` rollback-only; call `Rollback()` before reusing it.
 
 #### `Rollback()`
 
-```cpp
-Status Rollback()
-```
+Abort the active or rollback-only explicit transaction.
 
-Discard the active or rollback-only transaction and return the connection to
-auto-commit mode.
+Discards the private COW view, if any, and returns the `Connection` to idle.
 
-#### `HasActiveTransaction() const`
+#### `HasActiveTransaction() const noexcept`
 
-```cpp
-bool HasActiveTransaction() const noexcept
-```
+Return whether this `Connection` has an unfinished explicit transaction.
 
-Return whether this connection has an active or rollback-only explicit
-transaction.
+Returns `true` for both active and rollback-only states. Only a successful `Commit()` or `Rollback()` returns the `Connection` to idle.
 
 #### `GetSchema() const`
 
@@ -168,14 +142,18 @@ Get the database schema as a `YAML` string.
 
 Returns the complete graph schema definition in `YAML` format, including all vertex types, edge types, and their properties.
 
-**Usage Example:**
+**Usage Example:** 
 ```cpp
 std::string schema_yaml = conn->GetSchema();
 std::cout << "Schema:\n" << schema_yaml << std::endl;
 ```
 
+- **Notes:**
+  - During an active explicit transaction this returns that transaction's pinned read schema or private COW schema, rather than the published schema.
+
 - **Throws:**
   - `std::runtime_error`: if the connection is closed
+  - TxStateConflictException: if the active transaction is rollback-only
 
 - **Returns:** `std::string` YAML-formatted schema definition
 
@@ -187,16 +165,17 @@ Close the connection and release resources.
 
 Marks the connection as closed and releases any held resources. After closing, any `Query()` calls will fail.
 
-**Usage Example:**
+**Usage Example:** 
 ```cpp
 conn->Close();
 // conn->Query(...) will now return an error
 ```
 
 - **Notes:**
-  - Sequential repeated calls are idempotent; concurrent calls are not safe.
+  - Sequential repeated calls are idempotent. Concurrent calls are not safe.
   - Closing automatically unregisters this connection from its database.
   - The connection is also automatically closed in the destructor.
+  - An active or rollback-only explicit transaction is rolled back before temporary schema cleanup and execution-slot destruction.
 
 - **Since:** v0.1.0
 
@@ -207,3 +186,4 @@ Check if the connection is closed.
 - **Returns:** `true` if the connection has been closed, `false` if still active
 
 - **Since:** v0.1.0
+

--- a/doc/source/reference/cpp_api/connection.md
+++ b/doc/source/reference/cpp_api/connection.md
@@ -29,7 +29,7 @@ conn->Close();
 - `"update"` or `"u"`: Update/delete operations (SET, DELETE, MERGE)
 - `"schema"` or `"s"`: `Schema` modification operations (CREATE/DROP labels)
 
-**Thread Safety:** This class is NOT thread-safe. A `Connection` and its owned `ExecutionSlot` must be used by only one thread at a time. Use a separate `Connection` per thread.
+**Thread Safety:** This class is NOT thread-safe; use one `Connection` per thread. Multiple concurrent connections are only allowed on a READ_ONLY database; a READ_WRITE database permits a single connection.
 
 **Lifecycle:**
 - Created via `NeugDB::Connect()`

--- a/doc/source/reference/cpp_api/index.md
+++ b/doc/source/reference/cpp_api/index.md
@@ -15,7 +15,7 @@ The C++ API offers powerful capabilities for:
 - **[NeugDB](neug_db)** - The main entry point for database operations
 - **[Connection](connection)** - Execute Cypher queries against the database
 - **[NeugDBService](service)** - HTTP service for high-throughput scenarios
-- **[QueryResult](query_result)** - Container for query results with iterator access
+- **[QueryResult](query_result)** - Container for query results with cursor-based access
 
 ## Quick Start
 
@@ -67,7 +67,7 @@ if (!result.has_value()) {
 
 ## Thread Safety
 
-- `NeugDB`: Connection/service registration is synchronized; lifecycle changes
-  require connections to be idle
+- `NeugDB`: Connection/service registration is synchronized; lifecycle changes require connections to be idle
 - `Connection`: NOT thread-safe; use one connection per thread
 - `QueryResult`: Thread-safe (read-only after creation)
+

--- a/doc/source/reference/cpp_api/neug_db.md
+++ b/doc/source/reference/cpp_api/neug_db.md
@@ -77,7 +77,7 @@ db.Open("/path/to/graph", 8, neug::DBMode::READ_WRITE, "gopt");
 
 - **Parameters:**
   - `data_dir`: `Path` to the graph data directory
-  - `max_thread_num`: Database query capacity. 0 selects hardware concurrency (fallback 1); higher values warn and clamp. AP queries are single-threaded; intra-query parallelism is future work. In TP mode, it sizes the slot pool and caps service threads. Concurrent TP queries each use one slot and one thread.
+  - `max_thread_num`: Database query capacity. 0 selects hardware concurrency (fallback 1); a positive value is honored as-is and a negative value is rejected. AP queries are single-threaded; intra-query parallelism is future work. In TP mode, it sizes the slot pool and caps service threads. Concurrent TP queries each use one slot and one thread.
   - `mode`: Database access mode (READ_ONLY or READ_WRITE)
   - `planner_kind`: Query planner type: "gopt" (Graph Optimizer) or "greedy"
   - `checkpoint_on_close`: Create checkpoint (persist data) when closing

--- a/doc/source/reference/cpp_api/neug_db.md
+++ b/doc/source/reference/cpp_api/neug_db.md
@@ -26,7 +26,7 @@ db.Close();
 
 **Key Components:**
 - `PropertyGraph`: Underlying graph data storage engine
-- `ExecutionSlot`: Shared AP/TP Cypher query compilation and execution
+- `ExecutionSlot`: Cypher query compilation and execution
 - `ConnectionManager`: Client connection pool management
 - `IGraphPlanner`: Query optimization (GOPT or Greedy planner)
 
@@ -34,15 +34,10 @@ db.Close();
 - `DBMode::READ_ONLY`: Read-only access for analytics workloads
 - `DBMode::READ_WRITE`: Full transactional read/write access
 
-**Thread Safety:** Connection creation and registration are synchronized, and
-separate connections can execute queries concurrently. Individual `Connection`
-instances are not thread-safe.
+**Thread Safety:** `Connection` creation and registration are synchronized, and separate connections can execute queries concurrently. Individual `Connection` instances are not thread-safe.
 
 **Resource Management:**
-- File locking serializes write access across processes: a database opened in
-  read-write mode is exclusive, while multiple read-only processes (or
-  multiple read-only instances within one process) can share the same
-  database directory concurrently
+- File locking serializes write access across processes: a database opened in read-write mode is exclusive, while multiple read-only processes (or multiple read-only instances within one process) can share the same database directory concurrently
 - Automatic WAL (Write-Ahead Log) for crash recovery
 - Configurable checkpoint on close
 
@@ -64,19 +59,12 @@ Open the database from persistent storage.
 
 Initializes and opens the NeuG database from the specified data directory. This method loads the graph schema, vertex/edge data, and initializes the query processor and planner.
 
-**Data Directory Structure:** Persistent state is selected by `checkpoint/CURRENT` and stored as immutable checkpoint objects, manifests, WAL epochs, and per-open runtime workspaces:
-
-```text
-data_dir/
-├── checkpoint/
-│   ├── CURRENT
-│   ├── manifests/<id>.manifest
-│   └── objects/<object-id>
-├── wal/<id>/
-└── runtime/open-<epoch>/
-```
-
-`CURRENT` atomically selects the manifest used at open. A manifest stores immutable object IDs and the `base_ts` that bounds replay of its matching WAL epoch. Unreachable staging objects or manifests are not selected. The legacy `checkpoint-N` directory format is unsupported and rejected without modification.
+**Data Directory Structure:** Checkpointed data is organized as:
+- `checkpoint/CURRENT`: atomically published manifest id
+- `checkpoint/manifests/`: immutable manifest files
+- `checkpoint/objects/`: immutable module objects
+- `wal/<id>/`: WAL epoch for each manifest
+- `runtime/open-<epoch>/`: mutable allocator workspace for an open process
 
 **Usage Example:** 
 ```cpp
@@ -88,15 +76,11 @@ db.Open("/path/to/graph", 8, neug::DBMode::READ_WRITE, "gopt");
 ```
 
 - **Parameters:**
-  - `data_dir`: Path to the graph data directory
-  - `max_thread_num`: Database query capacity; `0` selects hardware concurrency (fallback `1`), while higher inputs warn and clamp to it.
-
-    Embedded (AP) queries are currently single-threaded; using this setting for intra-query parallelism is future work.
-
-    In TP mode, it sizes the slot pool and caps service threads. Queries run concurrently; each uses one slot/thread.
+  - `data_dir`: `Path` to the graph data directory
+  - `max_thread_num`: Database query capacity. 0 selects hardware concurrency (fallback 1); higher values warn and clamp. AP queries are single-threaded; intra-query parallelism is future work. In TP mode, it sizes the slot pool and caps service threads. Concurrent TP queries each use one slot and one thread.
   - `mode`: Database access mode (READ_ONLY or READ_WRITE)
   - `planner_kind`: Query planner type: "gopt" (Graph Optimizer) or "greedy"
-  - `checkpoint_on_close`: Create a checkpoint (persist data) when closing
+  - `checkpoint_on_close`: Create checkpoint (persist data) when closing
 
 - **Notes:**
   - This overload is primarily designed for Python bindings.
@@ -148,12 +132,11 @@ db.Open("/path/to/data");
 // ... perform operations ...
 db.Close();  // Persist data and cleanup
 ```
+The caller must ensure no `Connection` operation is in progress.
 
 - **Notes:**
-  - This method is idempotent - calling it multiple times is safe.
-  - After closing, the same `NeugDB` instance can be opened again.
-  - Checkpoint-on-close is best effort. If it fails, `Close()` logs an error, suppresses the exception, and continues releasing resources.
-  - No connection operation may be in progress when this method is called.
+  - This method is idempotent after a successful close. If the optional shutdown checkpoint fails before consuming the live graph, `Close()` throws and leaves the database open so the caller can correct the failure and retry. A failure after consumption finishes teardown and is then rethrown; that instance cannot be reused.
+  - After closing, the database cannot be reopened. Create a new `NeugDB` instance to open the database again.
 
 - **Since:** v0.1.0
 
@@ -163,13 +146,25 @@ Check if the database is closed.
 
 - **Returns:** `true` if the database is closed.
 
+#### `HasActiveService() const`
+
+Check if a `NeugDBService` is currently associated with this database.
+
+At most one `NeugDBService` can be associated with a `NeugDB` instance at any given time. While a service is associated, local connections via `Connect()` are rejected and `Close()` fails.
+
+- **Returns:** `true` if a `NeugDBService` is associated with this database.
+
+#### `HasOpenConnections() const`
+
+Check whether the database has an open local AP connection.
+
+Used to prevent an AP-to-TP transition from invalidating a connection still held by a caller.
+
 #### `Connect()`
 
 Create a new connection to the database for query execution.
 
-Creates and returns a `Connection` object that can be used to execute Cypher
-queries against the database. Connections share the planner and global query
-cache, while each connection exclusively owns its execution slot.
+Creates and returns a `Connection` object that can be used to execute Cypher queries against the database. The connection shares the query planner and global cache with other connections from the same database, while exclusively owning its `ExecutionSlot`.
 
 **Usage Example:** 
 ```cpp
@@ -184,9 +179,9 @@ conn->Close();  // Optional: auto-closed on destruction
 - **Notes:**
   - In READ_ONLY mode, multiple connections can be created.
   - In READ_WRITE mode, only one write connection is allowed.
-  - Calling `Connection::Close()` automatically unregisters the connection.
+  - Calling `Connection::Close` automatically unregisters the connection.
   - Connections share the planner instance for efficiency.
-  - Each connection must be used by only one thread at a time.
+  - Each `Connection` must be used by only one thread at a time.
 
 - **Throws:**
   - `std::runtime_error`: if database is not open or closed
@@ -194,3 +189,12 @@ conn->Close();  // Optional: auto-closed on destruction
 - **Returns:** `std::shared_ptr`<Connection> A shared pointer to the new `Connection`
 
 - **Since:** v0.1.0
+
+#### `PrepareForServing()`
+
+Prepare an opened database for TP service without rebuilding planner.
+
+This requires local AP connections to be closed, persists and refreshes the live graph when needed, then rebuilds query runtime handles against the refreshed graph. The planner and its metadata registry are intentionally preserved so runtime extension registrations loaded in AP mode stay available in TP mode. The version manager is replaced only when a new durable checkpoint starts a fresh WAL timeline; otherwise the existing timeline is preserved.
+New connections receive slots borrowing the refreshed resources.
+The caller must close all local `Connection` objects first.
+

--- a/doc/source/reference/cpp_api/query_result.md
+++ b/doc/source/reference/cpp_api/query_result.md
@@ -63,7 +63,14 @@ Return the current cursor position (0-based row index).
 Check whether the cell at current row is NULL.
 
 - **Parameters:**
-  - `column_index`
+  - `column_index`: Zero-based column index.
+
+#### `IsNull(const std::string &column_name) const`
+
+Check whether the named cell at current row is NULL.
+
+- **Parameters:**
+  - `column_name`: Column name from the result schema.
 
 #### `GetInt32(size_t column_index) const`
 

--- a/doc/source/reference/cpp_api/query_result.md
+++ b/doc/source/reference/cpp_api/query_result.md
@@ -13,7 +13,32 @@ Lightweight wrapper around protobuf `QueryResponse`.
 - cursor-based row traversal via ``hasNext()`` / ``next()``,
 - typed cell access via ``GetInt32()``, ``GetString()``, etc.
 
-### Cursor Traversal
+**Typed accessors:** Every getter reads from the current cursor row and has two overloads, by column index or by column name. Call `IsNull(...)` before reading a cell that may be NULL. Temporal columns (`date`, `timestamp`, `interval`) are not exposed as dedicated typed objects: use `GetString(...)` for their canonical string form (e.g. `"1970-01-01"`) and `GetInt64(...)` for the raw epoch value of `date` / `timestamp` columns.
+
+**Example:** 
+```cpp
+auto result = QueryResult::From(serialized);
+// Access by column index
+while (result.hasNext()) {
+    if (!result.IsNull(0)) {
+        int32_t id = result.GetInt32(0);
+        std::string name = result.GetString(1);
+    }
+    result.next();
+}
+// Access by column name
+result.Reset();
+while (result.hasNext()) {
+    if (!result.IsNull("id")) {
+        int32_t id = result.GetInt32("id");
+        std::string name = result.GetString("name");
+        double score = result.GetDouble("score");
+    }
+    result.next();
+}
+```
+
+### Public Methods
 
 #### `hasNext() const`
 
@@ -21,7 +46,9 @@ Check whether there are more rows to consume.
 
 #### `next()`
 
-Advance the cursor to the next row. Throws if no more rows are available.
+Advance the cursor to the next row.
+
+Throws if no more rows are available (check `hasNext()` first).
 
 #### `Reset()`
 
@@ -31,84 +58,156 @@ Reset the internal cursor back to the first row.
 
 Return the current cursor position (0-based row index).
 
-### Typed Value Accessors
-
-All getters read from the **current cursor row**. Each method has two overloads:
-by column index or by column name. Use `IsNull(...)` before reading a nullable
-cell. Choose a getter according to the column's underlying result type; these
-methods do not parse or coerce arbitrary source types. A getter throws
-`neug::exception::RuntimeError` when the cursor or column selector is invalid,
-or when the source column type is not listed for that getter.
-
-#### `IsNull(size_t column_index)` / `IsNull(const std::string& column_name)`
+#### `IsNull(size_t column_index) const`
 
 Check whether the cell at current row is NULL.
 
-#### `GetInt32(...)`
+- **Parameters:**
+  - `column_index`
 
-Return the current cell as a signed 32-bit integer. Call this method only when
-the source column type is `int32` or `bool`; any other source type causes a
-`neug::exception::RuntimeError`. An `int32` value is returned unchanged, while
-`true` is converted to `1` and `false` to `0`.
+#### `GetInt32(size_t column_index) const`
 
-#### `GetUInt32(...)`
+Return the current cell as a signed 32-bit integer.
 
-Return the current cell as an unsigned 32-bit integer. Call this method only
-when the source column type is `uint32` or `bool`; any other source type causes
-a `neug::exception::RuntimeError`. A `uint32` value is returned unchanged,
-while `true` is converted to `1` and `false` to `0`.
+The source column must have type int32 or `bool`. Any other source type causes an exception. An int32 value is returned unchanged; a `bool` value is converted to 1 or 0.
 
-#### `GetInt64(...)`
+- **Parameters:**
+  - `column_index`: Zero-based column index.
 
-Return the current cell as a signed 64-bit integer. Call this method only when
-the source column type is `int64`, `int32`, `uint32`, `bool`, `date`, or
-`timestamp`; any other source type causes a `neug::exception::RuntimeError`.
-An `int64` value is returned unchanged, smaller integers are widened, booleans
-become `1` or `0`, and `date` / `timestamp` values are returned as the raw epoch
-value stored by NeuG.
+#### `GetInt32(const std::string &column_name) const`
 
-#### `GetUInt64(...)`
+Return the named current cell as a signed 32-bit integer.
 
-Return the current cell as an unsigned 64-bit integer. Call this method only
-when the source column type is `uint64`, `uint32`, or `bool`; any other source
-type causes a `neug::exception::RuntimeError`. A `uint64` value is returned
-unchanged, a `uint32` value is widened, and booleans become `1` or `0`.
+The source column must have type int32 or `bool`. Any other source type causes an exception. An int32 value is returned unchanged; a `bool` value is converted to 1 or 0.
 
-#### `GetFloat(...)`
+- **Parameters:**
+  - `column_name`: Column name from the result schema.
 
-Return the current cell as a single-precision floating-point value. Call this
-method only when the source column type is `float`, `int32`, `uint32`, or
-`bool`; any other source type causes a `neug::exception::RuntimeError`. A
-`float` value is returned unchanged, integer values are converted to `float`,
-and booleans become `1.0f` or `0.0f`.
+#### `GetUInt32(size_t column_index) const`
 
-#### `GetDouble(...)`
+Return the current cell as an unsigned 32-bit integer.
 
-Return the current cell as a double-precision floating-point value. Call this
-method only when the source column type is `double`, `float`, `int32`, `uint32`,
-`int64`, `uint64`, or `bool`; any other source type causes a
-`neug::exception::RuntimeError`. A `double` value is returned unchanged, other
-numeric values are converted to `double`, and booleans become `1.0` or `0.0`.
-Large 64-bit integers may lose precision during conversion.
+The source column must have type uint32 or `bool`. Any other source type causes an exception. A uint32 value is returned unchanged; a `bool` value is converted to 1 or 0.
 
-#### `GetString(...)`
+- **Parameters:**
+  - `column_index`: Zero-based column index.
 
-Return the current cell as a string. This is the only typed getter that can be
-called for every source column type. String values are returned directly;
-other values use NeuG's human-readable string representation.
+#### `GetUInt32(const std::string &column_name) const`
 
-#### `GetBool(...)`
+Return the named current cell as an unsigned 32-bit integer.
 
-Return the current cell as a Boolean value. Call this method only when the
-source column type is `bool`; any other source type causes a
-`neug::exception::RuntimeError`. The Boolean value is returned unchanged.
+The source column must have type uint32 or `bool`. Any other source type causes an exception. A uint32 value is returned unchanged; a `bool` value is converted to 1 or 0.
 
-> Temporal columns (`date`, `timestamp`, `interval`) are not exposed as
-> dedicated typed objects. Use `GetString(...)` for their canonical string form
-> (e.g. `"1970-01-01"`), and `GetInt64(...)` to read the raw epoch value of
-> `date` / `timestamp` columns.
+- **Parameters:**
+  - `column_name`: Column name from the result schema.
 
-### Metadata
+#### `GetInt64(size_t column_index) const`
+
+Return the current cell as a signed 64-bit integer.
+
+The source column must have type int64, int32, uint32, `bool`, date, or timestamp. Any other source type causes an exception. Smaller integers are widened, `bool` is converted to 1 or 0, and date and timestamp values are returned as their raw stored epoch values.
+
+- **Parameters:**
+  - `column_index`: Zero-based column index.
+
+#### `GetInt64(const std::string &column_name) const`
+
+Return the named current cell as a signed 64-bit integer.
+
+The source column must have type int64, int32, uint32, `bool`, date, or timestamp. Any other source type causes an exception. Smaller integers are widened, `bool` is converted to 1 or 0, and date and timestamp values are returned as their raw stored epoch values.
+
+- **Parameters:**
+  - `column_name`: Column name from the result schema.
+
+#### `GetUInt64(size_t column_index) const`
+
+Return the current cell as an unsigned 64-bit integer.
+
+The source column must have type uint64, uint32, or `bool`. Any other source type causes an exception. A uint32 value is widened, and `bool` is converted to 1 or 0.
+
+- **Parameters:**
+  - `column_index`: Zero-based column index.
+
+#### `GetUInt64(const std::string &column_name) const`
+
+Return the named current cell as an unsigned 64-bit integer.
+
+The source column must have type uint64, uint32, or `bool`. Any other source type causes an exception. A uint32 value is widened, and `bool` is converted to 1 or 0.
+
+- **Parameters:**
+  - `column_name`: Column name from the result schema.
+
+#### `GetFloat(size_t column_index) const`
+
+Return the current cell as a single-precision floating-point value.
+
+The source column must have type `float`, int32, uint32, or `bool`. Any other source type causes an exception. Integers are converted to `float`, and `bool` is converted to 1.0 or 0.0.
+
+- **Parameters:**
+  - `column_index`: Zero-based column index.
+
+#### `GetFloat(const std::string &column_name) const`
+
+Return the named current cell as a single-precision floating-point value.
+
+The source column must have type `float`, int32, uint32, or `bool`. Any other source type causes an exception. Integers are converted to `float`, and `bool` is converted to 1.0 or 0.0.
+
+- **Parameters:**
+  - `column_name`: Column name from the result schema.
+
+#### `GetDouble(size_t column_index) const`
+
+Return the current cell as a `double`-precision floating-point value.
+
+The source column must have type `double`, `float`, int32, uint32, int64, uint64, or `bool`. Any other source type causes an exception. Numeric values are converted to `double`, and `bool` is converted to 1.0 or 0.0. Large 64-bit integers may lose precision.
+
+- **Parameters:**
+  - `column_index`: Zero-based column index.
+
+#### `GetDouble(const std::string &column_name) const`
+
+Return the named current cell as a `double`-precision floating-point value.
+
+The source column must have type `double`, `float`, int32, uint32, int64, uint64, or `bool`. Any other source type causes an exception. Numeric values are converted to `double`, and `bool` is converted to 1.0 or 0.0. Large 64-bit integers may lose precision.
+
+- **Parameters:**
+  - `column_name`: Column name from the result schema.
+
+#### `GetString(size_t column_index) const`
+
+Return the current cell as a string.
+
+This getter supports every source column type. String values are returned directly; all other values use their human-readable representation.
+
+- **Parameters:**
+  - `column_index`: Zero-based column index.
+
+#### `GetString(const std::string &column_name) const`
+
+Return the named current cell as a string.
+
+This getter supports every source column type. String values are returned directly; all other values use their human-readable representation.
+
+- **Parameters:**
+  - `column_name`: Column name from the result schema.
+
+#### `GetBool(size_t column_index) const`
+
+Return the current cell as a boolean value.
+
+The source column must have type `bool`. Any other source type causes an exception. The `bool` value is returned unchanged.
+
+- **Parameters:**
+  - `column_index`: Zero-based column index.
+
+#### `GetBool(const std::string &column_name) const`
+
+Return the named current cell as a boolean value.
+
+The source column must have type `bool`. Any other source type causes an exception. The `bool` value is returned unchanged.
+
+- **Parameters:**
+  - `column_name`: Column name from the result schema.
 
 #### `ColumnCount() const`
 
@@ -118,17 +217,15 @@ Get the number of columns.
 
 Get column names from schema.
 
-### Other Methods
-
 #### `ToString() const`
 
 Convert entire result set to string.
 
 #### `GetCurrentRowAsString() const`
 
-Convert the **current cursor row** to a human-readable, comma-separated string
-(NULL cells render as `null`). Handy for printing rows while iterating with
-`hasNext()` / `next()`. Throws if the cursor is past the end of the result set.
+Convert the current cursor row to a human-readable string.
+
+Produces a comma-separated list of the row's column values (NULL cells are rendered as "null"). Useful for printing rows while iterating with `hasNext()`/next(). Throws if the cursor is past the end of the result set.
 
 #### `length() const`
 
@@ -152,28 +249,13 @@ Useful when callers need to extend the lifetime of the response beyond the `Quer
 
 Serialize entire result set to string.
 
-### Example
+#### `has_profile_result() const`
 
-```cpp
-auto result = QueryResult::From(serialized);
+Check if profile result is available.
 
-// Access by column index
-while (result.hasNext()) {
-    if (!result.IsNull(0)) {
-        int32_t id = result.GetInt32(0);
-        std::string name = result.GetString(1);
-    }
-    result.next();
-}
+#### `profile_result_text() const`
 
-// Access by column name
-result.Reset();
-while (result.hasNext()) {
-    if (!result.IsNull("id")) {
-        int32_t id = result.GetInt32("id");
-        std::string name = result.GetString("name");
-        double score = result.GetDouble("score");
-    }
-    result.next();
-}
-```
+Get human-readable PROFILE/EXPLAIN text output.
+
+Returns empty string if no profile_result available. Suitable for CLI output and debugging.
+

--- a/doc/source/reference/cpp_api/service.md
+++ b/doc/source/reference/cpp_api/service.md
@@ -19,8 +19,6 @@ int main() {
   neug::ServiceConfig config;
   config.query_port = 10000;
   config.host_str = "0.0.0.0";
-  config.thread_num = 0;  // Auto-select service threads from database max_thread_num.
-  config.auto_compaction = true;
   // 3. Start HTTP service
   neug::NeugDBService service(db, config);
   std::string url = service.Start();
@@ -37,18 +35,10 @@ int main() {
 - `POST /cypher` - Execute Cypher queries
 - `GET /schema` - Retrieve graph schema
 - `GET /status` - Check service status
+- `POST /transactions` - Begin an explicit TP transaction session
+- `POST /transactions/{id}/query|commit|rollback` - Operate on a session
 
 **Thread Safety:** All public methods are thread-safe. The service uses a `TpExecutionSlotPool` internally to handle concurrent requests efficiently.
-
-**Service Threads:** `ServiceConfig::thread_num` controls the service thread
-count. The default `0` auto-selects from the database `max_thread_num`. If set
-explicitly, it must be less than or equal to the database `max_thread_num`. With
-the default database thread setting, `max_thread_num` is resolved from hardware
-concurrency and falls back to `1` if the runtime cannot detect it.
-Service threads run TP queries concurrently, but each query uses one execution slot and one thread.
-
-**Auto Compaction:** `ServiceConfig::auto_compaction` controls whether a
-background auto-compaction thread runs while serving. Default is `true`.
 
 ### Constructors & Destructors
 
@@ -56,19 +46,22 @@ background auto-compaction thread runs while serving. Default is `true`.
 
 Constructs a service around an existing database instance.
 
+Construction requires all existing embedded connections to be closed first.
+
 - **Parameters:**
   - `db`: Reference to the NeuG database that will handle queries
   - `config`
 
 - **Notes:**
   - The database should be opened and ready before creating the service
-  - Construction closes existing embedded connections; none may be in use.
+  - At most one `NeugDBService` can be associated with a `NeugDB` instance at any given time. The association is released when the service is destructed.
 
 #### `~NeugDBService()`
 
 Destructor that ensures proper cleanup.
 
 Automatically stops the HTTP handler manager if it's running and releases all associated resources.
+All `ExecutionSlotLease` objects acquired from this service must be destroyed before the service is destroyed.
 
 ### Public Methods
 
@@ -114,11 +107,9 @@ Retrieves the current service configuration.
 
 #### `AcquireExecutionSlot()`
 
-Leases an execution slot from the internal TP execution-slot pool.
+Leases an execution slot from the internal TP pool.
 
-Returns an `ExecutionSlotLease` that automatically returns the execution slot
-to the pool when it goes out of scope. Use this for direct query execution when
-you need fine-grained control over the lease lifetime.
+Returns an `ExecutionSlotLease` that automatically releases the execution slot back to the pool when it goes out of scope.
 
 **Usage Example:** 
 ```cpp
@@ -134,7 +125,7 @@ auto result = lease->ExecuteTransactionalRequest(
 - **Notes:**
   - Blocks if no execution slot is available in the pool
 
-- **Returns:** `ExecutionSlotLease` managing the leased execution slot
+- **Returns:** `ExecutionSlotLease` managing the acquired execution slot
 
 #### `IsRunning() const`
 
@@ -181,26 +172,14 @@ Convenience method that starts the HTTP server and blocks the calling thread unt
 
 **Full name:** `neug::ExecutionSlot`
 
-**Header:** `neug/main/execution_slot.h`
+Database execution slot for high-throughput query execution.
 
-Reusable execution context for AP and TP query execution.
-
-`ExecutionSlot` is a runtime-neutral execution context. It owns slot-local
-query state and borrows the database snapshot store, version manager,
-allocator, and optional WAL writer. Embedded connections own one slot each;
-service mode owns a fixed set through `TpExecutionSlotPool`, which also binds
-the TP-only WAL writers. The class itself has no brpc or bthread dependency.
-
-An `ExecutionSlot` must not be used concurrently. It is not bound to a physical
-pthread or bthread, so a request may keep the same execution slot, allocator,
-and WAL writer across cooperative yields.
-
-An `ExecutionSlot` borrows all constructor dependencies. Connections and the
-service pool release their slots before `NeugDB` destroys those dependencies.
+`ExecutionSlot` is a passive core execution context. It owns slot-local query state and borrows database-wide transaction, storage, allocator, and WAL resources. The class itself has no brpc or bthread dependency: TP slot scheduling and synchronization are injected by `TpExecutionSlotPool`, so the same execution core also serves embedded connections.
+Embedded connections exclusively own one `ExecutionSlot`. Service mode owns a fixed set through `TpExecutionSlotPool` and leases them per request.
 
 **Usage Example:** 
 ```cpp
-// Acquire execution slot from service
+// Lease execution slot from service
 auto lease = service.AcquireExecutionSlot();
 // Execute read query
 std::string query = R"({
@@ -220,24 +199,19 @@ auto write_result = lease->ExecuteTransactionalRequest(insert_query);
 **Internal Transaction Strategies:**
 - ``SnapshotReadTransaction``: Read-only snapshot access
 - ``MvccInsertTransaction``: Add new vertices and edges
-- ``SnapshotCowWriteTransaction``: Versioned COW updates used by transactional
-  execution
-- ``CurrentCowWriteTransaction``: Private COW updates of the AP current graph
+- ``SnapshotCowWriteTransaction``: Versioned private-COW updates
 - ``InPlaceCompactionTransaction``: Background compaction operations
+These are execution internals. `Connection` and Session expose logical read-only/read-write semantics and must not expose or require callers to select one of these strategies.
 
-These are `ExecutionSlot` implementation strategies. Connection and Session
-continue to expose logical read-only/read-write transaction semantics; clients
-do not select these internal types.
+**Concurrency:** An execution slot must not be used concurrently. It is not bound to a physical pthread or bthread worker and may resume on another physical worker after a cooperative yield while retaining the same allocator, cache, and WAL resources.
 
-**Thread Safety:** An execution slot must not be used concurrently. Sequential
-use may resume on a different physical worker because the slot is an execution
-context, not thread-local state.
+**Lifetime:** All borrowed constructor dependencies must outlive the `ExecutionSlot` and every transaction created from it. `Connection` and `TpExecutionSlotPool` release their slots before `NeugDB` destroys those shared dependencies.
 
 ### Public Methods
 
-#### `ExecuteTransactionalRequest(const std::string &query)`
+#### `ExecuteTransactionalRequest(const std::string &request)`
 
-Execute a Cypher query within the execution slot.
+Execute a serialized Cypher request in a transaction.
 
 Executes a query specified as a JSON string containing the Cypher query, access mode, and optional parameters. This is the primary method for query execution in high-throughput service scenarios.
 
@@ -279,9 +253,9 @@ auto param_result = lease->ExecuteTransactionalRequest(query);
 ```
 
 - **Parameters:**
-  - `query`: JSON string containing query, access_mode, and parameters
+  - `request`: JSON string containing query, access_mode, and parameters
 
-- **Returns:** Result containing `QueryResult` on success, or error status
+- **Returns:** Serialized QueryResponse on success, or error status
 
 
 ---
@@ -290,34 +264,32 @@ auto param_result = lease->ExecuteTransactionalRequest(query);
 
 **Full name:** `neug::TpExecutionSlotPool`
 
-Pool of database execution slots for concurrent query execution.
+Pool of database slots for concurrent query execution.
 
-`TpExecutionSlotPool` owns and schedules a fixed set of `ExecutionSlot`
-instances for TP queries. Each aligned entry stores its execution slot inline,
-keeps its allocator alive, and owns its WAL writer.
-`TpExecutionSlotPool` is used internally by `NeugDBService`. For most use cases, access execution slots through `NeugDBService::AcquireExecutionSlot()` rather than directly through the pool.
+`TpExecutionSlotPool` owns and schedules a fixed set of `ExecutionSlot` instances for TP query execution. Each aligned entry borrows a stable database-owned per-slot WAL writer.
+`TpExecutionSlotPool` is used internally by `NeugDBService`. For most use cases, access slots through `NeugDBService::AcquireExecutionSlot()` rather than directly through the pool.
 
 **Key Features:**
-- Service-owned execution slots with explicit lease/release
-- Thread-safe slot scheduling with bthread synchronization
-- Automatic WAL (Write-Ahead Log) management per slot
-- Memory-aligned TP slot contexts for cache efficiency
+- Owns service-local slots for query execution
+- Thread-safe lease/release with bthread synchronization
+- Stable WAL (Write-Ahead Log) writer per logical slot
+- 4096-byte-aligned per-slot Entry storage
 
-**Pool Size:** `NeugDBConfig::max_thread_num` determines the pool size. Each query exclusively leases one slot and one thread for its duration.
+**Pool Size:** `NeugDBConfig::max_thread_num` determines the pool size. Each TP query leases one slot and one thread for its duration.
 
 ### Public Methods
 
 #### `AcquireExecutionSlot()`
 
-Lease an execution slot from the pool.
+Lease a slot from the pool.
 
-Blocks if no execution slot is available.
+Blocks if no slot is available.
 
 - **Returns:** `ExecutionSlotLease` managing the leased slot. The slot is returned to the pool when the lease goes out of scope.
 
 #### `getExecutedQueryNum() const`
 
-Get the total number of executed queries across all execution slots.
+Get the total number of executed queries across all slots.
 
 Expect lock held by caller.
 
@@ -330,24 +302,7 @@ Expect lock held by caller.
 
 **Full name:** `neug::ExecutionSlotLease`
 
-Move-only RAII lease for exclusive use of an execution slot.
+Move-only RAII handle for exclusive use of a TP `ExecutionSlot`.
 
-`ExecutionSlotLease` automatically returns its execution slot to the
-`TpExecutionSlotPool` that issued it. Embedded connections do not lease their
-slot.
+`TpExecutionSlotPool` injects a noexcept release operation so this handle can return the slot without exposing bthread synchronization to `ExecutionSlot`.
 
-A lease must not outlive the `NeugDBService` that issued it.
-
-**Usage Example:** 
-```cpp
-{
-  // Lease an execution slot; this blocks if none is available.
-  auto lease = service.AcquireExecutionSlot();
-  // Use execution slot for queries
-  auto result = lease->ExecuteTransactionalRequest(query);
-} // ExecutionSlot automatically released here
-```
-
-**Thread Safety:** `ExecutionSlotLease` is move-only (non-copyable) to preserve
-exclusive slot use. Each lease should be used by a single logical request at a
-time.

--- a/doc/source/reference/python_api/connection.md
+++ b/doc/source/reference/python_api/connection.md
@@ -79,12 +79,13 @@ def begin_transaction(read_only: bool = False)
 Begin an explicit embedded AP transaction.
 
 - **Parameters:**
-  - `read_only` (bool): Pin one read view and reject writes when true. The
-    default starts a read-write transaction with a private COW view.
+  - `read_only` (bool)
+    Pin one read view and reject writes when true. The default starts a
+    read-write transaction with a private COW view.
 
 - **Raises:**
-  - **RuntimeError:** If the connection is closed or already has an active
-    transaction.
+  - **RuntimeError**
+    If the connection is closed or already has an active transaction.
 
 <a id="neug.connection.Connection.commit"></a>
 
@@ -94,8 +95,9 @@ Begin an explicit embedded AP transaction.
 def commit()
 ```
 
-Commit the active explicit transaction. A rollback-only transaction must be
-rolled back instead.
+Commit the active explicit transaction.
+
+A rollback-only transaction must be rolled back instead.
 
 <a id="neug.connection.Connection.rollback"></a>
 
@@ -169,8 +171,8 @@ database will be changed accordingly.
   - `access_mode` (str)
     The access mode of the query. It could be `read(r)`, `insert(i)`, `update(u)` (include deletion),
     or `schema(s)` for schema modifications. User should specify the correct access mode for the query
-    to ensure the correctness of the database. If the access mode is not specified, NeuG infers it
-    from the query text. Supported access modes are:
+    to ensure the correctness of the database. If the access mode is not specified, it is inferred from
+    the query text. Supported access modes are:
     - `read`,`r`,`READ`,`R`: for read-only queries
     - `insert`,`i`,`INSERT`,`I`: for insert-only queries
     - `update`,`u`,`UPDATE`,`U`: for update queries (include deletion)
@@ -196,3 +198,4 @@ Get the schema of the NeuG database.
 **Returns**:
 
 The schema of the NeuG database.
+

--- a/doc/source/reference/python_api/database.md
+++ b/doc/source/reference/python_api/database.md
@@ -72,7 +72,8 @@ Open a database.
     Note that in memory mode, the database will not be persisted to disk, and all data will be
     lost when the program exits. In this case, the db_path should not contain any illegal characters.
   - `mode` (str)
-    Mode to open the database, could be 'r', 'read', 'readwrite', 'w', 'rw', 'write'. Default is 'read-write'.
+    Mode to open the database. Read-only: 'r', 'read', 'read-only', 'read_only'.
+    Read-write: 'w', 'rw', 'write', 'readwrite', 'read-write', 'read_write'. Default is 'read-write'.
   - `max_thread_num` (int)
     Database query capacity; 0 selects hardware concurrency (fallback 1), while higher inputs warn and clamp to it.
 

--- a/doc/source/reference/python_api/database.md
+++ b/doc/source/reference/python_api/database.md
@@ -26,7 +26,9 @@ read-only mode, inside the same process or in different processes.
 When the database is opened in read-write mode, no other databases could open the same database directory in
 either read-only or read-write mode, inside the same process or in different processes.
 
-Note that opening a database in read-only mode still requires a writable data directory: the lock file is created on demand if missing, and read-only processes create temporary working files in their own `runtime/open-<epoch>/` directory. Read-only mode cannot be used on a read-only file system or mount.
+Note that opening a database in read-only mode still requires a writable data directory: the lock file is
+created on demand if missing, and read-only processes create temporary working files in their own
+`runtime/open-<epoch>/` directory. Read-only mode cannot be used on a read-only file system or mount.
 
 When the database is closed, all the connections to the database will be closed automatically.
 
@@ -44,7 +46,7 @@ When the database is closed, all the connections to the database will be closed 
     >>> conn.execute('COPY Person FROM "person.csv"')
     >>> conn.execute('COPY KNOWS FROM "knows.csv" (from="Person", to="Person");')
 
-    >>> res = conn.execute('MATCH(n) return n.id;)
+    >>> res = conn.execute('MATCH(n) RETURN n.id')
     >>> for record in res:
     >>>     print(record)
 
@@ -153,8 +155,8 @@ def serve(port: int = 10000,
 
 Start the database server for handling remote connections(TP mode).
 This method is used to start the database server for handling remote connections.
-When db.serve() is called, the database will switch to the TP mode, and all the connections to the local database
-will be closed. After that, no new connections to the local database will be allowed.
+Before db.serve() switches the database to TP mode, all local connections
+must be closed. After the switch, no new local connections are allowed.
 It will start a server that listens on a specific port, and clients can connect to the server to interact with the
 database. User could use Session to connect to the server. For detail usage, please refer to the
 documentation of Session.
@@ -167,14 +169,14 @@ documentation of Session.
   - `blocking` (bool)
     Whether to block the process after starting the database server.
   - `thread_num` (int)
-    Service thread count. 0 selects max_thread_num; explicit values cannot exceed it.
+    Service thread count. 0 selects max_thread_num; explicit values are clamped to it.
 
     Service threads run TP queries concurrently, but each query uses one execution context and one thread.
   - `auto_compaction` (bool)
     Enable background auto-compaction while serving. Default is `True`.
   - `explicit_transaction_timeout_ms` (int)
-    Absolute lifetime of an explicit transaction in milliseconds. Default is
-    `60000`.
+    Absolute lifetime of an explicit transaction in milliseconds.
+    Default is `60000`.
 
 - **Returns:**
   - `uri` (str)
@@ -182,8 +184,9 @@ documentation of Session.
 
 - **Raises:**
   - **ValueError**
-    If `thread_num` is negative, greater than the available CPU core count, or
-    greater than the database `max_thread_num`.
+    If `thread_num` is negative or `explicit_transaction_timeout_ms` is not
+    positive. A `thread_num` exceeding `max_thread_num` or the CPU count is
+    clamped with a warning, not rejected.
   - **RuntimeError**
     If there are open connections to the local database.
     If the database is already serving.
@@ -191,8 +194,7 @@ documentation of Session.
 - **Notes:**
   - **Make sure to close all connections before starting the server.**
   - **After starting the server, no new connections to the local database will be allowed.**
-  - **`thread_num` controls server-side service threads; client-side `Session(..., num_threads=...)` controls the HTTP connection pool used by that client.**
-  - **`auto_compaction` controls serve-time background compaction behavior.**
+  - **`thread_num` sizes server-side service threads; the client-side `Session(num_threads=...)` sizes its HTTP pool.**
 
 <a id="neug.database.Database.stop_serving"></a>
 
@@ -233,12 +235,17 @@ Connect to the database asynchronously.
 ### close
 
 ```python
-def close()
+def close(log=True)
 ```
 
 Close the database and all of its connections.
 
-For a read-write database with `checkpoint_on_close=True`, this method creates a checkpoint before closing. If the checkpoint fails, `close()` raises an exception. Depending on when the failure occurs, the database may remain open for another attempt or may already be closed. Calling this method again after a successful close has no effect.
+For a read-write database with `checkpoint_on_close=True`, this method
+creates a checkpoint before releasing database resources.
+The method is idempotent after a successful close. A checkpoint failure
+before its destructive dump raises an exception and leaves the database
+open so the caller can correct the problem and retry. A failure after
+the destructive dump completes teardown and is then raised.
 
 <a id="neug.database.Database.load_builtin_dataset"></a>
 

--- a/doc/source/reference/python_api/query_result.md
+++ b/doc/source/reference/python_api/query_result.md
@@ -19,7 +19,6 @@ It has the following methods to iterate over the results.
     - `getNext()`: Returns the next result as a list.
     - `length()`: Returns the total number of results.
     - `column_names()`: Returns the projected column names as strings.
-    - `get_profile_metrics()`: Returns structured PROFILE or EXPLAIN metrics.
 
 ```python
 
@@ -71,6 +70,39 @@ TODO(zhanglei,xiaoli): Make sure the format consistency with neo4j bolt response
   - **str**
     The result in Bolt response format.
 
+<a id="neug.query_result.QueryResult.has_profile_result"></a>
+
+### has\_profile\_result
+
+```python
+def has_profile_result() -> bool
+```
+
+Check if profile result is available.
+
+- **Returns:**
+  - **bool**
+    True if the query was executed in PROFILE or EXPLAIN mode,
+    False for normal queries.
+
+<a id="neug.query_result.QueryResult.get_profile_text"></a>
+
+### get\_profile\_text
+
+```python
+def get_profile_text() -> str
+```
+
+Get human-readable PROFILE/EXPLAIN text output.
+
+Suitable for CLI output and debugging. Returns empty string if
+no profile result is available.
+
+- **Returns:**
+  - **str**
+    Formatted execution tree with operator timings and row counts.
+    Returns empty string if no profile result available.
+
 <a id="neug.query_result.QueryResult.get_profile_metrics"></a>
 
 ### get\_profile\_metrics
@@ -79,23 +111,29 @@ TODO(zhanglei,xiaoli): Make sure the format consistency with neo4j bolt response
 def get_profile_metrics() -> dict
 ```
 
-Return detailed PROFILE or EXPLAIN metrics as a Python dictionary:
+Return detailed PROFILE or EXPLAIN metrics as a Python dictionary.
+
+The result contains complete execution plan metrics, including timing
+and output information for each operator in the query execution tree.
+Returns an empty dict if no profile result is available.
 
 ```python
-{
-    "total_elapsed_ms": float,
-    "total_output_rows": int,
-    "operators": [
-        {
-            "operator_id": int,
-            "parent_id": int,
-            "operator_name": str,
-            "elapsed_ms": float,
-            "output_rows": int,
-            "child_ids": [int],
-        }
-    ],
-}
+
+    {
+        "total_elapsed_ms": float,
+        "total_output_rows": int,
+        "operators": [
+            {
+                "operator_id": int,
+                "parent_id": int,
+                "operator_name": str,
+                "elapsed_ms": float,
+                "output_rows": int,
+                "child_ids": [int],
+            }
+        ],
+    }
+
 ```
 
 <a id="neug.query_result.QueryResult.to_arrow"></a>

--- a/doc/source/reference/python_api/session.md
+++ b/doc/source/reference/python_api/session.md
@@ -170,7 +170,7 @@ state.
 
 - `query`: The query string to be executed.
 - `access_mode`: The access mode for the query. When omitted, NeuG infers it
-  from the query text. Supported modes are:
+from the query text. Supported modes are:
 - `read` or `r`: Read-only queries
 - `insert` or `i`: Insert-only operations
 - `update` or `u`: Update/delete operations
@@ -219,3 +219,4 @@ def timeout()
 ```
 
 Get the timeout duration for the session, in seconds.
+

--- a/include/neug/main/connection.h
+++ b/include/neug/main/connection.h
@@ -66,9 +66,9 @@ class ExecutionSlot;
  * - `"update"` or `"u"`: Update/delete operations (SET, DELETE, MERGE)
  * - `"schema"` or `"s"`: Schema modification operations (CREATE/DROP labels)
  *
- * **Thread Safety:** This class is NOT thread-safe. A Connection and its owned
- * ExecutionSlot must be used by only one thread at a time. Use a separate
- * Connection per thread.
+ * **Thread Safety:** This class is NOT thread-safe; use one Connection per
+ * thread. Multiple concurrent connections are only allowed on a READ_ONLY
+ * database; a READ_WRITE database permits a single connection.
  *
  * **Lifecycle:**
  * - Created via NeugDB::Connect()

--- a/include/neug/main/execution_slot.h
+++ b/include/neug/main/execution_slot.h
@@ -106,7 +106,9 @@ class ExecutionSlotLease {
  *
  * ExecutionSlot is a passive core execution context. It owns slot-local query
  * state and borrows database-wide transaction, storage, allocator, and WAL
- * resources.
+ * resources. The class itself has no brpc or bthread dependency: TP slot
+ * scheduling and synchronization are injected by TpExecutionSlotPool, so the
+ * same execution core also serves embedded connections.
  *
  * Embedded connections exclusively own one ExecutionSlot. Service mode owns a
  * fixed set through TpExecutionSlotPool and leases them per request.

--- a/include/neug/main/neug_db.h
+++ b/include/neug/main/neug_db.h
@@ -151,10 +151,10 @@ class NEUG_API NeugDB {
    *
    * @param data_dir Path to the graph data directory
    * @param max_thread_num Database query capacity. 0 selects hardware
-   * concurrency (fallback 1); higher values warn and clamp. AP queries are
-   * single-threaded; intra-query parallelism is future work. In TP mode, it
-   * sizes the slot pool and caps service threads. Concurrent TP queries each
-   * use one slot and one thread.
+   * concurrency (fallback 1); a positive value is honored as-is and a
+   * negative value is rejected. AP queries are single-threaded; intra-query
+   * parallelism is future work. In TP mode, it sizes the slot pool and caps
+   * service threads. Concurrent TP queries each use one slot and one thread.
    * @param mode Database access mode (READ_ONLY or READ_WRITE)
    * @param planner_kind Query planner type: "gopt" (Graph Optimizer) or
    * "greedy"

--- a/include/neug/main/query_result.h
+++ b/include/neug/main/query_result.h
@@ -37,6 +37,38 @@ namespace neug {
  * - debugging output (`ToString()`),
  * - cursor-based row traversal via `hasNext()` / `next()`,
  * - typed cell access via `GetInt32()`, `GetString()`, etc.
+ *
+ * **Typed accessors:** Every getter reads from the current cursor row and has
+ * two overloads, by column index or by column name. Call `IsNull(...)` before
+ * reading a cell that may be NULL. Temporal columns (`date`, `timestamp`,
+ * `interval`) are not exposed as dedicated typed objects: use `GetString(...)`
+ * for their canonical string form (e.g. `"1970-01-01"`) and `GetInt64(...)` for
+ * the raw epoch value of `date` / `timestamp` columns.
+ *
+ * **Example:**
+ * @code{.cpp}
+ * auto result = QueryResult::From(serialized);
+ *
+ * // Access by column index
+ * while (result.hasNext()) {
+ *     if (!result.IsNull(0)) {
+ *         int32_t id = result.GetInt32(0);
+ *         std::string name = result.GetString(1);
+ *     }
+ *     result.next();
+ * }
+ *
+ * // Access by column name
+ * result.Reset();
+ * while (result.hasNext()) {
+ *     if (!result.IsNull("id")) {
+ *         int32_t id = result.GetInt32("id");
+ *         std::string name = result.GetString("name");
+ *         double score = result.GetDouble("score");
+ *     }
+ *     result.next();
+ * }
+ * @endcode
  */
 
 class NEUG_API QueryResult {

--- a/include/neug/main/query_result.h
+++ b/include/neug/main/query_result.h
@@ -135,8 +135,15 @@ class NEUG_API QueryResult {
 
   /**
    * @brief Check whether the cell at current row is NULL.
+   *
+   * @param column_index Zero-based column index.
    */
   bool IsNull(size_t column_index) const;
+  /**
+   * @brief Check whether the named cell at current row is NULL.
+   *
+   * @param column_name Column name from the result schema.
+   */
   bool IsNull(const std::string& column_name) const;
 
   /**

--- a/tools/python_bind/neug/connection.py
+++ b/tools/python_bind/neug/connection.py
@@ -107,8 +107,8 @@ class Connection(object):
     def has_active_transaction(self) -> bool:
         """Whether this connection has an active explicit transaction.
 
-        The property remains true while a failed transaction is rollback-only.
-        Call :meth:`rollback` to return the connection to auto-commit mode.
+        The property remains true while a failed transaction is rollback-only. Call
+        `rollback()` to return the connection to auto-commit mode.
         """
         return self._is_open and self._py_connection.has_active_transaction
 
@@ -161,7 +161,7 @@ class Connection(object):
         Execute a cypher query on the database. User could specify multiple queries in a single string,
         separated by semicolons. The query will be executed in the order they are specified.
         If any query fails, the whole execution will be rolled back.
-        If the query is a DDL query, such as `CREATE TABLE`, `DROP TABLE`, etc., the database will be
+        If the query is a DDL query, such as `CREATE NODE TABLE`, `CREATE REL TABLE`, `DROP TABLE`, etc., the database will be
         modified accordingly.
 
         For the details of the query syntax, please refer to the documentation of cypher manual.
@@ -172,10 +172,12 @@ class Connection(object):
 
         If the query is a DDL or DML query, the result will be an empty `QueryResult` object.
 
-        Inside an explicit transaction, a failed query leaves the transaction
-        rollback-only. Call :meth:`rollback` before executing another query.
+        Inside an explicit transaction, a query that reaches the database engine and
+        fails leaves the transaction rollback-only. Call `rollback()` before executing
+        another query. Client-side validation errors that occur before execution, such
+        as an invalid `access_mode`, do not change the transaction state.
 
-        Some of the cypher queries could change the state of the database, such as `CREATE TABLE`, `INSERT`,
+        Some of the cypher queries could change the state of the database, such as `CREATE NODE TABLE`, `INSERT`,
         `UPDATE`, `DELETE`, etc. Other queries, such as `MATCH(n) RETURN n.id`, will not change the state of
         the database, but will return the results of the query.
 
@@ -188,17 +190,17 @@ class Connection(object):
             >>> from neug import Database
             >>> db = Database("/tmp/test.db", mode="w")
             >>> conn = db.connect()
-            >>> res = conn.execute('CREATE TABLE person(id INT64, name STRING);')
-            >>> res = conn.execute('CREATE TABLE knows(FROM person TO person, weight DOUBLE);')
-            >>> res = conn.execute('COPY person FROM "person.csv"')
-            >>> res = conn.execute('COPY knows FROM "knows.csv" (from="person", to="person");')
+            >>> res = conn.execute('CREATE NODE TABLE Person(id INT64, name STRING);')
+            >>> res = conn.execute('CREATE REL TABLE KNOWS(FROM Person TO Person, weight DOUBLE);')
+            >>> res = conn.execute('COPY Person FROM "person.csv"')
+            >>> res = conn.execute('COPY KNOWS FROM "knows.csv" (from="Person", to="Person");')
             >>> res = conn.execute('MATCH(n) RETURN n.id')
             >>> for record in res:
             >>>    print(record)
-            >>> res = conn.execute('MATCH(p:person)-[knows]->(q:person) RETURN p.id, q.id LIMIT 10;')
+            >>> res = conn.execute('MATCH(p:Person)-[:KNOWS]->(q:Person) RETURN p.id, q.id LIMIT 10;')
             >>> # submitting query with parameters
             >>> res = conn.execute(
-                'MATCH (n:person) WHERE n.id = $id RETURN n.name', access_mode='r', parameters={'id': 12345})
+                'MATCH (n:Person) WHERE n.id = $id RETURN n.name', access_mode='r', parameters={'id': 12345})
 
 
         Parameters

--- a/tools/python_bind/neug/database.py
+++ b/tools/python_bind/neug/database.py
@@ -98,7 +98,8 @@ class Database(object):
             Note that in memory mode, the database will not be persisted to disk, and all data will be
             lost when the program exits. In this case, the db_path should not contain any illegal characters.
         mode : str
-            Mode to open the database, could be 'r', 'read', 'readwrite', 'w', 'rw', 'write'. Default is 'read-write'.
+            Mode to open the database. Read-only: 'r', 'read', 'read-only', 'read_only'.
+            Read-write: 'w', 'rw', 'write', 'readwrite', 'read-write', 'read_write'. Default is 'read-write'.
         max_thread_num : int
             Database query capacity; 0 selects hardware concurrency (fallback 1), while higher inputs warn and clamp to it.
 

--- a/tools/python_bind/neug/database.py
+++ b/tools/python_bind/neug/database.py
@@ -55,6 +55,10 @@ class Database(object):
     When the database is opened in read-write mode, no other databases could open the same database directory in
     either read-only or read-write mode, inside the same process or in different processes.
 
+    Note that opening a database in read-only mode still requires a writable data directory: the lock file is
+    created on demand if missing, and read-only processes create temporary working files in their own
+    `runtime/open-<epoch>/` directory. Read-only mode cannot be used on a read-only file system or mount.
+
     When the database is closed, all the connections to the database will be closed automatically.
 
     .. code:: python
@@ -64,14 +68,14 @@ class Database(object):
         >>> conn = db.connect()
 
         >>> # Use the connection to interact with the database
-        >>> conn.execute('CREATE TABLE person(id INT64, name STRING);')
-        >>> conn.execute('CREATE TABLE knows(FROM person TO person, weight DOUBLE);')
+        >>> conn.execute('CREATE NODE TABLE Person(id INT64, name STRING);')
+        >>> conn.execute('CREATE REL TABLE KNOWS(FROM Person TO Person, weight DOUBLE);')
 
         >>> # Import data from csv file.
-        >>> conn.execute('COPY person FROM "person.csv"')
-        >>> conn.execute('COPY knows FROM "knows.csv" (from="person", to="person");')
+        >>> conn.execute('COPY Person FROM "person.csv"')
+        >>> conn.execute('COPY KNOWS FROM "knows.csv" (from="Person", to="Person");')
 
-        >>> res = conn.execute('MATCH(n) return n.id;)
+        >>> res = conn.execute('MATCH(n) RETURN n.id')
         >>> for record in res:
         >>>     print(record)
     """
@@ -94,7 +98,7 @@ class Database(object):
             Note that in memory mode, the database will not be persisted to disk, and all data will be
             lost when the program exits. In this case, the db_path should not contain any illegal characters.
         mode : str
-            Mode to open the database, could be 'r', 'read', 'readwrite', 'w', 'rw', 'write'. Default is 'readwrite'.
+            Mode to open the database, could be 'r', 'read', 'readwrite', 'w', 'rw', 'write'. Default is 'read-write'.
         max_thread_num : int
             Database query capacity; 0 selects hardware concurrency (fallback 1), while higher inputs warn and clamp to it.
 
@@ -106,13 +110,11 @@ class Database(object):
             If False, no checkpoint is created automatically when close the database.
         buffer_strategy : str
             Buffer strategy to use for the database, could be 'InMemory' (or 'M_FULL'), 'SyncToFile' (or 'M_LAZY')
-            or 'HugePagePreferred' (or 'M_HUGE'). Default is 'M_FULL'.
-            - 'InMemory' / 'M_FULL': The database will be opened fully in memory, and the changes will not be
-              persisted to disk until checkpoint is created.
-            - 'SyncToFile' / 'M_LAZY': The database will be opened in memory on demand, suitable for large databases
-              that cannot fit into memory. Also changes will not be persisted to disk until checkpoint is created.
-            - 'HugePagePreferred' / 'M_HUGE': Similar to 'InMemory', but it will try to use huge pages for memory
-              allocation, which may improve performance for large databases.
+            or 'HugePagePreferred' (or 'M_HUGE'). Default is 'M_FULL'. This setting controls how graph data is
+            loaded into memory; it does not affect durability.
+            - 'InMemory' / 'M_FULL': Open the database fully in memory.
+            - 'SyncToFile' / 'M_LAZY': Load database pages on demand, suitable for databases that do not fit in memory.
+            - 'HugePagePreferred' / 'M_HUGE': Similar to 'InMemory', but prefer huge pages when available.
 
         Raises
         ------
@@ -283,14 +285,14 @@ class Database(object):
         blocking : bool
             Whether to block the process after starting the database server.
         thread_num : int
-            Service thread count. 0 selects max_thread_num; explicit values cannot exceed it.
+            Service thread count. 0 selects max_thread_num; explicit values are clamped to it.
 
             Service threads run TP queries concurrently, but each query uses one execution context and one thread.
         auto_compaction : bool
-            Enable background auto-compaction while serving. Default is True.
+            Enable background auto-compaction while serving. Default is `True`.
         explicit_transaction_timeout_ms : int
             Absolute lifetime of an explicit transaction in milliseconds.
-            Default is 60000.
+            Default is `60000`.
 
         Returns
         -------
@@ -299,6 +301,10 @@ class Database(object):
 
         Raises
         ------
+        ValueError
+            If `thread_num` is negative or `explicit_transaction_timeout_ms` is not
+            positive. A `thread_num` exceeding `max_thread_num` or the CPU count is
+            clamped with a warning, not rejected.
         RuntimeError
             If there are open connections to the local database.
             If the database is already serving.
@@ -307,6 +313,7 @@ class Database(object):
         -----
         Make sure to close all connections before starting the server.
         After starting the server, no new connections to the local database will be allowed.
+        `thread_num` sizes server-side service threads; the client-side `Session(num_threads=...)` sizes its HTTP pool.
         """
         if thread_num < 0:
             raise ValueError(
@@ -416,7 +423,7 @@ class Database(object):
         """
         Close the database and all of its connections.
 
-        For a read-write database with ``checkpoint_on_close=True``, this method
+        For a read-write database with `checkpoint_on_close=True`, this method
         creates a checkpoint before releasing database resources.
         The method is idempotent after a successful close. A checkpoint failure
         before its destructive dump raises an exception and leaves the database

--- a/tools/python_bind/neug/query_result.py
+++ b/tools/python_bind/neug/query_result.py
@@ -177,26 +177,28 @@ class QueryResult(object):
 
     def get_profile_metrics(self) -> dict:
         """
-        Get detailed profile metrics for all operators.
+        Return detailed PROFILE or EXPLAIN metrics as a Python dictionary.
 
-        Returns complete execution plan metrics including timing and output
-        information for each operator in the query execution tree.
+        The result contains complete execution plan metrics, including timing
+        and output information for each operator in the query execution tree.
+        Returns an empty dict if no profile result is available.
 
-        Returns
-        -------
-        dict
-            Complete profile data with keys:
-            - 'total_elapsed_ms' (float): Total execution time in milliseconds
-            - 'total_output_rows' (int): Total output rows from query
-            - 'operators' (list): List of operator metrics, each dict contains:
-                - 'operator_id' (int): Unique operator identifier
-                - 'parent_id' (int): Parent operator id (-1 for root)
-                - 'operator_name' (str): Human-readable operator name
-                - 'elapsed_ms' (float): Execution time in milliseconds
-                - 'output_rows' (int): Number of output tuples
-                - 'child_ids' (list): IDs of child operators
+        .. code:: python
 
-            Returns empty dict if no profile result available.
+            {
+                "total_elapsed_ms": float,
+                "total_output_rows": int,
+                "operators": [
+                    {
+                        "operator_id": int,
+                        "parent_id": int,
+                        "operator_name": str,
+                        "elapsed_ms": float,
+                        "output_rows": int,
+                        "child_ids": [int],
+                    }
+                ],
+            }
         """
         if not self.has_profile_result():
             return {}


### PR DESCRIPTION
Fix #1056 

## What

Follow-up to #1051. Makes `make api-docs` / `make html` regenerate the committed reference docs **without drift** — by fixing the sources (docstrings + headers) instead of hand-editing the generated `.md`, and committing the regenerated output.

## Why

#1051 fixed stale source residue but left two gaps:

1. Python docstrings still had bugs that regeneration would surface (label casing, Cypher syntax, reST `:meth:` / double-backtick residues).
2. The hand-curated C++ `query_result.md` / `service.md` had diverged from their headers, so any regeneration clobbered the curation.

## Changes

**Python docstrings** (`connection.py`, `database.py`, `query_result.py`)

- Fix label casing + Cypher in examples: `person` -> `Person`, `-[knows]->` -> `-[:KNOWS]->`, `CREATE TABLE` -> `CREATE NODE/REL TABLE`.
- Replace reST residues: `:meth:` -> plain `rollback()`; double-backtick -> single backtick.
- `Database`: correct `mode` default to `'read-write'`; note read-only still needs a writable data dir; tighten `buffer_strategy` (memory-loading, not durability).
- `serve()`: open connections **must be closed** (it raises, not auto-closes); `thread_num` is **clamped**, not rejected; accurate `ValueError` + Notes.
- `get_profile_metrics`: rewrite as a code block so the dict shape survives the generator (nested lists get flattened).

**C++ headers** (`query_result.h`, `execution_slot.h`)

- `QueryResult`: add the Example block + typed-accessor / temporal-column guidance, ported back from the curated `.md`.
- `ExecutionSlot`: note it has no brpc/bthread dependency (injected by `TpExecutionSlotPool`), so the same core serves embedded + TP.

**Regenerated reference docs** (`doc/source/reference/{cpp,python}_api/*.md`)

- Also picks up stale-source corrections the committed docs had missed (`Connection::Query` now takes `rapidjson::Value`; `NeugDB::Close` checkpoint-failure semantics) and new methods (`HasActiveService`, `HasOpenConnections`, `PrepareForServing`, profile accessors).

## Verification

- `make api-docs` is **idempotent**: re-running against `main` produces zero diff.
- flake8 / black / isort / clang-format (10.0.1) all clean.

## Note

`neug_db.md`'s `Open()` "Data Directory Structure" now uses the header's concise bullet list rather than the curated tree diagram + `base_ts` / `checkpoint-N` prose. That on-disk detail fits better in `storages/README.md`; can enrich `neug_db.h` separately if desired.
